### PR TITLE
Changed French string for automatically install updates checkbox

### DIFF
--- a/Sparkle/fr.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/fr.lproj/SUAutomaticUpdateAlert.xib
@@ -96,7 +96,7 @@ Gw
                     <button id="17">
                         <rect key="frame" x="105" y="58" width="619" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <buttonCell key="cell" type="check" title="Automatiquement télécharger et installer les mises à jour à l’avenir" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="43">
+                        <buttonCell key="cell" type="check" title="Télécharger et installer automatiquement les mises à jour" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="43">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>

--- a/Sparkle/fr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/fr.lproj/SUUpdateAlert.xib
@@ -173,7 +173,7 @@ DQ
                     </textField>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="117">
                         <rect key="frame" x="106" y="49" width="495" height="18"/>
-                        <buttonCell key="cell" type="check" title="Automatiquement télécharger et installer les mises à jour à l’avenir" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="175">
+                        <buttonCell key="cell" type="check" title="Télécharger et installer automatiquement les mises à jour" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="175">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>


### PR DESCRIPTION
Suggested by a French user:

« Automatiquement » before the two verbs is a little akward, not incorrect but unusual. And « à l’avenir » (« in the future » is really not necessary, usually they don’t mention it.