### PR TITLE
Add support for sparkle:requiredVersion to signify mandatory program updates.

### DIFF
--- a/SUBasicUpdateDriver.h
+++ b/SUBasicUpdateDriver.h
@@ -33,6 +33,7 @@
 - (BOOL)hostSupportsItem:(SUAppcastItem *)ui;
 - (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui;
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui;
+- (BOOL)itemContainsRequiredUpdate:(SUAppcastItem *)ui;
 - (void)didFindValidUpdate;
 - (void)didNotFindUpdate;
 

--- a/SUBasicUpdateDriver.m
+++ b/SUBasicUpdateDriver.m
@@ -81,6 +81,12 @@
 	return [self hostSupportsItem:ui] && [self isItemNewer:ui] && ![self itemContainsSkippedVersion:ui];
 }
 
+- (BOOL)itemContainsRequiredUpdate:(SUAppcastItem *)ui
+{
+	NSString *minimumHostVersion = [[[ui propertiesDictionary] objectForKey:@"enclosure"] objectForKey:@"sparkle:requiredVersion"];
+	return [[self versionComparator] compareVersion:[host version] toVersion:minimumHostVersion] == NSOrderedAscending;
+}
+
 - (void)appcastDidFinishLoading:(SUAppcast *)ac
 {
 	if ([[updater delegate] respondsToSelector:@selector(updater:didFinishLoadingAppcast:)])

--- a/SUUIBasedUpdateDriver.m
+++ b/SUUIBasedUpdateDriver.m
@@ -18,7 +18,7 @@
 
 - (void)didFindValidUpdate
 {
-	updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:updateItem host:host];
+	updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:updateItem isRequired:[self itemContainsRequiredUpdate:updateItem] host:host];
 	[updateAlert setDelegate:self];
 	
 	id<SUVersionDisplay>	versDisp = nil;

--- a/SUUpdateAlert.h
+++ b/SUUpdateAlert.h
@@ -35,9 +35,10 @@ typedef enum
 	IBOutlet NSButton *laterButton;
 	NSProgressIndicator *releaseNotesSpinner;
 	BOOL webViewFinishedLoading;
+	BOOL updateRequired;
 }
 
-- (id)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)host;
+- (id)initWithAppcastItem:(SUAppcastItem *)item isRequired:(BOOL)updateRequired host:(SUHost *)aHost;
 - (void)setDelegate:delegate;
 
 - (IBAction)installUpdate:sender;

--- a/SUUpdateAlert.m
+++ b/SUUpdateAlert.m
@@ -27,13 +27,14 @@
 
 @implementation SUUpdateAlert
 
-- (id)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost
+- (id)initWithAppcastItem:(SUAppcastItem *)item isRequired:(BOOL)required host:(SUHost *)aHost
 {
 	self = [super initWithHost:host windowNibName:@"SUUpdateAlert"];
 	if (self)
 	{
 		host = [aHost retain];
 		updateItem = [item retain];
+		updateRequired = required;
 		[self setShouldCascadeWindows:NO];
 		
 		// Alex: This dummy line makes sure that the binary is linked against WebKit.
@@ -153,6 +154,10 @@
 
 - (void)awakeFromNib
 {	
+	// Hide Skip/Later buttons if a minimum version is specified and the host version is not at least that version
+	[skipButton setHidden:updateRequired];
+	[laterButton setHidden:updateRequired];
+
 	NSString*	sizeStr = [host objectForInfoDictionaryKey:SUFixedHTMLDisplaySizeKey];
 
 	if( [host isBackgroundApplication] )
@@ -264,6 +269,10 @@
 
 - (BOOL)windowShouldClose:note
 {
+	// Quit on close window if update is required
+	if (updateRequired)
+		[[NSApplication sharedApplication] terminate:self];
+
 	[self endWithSelection:SURemindMeLaterChoice];
 	return YES;
 }


### PR DESCRIPTION
Our cloud-centric application occasionally requires server-side changes which break older clients. In that case, the application should not be allowed to run without updating.

Check the appcastItem's enclosure for a field labeled
"sparkle:requiredVersion". If found, compare that version to the host's
currently-running version. If the host is not running at least the
required version, do not allow it to launch without an update.  This
means hiding the "Skip" and "Later" buttons in the Update alert, and
terminating the program if the user closes the update alert dialog (via
the window control) without launching the update.
