### PR TITLE
Don't call SUClearLog() unless logging something

### DIFF
--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -37,6 +37,7 @@ void SUClearLog(void)
     FILE *logfile = fopen([[SULogFilePath stringByExpandingTildeInPath] fileSystemRepresentation], "w");
     if (logfile) {
         fclose(logfile);
+        SULog(@"===== %@ =====", [[NSFileManager defaultManager] displayNameAtPath:[[NSBundle mainBundle] bundlePath]]);
     }
 }
 
@@ -53,6 +54,12 @@ void SUClearLog(void)
 
 void SULog(NSString *format, ...)
 {
+    static BOOL loggedYet = NO;
+    if (!loggedYet) {
+        loggedYet = YES;
+        SUClearLog();
+    }
+
     va_list ap;
     va_start(ap, format);
     NSString *theStr = [[NSString alloc] initWithFormat:format arguments:ap];

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -332,9 +332,6 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 	if ([self updateInProgress]) { return; }
 	if (self.checkTimer) { [self.checkTimer invalidate]; self.checkTimer = nil; }		// Timer is non-repeating, may have invalidated itself, so we had to retain it.
 
-    SUClearLog();
-    SULog(@"===== %@ =====", [[NSFileManager defaultManager] displayNameAtPath:[[NSBundle mainBundle] bundlePath]]);
-
     [self willChangeValueForKey:@"lastUpdateCheckDate"];
     [self.host setObject:[NSDate date] forUserDefaultsKey:SULastCheckTimeKey];
     [self didChangeValueForKey:@"lastUpdateCheckDate"];


### PR DESCRIPTION
Sparkle currently clears the log file and logs a `===== APPNAME =====` line every time `checkForUpdatesWithDriver:` is called; this of course happens e.g. immediately after launching the app if a check is due. This has two problems:
1. Contrary to `SUClearLog()` documentation, this doesn’t result in the last update’s log being preserved in the log. In fact, running any Sparkle-using app could erase the potentially important log content.
2. It is rather annoying, because it pops up debug log pane in Xcode (I have it configured to be hidden unless here’s some debugging activity happening).

This PR changes the behavior to what is IMHO more logical: Sparkle doesn’t touch the log unless it has something to add to it. When `SULog()` is called for the first time, it clears the log and adds information about the app to it. This ensures that the log file isn’t touched needlessly.
