### PR TITLE
Added headless guided package installation

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -157,6 +157,9 @@
 		61F83F720DBFE140006FDD30 /* SUBasicUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */; };
 		61F83F740DBFE141006FDD30 /* SUBasicUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */; settings = {ATTRIBUTES = (); }; };
 		61FA52880E2D9EA400EF58AD /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* Sparkle.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		767B61AC1972D488004E0C3C /* SUGuidedPackageInstaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 767B61AA1972D488004E0C3C /* SUGuidedPackageInstaller.h */; };
+		767B61AD1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */; };
+		767B61AE1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -494,6 +497,8 @@
 		61F614540E24A12D009F47E7 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUBasicUpdateDriver.h; sourceTree = "<group>"; };
 		61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBasicUpdateDriver.m; sourceTree = "<group>"; };
+		767B61AA1972D488004E0C3C /* SUGuidedPackageInstaller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUGuidedPackageInstaller.h; sourceTree = "<group>"; };
+		767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUGuidedPackageInstaller.m; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Sparkle-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Sparkle-Info.plist"; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* Sparkle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sparkle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1941CA0D94A70100DD942E /* ConfigFrameworkDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ConfigFrameworkDebug.xcconfig; sourceTree = "<group>"; };
@@ -811,6 +816,8 @@
 				618FA5040DAE8AB80026945C /* SUPlainInstaller.m */,
 				6129984309C9E2DA00B7442F /* SUPlainInstallerInternals.h */,
 				61B5F8E509C4CE3C00B25A18 /* SUPlainInstallerInternals.m */,
+				767B61AA1972D488004E0C3C /* SUGuidedPackageInstaller.h */,
+				767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */,
 			);
 			name = Installation;
 			sourceTree = "<group>";
@@ -951,6 +958,7 @@
 				6196CFF909C72148000DC222 /* SUStatusController.h in Headers */,
 				61A2279C0D1CEE7600430CCD /* SUSystemProfiler.h in Headers */,
 				61B93A3C0DD02D7000DCD2F8 /* SUUIBasedUpdateDriver.h in Headers */,
+				767B61AC1972D488004E0C3C /* SUGuidedPackageInstaller.h in Headers */,
 				61299A8D09CA790200B7442F /* SUUnarchiver.h in Headers */,
 				6102FE5B0E08C7EC00F85D09 /* SUUnarchiver_Private.h in Headers */,
 				61B5FCDF09C52A9F00B25A18 /* SUUpdateAlert.h in Headers */,
@@ -1322,6 +1330,7 @@
 				55C14F22136EF86000649790 /* SUStandardVersionComparator.m in Sources */,
 				55C14F20136EF84300649790 /* SUStatusController.m in Sources */,
 				55C14F23136EF86700649790 /* SUSystemProfiler.m in Sources */,
+				767B61AE1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */,
 				55C14F2A136EF9A900649790 /* SUWindowController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1374,6 +1383,7 @@
 				618FA5020DAE88B40026945C /* SUInstaller.m in Sources */,
 				55C14F07136EF6DB00649790 /* SULog.m in Sources */,
 				618FA5230DAE8E8A0026945C /* SUPackageInstaller.m in Sources */,
+				767B61AD1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */,
 				61D85D6D0E10B2ED00F9B4A9 /* SUPipedUnarchiver.m in Sources */,
 				618FA5060DAE8AB80026945C /* SUPlainInstaller.m in Sources */,
 				61B5F8EF09C4CE3C00B25A18 /* SUPlainInstallerInternals.m in Sources */,

--- a/Sparkle/SUGuidedPackageInstaller.h
+++ b/Sparkle/SUGuidedPackageInstaller.h
@@ -1,0 +1,62 @@
+//
+//  SUGuidedPackageInstaller.h
+//  Sparkle
+//
+//  Created by Graham Miln on 14/05/2010.
+//  Copyright 2010 Dragon Systems Software Limited. All rights reserved.
+//
+
+/*!
+# Sparkle Guided Installations
+
+A guided installation allows Sparkle to download and install a package (pkg) or multi-package (mpkg) without user interaction.
+
+A guided installation occurs when Sparkle finds a `.sparkle_guide.plist` in the root of the download; the file contains the relative path of the installer package to install.
+
+The file must be a property list and have a dictionary root. The only required key pair value is `package`.
+
+The `package` key value pair must be set to a relative path to the package or multi-package to install. The path is relative to the guide file.
+
+Example Contents of Sparkle Guide file:
+
+	<?xml version="1.0" encoding="UTF-8"?>
+	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+	<plist version="1.0">
+	<dict>
+		<key>package</key>
+		<string>My Package.pkg</string>
+	</dict>
+	</plist>
+
+Example Path of Sparkle Guide file:
+
+	/Volumes/MyUpdateDiskImage/.sparkle_guide.plist
+
+The installer package is installed using Mac OS X's built-in command line installer, `/usr/sbin/installer`. No installation interface is shown to the user.
+
+A guided installation can be started by applications other than the application being replaced. This is particularly useful where helper applications or agents are used.
+
+## Notes
+This method has been tested and successfully deployed on Mac OS X 10.4 - 10.8.
+
+## To Do
+- Replace the use of `AuthorizationExecuteWithPrivilegesAndWait`. This method remains because it is well supported and tested. Ideally a helper tool or XPC would be used.
+*/
+
+#ifndef SUGUIDEDPACKAGEINSTALLER_H
+#define SUGUIDEDPACKAGEINSTALLER_H
+
+#import "Sparkle.h"
+#import "SUInstaller.h"
+
+extern NSString* SUInstallerGuidedInstallerFilename; // default filename for guided installer property list
+
+@interface SUGuidedPackageInstaller : SUInstaller { }
+/*! Search for and return any installer guide */
++ (NSString *)installerGuideWithinUpdateFolder:(NSString *)updateFolder;
+
+/*! Perform the guided installation */
++ (void)performInstallationToPath:(NSString *)path fromPath:(NSString *)installerGuide host:(SUHost *)host delegate:delegate synchronously:(BOOL)synchronously versionComparator:(id <SUVersionComparison>)comparator;
+@end
+
+#endif

--- a/Sparkle/SUGuidedPackageInstaller.m
+++ b/Sparkle/SUGuidedPackageInstaller.m
@@ -1,0 +1,272 @@
+//
+//  SUGuidedPackageInstaller.m
+//  Sparkle
+//
+//  Created by Graham Miln on 14/05/2010.
+//  Copyright 2010 Dragon Systems Software Limited. All rights reserved.
+//
+
+#import <sys/stat.h>
+#import <Security/Security.h>
+
+#import "SUGuidedPackageInstaller.h"
+
+NSString* SUInstallerGuidedInstallerFilename = @".sparkle_guide.plist"; // top level file to search for within update folder
+
+// Constants
+static NSString* SUGuidedPackageInstallerKeyGuidePath = @"SUGuidedPackageInstallerKeyGuidePath"; // NSString*
+static NSString* SUGuidedPackageInstallerKeyGuide = @"SUGuidedPackageInstallerKeyGuide"; // NSDictionary*
+static NSString* SUGuidedPackageInstallerKeyHost = @"SUGuidedPackageInstallerKeyHost"; // SUHost*
+static NSString* SUGuidedPackageInstallerKeyDelegate = @"SUGuidedPackageInstallerKeyDelegate"; // id
+static NSString* SUGuidedPackageInstallerKeyResult = @"SUGuidedPackageInstallerKeyResult"; // NSNumber[bool]
+static NSString* SUGuidedPackageInstallerKeyError = @"SUGuidedPackageInstallerKeyError"; // NSError*
+
+static NSString* SUGuidedPackageInstallerGuideKeyPackage = @"package"; // NSString*
+
+static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authorization, const char* executablePath, AuthorizationFlags options, const char* const* arguments)
+{
+	sig_t oldSigChildHandler = signal(SIGCHLD, SIG_DFL);
+	BOOL returnValue = YES;
+	
+    /* AuthorizationExecuteWithPrivileges used to support 10.4+; should be replaced with XPC or external process */
+	if (AuthorizationExecuteWithPrivileges(authorization, executablePath, options, (char* const*)arguments, NULL) == errAuthorizationSuccess)
+	{
+		int status = 0;
+		pid_t pid = wait(&status);
+		if (pid == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+			returnValue = NO;
+	}
+	else
+		returnValue = NO;
+	
+	signal(SIGCHLD, oldSigChildHandler);
+	return returnValue;
+}
+
+@interface SUGuidedPackageInstaller (SUGuidedPackageInstallerAuthentication)
++ (AuthorizationRef)authorizationForExecutable:(NSString*)executablePath;
+@end
+
+@interface SUGuidedPackageInstaller (SUGuidedPackageInstallerThreads)
+// Perform the installation script
++ (void)performInstallationWithInfo:(NSDictionary *)theInfo;
+// Complete the installation process
++ (void)finishInstallationWithInfo:(NSDictionary *)theInfo;
+@end
+
+@implementation SUGuidedPackageInstaller
+
+// Search for and return any installer guide
++ (NSString *)installerGuideWithinUpdateFolder:(NSString *)updateFolder
+{
+	NSParameterAssert(updateFolder);
+	
+	NSDirectoryEnumerator *dirEnum = [[NSFileManager defaultManager] enumeratorAtPath:updateFolder];
+	NSString *currentFile;
+	while ((currentFile = [dirEnum nextObject]))
+	{
+		if ([[currentFile lastPathComponent] isEqualToString:SUInstallerGuidedInstallerFilename])
+		{
+			// Found an installer guide
+			return [updateFolder stringByAppendingPathComponent:currentFile];
+		}
+	}
+	
+	// No guide found
+	return nil;
+}
+
++ (void)performInstallationToPath:(NSString *) __unused path fromPath:(NSString *)installerGuide host:(SUHost *)host delegate:delegate synchronously:(BOOL)synchronously versionComparator:(id <SUVersionComparison>) __unused comparator
+{
+	NSParameterAssert(installerGuide);
+	NSParameterAssert(host);
+	
+	// Fetch the contents of the guide
+	NSDictionary* guide = [NSDictionary dictionaryWithContentsOfFile:installerGuide];
+	if (guide == nil)
+	{
+		NSString* errorMessage = [NSString stringWithFormat:@"Sparkle Updater: Installer guide contents are malformed '%@'.",installerGuide];
+		NSError* error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:[NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey]];
+		[self finishInstallationToPath:installerGuide withResult:NO host:host error:error delegate:delegate];
+		return;	
+	}
+	
+	// Sanity check the contents of the guide
+	if ([guide objectForKey:SUGuidedPackageInstallerGuideKeyPackage] == NO)
+	{
+		NSString* errorMessage = [NSString stringWithFormat:@"Sparkle Updater: Installer guide is missing '%@' entry.",SUGuidedPackageInstallerGuideKeyPackage];
+		NSError* error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:[NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey]];
+		[self finishInstallationToPath:installerGuide withResult:NO host:host error:error delegate:delegate];
+		return;	
+	}
+	
+	// Package up installation details to allow for synchronous installation
+	NSDictionary* info = [NSDictionary dictionaryWithObjectsAndKeys:
+						  installerGuide,SUGuidedPackageInstallerKeyGuidePath,
+						  guide,SUGuidedPackageInstallerKeyGuide,
+						  host,SUGuidedPackageInstallerKeyHost,
+						  delegate,SUGuidedPackageInstallerKeyDelegate,
+						  nil];
+	
+	if (synchronously)
+	{
+		[self performInstallationWithInfo:info];
+	}
+	else
+	{
+		[NSThread detachNewThreadSelector:@selector(performInstallationWithInfo:) toTarget:self withObject:info];
+	}
+}
+
+@end
+
+@implementation SUGuidedPackageInstaller (SUGuidedPackageInstallerAuthentication)
+
++ (AuthorizationRef)authorizationForExecutable:(NSString*)executablePath
+{
+	NSParameterAssert(executablePath);
+	
+	// Get authorization using advice in Apple's Technical Q&A1172
+	
+	// ...create authorization without specific rights
+	AuthorizationRef auth = NULL;
+	OSStatus validAuth = AuthorizationCreate(NULL,
+											 kAuthorizationEmptyEnvironment, 
+											 kAuthorizationFlagDefaults,
+											 &auth);
+	// ...then extend authorization with desired rights
+	if ((validAuth == errAuthorizationSuccess) &&
+		(auth != NULL))
+	{		
+		const char* executableFileSystemRepresentation = [executablePath fileSystemRepresentation];
+		
+		// Prepare a right allowing script to execute with privileges
+		AuthorizationItem right;
+		memset(&right,0,sizeof(right));
+		right.name = kAuthorizationRightExecute;
+		right.value = (void*) executableFileSystemRepresentation;
+		right.valueLength = strlen(executableFileSystemRepresentation);
+		
+		// Package up the single right
+		AuthorizationRights rights;
+		memset(&rights,0,sizeof(rights));
+		rights.count = 1;
+		rights.items = &right;
+		
+		// Extend rights to run script
+		validAuth = AuthorizationCopyRights(auth,
+											&rights,
+											kAuthorizationEmptyEnvironment,
+											kAuthorizationFlagPreAuthorize |
+											kAuthorizationFlagExtendRights |
+											kAuthorizationFlagInteractionAllowed,
+											NULL);
+		if (validAuth != errAuthorizationSuccess)
+		{
+			// Error, clean up authorization
+			(void) AuthorizationFree(auth,kAuthorizationFlagDefaults);
+			auth = NULL;
+		}
+	}
+	
+	return auth;
+}
+
+@end
+
+@implementation SUGuidedPackageInstaller (SUGuidedPackageInstallerThreads)
+
+// Perform the installation script
++ (void)performInstallationWithInfo:(NSDictionary *)theInfo
+{
+	NSParameterAssert(theInfo);
+		
+	// Preflight
+	NSString* installerPath = @"/usr/sbin/installer"; // Mac OS X 10.2+ command line installer tool
+	NSError* error = nil;
+	
+	// Check installer executable exists
+	if ([[NSFileManager defaultManager] isExecutableFileAtPath:installerPath] == NO)
+	{
+		NSString* errorMessage = [NSString stringWithFormat:@"Sparkle Updater: Guide installer tool is missing."];
+		error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:[NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey]];
+	}
+	
+	// Package is relative to installer guide file
+	NSString* absolutePackagePath = nil;
+	if (error == nil)
+	{
+		NSString* installerGuideParentFolderPath = [[theInfo objectForKey:SUGuidedPackageInstallerKeyGuidePath] stringByDeletingLastPathComponent];
+		NSString* packagePath = [(NSDictionary*)[theInfo objectForKey:SUGuidedPackageInstallerKeyGuide] objectForKey:SUGuidedPackageInstallerGuideKeyPackage];
+		NSAssert(packagePath,@"package entry is missing from guide");
+		absolutePackagePath = [installerGuideParentFolderPath stringByAppendingPathComponent:packagePath];
+		
+		// Sanity check absolute package path exists 
+		if ([[NSFileManager defaultManager] fileExistsAtPath:absolutePackagePath] == NO)
+		{
+			NSString* errorMessage = [NSString stringWithFormat:@"Sparkle Updater: Guide installer tool is missing."];
+			error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:[NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey]];
+		}
+	}
+	
+	// Create authorization for installer executable
+	AuthorizationRef auth = nil;
+	BOOL validInstallation = NO;
+	if (error == nil)
+	{
+		auth = [self authorizationForExecutable:installerPath];
+		if (auth != NULL)
+		{
+			// Permission was granted to execute the installer with privileges
+			const char* const arguments[] = {
+//				[installerPath fileSystemRepresentation],
+				"-pkg",
+				[absolutePackagePath fileSystemRepresentation],
+				"-target",
+				"/",
+				NULL
+			};
+			validInstallation = AuthorizationExecuteWithPrivilegesAndWait(auth, 
+																		  [installerPath fileSystemRepresentation],
+																		  kAuthorizationFlagDefaults, 
+																		  arguments);
+			// TODO: wait for communications pipe to close via fileno & CFSocketCreateWithNative
+		}
+		else
+		{
+			NSString* errorMessage = [NSString stringWithFormat:@"Sparkle Updater: Script authorization denied."];
+			error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:[NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey]];
+		}
+	}
+	
+	// Release any authorization
+	if (auth)
+	{
+		AuthorizationFree(auth,kAuthorizationFlagDefaults);
+	}
+	
+	// Modify info to include the installation script's outcome
+	NSMutableDictionary* resultInfo = [theInfo mutableCopy];
+	[resultInfo setObject:[NSNumber numberWithBool:validInstallation] forKey:SUGuidedPackageInstallerKeyResult];
+	if ((validInstallation == NO) &&
+		(error))
+	{
+		[resultInfo setObject:error forKey:SUGuidedPackageInstallerKeyError];
+	}
+	
+	[self performSelectorOnMainThread:@selector(finishInstallationWithInfo:) withObject:resultInfo waitUntilDone:NO];
+}
+
+// Complete the installation process
++ (void)finishInstallationWithInfo:(NSDictionary *)theInfo
+{
+	NSParameterAssert(theInfo);
+	
+	[self finishInstallationToPath:[theInfo objectForKey:SUGuidedPackageInstallerKeyGuidePath]
+						withResult:[[theInfo objectForKey:SUGuidedPackageInstallerKeyResult] boolValue]
+							  host:[theInfo objectForKey:SUGuidedPackageInstallerKeyHost]
+							 error:[theInfo objectForKey:SUGuidedPackageInstallerKeyError]
+						  delegate:[theInfo objectForKey:SUGuidedPackageInstallerKeyDelegate]];
+}
+
+@end


### PR DESCRIPTION
Added support for headless guided installation of `pkg` and `mpkg` files; see https://github.com/sparkle-project/Sparkle/issues/348. This allows the installation of Installer packages without a user interface. This method also allows one application to update a suite of tools through an Installer package.

Ported existing code to use ARC and inlined the documentation. The original code has been well tested and used in commercial products for many years. That code supported 10.4 and later. I have minimised the changes to avoid introducing bugs or problems. I expect further changes can be made given the shift to supporting 10.7+.

Ideally, the use of `AuthorizationExecuteWithPrivileges` should be replaced with an XPC or an external authtool like process.