### PR TITLE
pull-request to help plugin/bundle developers avoid class collisions

### DIFF
--- a/Sparkle.pch
+++ b/Sparkle.pch
@@ -20,8 +20,6 @@
 
 #ifdef __OBJC__
 
-#define ClassPrefix RRGM
-
 #ifdef ClassPrefix
 #define _ClassPrefix_CONCAT_2(c,d) c ## d
 #define _ClassPrefix_CONCAT(a,b) _ClassPrefix_CONCAT_2(a,b)


### PR DESCRIPTION
added defines to prefix all the class names with the contents of the ClassPrefix preprocessor macro so that plugin/bundle developers can avoid namespace collisions with the app and other plugin authors that make use of Sparkle.
