### PR TITLE
Allow text to expand

### DIFF
--- a/ar.lproj/SUUpdateAlert.xib
+++ b/ar.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/cs.lproj/SUUpdateAlert.xib
+++ b/cs.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/da.lproj/SUUpdateAlert.xib
+++ b/da.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/de.lproj/SUUpdateAlert.xib
+++ b/de.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/el.lproj/SUUpdateAlert.xib
+++ b/el.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/en.lproj/SUUpdateAlert.xib
+++ b/en.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/es.lproj/SUUpdateAlert.xib
+++ b/es.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/fr.lproj/SUUpdateAlert.xib
+++ b/fr.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/is.lproj/SUUpdateAlert.xib
+++ b/is.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/it.lproj/SUUpdateAlert.xib
+++ b/it.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="514" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/ja.lproj/SUUpdateAlert.xib
+++ b/ja.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="514" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/ko.lproj/SUUpdateAlert.xib
+++ b/ko.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/nb.lproj/SUUpdateAlert.xib
+++ b/nb.lproj/SUUpdateAlert.xib
@@ -157,10 +157,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/nl.lproj/SUUpdateAlert.xib
+++ b/nl.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="514" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/pl.lproj/SUUpdateAlert.xib
+++ b/pl.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/pt_BR.lproj/SUUpdateAlert.xib
+++ b/pt_BR.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="496" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/pt_PT.lproj/SUUpdateAlert.xib
+++ b/pt_PT.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/ro.lproj/SUUpdateAlert.xib
+++ b/ro.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="514" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/ru.lproj/SUUpdateAlert.xib
+++ b/ru.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="544" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/sk.lproj/SUUpdateAlert.xib
+++ b/sk.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/sl.lproj/SUUpdateAlert.xib
+++ b/sl.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="514" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/sv.lproj/SUUpdateAlert.xib
+++ b/sv.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="544" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/th.lproj/SUUpdateAlert.xib
+++ b/th.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/tr.lproj/SUUpdateAlert.xib
+++ b/tr.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/uk.lproj/SUUpdateAlert.xib
+++ b/uk.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="544" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/zh_CN.lproj/SUUpdateAlert.xib
+++ b/zh_CN.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">

--- a/zh_TW.lproj/SUUpdateAlert.xib
+++ b/zh_TW.lproj/SUUpdateAlert.xib
@@ -156,10 +156,10 @@ DQ
                             </binding>
                         </connections>
                     </box>
-                    <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="101">
+                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
-                            <constraint firstAttribute="height" priority="300" constant="28" id="H6E-te-Fog"/>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="KUO-Dw-g6s"/>
                         </constraints>
                         <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="174">


### PR DESCRIPTION
Trying to fix this:

![no-wrap](https://cloud.githubusercontent.com/assets/72159/3421024/41fa1110-fed2-11e3-84cf-99d624649abe.png)

The autolayout alone doesn't seem to cut it, even though constraints are pretty relaxed about height of that field.

I've also tried subclassing:

http://stackoverflow.com/questions/10463680/how-to-let-nstextfield-grow-with-the-text-in-auto-layout

but I'm not sure if it worked at all, since I just kept getting field that's always 2 lines high.

Any ideas?
