### PR TITLE
Keep old namespace and framework's bundle ID for backwards compatibility

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>org.sparkle-project.Sparkle</string>
+	<string>org.andymatuschak.Sparkle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sample Appcast.xml
+++ b/Sample Appcast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://sparkle-project.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
       <title>Your Great App's Changelog</title>
       <link>http://you.com/app/appcast.xml</link>

--- a/Sparkle.pch
+++ b/Sparkle.pch
@@ -8,7 +8,7 @@
 
 #ifdef __OBJC__
 
-#define SPARKLE_BUNDLE [NSBundle bundleWithIdentifier:@"org.sparkle-project.Sparkle"]
+#define SPARKLE_BUNDLE [NSBundle bundleWithIdentifier:@"org.andymatuschak.Sparkle"]
 #define SULocalizedString(key,comment) NSLocalizedStringFromTableInBundle(key, @"Sparkle", SPARKLE_BUNDLE, comment)
 #define SUAbstractFail() NSAssert2(nil, @"Can't call %@ on an instance of %@; this is an abstract method!", __PRETTY_FUNCTION__, [self class]);
 


### PR DESCRIPTION
I suggest keeping Andy's bundle ID and namespace URI.

It's still the same Sparkle, it's still backwards compatible, so there's no need to mark it as technically different thing.

I've kept changed identifiers for private things like tests, and we can use new domain for new identifiers added in the future.

However, I think existing public unique identifiers should be kept for as long as Sparkle remains backwards-compatible.
