### PR TITLE
Use NSFileManager interface for DMG unarchive only for 10.7+. 

### DIFF
--- a/SUDiskImageUnarchiver.m
+++ b/SUDiskImageUnarchiver.m
@@ -65,8 +65,8 @@
 	mountedSuccessfully = YES;
 	
 	// Now that we've mounted it, we need to copy out its contents.
-	if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_5) {
-		// On 10.6 and later we don't want to use the File Manager API and instead want to use NSFileManager (fixes #827357).
+	if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) {
+		// On 10.7 and later we don't want to use the File Manager API and instead want to use NSFileManager (fixes #827357).
 		NSFileManager *manager = [[[NSFileManager alloc] init] autorelease];
         NSError *error = nil;
         NSArray *contents = [manager contentsOfDirectoryAtPath:mountPoint error:&error];
@@ -91,7 +91,7 @@
             
             if (![manager copyItemAtPath:fromPath toPath:toPath error:&error])
             {
-                SULog(@"Couldn't copy item: %@", error);
+                SULog(@"Couldn't copy item: %@ : %@", error, error.userInfo ? error.userInfo : @"");
                 goto reportError;
             }
         }


### PR DESCRIPTION
On 10.6,  [NSFileManager copyItemAtPath:toPath:error:] can fail with "Argument list too long" if the app bundle contains too many files. The switch to NSFileManager was only required for 10.7 anyway, 10.6 always worked fine.

For background info,  you might want to check this out: https://jira.atlassian.com/browse/SRCTREE-1066 
