### PR TITLE
Fix BinaryDelta sometimes failing when a dir becomes a dir link

### DIFF
--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -206,10 +206,23 @@ int main(int __unused argc, char __unused *argv[])
             NSDictionary *info = infoForFile(ent);
             NSDictionary *oldInfo = originalTreeState[key];
 
-            if ([info isEqual:oldInfo])
+            if ([info isEqual:oldInfo]) {
                 [newTreeState removeObjectForKey:key];
-            else
+            } else {
                 newTreeState[key] = info;
+                
+                if (oldInfo && [oldInfo[@"type"] unsignedShortValue] == FTS_D && [info[@"type"] unsignedShortValue] != FTS_D) {
+                    NSArray *pathComponents = key.pathComponents;
+
+                    for (NSString *subpath in originalTreeState) {
+                        NSArray *subpathComponents = subpath.pathComponents;
+                        if (subpathComponents.count > pathComponents.count &&
+                            [pathComponents isEqualToArray:[subpathComponents subarrayWithRange:NSMakeRange(0, pathComponents.count)]]) {
+                            [newTreeState removeObjectForKey:subpath];
+                        }
+                    }
+                }
+            }
         }
         fts_close(fts);
 

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -212,13 +212,13 @@ int main(int __unused argc, char __unused *argv[])
                 newTreeState[key] = info;
                 
                 if (oldInfo && [oldInfo[@"type"] unsignedShortValue] == FTS_D && [info[@"type"] unsignedShortValue] != FTS_D) {
-                    NSArray *pathComponents = key.pathComponents;
+                    NSArray *parentPathComponents = key.pathComponents;
 
-                    for (NSString *subpath in originalTreeState) {
-                        NSArray *subpathComponents = subpath.pathComponents;
-                        if (subpathComponents.count > pathComponents.count &&
-                            [pathComponents isEqualToArray:[subpathComponents subarrayWithRange:NSMakeRange(0, pathComponents.count)]]) {
-                            [newTreeState removeObjectForKey:subpath];
+                    for (NSString *childPath in originalTreeState) {
+                        NSArray *childPathComponents = childPath.pathComponents;
+                        if (childPathComponents.count > parentPathComponents.count &&
+                            [parentPathComponents isEqualToArray:[childPathComponents subarrayWithRange:NSMakeRange(0, parentPathComponents.count)]]) {
+                            [newTreeState removeObjectForKey:childPath];
                         }
                     }
                 }


### PR DESCRIPTION
This can occur in the following case:
```
original_tree:
	A/
	Current/
		B

new_tree:
	A/
		B
	Current -> A/
```
Because symbolic links are not followed, Current/B can be marked as deleted. If A/B is added before the deletion, then A will end up as an empty directory.

Our fix is to remove all child paths of a directory from consideration when it changes from a directory to another type of file. This should also decrease the size of the diff even in harmless cases such as when a directory changes into a regular file.