### PR TITLE
Using a weak id delegate property will crash during instantiation of NIB on OS X 10.7

### DIFF
--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -25,7 +25,7 @@
  */
 SU_EXPORT @interface SUUpdater : NSObject
 
-@property (weak) IBOutlet id<SUUpdaterDelegate> delegate;
+@property (unsafe_unretained) IBOutlet id<SUUpdaterDelegate> delegate;
 
 + (SUUpdater *)sharedUpdater;
 + (SUUpdater *)updaterForBundle:(NSBundle *)bundle;


### PR DESCRIPTION
When adding SUUpdater in IB (in the NIB) and making a reference from the SUUpdater delegate to a ViewController will crash on OS X 10.7 because the delegate is a weak property.

Crash report:

```
objc[308]: garbage collection is OFF
objc[308]: cannot form weak reference to instance (0x7fc55b481cf0) of class MainWindowViewController

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib                 0x00007fff97cb5768 _objc_trap + 4
1   libobjc.A.dylib                 0x00007fff97cb58aa _objc_fatal + 195
2   libobjc.A.dylib                 0x00007fff97cc14ad weak_register_no_lock + 346
3   libobjc.A.dylib                 0x00007fff97cc1a59 objc_storeWeak + 360
4   com.apple.CoreFoundation        0x00007fff8d49770d -[NSObject performSelector:withObject:] + 61
5   com.apple.AppKit                0x00007fff8c7c5baa -[NSNibOutletConnector establishConnection] + 405
6   com.apple.AppKit                0x00007fff8c7c32a1 -[NSIBObjectData nibInstantiateWithOwner:topLevelObjects:] + 1079
7   com.apple.AppKit                0x00007fff8c7b98bb loadNib + 322
8   com.apple.AppKit                0x00007fff8c7b8db8 +[NSBundle(NSNibLoading) _loadNibFile:nameTable:withZone:ownerBundle:] + 217
9   com.apple.AppKit                0x00007fff8c7b8cd3 +[NSBundle(NSNibLoading) loadNibFile:externalNameTable:withZone:] + 141
10  com.apple.AppKit                0x00007fff8c7b8c16 +[NSBundle(NSNibLoading) loadNibNamed:owner:] + 364
11  com.apple.AppKit                0x00007fff8ca29cd7 NSApplicationMain + 398
12  com.VortexApps.NZBVortex3       0x0000000100785f43 main + 275
13  com.VortexApps.NZBVortex3       0x000000010073e604 start + 52
```
