### PR TITLE
Add ability for host bundle to specify a custom name

### DIFF
--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -102,7 +102,13 @@ typedef struct {
 
 - (NSString *)name
 {
-    NSString *name = [self.bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    NSString *name;
+
+    // Allow host bundle to provide a custom name
+    name = [self objectForInfoDictionaryKey:@"SUBundleName"];
+    if (name) return name;
+
+    name = [self.bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
 	if (name) return name;
 
     name = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];


### PR DESCRIPTION
At our work our app names have the version number in them directly, for example "MyApp 3" and so some of Sparkle's messages read awkwardly when the version comes immediately after the name. So this change allows us to set the name that Sparkle uses to "MyApp" by adding an entry to the Info.plist file.