### PR TITLE
Fix Autoupdate.app crash on 10.7 (issue #441)

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -32,6 +32,7 @@ static const NSTimeInterval SUParentQuitCheckInterval = .25;
 @property (strong) SUHost *host;
 @property (assign) BOOL shouldRelaunch;
 @property (assign) BOOL shouldShowUI;
+@property (strong) SUStatusController *statusController;
 
 - (void)parentHasQuit;
 
@@ -86,6 +87,7 @@ static const NSTimeInterval SUParentQuitCheckInterval = .25;
 - (void)dealloc
 {
     [self.longInstallationTimer invalidate];
+    [self.statusController close];
 }
 
 
@@ -152,7 +154,10 @@ static const NSTimeInterval SUParentQuitCheckInterval = .25;
         [statusCtl beginActionWithTitle:SULocalizedString(@"Installing update...", @"")
                         maxProgressValue: 0 statusText: @""];
         [statusCtl showWindow:self];
-    }
+
+        [self.statusController close]; // If there's an existing status controller, close it before we release our strong reference to it.
+        self.statusController = statusCtl; // Keep a strong reference to the status controller, or else it might get prematurely deallocated.
+}
 
     [SUInstaller installFromUpdateFolder:self.folderpath
                                 overHost:self.host


### PR DESCRIPTION
Autoupdate.app can crash in the middle of installing an update, leaving
the user with a broken application. The crash is caused by the status
window’s controller (SUStatusController) being prematurely deallocated
before the window is closed. This change prevents such a crash by
keeping a strong reference to the SUStatusController in
TerminationListener.