### PR TITLE
Make the error definitions public

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		55C14F7E136F005000649790 /* SUPlainInstallerInternals.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B5F8E509C4CE3C00B25A18 /* SUPlainInstallerInternals.m */; };
 		55C14F9A136F045400649790 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		55C14FC7136F05E100649790 /* Sparkle.strings in Resources */ = {isa = PBXBuildFile; fileRef = 61AAE8220A321A7F00D8810D /* Sparkle.strings */; };
+		55E6F33319EC9F6C00005E76 /* SUErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E6F33219EC9F6C00005E76 /* SUErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5AF9DC3C1981DBEE001EA135 /* SUDSAVerifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF9DC3B1981DBEE001EA135 /* SUDSAVerifierTest.m */; };
 		5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		5D06E8EA0FD68CDB005AE3F6 /* SUBinaryDeltaTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E30FD68CC7005AE3F6 /* SUBinaryDeltaTool.m */; };
@@ -398,6 +399,7 @@
 		55C14F04136EF6DB00649790 /* SULog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SULog.h; sourceTree = "<group>"; };
 		55C14F05136EF6DB00649790 /* SULog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SULog.m; sourceTree = "<group>"; };
 		55C14F31136EFC2400649790 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		55E6F33219EC9F6C00005E76 /* SUErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUErrors.h; sourceTree = "<group>"; };
 		5AEF45D9189D1CC90030D7DC /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		5AF9DC3B1981DBEE001EA135 /* SUDSAVerifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUDSAVerifierTest.m; sourceTree = "<group>"; };
 		5D06E8D00FD68C7C005AE3F6 /* BinaryDelta */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BinaryDelta; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -868,6 +870,7 @@
 				61CFB3280E385186007A1735 /* Sparkle.pch */,
 				61299A5B09CA6D4500B7442F /* SUConstants.h */,
 				61299A5F09CA6EB100B7442F /* SUConstants.m */,
+				55E6F33219EC9F6C00005E76 /* SUErrors.h */,
 				14652F8319A9759F00959E44 /* SUExport.h */,
 				61EF67580E25C5B400F754E0 /* SUHost.h */,
 				61EF67550E25B58D00F754E0 /* SUHost.m */,
@@ -1008,6 +1011,7 @@
 				6158A1C5137904B300487EC1 /* SUUpdater_Private.h in Headers */,
 				61A354550DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.h in Headers */,
 				61A2259E0D1C495D00430CCD /* SUVersionComparisonProtocol.h in Headers */,
+				55E6F33319EC9F6C00005E76 /* SUErrors.h in Headers */,
 				3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */,
 				61180BCA0D64138900B4E0D1 /* SUWindowController.h in Headers */,
 			);

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -79,33 +79,4 @@ extern NSString *const SURSSElementLink;
 extern NSString *const SURSSElementPubDate;
 extern NSString *const SURSSElementTitle;
 
-// -----------------------------------------------------------------------------
-//	Errors:
-// -----------------------------------------------------------------------------
-
-extern NSString *const SUSparkleErrorDomain;
-typedef NS_ENUM(OSStatus, SUError) {
-    // Appcast phase errors.
-    SUAppcastParseError = 1000,
-    SUNoUpdateError = 1001,
-    SUAppcastError = 1002,
-    SURunningFromDiskImageError = 1003,
-
-    // Downlaod phase errors.
-    SUTemporaryDirectoryError = 2000,
-
-    // Extraction phase errors.
-    SUUnarchivingError = 3000,
-    SUSignatureError = 3001,
-
-    // Installation phase errors.
-    SUFileCopyFailure = 4000,
-    SUAuthenticationFailure = 4001,
-    SUMissingUpdateError = 4002,
-    SUMissingInstallerToolError = 4003,
-    SURelaunchError = 4004,
-    SUInstallationError = 4005,
-    SUDowngradeError = 4006
-};
-
 #endif

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -1,0 +1,44 @@
+//
+//  SUErrors.h
+//  Sparkle
+//
+//  Created by C.W. Betts on 10/13/14.
+//  Copyright (c) 2014 Sparkle Project. All rights reserved.
+//
+
+#ifndef SUERRORS_H
+#define SUERRORS_H
+
+#import <Foundation/Foundation.h>
+#import "SUExport.h"
+
+/**
+ * Error domain used by Sparkle
+ */
+SU_EXPORT extern NSString *const SUSparkleErrorDomain;
+
+typedef NS_ENUM(OSStatus, SUError) {
+    // Appcast phase errors.
+    SUAppcastParseError = 1000,
+    SUNoUpdateError = 1001,
+    SUAppcastError = 1002,
+    SURunningFromDiskImageError = 1003,
+    
+    // Downlaod phase errors.
+    SUTemporaryDirectoryError = 2000,
+    
+    // Extraction phase errors.
+    SUUnarchivingError = 3000,
+    SUSignatureError = 3001,
+    
+    // Installation phase errors.
+    SUFileCopyFailure = 4000,
+    SUAuthenticationFailure = 4001,
+    SUMissingUpdateError = 4002,
+    SUMissingInstallerToolError = 4003,
+    SURelaunchError = 4004,
+    SUInstallationError = 4005,
+    SUDowngradeError = 4006
+};
+
+#endif

--- a/Sparkle/Sparkle.h
+++ b/Sparkle/Sparkle.h
@@ -18,5 +18,6 @@
 #import <Sparkle/SUUpdater.h>
 #import <Sparkle/SUVersionComparisonProtocol.h>
 #import <Sparkle/SUVersionDisplayProtocol.h>
+#import <Sparkle/SUErrors.h>
 
 #endif

--- a/Sparkle/Sparkle.pch
+++ b/Sparkle/Sparkle.pch
@@ -10,6 +10,7 @@
 
 #import <Cocoa/Cocoa.h>
 #import "SUConstants.h"
+#import "SUErrors.h"
 
 #define SULocalizedString(key, comment) NSLocalizedStringFromTableInBundle(key, @"Sparkle", [NSBundle bundleWithIdentifier:SUBundleIdentifier] ? [NSBundle bundleWithIdentifier:SUBundleIdentifier] : [NSBundle mainBundle], comment)
 


### PR DESCRIPTION
In reference to #432, this patch makes the declarations that are used internally by Sparkle so developers can check what specific error was encountered.
