### PR TITLE
Hush method return type warnings when importing SUUpdater.h

### DIFF
--- a/SUUpdater.h
+++ b/SUUpdater.h
@@ -27,12 +27,12 @@
 
 + (SUUpdater *)sharedUpdater;
 + (SUUpdater *)updaterForBundle:(NSBundle *)bundle;
-- initForBundle:(NSBundle *)bundle;
+- (id)initForBundle:(NSBundle *)bundle;
 
 - (NSBundle *)hostBundle;
 
 - (void)setDelegate:(id)delegate;
-- delegate;
+- (id)delegate;
 
 - (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyChecks;
 - (BOOL)automaticallyChecksForUpdates;

--- a/SUUpdater.m
+++ b/SUUpdater.m
@@ -551,7 +551,7 @@ static NSString * const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefault
 	return driver && ([driver finished] == NO);
 }
 
-- delegate { return delegate; }
+- (id)delegate { return delegate; }
 - (NSBundle *)hostBundle { return [host bundle]; }
 
 @end


### PR DESCRIPTION
Just a small semantic issue.

When including SUUpdater.h in projects with a warning level set to -Wextra warnings are generated because - delegate and - initForBundle: have no return type specified.

Clang seems to have a sweet spot with -Wall and -Wextra so it would be nice to be able to include Sparkle in a project without it generating any additional warning noise.

http://programmers.stackexchange.com/questions/122608/clang-warning-flags-for-objective-c-development
