### PR TITLE
Clean up after install on quit updates

### DIFF
--- a/finish_installation.m
+++ b/finish_installation.m
@@ -117,19 +117,20 @@
         else
             appPath = [host installationPath];
         [[NSWorkspace sharedWorkspace] openFile: appPath];
-        if( folderpath )
-        {
-            NSError*		theError = nil;
-            if( ![SUPlainInstaller _removeFileAtPath: [SUInstaller updateFolder] error: &theError] )
-                SULog( @"Couldn't remove update folder: %@.", theError );
-        }
-    #if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_4
-        [[NSFileManager defaultManager] removeFileAtPath: selfPath handler: nil];
-    #else
-        [[NSFileManager defaultManager] removeItemAtPath: selfPath error: NULL];
-    #endif
     }
-    
+
+    if (folderpath)
+    {
+        NSError *theError = nil;
+        if( ![SUPlainInstaller _removeFileAtPath: [SUInstaller updateFolder] error: &theError] )
+            SULog( @"Couldn't remove update folder: %@.", theError );
+    }
+#if MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_4
+    [[NSFileManager defaultManager] removeFileAtPath: selfPath handler: nil];
+#else
+    [[NSFileManager defaultManager] removeItemAtPath: selfPath error: NULL];
+#endif
+
 	exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
Previously the downloaded and extracted updates were only deleted if the host app was relaunched.
