### PR TITLE
Ability to add custom http headers to appcast request

### DIFF
--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -19,6 +19,7 @@ SU_EXPORT @interface SUAppcast : NSObject <NSURLDownloadDelegate>
 
 @property (weak) id<SUAppcastDelegate> delegate;
 @property (copy) NSString *userAgentString;
+@property (copy) NSDictionary *httpHeaders;
 
 - (void)fetchAppcastFromURL:(NSURL *)url;
 

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -57,7 +57,10 @@
     }
 
     if (self.httpHeaders) {
-        [request setValuesForKeysWithDictionary:self.httpHeaders];
+        for (NSString *key in self.httpHeaders) {
+            id value = [self.httpHeaders objectForKey:key];
+            [request setValue:value forHTTPHeaderField:key];
+        }
     }
 
     [request setValue:@"application/rss+xml,*/*;q=0.1" forHTTPHeaderField:@"Accept"];

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -45,6 +45,7 @@
 @synthesize downloadFilename;
 @synthesize delegate;
 @synthesize userAgentString;
+@synthesize httpHeaders;
 @synthesize download;
 @synthesize items;
 
@@ -53,6 +54,10 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
     if (self.userAgentString) {
         [request setValue:self.userAgentString forHTTPHeaderField:@"User-Agent"];
+    }
+
+    if (self.httpHeaders) {
+        [request setValuesForKeysWithDictionary:self.httpHeaders];
     }
 
     [request setValue:@"application/rss+xml,*/*;q=0.1" forHTTPHeaderField:@"Accept"];

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -56,6 +56,7 @@
 
     [appcast setDelegate:self];
     [appcast setUserAgentString:[self.updater userAgentString]];
+    [appcast setHttpHeaders:[self.updater httpHeaders]];
     [appcast fetchAppcastFromURL:URL];
 }
 

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -46,6 +46,8 @@ SU_EXPORT @interface SUUpdater : NSObject
 
 @property (nonatomic, copy) NSString *userAgentString;
 
+@property (copy) NSDictionary *httpHeaders;
+
 @property BOOL sendsSystemProfile;
 
 @property BOOL automaticallyDownloadsUpdates;

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -51,7 +51,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize delegate;
 @synthesize checkTimer;
 @synthesize userAgentString = customUserAgentString;
-
+@synthesize httpHeaders;
 @synthesize driver;
 @synthesize host;
 


### PR DESCRIPTION
I had a need for customizing the request further than just URL and User Agent.

This patch allows for SUAppcast (via SUUpdater) to take arbitrary headers as NSDictionary.