### PR TITLE
Fix manual update checks when an automatic update is pending

### DIFF
--- a/SUAutomaticUpdateDriver.m
+++ b/SUAutomaticUpdateDriver.m
@@ -19,6 +19,7 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
 
 - (void)showUpdateAlert
 {
+	isInterruptible = NO;
 	alert = [[SUAutomaticUpdateAlert alloc] initWithAppcastItem:updateItem host:host delegate:self];
 	
 	// If the app is a menubar app or the like, we need to focus it first and alter the
@@ -69,6 +70,9 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
     else
     {
         showUpdateAlertTimer = [[NSTimer scheduledTimerWithTimeInterval:SUAutomaticUpdatePromptImpatienceTimer target:self selector:@selector(showUpdateAlert) userInfo:nil repeats:NO] retain];
+
+        // At this point the driver is idle, allow it to be interrupted for user-initiated update checks.
+        isInterruptible = YES;
     }
 }
 
@@ -126,7 +130,8 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
 			break;
 			
 		case SUInstallLaterChoice:
-            // No-op: we're already waiting on quit.
+			// We're already waiting on quit, just indicate that we're idle.
+			isInterruptible = YES;
 			break;
 
 		case SUDoNotInstallChoice:

--- a/SUUpdateDriver.h
+++ b/SUUpdateDriver.h
@@ -21,11 +21,13 @@ extern NSString * const SUUpdateDriverFinishedNotification;
 	NSURL *appcastURL;
 	
 	BOOL finished;
+	BOOL isInterruptible;
 }
 
 - initWithUpdater:(SUUpdater *)updater;
 - (void)checkForUpdatesAtURL:(NSURL *)URL host:(SUHost *)host;
 - (void)abortUpdate;
+- (BOOL)isInterruptible;
 - (BOOL)finished;
 
 @end

--- a/SUUpdateDriver.m
+++ b/SUUpdateDriver.m
@@ -33,6 +33,8 @@ NSString * const SUUpdateDriverFinishedNotification = @"SUUpdateDriverFinished";
 	[[NSNotificationCenter defaultCenter] postNotificationName:SUUpdateDriverFinishedNotification object:self];
 }
 
+- (BOOL)isInterruptible { return isInterruptible; }
+
 - (BOOL)finished { return finished; }
 
 - (void)dealloc

--- a/SUUpdater.m
+++ b/SUUpdater.m
@@ -288,6 +288,9 @@ static NSString * const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefault
 
 - (IBAction)checkForUpdates: (id)sender
 {
+	if (driver && [driver isInterruptible])
+		[driver abortUpdate];
+
 	[self checkForUpdatesWithDriver:[[[SUUserInitiatedUpdateDriver alloc] initWithUpdater:self] autorelease]];
 }
 


### PR DESCRIPTION
When a silent update has been downloaded and is waiting on termination user-initiated checks do nothing because the automatic update driver is not finished. Added an isInterruptible property to indicate such states and allow the driver to be aborted for manual checks.

An alternative would be to tell the automatic update driver to just show its prompt when in this state. This would avoid a duplicate download, but the interruptible query has the advantage of being simple and catching any new update released since the automatic download.
