### PR TITLE
Fix BinaryDelta failing on filenames changing case

### DIFF
--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -227,7 +227,16 @@ int main(int __unused argc, char __unused *argv[])
         NSOperationQueue *deltaQueue = [[NSOperationQueue alloc] init];
         NSMutableArray *deltaOperations = [NSMutableArray array];
 
-        NSArray *keys = [[newTreeState allKeys] sortedArrayUsingSelector:@selector(compare:)];
+        // Sort the keys by preferring the ones from the original tree to appear first
+        // We want to enforce deleting before extracting in the case paths differ only by case
+        NSArray *keys = [[newTreeState allKeys] sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
+            NSComparisonResult insensitiveCompareResult = [key1 caseInsensitiveCompare:key2];
+            if (insensitiveCompareResult != NSOrderedSame) {
+                return insensitiveCompareResult;
+            }
+
+            return originalTreeState[key1] ? NSOrderedAscending : NSOrderedDescending;
+        }];
         for (NSString* key in keys) {
             id value = [newTreeState valueForKey:key];
 


### PR DESCRIPTION
When a filename changes case, make sure we have the file deleted in the old tree before being extracted into the new one.
Note that we don't try creating a diff if a file is renamed with a different case, just like we don't track file names changing in other ways.
See issue #474