### PR TITLE
XPC service for Lion Sandboxing

### DIFF
--- a/Configurations/ConfigService.xcconfig
+++ b/Configurations/ConfigService.xcconfig
@@ -1,0 +1,5 @@
+// Sandbox Service only
+
+PRODUCT_NAME = com.andymatuschak.Sparkle.SandboxService
+WRAPPER_EXTENSION = xpc
+MACH_O_TYPE = mh_execute

--- a/Configurations/ConfigServiceDebug.xcconfig
+++ b/Configurations/ConfigServiceDebug.xcconfig
@@ -1,0 +1,5 @@
+#include "ConfigCommon.xcconfig"
+#include "ConfigCommonDebug.xcconfig"
+#include "ConfigService.xcconfig"
+
+OTHER_CFLAGS = -fsingle-precision-constant -DDEBUG

--- a/Configurations/ConfigServiceRelease.xcconfig
+++ b/Configurations/ConfigServiceRelease.xcconfig
@@ -1,0 +1,3 @@
+#include "ConfigCommon.xcconfig"
+#include "ConfigCommonRelease.xcconfig"
+#include "ConfigService.xcconfig"

--- a/SUBasicUpdateDriver.m
+++ b/SUBasicUpdateDriver.m
@@ -19,6 +19,7 @@
 #import "SUPlainInstallerInternals.h"
 #import "SUBinaryDeltaCommon.h"
 #import "SUUpdater_Private.h"
+#import "SUXPC.h"
 
 @interface SUBasicUpdateDriver () <NSURLDownloadDelegate>; @end
 
@@ -272,6 +273,10 @@
         [self abortUpdate];
         return;
     }
+	
+	BOOL running10_7 = floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6;
+	BOOL useXPC = running10_7 && [[NSFileManager defaultManager] fileExistsAtPath:
+								  [[host bundlePath] stringByAppendingPathComponent:@"Contents/XPCServices/com.andymatuschak.Sparkle.SandboxService.xpc"]];
     
     // Give the host app an opportunity to postpone the install and relaunch.
     static BOOL postponedOnce = NO;
@@ -302,7 +307,12 @@
 #endif
 
 	// Only the paranoid survive: if there's already a stray copy of relaunch there, we would have problems.
-	if( [SUPlainInstaller copyPathWithAuthentication: relaunchPathToCopy overPath: targetPath temporaryName: nil error: &error] )
+	BOOL copiedRelaunchTool = FALSE;
+	if( useXPC )
+		copiedRelaunchTool = [SUXPC copyPathWithAuthentication: relaunchPathToCopy overPath: targetPath temporaryName: nil error: &error];
+	else
+		copiedRelaunchTool = [SUPlainInstaller copyPathWithAuthentication: relaunchPathToCopy overPath: targetPath temporaryName: nil error: &error];
+	if( copiedRelaunchTool )
 		relaunchPath = [targetPath retain];
 	else
 		[self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:SULocalizedString(@"An error occurred while extracting the archive. Please try again later.", nil), NSLocalizedDescriptionKey, [NSString stringWithFormat:@"Couldn't copy relauncher (%@) to temporary path (%@)! %@", relaunchPathToCopy, targetPath, (error ? [error localizedDescription] : @"")], NSLocalizedFailureReasonErrorKey, nil]]];
@@ -323,7 +333,11 @@
     if ([[updater delegate] respondsToSelector:@selector(pathToRelaunchForUpdater:)])
         pathToRelaunch = [[updater delegate] pathToRelaunchForUpdater:updater];
     NSString *relaunchToolPath = [relaunchPath stringByAppendingPathComponent: @"/Contents/MacOS/finish_installation"];
-    [NSTask launchedTaskWithLaunchPath: relaunchToolPath arguments:[NSArray arrayWithObjects:[host bundlePath], pathToRelaunch, [NSString stringWithFormat:@"%d", [[NSProcessInfo processInfo] processIdentifier]], tempDir, relaunch ? @"1" : @"0", nil]];
+	NSArray *arguments = [NSArray arrayWithObjects:[host bundlePath], pathToRelaunch, [NSString stringWithFormat:@"%d", [[NSProcessInfo processInfo] processIdentifier]], tempDir, relaunch ? @"1" : @"0", nil];
+	if( useXPC )
+		[SUXPC launchTaskWithLaunchPath: relaunchToolPath arguments:arguments];
+	else
+		[NSTask launchedTaskWithLaunchPath: relaunchToolPath arguments:arguments];
 
     [NSApp terminate:self];
 }

--- a/SUPlainInstallerInternals.m
+++ b/SUPlainInstallerInternals.m
@@ -524,7 +524,10 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
 	// new home in case it's moved across filesystems: if that
 	// happens, the move is actually a copy, and it may result
 	// in the application being quarantined.
-	[self performSelectorOnMainThread:@selector(releaseFromQuarantine:) withObject:dst waitUntilDone:YES];
+	if ([NSThread isMultiThreaded])
+		[self performSelectorOnMainThread:@selector(releaseFromQuarantine:) withObject:dst waitUntilDone:YES];
+	else
+		[self releaseFromQuarantine:dst];
 	
 	return YES;
 }

--- a/SUXPC.h
+++ b/SUXPC.h
@@ -1,0 +1,16 @@
+//
+//  SUXPC.h
+//  Sparkle
+//
+//  Created by Whitney Young on 3/19/12.
+//  Copyright (c) 2012 FadingRed. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SUXPC : NSObject
+
++ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst temporaryName:(NSString *)tmp error:(NSError **)error;
++ (void)launchTaskWithLaunchPath:(NSString *)path arguments:(NSArray *)arguments;
+
+@end

--- a/SUXPC.m
+++ b/SUXPC.m
@@ -1,0 +1,72 @@
+//
+//  SUXPC.m
+//  Sparkle
+//
+//  Created by Whitney Young on 3/19/12.
+//  Copyright (c) 2012 FadingRed. All rights reserved.
+//
+
+#import <xpc/xpc.h>
+#import "SUXPC.h"
+
+
+@implementation SUXPC
+
++ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst temporaryName:(NSString *)tmp error:(NSError **)error {
+	xpc_connection_t connection = xpc_connection_create("com.andymatuschak.Sparkle.SandboxService", NULL);
+	xpc_connection_set_event_handler(connection, ^(xpc_object_t event) {
+		xpc_dictionary_apply(event, ^bool(const char *key, xpc_object_t value) {
+			NSLog(@"XPC %s: %s", key, xpc_string_get_string_ptr(value));
+			return true;
+		});
+	});
+	xpc_connection_resume(connection);
+
+	xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
+	xpc_dictionary_set_string(message, "id", "copy_path");
+	
+	if( src )
+		xpc_dictionary_set_string(message, "source", [src fileSystemRepresentation]);
+	if( dst )
+		xpc_dictionary_set_string(message, "destination", [dst fileSystemRepresentation]);
+	if( tmp )
+		xpc_dictionary_set_string(message, "tmp", [tmp UTF8String]);
+	
+	xpc_object_t response = xpc_connection_send_message_with_reply_sync(connection, message);
+	xpc_type_t type = xpc_get_type(response);
+	return type == XPC_TYPE_DICTIONARY;
+}
+
++ (void)launchTaskWithLaunchPath:(NSString *)path arguments:(NSArray *)arguments {
+	xpc_connection_t connection = xpc_connection_create("com.andymatuschak.Sparkle.SandboxService", NULL);
+	xpc_connection_set_event_handler(connection, ^(xpc_object_t event) {
+		xpc_dictionary_apply(event, ^bool(const char *key, xpc_object_t value) {
+			NSLog(@"XPC %s: %s", key, xpc_string_get_string_ptr(value));
+			return true;
+		});
+	});
+	xpc_connection_resume(connection);
+	
+	xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
+	xpc_dictionary_set_string(message, "id", "launch_task");
+	
+	if( path )
+		xpc_dictionary_set_string(message, "path", [path fileSystemRepresentation]);
+	
+	xpc_object_t array = xpc_array_create(NULL, 0);
+	for (id argument in arguments) {
+		xpc_array_append_value(array, xpc_string_create([argument UTF8String]));
+	}
+	
+	xpc_dictionary_set_value(message, "arguments", array);
+	
+	xpc_object_t response = xpc_connection_send_message_with_reply_sync(connection, message);
+	xpc_type_t type = xpc_get_type(response);
+	BOOL success = (type == XPC_TYPE_DICTIONARY);
+	
+	if (!success) {
+		NSLog(@"XPC launch error");
+	}
+}
+
+@end

--- a/SandboxService.plist
+++ b/SandboxService.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+	</dict>
+</dict>
+</plist>

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -131,6 +131,20 @@
 		61F83F720DBFE140006FDD30 /* SUBasicUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */; };
 		61F83F740DBFE141006FDD30 /* SUBasicUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */; settings = {ATTRIBUTES = (); }; };
 		61FA52880E2D9EA400EF58AD /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* Sparkle.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		8B887B611517F3AC000BB292 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B887B601517F3AC000BB292 /* Foundation.framework */; };
+		8B887B7E1517F888000BB292 /* SUXPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B887B7C1517F888000BB292 /* SUXPC.h */; };
+		8B887B7F1517F888000BB292 /* SUXPC.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B887B7D1517F888000BB292 /* SUXPC.m */; };
+		8B887B811517FAA3000BB292 /* SUPlainInstallerInternals.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B5F8E509C4CE3C00B25A18 /* SUPlainInstallerInternals.m */; };
+		8B887B821517FAA4000BB292 /* SUPlainInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 618FA5040DAE8AB80026945C /* SUPlainInstaller.m */; };
+		8B887B831517FAE9000BB292 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55C14F31136EFC2400649790 /* SystemConfiguration.framework */; };
+		8B887B841517FAEC000BB292 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6117796E0D1112E000749C97 /* IOKit.framework */; };
+		8B887B861517FAFE000BB292 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
+		8B887B881517FB1C000BB292 /* SUInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 618FA5000DAE88B40026945C /* SUInstaller.m */; };
+		8B887B891517FB3E000BB292 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
+		8B887B8A1517FB43000BB292 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
+		8B887B8B1517FB52000BB292 /* SUPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 618FA5210DAE8E8A0026945C /* SUPackageInstaller.m */; };
+		8B887B8C1517FB5D000BB292 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0867D6A5FE840307C02AAC07 /* AppKit.framework */; };
+		8B887B8E15180767000BB292 /* sandbox_service.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B887B8D15180767000BB292 /* sandbox_service.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -161,6 +175,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
 			remoteInfo = Sparkle;
+		};
+		8B887B731517F472000BB292 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B887B5D1517F3AB000BB292;
+			remoteInfo = Service;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -379,6 +400,15 @@
 		61F614540E24A12D009F47E7 /* it */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUBasicUpdateDriver.h; sourceTree = "<group>"; };
 		61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBasicUpdateDriver.m; sourceTree = "<group>"; };
+		8B887B5E1517F3AB000BB292 /* com.andymatuschak.Sparkle.SandboxService.xpc */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = com.andymatuschak.Sparkle.SandboxService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B887B601517F3AC000BB292 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		8B887B701517F447000BB292 /* ConfigService.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigService.xcconfig; sourceTree = "<group>"; };
+		8B887B711517F447000BB292 /* ConfigServiceDebug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigServiceDebug.xcconfig; sourceTree = "<group>"; };
+		8B887B721517F447000BB292 /* ConfigServiceRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigServiceRelease.xcconfig; sourceTree = "<group>"; };
+		8B887B7C1517F888000BB292 /* SUXPC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUXPC.h; sourceTree = SOURCE_ROOT; };
+		8B887B7D1517F888000BB292 /* SUXPC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUXPC.m; sourceTree = SOURCE_ROOT; };
+		8B887B8D15180767000BB292 /* sandbox_service.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = sandbox_service.m; sourceTree = SOURCE_ROOT; };
+		8B887B8F15180773000BB292 /* SandboxService.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = SandboxService.plist; sourceTree = SOURCE_ROOT; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* Sparkle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sparkle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1941CA0D94A70100DD942E /* ConfigFrameworkDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ConfigFrameworkDebug.xcconfig; sourceTree = "<group>"; };
@@ -439,6 +469,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8B887B5B1517F3AB000BB292 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B887B611517F3AC000BB292 /* Foundation.framework in Frameworks */,
+				8B887B831517FAE9000BB292 /* SystemConfiguration.framework in Frameworks */,
+				8B887B841517FAEC000BB292 /* IOKit.framework in Frameworks */,
+				8B887B8C1517FB5D000BB292 /* AppKit.framework in Frameworks */,
+				8B887B861517FAFE000BB292 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8DC2EF560486A6940098B216 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -465,6 +507,7 @@
 				612279D90DB5470200AB99EA /* Sparkle Unit Tests.octest */,
 				5D06E8D00FD68C7C005AE3F6 /* BinaryDelta */,
 				55C14BB7136EEF1500649790 /* finish_installation.app */,
+				8B887B5E1517F3AB000BB292 /* com.andymatuschak.Sparkle.SandboxService.xpc */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -478,12 +521,14 @@
 				55C14BD5136EEFD000649790 /* finish_installation tool */,
 				6101354A0DD25B7F0049ACDF /* Unarchiving */,
 				61299B3A09CB056100B7442F /* User Interface */,
+				8B887B621517F3AC000BB292 /* Sandbox Service */,
 				61B5F8F309C4CE5900B25A18 /* Other Sources */,
 				089C1665FE841158C02AAC07 /* Framework Resources */,
 				61227A100DB5484000AB99EA /* Tests */,
 				61B5F91D09C4CF7F00B25A18 /* Test Application Sources */,
 				0867D69AFE84028FC02AAC07 /* Apple Frameworks and Libraries */,
 				FA1941C40D94A6EA00DD942E /* Configurations */,
+				8B887B5F1517F3AB000BB292 /* Frameworks */,
 				034768DFFF38A50411DB9C8B /* Products */,
 			);
 			name = Sparkle;
@@ -698,6 +743,42 @@
 			name = "Update Control";
 			sourceTree = "<group>";
 		};
+		8B887B5F1517F3AB000BB292 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8B887B601517F3AC000BB292 /* Foundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8B887B621517F3AC000BB292 /* Sandbox Service */ = {
+			isa = PBXGroup;
+			children = (
+				8B887B801517F8B4000BB292 /* Service */,
+				8B887B631517F3AC000BB292 /* Interface */,
+			);
+			name = "Sandbox Service";
+			path = Update;
+			sourceTree = "<group>";
+		};
+		8B887B631517F3AC000BB292 /* Interface */ = {
+			isa = PBXGroup;
+			children = (
+				8B887B7C1517F888000BB292 /* SUXPC.h */,
+				8B887B7D1517F888000BB292 /* SUXPC.m */,
+			);
+			name = Interface;
+			sourceTree = "<group>";
+		};
+		8B887B801517F8B4000BB292 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				8B887B8D15180767000BB292 /* sandbox_service.m */,
+				8B887B8F15180773000BB292 /* SandboxService.plist */,
+			);
+			name = Service;
+			sourceTree = "<group>";
+		};
 		FA1941C40D94A6EA00DD942E /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
@@ -718,6 +799,9 @@
 				FA1941CE0D94A70100DD942E /* ConfigRelaunch.xcconfig */,
 				FA1941D30D94A70100DD942E /* ConfigRelaunchDebug.xcconfig */,
 				FA1941D40D94A70100DD942E /* ConfigRelaunchRelease.xcconfig */,
+				8B887B701517F447000BB292 /* ConfigService.xcconfig */,
+				8B887B711517F447000BB292 /* ConfigServiceDebug.xcconfig */,
+				8B887B721517F447000BB292 /* ConfigServiceRelease.xcconfig */,
 				FA3AAF3B1050B273004B3130 /* ConfigUnitTest.xcconfig */,
 				FA3AAF3A1050B273004B3130 /* ConfigUnitTestDebug.xcconfig */,
 				FA3AAF391050B273004B3130 /* ConfigUnitTestRelease.xcconfig */,
@@ -772,6 +856,7 @@
 				55C14F06136EF6DB00649790 /* SULog.h in Headers */,
 				55C14F0F136EF73600649790 /* finish_installation.pch in Headers */,
 				6158A1C5137904B300487EC1 /* SUUpdater_Private.h in Headers */,
+				8B887B7E1517F888000BB292 /* SUXPC.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -851,6 +936,23 @@
 			productReference = 61B5F90209C4CEE200B25A18 /* Sparkle Test App.app */;
 			productType = "com.apple.product-type.application";
 		};
+		8B887B5D1517F3AB000BB292 /* sandbox_service */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B887B6E1517F3AC000BB292 /* Build configuration list for PBXNativeTarget "sandbox_service" */;
+			buildPhases = (
+				8B887B5A1517F3AB000BB292 /* Sources */,
+				8B887B5B1517F3AB000BB292 /* Frameworks */,
+				8B887B5C1517F3AB000BB292 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = sandbox_service;
+			productName = Update;
+			productReference = 8B887B5E1517F3AB000BB292 /* com.andymatuschak.Sparkle.SandboxService.xpc */;
+			productType = "com.apple.product-type.bundle";
+		};
 		8DC2EF4F0486A6940098B216 /* Sparkle */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB91AD08733DA50010E9CD /* Build configuration list for PBXNativeTarget "Sparkle" */;
@@ -867,6 +969,7 @@
 			);
 			dependencies = (
 				55C14F97136F044100649790 /* PBXTargetDependency */,
+				8B887B741517F472000BB292 /* PBXTargetDependency */,
 			);
 			name = Sparkle;
 			productInstallPath = "$(HOME)/Library/Frameworks";
@@ -936,6 +1039,7 @@
 				612279D80DB5470200AB99EA /* Sparkle Unit Tests */,
 				5D06E8CF0FD68C7C005AE3F6 /* BinaryDelta */,
 				55C14BB6136EEF1500649790 /* finish_installation */,
+				8B887B5D1517F3AB000BB292 /* sandbox_service */,
 			);
 		};
 /* End PBXProject section */
@@ -966,6 +1070,13 @@
 				61B5F92F09C4CFD800B25A18 /* MainMenu.nib in Resources */,
 				61BBDF820A49220C00378739 /* Sparkle.icns in Resources */,
 				618E9CFD0E7328F1004646D8 /* dsa_pub.pem in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B887B5C1517F3AB000BB292 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1106,6 +1217,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8B887B5A1517F3AB000BB292 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B887B881517FB1C000BB292 /* SUInstaller.m in Sources */,
+				8B887B821517FAA4000BB292 /* SUPlainInstaller.m in Sources */,
+				8B887B811517FAA3000BB292 /* SUPlainInstallerInternals.m in Sources */,
+				8B887B8B1517FB52000BB292 /* SUPackageInstaller.m in Sources */,
+				8B887B8A1517FB43000BB292 /* SUConstants.m in Sources */,
+				8B887B891517FB3E000BB292 /* SULog.m in Sources */,
+				8B887B8E15180767000BB292 /* sandbox_service.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8DC2EF540486A6940098B216 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1144,6 +1269,7 @@
 				5D06E8ED0FD68CE4005AE3F6 /* SUBinaryDeltaCommon.m in Sources */,
 				5D06E93A0FD69271005AE3F6 /* SUBinaryDeltaUnarchiver.m in Sources */,
 				55C14F07136EF6DB00649790 /* SULog.m in Sources */,
+				8B887B7F1517F888000BB292 /* SUXPC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1169,6 +1295,11 @@
 			isa = PBXTargetDependency;
 			target = 8DC2EF4F0486A6940098B216 /* Sparkle */;
 			targetProxy = 61FA528C0E2D9EB200EF58AD /* PBXContainerItemProxy */;
+		};
+		8B887B741517F472000BB292 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8B887B5D1517F3AB000BB292 /* sandbox_service */;
+			targetProxy = 8B887B731517F472000BB292 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1478,6 +1609,30 @@
 			};
 			name = Release;
 		};
+		8B887B6B1517F3AC000BB292 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8B887B711517F447000BB292 /* ConfigServiceDebug.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = SandboxService.plist;
+			};
+			name = Debug;
+		};
+		8B887B6C1517F3AC000BB292 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8B887B721517F447000BB292 /* ConfigServiceRelease.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = SandboxService.plist;
+			};
+			name = Release;
+		};
+		8B887B6D1517F3AC000BB292 /* Release (GC dual-mode; 10.5+) */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8B887B721517F447000BB292 /* ConfigServiceRelease.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = SandboxService.plist;
+			};
+			name = "Release (GC dual-mode; 10.5+)";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1537,6 +1692,16 @@
 				61B5F90609C4CEE300B25A18 /* Debug */,
 				61B5F90709C4CEE300B25A18 /* Release */,
 				61072EAF0DF263BD008FE88B /* Release (GC dual-mode; 10.5+) */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8B887B6E1517F3AC000BB292 /* Build configuration list for PBXNativeTarget "sandbox_service" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B887B6B1517F3AC000BB292 /* Debug */,
+				8B887B6C1517F3AC000BB292 /* Release */,
+				8B887B6D1517F3AC000BB292 /* Release (GC dual-mode; 10.5+) */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/finish_installation.m
+++ b/finish_installation.m
@@ -116,6 +116,7 @@
             appPath = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:executablepath length:strlen(executablepath)];
         else
             appPath = [host installationPath];
+		
         [[NSWorkspace sharedWorkspace] openFile: appPath];
     }
 

--- a/sandbox_service.m
+++ b/sandbox_service.m
@@ -1,0 +1,91 @@
+//
+//  main.m
+//  Update
+//
+//  Created by Whitney Young on 3/19/12.
+//  Copyright (c) 2012 FadingRed. All rights reserved.
+//
+
+#include <xpc/xpc.h>
+#include <Foundation/Foundation.h>
+#import "SUPlainInstallerInternals.h"
+
+static void peer_event_handler(xpc_connection_t peer, xpc_object_t event) 
+{
+	xpc_type_t type = xpc_get_type(event);
+	if (type == XPC_TYPE_ERROR) {
+		if (event == XPC_ERROR_CONNECTION_INVALID) {
+			// The client process on the other end of the connection has either
+			// crashed or cancelled the connection. After receiving this error,
+			// the connection is in an invalid state, and you do not need to
+			// call xpc_connection_cancel(). Just tear down any associated state
+			// here.
+		} else if (event == XPC_ERROR_TERMINATION_IMMINENT) {
+			// Handle per-connection termination cleanup.
+		}
+	} else {
+		assert(type == XPC_TYPE_DICTIONARY);
+		// Handle the message.
+		const char *identifier = xpc_dictionary_get_string(event, "id");
+		BOOL copyPath = strcmp(identifier, "copy_path") == 0;
+		BOOL launchTask = strcmp(identifier, "launch_task") == 0;
+		
+		if( copyPath )
+		{
+			const char *src = xpc_dictionary_get_string(event, "source");
+			const char *dst = xpc_dictionary_get_string(event, "destination");
+			const char *tmp = xpc_dictionary_get_string(event, "tmp");
+			
+			NSFileManager *manager = [NSFileManager defaultManager];
+			NSString *relaunchPathToCopy = src ? [manager stringWithFileSystemRepresentation:src length:strlen(src)] : nil;
+			NSString *targetPath = dst ? [manager stringWithFileSystemRepresentation:dst length:strlen(dst)] : nil;
+			NSString *temporaryName = tmp ? [NSString stringWithUTF8String:tmp] : nil;
+			NSError *error = nil;
+			[SUPlainInstaller copyPathWithAuthentication: relaunchPathToCopy overPath: targetPath temporaryName: temporaryName error: &error];
+			
+			// send response to indicate ok
+			xpc_object_t reply = xpc_dictionary_create_reply(event);
+			xpc_connection_send_message(peer, reply);
+		}
+		else if( launchTask )
+		{
+			const char *path = xpc_dictionary_get_string(event, "path");
+			xpc_object_t array = xpc_dictionary_get_value(event, "arguments");
+
+			NSFileManager *manager = [NSFileManager defaultManager];
+			NSString *relaunchToolPath = path ? [manager stringWithFileSystemRepresentation:path length:strlen(path)] : nil;;
+			NSMutableArray *arguments = [NSMutableArray array];
+			
+			for (size_t i = 0; i < xpc_array_get_count(array); i++) {
+				[arguments addObject:
+				 [NSString stringWithUTF8String:xpc_array_get_string(array, i)]];
+			}
+			
+			[NSTask launchedTaskWithLaunchPath: relaunchToolPath arguments:arguments];
+			
+			// send response to indicate ok
+			xpc_object_t reply = xpc_dictionary_create_reply(event);
+			xpc_connection_send_message(peer, reply);
+		}
+	}
+}
+
+static void event_handler(xpc_connection_t peer) 
+{
+	// By defaults, new connections will target the default dispatch
+	// concurrent queue.
+	xpc_connection_set_event_handler(peer, ^(xpc_object_t event) {
+		peer_event_handler(peer, event);
+	});
+	
+	// This will tell the connection to begin listening for events. If you
+	// have some other initialization that must be done asynchronously, then
+	// you can defer this call until after that initialization is done.
+	xpc_connection_resume(peer);
+}
+
+int main(int argc, const char *argv[])
+{
+	xpc_main(event_handler);
+	return 0;
+}


### PR DESCRIPTION
This fixes #163. It requires that you copy the XPC service into your main application bundle in Contents/XPCServices and runs the remove from quarantine step of copying the finish_installation app as well as launching finish_installation app outside of the sandbox. Sparkle will function exactly as it does now for applications that do not copy the XPC service into their application bundle.
