### PR TITLE
Fix invalid parameter error on check for updates

### DIFF
--- a/Sparkle/SUAutomaticUpdateAlert.m
+++ b/Sparkle/SUAutomaticUpdateAlert.m
@@ -23,7 +23,7 @@
 
 - (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost delegate:(id<SUAutomaticUpdateAlertDelegate>)del
 {
-    self = [super initWithHost:aHost windowNibName:@"SUAutomaticUpdateAlert"];
+    self = [super initWithWindowNibName:@"SUAutomaticUpdateAlert"];
 	if (self)
 	{
         self.updateItem = item;

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -31,7 +31,7 @@
 
 - (instancetype)initWithHost:(SUHost *)aHost
 {
-    self = [super initWithHost:aHost windowNibName:@"SUStatus"];
+    self = [super initWithWindowNibName:@"SUStatus"];
 	if (self)
 	{
         self.host = aHost;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -54,7 +54,7 @@
 
 - (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost
 {
-    self = [super initWithHost:host windowNibName:@"SUUpdateAlert"];
+    self = [super initWithWindowNibName:@"SUUpdateAlert"];
 	if (self)
 	{
         host = aHost;

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -45,7 +45,7 @@
 
 - (instancetype)initWithHost:(SUHost *)aHost systemProfile:(NSArray *)profile delegate:(id<SUUpdatePermissionPromptDelegate>)d
 {
-    self = [super initWithHost:aHost windowNibName:@"SUUpdatePermissionPrompt"];
+    self = [super initWithWindowNibName:@"SUUpdatePermissionPrompt"];
 	if (self)
 	{
         host = aHost;

--- a/Sparkle/SUWindowController.h
+++ b/Sparkle/SUWindowController.h
@@ -14,7 +14,7 @@
 @class SUHost;
 @interface SUWindowController : NSWindowController
 // We use this instead of plain old NSWindowController initWithWindowNibName so that we'll be able to find the right path when running in a bundle loaded from another app.
-- (instancetype)initWithHost:(SUHost *)host windowNibName:(NSString *)nibName;
+- (instancetype)initWithWindowNibName:(NSString *)nibName;
 @end
 
 #endif

--- a/Sparkle/SUWindowController.m
+++ b/Sparkle/SUWindowController.m
@@ -11,16 +11,9 @@
 
 @implementation SUWindowController
 
-- (instancetype)initWithHost:(SUHost *)host windowNibName:(NSString *)nibName
+- (instancetype)initWithWindowNibName:(NSString *)nibName
 {
-    NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:nibName ofType:@"nib"];
-    if (path == nil) // Slight hack to resolve issues with running Sparkle in debug configurations.
-    {
-        NSString *frameworkPath = [[[host bundle] sharedFrameworksPath] stringByAppendingPathComponent:@"Sparkle.framework"];
-        NSBundle *framework = [NSBundle bundleWithPath:frameworkPath];
-        path = [framework pathForResource:nibName ofType:@"nib"];
-    }
-    self = [super initWithWindowNibPath:path owner:self];
+    self = [super initWithWindowNibName:nibName owner:self];
     return self;
 }
 


### PR DESCRIPTION
See https://github.com/sparkle-project/Sparkle/issues/237#issuecomment-11618894

Got this error tonight with Sparkle 1.8.0 in a [project](https://github.com/editxt/editxt/tree/1.7.1) using Python 3.3/py2app 0.9. Got the error on both Mac OS X 10.8 and 10.9, although only intermittently on 10.8.

```
ObjC exception NSInternalInconsistencyException (reason: Invalid parameter not satisfying: windowNibPath) discarded
Stack trace (most recent call last):
  0x608000216a20
  ffi_call_unix64 (in _objc.so) + 79
  -[SUUpdater checkForUpdates:] (in Sparkle) (SUUpdater.m:324)
  -[SUUpdater checkForUpdatesWithDriver:] (in Sparkle) (SUUpdater.m:361)
  -[SUUserInitiatedUpdateDriver checkForUpdatesAtURL:host:] (in Sparkle) (SUUserInitiatedUpdateDriver.m:43)
  -[SUStatusController initWithHost:] (in Sparkle) (SUStatusController.m:34)
  -[SUWindowController initWithHost:windowNibName:] (in Sparkle) (SUWindowController.m:23)
  -[NSWindowController initWithWindowNibPath:owner:] (in AppKit) + 139
  -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] (in Foundation) + 189
  +[NSException raise:format:arguments:] (in CoreFoundation) + 104
  objc_exception_throw (in libobjc.A.dylib) + 43
  NSExceptionHandlerExceptionRaiser (in ExceptionHandling) + 172
```
