### PR TITLE
Add Travis continuous integration support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: objective-c
+script: make travis

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ localizable-strings:
 release:
 	xcodebuild -scheme Distribution -configuration Release -derivedDataPath "$(BUILDDIR)"
 	open -R "$(BUILDDIR)/Build/Products/Release/Sparkle-"*.tar.bz2
+
+travis:
+	xcodebuild clean build


### PR DESCRIPTION
Travis provides free [continuous integration](http://en.wikipedia.org/wiki/Continuous_integration) for public GitHub hosted projects. Sparkle would benefit from continuous integration to help avoid new code breaking old.

**After merging an administrator needs to complete the following steps to connect GitHub and Travis for Sparkle**
# Adding Travis Support

Travis requires administrator rights to the github repository. This is [not ideal](http://docs.travis-ci.com/user/github-oauth-scopes/) and a known limitation of GitHub's API.

To reduce the risk of problems and to allow security breaches to dealt with easily, isolate Travis support:
1. Create a new GitHub user account called `sparkle-robot`
2. Give `sparkle-robot` administrator rights to **only** the Sparkle code project.
3. [Associate Sparkle with Travis](http://docs.travis-ci.com/user/getting-started/) through `sparkle-robot` 

In case of future problems, the `sparkle-robot` account can be isolated and administrator rights revoked.
## Adding Build Status

Once Travis has been set-up, a build status graphic can be embedded within Sparkle's read me file. The graphic will looking something like:

[![Build Status](https://travis-ci.org/DrawKit/DrawKit.png?branch=master)](https://travis-ci.org/DrawKit/DrawKit)

The markdown for a graphic like this is:

```
[![Build Status](https://travis-ci.org/sparkle-project/Sparkle.png?branch=master)](https://travis-ci.org/sparkle-project/Sparkle)
```
