### PR TITLE
Support a custom user defaults domain

### DIFF
--- a/SUConstants.h
+++ b/SUConstants.h
@@ -59,6 +59,7 @@ extern NSString *const SULastProfileSubmitDateKey;
 extern NSString *const SUPromptUserOnFirstLaunchKey;
 extern NSString *const SUFixedHTMLDisplaySizeKey;
 extern NSString *const SUKeepDownloadOnFailedInstallKey;
+extern NSString *const SUDefaultsDomainKey;
 
 // -----------------------------------------------------------------------------
 //	Errors:

--- a/SUConstants.m
+++ b/SUConstants.m
@@ -35,6 +35,7 @@ NSString *const SULastProfileSubmitDateKey = @"SULastProfileSubmissionDate";
 NSString *const SUPromptUserOnFirstLaunchKey = @"SUPromptUserOnFirstLaunch";
 NSString *const SUFixedHTMLDisplaySizeKey = @"SUFixedHTMLDisplaySize";
 NSString *const SUKeepDownloadOnFailedInstallKey = @"SUKeepDownloadOnFailedInstall";
+NSString *const SUDefaultsDomainKey = @"SUDefaultsDomain";
 
 NSString *const SUSparkleErrorDomain = @"SUSparkleErrorDomain";
 OSStatus SUAppcastParseError = 1000;

--- a/SUHost.h
+++ b/SUHost.h
@@ -14,6 +14,8 @@
 {
 @private
 	NSBundle *bundle;
+	NSString *defaultsDomain;
+	BOOL usesStandardUserDefaults;
 }
 
 + (NSString *)systemVersionString;


### PR DESCRIPTION
This is useful for situations like a background app that updates a
parent preference pane but wants to maintain defaults in the background
app's domain.
