### PR TITLE
Make the setTestFeedURL test run.

### DIFF
--- a/Tests/SUUpdaterTest.m
+++ b/Tests/SUUpdaterTest.m
@@ -60,7 +60,7 @@
     [queue waitUntilAllOperationsAreFinished];
 }
 
-- (void)setTestFeedURL
+- (void)testSetTestFeedURL
 {
     [updater setFeedURL:[NSURL URLWithString:@""]]; // this WON'T throw
 


### PR DESCRIPTION
I think the test framework saw `setTestFeedURL` as a setter. This change changes it to `testSetTestFeedURL`, which will run as a test.

And for some odd reason, crashes.
