### PR TITLE
Removing redundate `NSString` cast; see #509

### DIFF
--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -164,7 +164,7 @@ static NSString *sUpdateFolder = nil;
 
 + (void)registerWithLaunchServices:(NSString *)installationPath
 {
-    NSURL* installationURL = [NSURL fileURLWithPath:(NSString*)installationPath];
+    NSURL* installationURL = [NSURL fileURLWithPath:installationPath];
     if (installationURL != nil)
     {
         OSStatus registerStatus = LSRegisterURL((__bridge CFURLRef)installationURL,true);


### PR DESCRIPTION
Thanks to @kainjow for spotting this mistake in #508 and #509.