### PR TITLE
OpenSSL path should be globally replaced, right? 

### DIFF
--- a/sign_update.rb
+++ b/sign_update.rb
@@ -4,4 +4,4 @@ if ARGV.length < 2
   exit
 end
 openssl = "/usr/bin/openssl"
-puts `#{openssl} dgst -sha1 -binary < "#{ARGV[0]}" | openssl dgst -dss1 -sign "#{ARGV[1]}" | openssl enc -base64`
+puts `#{openssl} dgst -sha1 -binary < "#{ARGV[0]}" | #{openssl} dgst -dss1 -sign "#{ARGV[1]}" | #{openssl} enc -base64`


### PR DESCRIPTION
With MacPorts OpenSSL installed, this version produces different results, which makes me nervous.
