### PR TITLE
Binary delta Improvements

### DIFF
--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -131,7 +131,10 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
 
         const char *value;
         if (!xar_prop_get(file, "delete", &value) || !xar_prop_get(file, "delete-then-extract", &value)) {
-            removeTree(destinationFilePath);
+            if (!removeTree(destinationFilePath)) {
+                fprintf(stderr, "delete or delete-then-extract: failed to remove %s\n", [destination fileSystemRepresentation]);
+                return 1;
+            }
             if (!xar_prop_get(file, "delete", &value))
                 continue;
         }

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -47,32 +47,32 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         if (!strcmp(xar_subdoc_name(subdoc), "binary-delta-attributes")) {
             const char *value = 0;
             
-            // only available in version 2.0 or later
+            // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, "major-version", &value);
             if (value)
                 majorDiffVersion = (uint16_t)[@(value) intValue];
             
-            // only available in version 2.0 or later
+            // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, "minor-version", &value);
             if (value)
                 minorDiffVersion = (uint16_t)[@(value) intValue];
             
-            // deprecated since version 2.0
+            // only available in version 1.0
             xar_subdoc_prop_get(subdoc, "before-sha1", &value);
             if (value)
                 expectedBeforeHashv1 = @(value);
 
-            // deprecated since version 2.0
+            // only available in version 1.0
             xar_subdoc_prop_get(subdoc, "after-sha1", &value);
             if (value)
                 expectedAfterHashv1 = @(value);
             
-            // only available in version 2.0 or later
+            // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, "before-tree-sha1", &value);
             if (value)
                 expectedNewBeforeHash = @(value);
             
-            // only available in version 2.0 or later
+            // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, "after-tree-sha1", &value);
             if (value)
                 expectedNewAfterHash = @(value);

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -33,8 +33,8 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         return 1;
     }
     
-    uint16_t majorDiffVersion = FIRST_DELTA_DIFF_MAJOR_VERSION;
-    uint16_t minorDiffVersion = FIRST_DELTA_DIFF_MINOR_VERSION;
+    SUBinaryDeltaMajorVersion majorDiffVersion = FIRST_DELTA_DIFF_MAJOR_VERSION;
+    SUBinaryDeltaMinorVersion minorDiffVersion = FIRST_DELTA_DIFF_MINOR_VERSION;
 
     NSString *expectedBeforeHashv1 = nil;
     NSString *expectedAfterHashv1 = nil;
@@ -50,12 +50,12 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
             // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, MAJOR_DIFF_VERSION_KEY, &value);
             if (value)
-                majorDiffVersion = (uint16_t)[@(value) intValue];
+                majorDiffVersion = (SUBinaryDeltaMajorVersion)[@(value) intValue];
             
             // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, MINOR_DIFF_VERSION_KEY, &value);
             if (value)
-                minorDiffVersion = (uint16_t)[@(value) intValue];
+                minorDiffVersion = (SUBinaryDeltaMinorVersion)[@(value) intValue];
             
             // available in version 2.0 or later
             xar_subdoc_prop_get(subdoc, BEFORE_TREE_SHA1_KEY, &value);
@@ -89,7 +89,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         return 1;
     }
     
-    BOOL usesNewTreeHash = MAJOR_VERSION_IS_AT_LEAST(majorDiffVersion, BEIGE_MAJOR_VERSION);
+    BOOL usesNewTreeHash = MAJOR_VERSION_IS_AT_LEAST(majorDiffVersion, SUBeigeMajorVersion);
     
     NSString *expectedBeforeHash = usesNewTreeHash ? expectedNewBeforeHash : expectedBeforeHashv1;
     NSString *expectedAfterHash = usesNewTreeHash ? expectedNewAfterHash : expectedAfterHashv1;

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -141,9 +141,16 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
                 fprintf(stderr, "Unable to patch %s to destination %s\n", [sourceFilePath fileSystemRepresentation], [destinationFilePath fileSystemRepresentation]);
                 return 1;
             }
-        } else {
+        } else if (xar_prop_get(file, "mod-permissions", &value)) {
             if (xar_extract_tofile(x, file, [destinationFilePath fileSystemRepresentation]) != 0) {
                 fprintf(stderr, "Unable to extract file to %s\n", [destinationFilePath fileSystemRepresentation]);
+                return 1;
+            }
+        }
+        
+        if (!xar_prop_get(file, "mod-permissions", &value)) {
+            if (!modifyPermissions(destinationFilePath, (mode_t)[[NSString stringWithUTF8String:value] intValue])) {
+                fprintf(stderr, "Unable to modify permissions (%s) on file %s\n", value, [destinationFilePath fileSystemRepresentation]);
                 return 1;
             }
         }

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -16,28 +16,31 @@
 #define IS_VALID_PERMISSIONS(mode) \
     (((mode & PERMISSION_FLAGS) == 0755) || ((mode & PERMISSION_FLAGS) == 0644))
 
-#define DIFF_VERSION_IS_AT_LEAST(actualMajor, actualMinor, expectedMajor, expectedMinor) \
-    ((actualMajor > expectedMajor) || (actualMajor == expectedMajor && actualMinor >= expectedMinor))
+#define MAJOR_VERSION_IS_AT_LEAST(actualMajor, expectedMajor) (actualMajor >= expectedMajor)
+#define LATEST_MINOR_VERSION_FOR_MAJOR_VERSION(major) \
+    (major == AZURE_MAJOR_VERSION ? AZURE_MINOR_VERSION : BEIGE_MINOR_VERSION)
+
+// Each major version will be assigned a name of a color
+// Changes that break backwards compatibility will have different major versions
+// Changes that affect creating but not applying patches will have different minor versions
+
+#define AZURE_MAJOR_VERSION 1
+#define AZURE_MINOR_VERSION 0
+
+#define BEIGE_MAJOR_VERSION 2
+#define BEIGE_MINOR_VERSION 0
 
 #define FIRST_DELTA_DIFF_MAJOR_VERSION 1
 #define FIRST_DELTA_DIFF_MINOR_VERSION 0
 
-#define LATEST_DELTA_DIFF_MAJOR_VERSION 1
-#define LATEST_DELTA_DIFF_MAJOR_VERSION_STR _LATEST_DELTA_DIFF_VERSION_STR(LATEST_DELTA_DIFF_MAJOR_VERSION)
-
-#define LATEST_DELTA_DIFF_MINOR_VERSION 1
-#define LATEST_DELTA_DIFF_MINOR_VERSION_STR _LATEST_DELTA_DIFF_VERSION_STR(LATEST_DELTA_DIFF_MINOR_VERSION)
-
-// See https://gcc.gnu.org/onlinedocs/cpp/Stringification.html#Stringification
-#define __LATEST_DELTA_DIFF_VERSION_STR(s) #s
-#define _LATEST_DELTA_DIFF_VERSION_STR(s) __LATEST_DELTA_DIFF_VERSION_STR(s)
+#define LATEST_DELTA_DIFF_MAJOR_VERSION BEIGE_MAJOR_VERSION
 
 @class NSString;
 @class NSData;
 
 extern int compareFiles(const FTSENT **a, const FTSENT **b);
 extern NSData *hashOfFileContents(FTSENT *ent);
-extern NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t minorVersion);
+extern NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion);
 extern NSString *hashOfTree(NSString *path);
 extern BOOL removeTree(NSString *path);
 extern BOOL copyTree(NSString *source, NSString *dest);

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -28,7 +28,7 @@
 
 // Properties no longer used in new patches
 #define BEFORE_TREE_SHA1_OLD_KEY "before-sha1"
-#define AFTER_TREE_SHA1_OLD_KEY "before-sha1"
+#define AFTER_TREE_SHA1_OLD_KEY "after-sha1"
 
 #define MAJOR_VERSION_IS_AT_LEAST(actualMajor, expectedMajor) (actualMajor >= expectedMajor)
 

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -31,23 +31,28 @@
 #define AFTER_TREE_SHA1_OLD_KEY "before-sha1"
 
 #define MAJOR_VERSION_IS_AT_LEAST(actualMajor, expectedMajor) (actualMajor >= expectedMajor)
-#define LATEST_MINOR_VERSION_FOR_MAJOR_VERSION(major) \
-    (major == AZURE_MAJOR_VERSION ? AZURE_MINOR_VERSION : BEIGE_MINOR_VERSION)
 
 // Each major version will be assigned a name of a color
 // Changes that break backwards compatibility will have different major versions
 // Changes that affect creating but not applying patches will have different minor versions
 
-#define AZURE_MAJOR_VERSION 1
-#define AZURE_MINOR_VERSION 0
+typedef NS_ENUM(uint16_t, SUBinaryDeltaMajorVersion)
+{
+    SUAzureMajorVersion = 1,
+    SUBeigeMajorVersion = 2
+};
 
-#define BEIGE_MAJOR_VERSION 2
-#define BEIGE_MINOR_VERSION 0
+// Only keep track of the latest minor version for each major version
+typedef NS_ENUM(uint16_t, SUBinaryDeltaMinorVersion)
+{
+    SUAzureMinorVersion = 0,
+    SUBeigeMinorVersion = 0,
+};
 
-#define FIRST_DELTA_DIFF_MAJOR_VERSION 1
-#define FIRST_DELTA_DIFF_MINOR_VERSION 0
+#define FIRST_DELTA_DIFF_MAJOR_VERSION SUAzureMajorVersion
+#define FIRST_DELTA_DIFF_MINOR_VERSION SUAzureMinorVersion
 
-#define LATEST_DELTA_DIFF_MAJOR_VERSION BEIGE_MAJOR_VERSION
+#define LATEST_DELTA_DIFF_MAJOR_VERSION SUBeigeMajorVersion
 
 @class NSString;
 @class NSData;
@@ -63,4 +68,5 @@ extern NSString *pathRelativeToDirectory(NSString *directory, NSString *path);
 NSString *temporaryFilename(NSString *base);
 NSString *temporaryDirectory(NSString *base);
 NSString *stringWithFileSystemRepresentation(const char*);
+SUBinaryDeltaMinorVersion latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion);
 #endif

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -22,11 +22,12 @@
 #define BEFORE_TREE_SHA1_KEY "before-tree-sha1"
 #define AFTER_TREE_SHA1_KEY "after-tree-sha1"
 #define DELETE_KEY "delete"
-#define DELETE_THEN_EXTRACT_KEY "delete-then-extract"
+#define EXTRACT_KEY "extract"
 #define BINARY_DELTA_KEY "binary-delta"
 #define MODIFY_PERMISSIONS_KEY "mod-permissions"
 
 // Properties no longer used in new patches
+#define DELETE_THEN_EXTRACT_OLD_KEY "delete-then-extract"
 #define BEFORE_TREE_SHA1_OLD_KEY "before-sha1"
 #define AFTER_TREE_SHA1_OLD_KEY "after-sha1"
 

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -16,6 +16,20 @@
 #define IS_VALID_PERMISSIONS(mode) \
     (((mode & PERMISSION_FLAGS) == 0755) || ((mode & PERMISSION_FLAGS) == 0644))
 
+#define BINARY_DELTA_ATTRIBUTES_KEY "binary-delta-attributes"
+#define MAJOR_DIFF_VERSION_KEY "major-version"
+#define MINOR_DIFF_VERSION_KEY "minor-version"
+#define BEFORE_TREE_SHA1_KEY "before-tree-sha1"
+#define AFTER_TREE_SHA1_KEY "after-tree-sha1"
+#define DELETE_KEY "delete"
+#define DELETE_THEN_EXTRACT_KEY "delete-then-extract"
+#define BINARY_DELTA_KEY "binary-delta"
+#define MODIFY_PERMISSIONS_KEY "mod-permissions"
+
+// Properties no longer used in new patches
+#define BEFORE_TREE_SHA1_OLD_KEY "before-sha1"
+#define AFTER_TREE_SHA1_OLD_KEY "before-sha1"
+
 #define MAJOR_VERSION_IS_AT_LEAST(actualMajor, expectedMajor) (actualMajor >= expectedMajor)
 #define LATEST_MINOR_VERSION_FOR_MAJOR_VERSION(major) \
     (major == AZURE_MAJOR_VERSION ? AZURE_MINOR_VERSION : BEIGE_MINOR_VERSION)

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -9,8 +9,6 @@
 #ifndef SUBINARYDELTACOMMON_H
 #define SUBINARYDELTACOMMON_H
 
-#define _DARWIN_NO_64_BIT_INODE 1
-
 #include <fts.h>
 
 // Only track executable bits, which is what VCS's like git and hg do as well

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(uint16_t, SUBinaryDeltaMajorVersion)
 // Only keep track of the latest minor version for each major version
 typedef NS_ENUM(uint16_t, SUBinaryDeltaMinorVersion)
 {
-    SUAzureMinorVersion = 0,
+    SUAzureMinorVersion = 1,
     SUBeigeMinorVersion = 0,
 };
 

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -11,9 +11,10 @@
 
 #include <fts.h>
 
-// Only track executable bits, which is what VCS's like git and hg do as well
-// Other permission bits might be too sketchy to track
-#define EXECUTABLE_PERMISSIONS (S_IXUSR | S_IXGRP | S_IXOTH)
+#define PERMISSION_FLAGS (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID | S_ISVTX)
+
+#define IS_VALID_PERMISSIONS(mode) \
+    (((mode & PERMISSION_FLAGS) == 0755) || ((mode & PERMISSION_FLAGS) == 0644))
 
 #define DIFF_VERSION_IS_AT_LEAST(actualMajor, actualMinor, expectedMajor, expectedMinor) \
     ((actualMajor > expectedMajor) || (actualMajor == expectedMajor && actualMinor >= expectedMinor))

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -41,6 +41,7 @@ extern NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, ui
 extern NSString *hashOfTree(NSString *path);
 extern BOOL removeTree(NSString *path);
 extern BOOL copyTree(NSString *source, NSString *dest);
+extern BOOL modifyPermissions(NSString *path, mode_t desiredPermissions);
 extern NSString *pathRelativeToDirectory(NSString *directory, NSString *path);
 NSString *temporaryFilename(NSString *base);
 NSString *temporaryDirectory(NSString *base);

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -9,17 +9,41 @@
 #ifndef SUBINARYDELTACOMMON_H
 #define SUBINARYDELTACOMMON_H
 
+#define _DARWIN_NO_64_BIT_INODE 1
+
 #include <fts.h>
+
+// Only track executable bits, which is what VCS's like git and hg do as well
+// Other permission bits might be too sketchy to track
+#define EXECUTABLE_PERMISSIONS (S_IXUSR | S_IXGRP | S_IXOTH)
+
+#define DIFF_VERSION_IS_AT_LEAST(actualMajor, actualMinor, expectedMajor, expectedMinor) \
+    ((actualMajor > expectedMajor) || (actualMajor == expectedMajor && actualMinor >= expectedMinor))
+
+#define FIRST_DELTA_DIFF_MAJOR_VERSION 1
+#define FIRST_DELTA_DIFF_MINOR_VERSION 0
+
+#define LATEST_DELTA_DIFF_MAJOR_VERSION 1
+#define LATEST_DELTA_DIFF_MAJOR_VERSION_STR _LATEST_DELTA_DIFF_VERSION_STR(LATEST_DELTA_DIFF_MAJOR_VERSION)
+
+#define LATEST_DELTA_DIFF_MINOR_VERSION 1
+#define LATEST_DELTA_DIFF_MINOR_VERSION_STR _LATEST_DELTA_DIFF_VERSION_STR(LATEST_DELTA_DIFF_MINOR_VERSION)
+
+// See https://gcc.gnu.org/onlinedocs/cpp/Stringification.html#Stringification
+#define __LATEST_DELTA_DIFF_VERSION_STR(s) #s
+#define _LATEST_DELTA_DIFF_VERSION_STR(s) __LATEST_DELTA_DIFF_VERSION_STR(s)
 
 @class NSString;
 @class NSData;
 
 extern int compareFiles(const FTSENT **a, const FTSENT **b);
-extern NSData *hashOfFile(FTSENT *ent);
+extern NSData *hashOfFileContents(FTSENT *ent);
+extern NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t minorVersion);
 extern NSString *hashOfTree(NSString *path);
-extern void removeTree(NSString *path);
-extern void copyTree(NSString *source, NSString *dest);
+extern BOOL removeTree(NSString *path);
+extern BOOL copyTree(NSString *source, NSString *dest);
 extern NSString *pathRelativeToDirectory(NSString *directory, NSString *path);
 NSString *temporaryFilename(NSString *base);
+NSString *temporaryDirectory(NSString *base);
 NSString *stringWithFileSystemRepresentation(const char*);
 #endif

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(uint16_t, SUBinaryDeltaMinorVersion)
 };
 
 #define FIRST_DELTA_DIFF_MAJOR_VERSION SUAzureMajorVersion
-#define FIRST_DELTA_DIFF_MINOR_VERSION SUAzureMinorVersion
+#define FIRST_DELTA_DIFF_MINOR_VERSION 0
 
 #define LATEST_DELTA_DIFF_MAJOR_VERSION SUBeigeMajorVersion
 

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -215,7 +215,8 @@ BOOL modifyPermissions(NSString *path, mode_t desiredPermissions)
         return NO;
     }
     mode_t newMode = ([permissions unsignedShortValue] & ~PERMISSION_FLAGS) | desiredPermissions;
-    if (![fileManager setAttributes:@{NSFilePosixPermissions : @(newMode)} ofItemAtPath:path error:nil]) {
+    int (*changeModeFunc)(const char *, mode_t) = [attributes[NSFileType] isEqualToString:NSFileTypeSymbolicLink] ? lchmod : chmod;
+    if (changeModeFunc([path fileSystemRepresentation], newMode) != 0) {
         return NO;
     }
     return YES;

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -17,6 +17,10 @@
 #include <sys/stat.h>
 #include <xar/xar.h>
 
+// Only track executable bits for tree hashing, which is what VCS's like git and hg do as well
+// Other permission bits might be too sketchy to track
+#define EXECUTABLE_PERMISSIONS (S_IXUSR | S_IXGRP | S_IXOTH)
+
 int compareFiles(const FTSENT **a, const FTSENT **b)
 {
     return strcoll((*a)->fts_name, (*b)->fts_name);

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -200,3 +200,21 @@ BOOL copyTree(NSString *source, NSString *dest)
 {
     return [[NSFileManager defaultManager] copyItemAtPath:source toPath:dest error:nil];
 }
+
+BOOL modifyPermissions(NSString *path, mode_t desiredPermissions)
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSDictionary *attributes = [fileManager attributesOfItemAtPath:path error:nil];
+    if (!attributes) {
+        return NO;
+    }
+    NSNumber *permissions = attributes[NSFilePosixPermissions];
+    if (!permissions) {
+        return NO;
+    }
+    mode_t newMode = ([permissions unsignedShortValue] & ~PERMISSION_FLAGS) | desiredPermissions;
+    if (![fileManager setAttributes:@{NSFilePosixPermissions : @(newMode)} ofItemAtPath:path error:nil]) {
+        return NO;
+    }
+    return YES;
+}

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -131,7 +131,7 @@ NSData *hashOfFileContents(FTSENT *ent)
     return [NSData dataWithBytes:fileHash length:CC_SHA1_DIGEST_LENGTH];
 }
 
-NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t minorVersion)
+NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
 {
     const char *sourcePaths[] = {[path fileSystemRepresentation], 0};
     FTS *fts = fts_open((char* const*)sourcePaths, FTS_PHYSICAL | FTS_NOCHDIR, compareFiles);
@@ -148,7 +148,7 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t 
         if (ent->fts_info != FTS_F && ent->fts_info != FTS_SL && ent->fts_info != FTS_D)
             continue;
         
-        if (ent->fts_info == FTS_D && !DIFF_VERSION_IS_AT_LEAST(majorVersion, minorVersion, 1, 1)) {
+        if (ent->fts_info == FTS_D && !MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION)) {
             continue;
         }
         
@@ -165,7 +165,7 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t 
         const char *relativePathBytes = [relativePath fileSystemRepresentation];
         CC_SHA1_Update(&hashContext, relativePathBytes, (CC_LONG)strlen(relativePathBytes));
         
-        if (DIFF_VERSION_IS_AT_LEAST(majorVersion, minorVersion, 1, 1)) {
+        if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION)) {
             uint16_t mode = ent->fts_statp->st_mode;
             uint16_t type = ent->fts_info;
             uint16_t permissions = mode & PERMISSION_FLAGS;
@@ -189,7 +189,7 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t 
 
 extern NSString *hashOfTree(NSString *path)
 {
-    return hashOfTreeWithVersion(path, LATEST_DELTA_DIFF_MAJOR_VERSION, LATEST_DELTA_DIFF_MINOR_VERSION);
+    return hashOfTreeWithVersion(path, LATEST_DELTA_DIFF_MAJOR_VERSION);
 }
 
 BOOL removeTree(NSString *path)

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -17,10 +17,6 @@
 #include <sys/stat.h>
 #include <xar/xar.h>
 
-// Only track executable bits for tree hashing, which is what VCS's like git and hg do as well
-// Other permission bits might be too sketchy to track
-#define EXECUTABLE_PERMISSIONS (S_IXUSR | S_IXGRP | S_IXOTH)
-
 int compareFiles(const FTSENT **a, const FTSENT **b)
 {
     return strcoll((*a)->fts_name, (*b)->fts_name);
@@ -172,7 +168,7 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t 
         if (DIFF_VERSION_IS_AT_LEAST(majorVersion, minorVersion, 1, 1)) {
             uint16_t mode = ent->fts_statp->st_mode;
             uint16_t type = ent->fts_info;
-            uint16_t executablePermissions = mode & EXECUTABLE_PERMISSIONS;
+            uint16_t executablePermissions = mode & PERMISSION_FLAGS;
             
             CC_SHA1_Update(&hashContext, &type, sizeof(type));
             CC_SHA1_Update(&hashContext, &executablePermissions, sizeof(executablePermissions));

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -35,6 +35,17 @@ NSString *stringWithFileSystemRepresentation(const char *input) {
     return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:input length:strlen(input)];
 }
 
+SUBinaryDeltaMinorVersion latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion)
+{
+    switch (majorVersion) {
+        case SUAzureMajorVersion:
+            return SUAzureMinorVersion;
+        case SUBeigeMajorVersion:
+            return SUBeigeMinorVersion;
+    }
+    return 0;
+}
+
 NSString *temporaryFilename(NSString *base)
 {
     NSString *template = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.XXXXXXXXXX", base]];
@@ -148,7 +159,7 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
         if (ent->fts_info != FTS_F && ent->fts_info != FTS_SL && ent->fts_info != FTS_D)
             continue;
         
-        if (ent->fts_info == FTS_D && !MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION)) {
+        if (ent->fts_info == FTS_D && !MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion)) {
             continue;
         }
         
@@ -165,7 +176,7 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
         const char *relativePathBytes = [relativePath fileSystemRepresentation];
         CC_SHA1_Update(&hashContext, relativePathBytes, (CC_LONG)strlen(relativePathBytes));
         
-        if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION)) {
+        if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion)) {
             uint16_t mode = ent->fts_statp->st_mode;
             uint16_t type = ent->fts_info;
             uint16_t permissions = mode & PERMISSION_FLAGS;

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -168,10 +168,10 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion, uint16_t 
         if (DIFF_VERSION_IS_AT_LEAST(majorVersion, minorVersion, 1, 1)) {
             uint16_t mode = ent->fts_statp->st_mode;
             uint16_t type = ent->fts_info;
-            uint16_t executablePermissions = mode & PERMISSION_FLAGS;
+            uint16_t permissions = mode & PERMISSION_FLAGS;
             
             CC_SHA1_Update(&hashContext, &type, sizeof(type));
-            CC_SHA1_Update(&hashContext, &executablePermissions, sizeof(executablePermissions));
+            CC_SHA1_Update(&hashContext, &permissions, sizeof(permissions));
         }
     }
     fts_close(fts);

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -195,7 +195,11 @@ extern NSString *hashOfTree(NSString *path)
 BOOL removeTree(NSString *path)
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    return ![fileManager fileExistsAtPath:path] ? YES : [fileManager removeItemAtPath:path error:nil];
+    // Don't use fileExistsForPath: because it will try to follow symbolic links
+    if (![fileManager attributesOfItemAtPath:path error:nil]) {
+        return YES;
+    }
+    return [fileManager removeItemAtPath:path error:nil];
 }
 
 BOOL copyTree(NSString *source, NSString *dest)

--- a/Sparkle/SUBinaryDeltaCreate.h
+++ b/Sparkle/SUBinaryDeltaCreate.h
@@ -10,6 +10,6 @@
 #define SUBINARYDELTACREATE_H
 
 @class NSString;
-int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile);
+int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, uint16_t majorVersion);
 
 #endif

--- a/Sparkle/SUBinaryDeltaCreate.h
+++ b/Sparkle/SUBinaryDeltaCreate.h
@@ -9,7 +9,9 @@
 #ifndef SUBINARYDELTACREATE_H
 #define SUBINARYDELTACREATE_H
 
+#import "SUBinaryDeltaCommon.h"
+
 @class NSString;
-int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, uint16_t majorVersion);
+int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion);
 
 #endif

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -184,7 +184,7 @@ static BOOL shouldChangePermissions(NSDictionary *originalInfo, NSDictionary *ne
     return YES;
 }
 
-int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, uint16_t majorVersion)
+int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion)
 {
     if (majorVersion < FIRST_DELTA_DIFF_MAJOR_VERSION) {
         fprintf(stderr, "Version provided (%u) is not valid", majorVersion);
@@ -196,7 +196,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         return 1;
     }
     
-    uint16_t minorVersion = LATEST_MINOR_VERSION_FOR_MAJOR_VERSION(majorVersion);
+    SUBinaryDeltaMinorVersion minorVersion = latestMinorVersionForMajorVersion(majorVersion);
     
     NSMutableDictionary *originalTreeState = [NSMutableDictionary dictionary];
 
@@ -326,9 +326,9 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     
     // Version 1 patches don't have a major or minor version field, so we need to differentiate between the hash keys
     const char *beforeHashKey =
-        MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION) ? BEFORE_TREE_SHA1_KEY : BEFORE_TREE_SHA1_OLD_KEY;
+        MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion) ? BEFORE_TREE_SHA1_KEY : BEFORE_TREE_SHA1_OLD_KEY;
     const char *afterHashKey =
-        MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION) ? AFTER_TREE_SHA1_KEY : AFTER_TREE_SHA1_OLD_KEY;
+        MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion) ? AFTER_TREE_SHA1_KEY : AFTER_TREE_SHA1_OLD_KEY;
     
     xar_subdoc_prop_set(attributes, beforeHashKey, [beforeHash UTF8String]);
     xar_subdoc_prop_set(attributes, afterHashKey, [afterHash UTF8String]);
@@ -359,7 +359,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         NSDictionary *originalInfo = originalTreeState[key];
         NSDictionary *newInfo = newTreeState[key];
         if (shouldSkipDeltaCompression(originalInfo, newInfo)) {
-            if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION) && shouldSkipExtracting(originalInfo, newInfo)) {
+            if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion) && shouldSkipExtracting(originalInfo, newInfo)) {
                 if (shouldChangePermissions(originalInfo, newInfo)) {
                     xar_file_t newFile = xar_add_frombuffer(x, 0, [key fileSystemRepresentation], (char *)"", 1);
                     assert(newFile);
@@ -376,7 +376,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
             }
         } else {
             NSNumber *permissions =
-                (MAJOR_VERSION_IS_AT_LEAST(majorVersion, BEIGE_MAJOR_VERSION) && shouldChangePermissions(originalInfo, newInfo)) ?
+                (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion) && shouldChangePermissions(originalInfo, newInfo)) ?
                 newInfo[INFO_PERMISSIONS_KEY] :
                 nil;
             CreateBinaryDeltaOperation *operation = [[CreateBinaryDeltaOperation alloc] initWithRelativePath:key oldTree:source newTree:destination permissions:permissions];

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -371,7 +371,15 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
                 assert(newFile);
                 
                 if (shouldDeleteThenExtract(originalInfo, newInfo)) {
-                    xar_prop_set(newFile, DELETE_THEN_EXTRACT_KEY, "true");
+                    if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion)) {
+                        xar_prop_set(newFile, DELETE_KEY, "true");
+                    } else {
+                        xar_prop_set(newFile, DELETE_THEN_EXTRACT_OLD_KEY, "true");
+                    }
+                }
+                
+                if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion)) {
+                    xar_prop_set(newFile, EXTRACT_KEY, "true");
                 }
             }
         } else {

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -34,7 +34,7 @@ int main(int __unused argc, char __unused *argv[])
             return 1;
         }
         
-        uint16_t patchVersion = 0;
+        SUBinaryDeltaMajorVersion patchVersion;
         NSString *versionField = ([command isEqualToString:@"create"] && args.count == 6) ? args[2] : nil;
         if (!versionField) {
             patchVersion = LATEST_DELTA_DIFF_MAJOR_VERSION;

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -45,7 +45,7 @@ int main(int __unused argc, char __unused *argv[])
                 return 1;
             }
             // Ignore minor version if it's supplied
-            patchVersion = (uint16_t)[[versionComponents[1] componentsSeparatedByString:@"."][0] intValue];
+            patchVersion = (SUBinaryDeltaMajorVersion)[[versionComponents[1] componentsSeparatedByString:@"."][0] intValue];
         }
         
         NSString *oldPath = args[args.count - 3];

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -8,26 +8,49 @@
 
 #include "SUBinaryDeltaApply.h"
 #include "SUBinaryDeltaCreate.h"
+#import "SUBinaryDeltaCommon.h"
 #include <Foundation/Foundation.h>
 
 static void printUsage(void)
 {
-    fprintf(stderr, "Usage: BinaryDelta [create | apply] before-tree after-tree patch-file\n");
+    fprintf(stderr, "Usage:\n");
+    fprintf(stderr, "BinaryDelta create [--version=<version>] <before-tree> <after-tree> <patch-file>\n");
+    fprintf(stderr, "BinaryDelta apply <before-tree> <after-tree> <patch-file>\n");
 }
 
 int main(int __unused argc, char __unused *argv[])
 {
     @autoreleasepool {
         NSArray *args = [[NSProcessInfo processInfo] arguments];
-        if (args.count != 5) {
+        if (args.count < 5 || args.count > 6) {
             printUsage();
             return 1;
         }
 
         NSString *command = args[1];
-        NSString *oldPath = args[2];
-        NSString *newPath = args[3];
-        NSString *patchFile = args[4];
+        
+        if (![command isEqualToString:@"create"] && args.count > 5) {
+            printUsage();
+            return 1;
+        }
+        
+        uint16_t patchVersion = 0;
+        NSString *versionField = ([command isEqualToString:@"create"] && args.count == 6) ? args[2] : nil;
+        if (!versionField) {
+            patchVersion = LATEST_DELTA_DIFF_MAJOR_VERSION;
+        } else {
+            NSArray *versionComponents = [versionField componentsSeparatedByString:@"="];
+            if (versionComponents.count != 2 || ![versionComponents[0] isEqualToString:@"--version"]) {
+                printUsage();
+                return 1;
+            }
+            // Ignore minor version if it's supplied
+            patchVersion = (uint16_t)[[versionComponents[1] componentsSeparatedByString:@"."][0] intValue];
+        }
+        
+        NSString *oldPath = args[args.count - 3];
+        NSString *newPath = args[args.count - 2];
+        NSString *patchFile = args[args.count - 1];
 
         BOOL isDirectory;
         if (![[NSFileManager defaultManager] fileExistsAtPath:oldPath isDirectory:&isDirectory] || !isDirectory) {
@@ -43,7 +66,7 @@ int main(int __unused argc, char __unused *argv[])
                 result = 1;
                 fprintf(stderr, "Usage: after-tree must be a directory\n");
             } else {
-                result = createBinaryDelta(oldPath, newPath, patchFile);
+                result = createBinaryDelta(oldPath, newPath, patchFile, patchVersion);
             }
         } else {
             result = 1;

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -132,7 +132,6 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 - (void)testEmptyDirectoryDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
-        NSData *emptyData = [NSData data];
         NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
         NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
         
@@ -154,7 +153,6 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 - (void)testDifferentlyNamedEmptyDirectoryDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
-        NSData *emptyData = [NSData data];
         NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
         NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"B"];
         

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -93,6 +93,13 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     return [beforeHash isEqualToString:afterHash];
 }
 
+- (void)testNoFilesDiff
+{
+    [self createAndApplyPatchWithHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        XCTAssertTrue([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
+    }];
+}
+
 - (void)testEmptyDataDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -57,7 +57,8 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         beforeDiffHandler(fileManager, sourceDirectory, destinationDirectory);
     }
     
-    BOOL createdDiff = (createBinaryDelta(sourceDirectory, destinationDirectory, diffFile) == 0);
+    BOOL createdDiff =
+        (createBinaryDelta(sourceDirectory, destinationDirectory, diffFile, LATEST_DELTA_DIFF_MAJOR_VERSION) == 0);
     
     if (createdDiff && afterDiffHandler != nil) {
         afterDiffHandler(fileManager, sourceDirectory, destinationDirectory);

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -194,7 +194,6 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 - (void)testSameNonexistantSymlinkDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
-        NSData *emptyData = [NSData data];
         NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
         NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
         
@@ -216,7 +215,6 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 - (void)testDifferentNonexistantSymlinkDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
-        NSData *emptyData = [NSData data];
         NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
         NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
         
@@ -238,7 +236,6 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 - (void)testNonexistantSymlinkPermissionDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
-        NSData *emptyData = [NSData data];
         NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
         NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
         
@@ -285,7 +282,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:destinationFile atomically:YES]);
         
         XCTAssertFalse([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
-    } afterDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+    } afterDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *__unused destinationDirectory) {
         NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
         
         XCTAssertTrue([[NSData dataWithBytes:"testt" length:5] writeToFile:sourceFile atomically:YES]);

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -597,6 +597,107 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     }];
 }
 
+- (void)testInvalidRegularFileWithACLInBeforeTree
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString * __unused destinationDirectory) {
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:sourceFile atomically:YES]);
+        
+        acl_t acl = acl_init(1);
+        
+        acl_entry_t entry;
+        XCTAssertEqual(0, acl_create_entry(&acl, &entry));
+        
+        acl_permset_t permset;
+        XCTAssertEqual(0, acl_get_permset(entry, &permset));
+        
+        XCTAssertEqual(0, acl_add_perm(permset, ACL_SEARCH));
+        
+        XCTAssertEqual(0, acl_set_link_np([sourceFile fileSystemRepresentation], ACL_TYPE_EXTENDED, acl));
+        
+        XCTAssertEqual(0, acl_free(acl));
+    } afterDiffHandler:nil];
+    
+    XCTAssertFalse(success);
+}
+
+- (void)testInvalidRegularFileWithACLInAfterTree
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *__unused sourceDirectory, NSString *destinationDirectory) {
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:destinationFile atomically:YES]);
+        
+        acl_t acl = acl_init(1);
+        
+        acl_entry_t entry;
+        XCTAssertEqual(0, acl_create_entry(&acl, &entry));
+        
+        acl_permset_t permset;
+        XCTAssertEqual(0, acl_get_permset(entry, &permset));
+        
+        XCTAssertEqual(0, acl_add_perm(permset, ACL_SEARCH));
+        
+        XCTAssertEqual(0, acl_set_link_np([destinationFile fileSystemRepresentation], ACL_TYPE_EXTENDED, acl));
+        
+        XCTAssertEqual(0, acl_free(acl));
+        
+    } afterDiffHandler:nil];
+    
+    XCTAssertFalse(success);
+}
+
+- (void)testInvalidDirectoryWithACLInBeforeTree
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString * __unused destinationDirectory) {
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([fileManager createDirectoryAtPath:sourceFile withIntermediateDirectories:NO attributes:nil error:nil]);
+        
+        acl_t acl = acl_init(1);
+        
+        acl_entry_t entry;
+        XCTAssertEqual(0, acl_create_entry(&acl, &entry));
+        
+        acl_permset_t permset;
+        XCTAssertEqual(0, acl_get_permset(entry, &permset));
+        
+        XCTAssertEqual(0, acl_add_perm(permset, ACL_SEARCH));
+        
+        XCTAssertEqual(0, acl_set_link_np([sourceFile fileSystemRepresentation], ACL_TYPE_EXTENDED, acl));
+        
+        XCTAssertEqual(0, acl_free(acl));
+    } afterDiffHandler:nil];
+    
+    XCTAssertFalse(success);
+}
+
+- (void)testInvalidDirectoryWithACLInAfterTree
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *fileManager, NSString * __unused sourceDirectory, NSString *destinationDirectory) {
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([fileManager createDirectoryAtPath:destinationFile withIntermediateDirectories:NO attributes:nil error:nil]);
+        
+        acl_t acl = acl_init(1);
+        
+        acl_entry_t entry;
+        XCTAssertEqual(0, acl_create_entry(&acl, &entry));
+        
+        acl_permset_t permset;
+        XCTAssertEqual(0, acl_get_permset(entry, &permset));
+        
+        XCTAssertEqual(0, acl_add_perm(permset, ACL_SEARCH));
+        
+        XCTAssertEqual(0, acl_set_link_np([destinationFile fileSystemRepresentation], ACL_TYPE_EXTENDED, acl));
+        
+        XCTAssertEqual(0, acl_free(acl));
+    } afterDiffHandler:nil];
+    
+    XCTAssertFalse(success);
+}
+
 - (void)testRegularFileToSymlinkChange
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -106,6 +106,20 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     }];
 }
 
+- (void)testNoFilesDiffWithInvalidLowVersion
+{
+    XCTAssertFalse([self createAndApplyPatchUsingVersion:(SUBinaryDeltaMajorVersion)0 beforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        XCTAssertTrue([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
+    } afterDiffHandler:nil]);
+}
+
+- (void)testNoFilesDiffWithInvalidHighVersion
+{
+    XCTAssertFalse([self createAndApplyPatchUsingVersion:(SUBinaryDeltaMajorVersion)9999 beforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        XCTAssertTrue([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
+    } afterDiffHandler:nil]);
+}
+
 - (void)testEmptyDataDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -434,6 +434,36 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     }];
 }
 
+- (void)testRemovingSymlink
+{
+    [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        
+        NSError *error = nil;
+        if (![fileManager createSymbolicLinkAtPath:sourceFile withDestinationPath:@"B" error:&error]) {
+            NSLog(@"Error in creating symlink: %@", error);
+            XCTFail(@"Failed to create symlink");
+        }
+        
+        XCTAssertFalse([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
+    }];
+}
+
+- (void)testAddingSymlink
+{
+    [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
+        
+        NSError *error = nil;
+        if (![fileManager createSymbolicLinkAtPath:destinationFile withDestinationPath:@"B" error:&error]) {
+            NSLog(@"Error in creating symlink: %@", error);
+            XCTFail(@"Failed to create symlink");
+        }
+        
+        XCTAssertFalse([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
+    }];
+}
+
 - (void)testSmallFilePermissionChangeWithNoContentChange
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -116,12 +116,12 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         if (![fileManager createDirectoryAtPath:destinationFile withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         XCTAssertTrue([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
@@ -138,12 +138,12 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         if (![fileManager createDirectoryAtPath:destinationFile withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         // This would fail for version 1.0
@@ -260,7 +260,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:destinationFile2 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         XCTAssertTrue([[self bigData2] writeToFile:destinationFile3 atomically:YES]);
@@ -298,7 +298,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile2 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         XCTAssertTrue([[self bigData2] writeToFile:sourceFile3 atomically:YES]);
@@ -435,12 +435,12 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile1 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         if (![fileManager createDirectoryAtPath:destinationFile1 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         XCTAssertTrue([[self bigData1] writeToFile:sourceFile2 atomically:YES]);
@@ -569,7 +569,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:destinationFile withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         XCTAssertFalse([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
@@ -585,7 +585,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory");
+            XCTFail("Failed to create directory");
         }
         
         NSData *data = [NSData dataWithBytes:"loltest" length:7];
@@ -610,17 +610,17 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile1 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory A in source");
+            XCTFail("Failed to create directory A in source");
         }
         
         if (![fileManager createDirectoryAtPath:sourceFile2 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory Current in source");
+            XCTFail("Failed to create directory Current in source");
         }
         
         if (![fileManager createDirectoryAtPath:destinationFile1 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory A in destination");
+            XCTFail("Failed to create directory A in destination");
         }
         
         if (![fileManager createSymbolicLinkAtPath:destinationFile3 withDestinationPath:@"A/" error:&error]) {
@@ -650,17 +650,17 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSError *error = nil;
         if (![fileManager createDirectoryAtPath:sourceFile1 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory A in source");
+            XCTFail("Failed to create directory A in source");
         }
         
         if (![fileManager createDirectoryAtPath:destinationFile1 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory A in destination");
+            XCTFail("Failed to create directory A in destination");
         }
         
         if (![fileManager createDirectoryAtPath:destinationFile2 withIntermediateDirectories:NO attributes:nil error:&error]) {
             NSLog(@"Failed creating directory with error: %@", error);
-            XCTAssertFalse("Failed to create directory Current in destination");
+            XCTFail("Failed to create directory Current in destination");
         }
         
         if (![fileManager createSymbolicLinkAtPath:sourceFile3 withDestinationPath:@"A/" error:&error]) {

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -107,6 +107,20 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     }];
 }
 
+- (void)testDifferentlyNamedEmptyDataDiff
+{
+    [self createAndApplyPatchWithHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        NSData *emptyData = [NSData data];
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"B"];
+        
+        XCTAssertTrue([emptyData writeToFile:sourceFile atomically:YES]);
+        XCTAssertTrue([emptyData writeToFile:destinationFile atomically:YES]);
+        
+        XCTAssertFalse([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
+    }];
+}
+
 - (void)testEmptyDirectoryDiff
 {
     [self createAndApplyPatchWithHandler:^(NSFileManager *fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {


### PR DESCRIPTION
OK, been working on this for a bit.

I found several bugs with BinaryDelta's tree hashing, and added the ability for BinaryDelta to diff/preserve permissions. I also created major/minor version fields in the file format. If the major field differs, this indicates the patch not being compatible. When the minor version differs, compatibility still works. Due to having to add permission diffs and having to change the hashing, I had to bump the major version.

Changes summary:
* Permissions are preserved and hashed on regular files, symbolic links, and directories now in all cases. Only permission modes 0755 and 0644 are allowed on files in the after-tree. Practical use: scripts turning into executable or vise versa, .app being compressed incorrectly with wrong permissions, fixing permissions from an old app in a new update...
* ACLs (Access Control Lists) are not allowed in either before-tree or after-tree; we don't try to preserve or hash them, and we don't want to diff on them. Extended file attributes are not hashed and completely ignored as they shouldn't contain vital information.
* _DARWIN_NO_64_BIT_INODE define was removed because I believe it's no longer needed since we only target 64-bit now.
* Directories are now hashed. They were intended to be by the original code since _hashOfFileContents has a case for them. This was a bug.
* File types (regular file, directory, symbolic link) are now hashed. This prevents hash collisions for two different trees in a few cases.
* More error handling is now done. Cleaned up code a bit by adding constants. Added a lot of tests.
* Added major/minor version fields to the patch format. Bumped the (major) patch version to 2. Patches created by BinaryDelta now will not work on older versions unless you create a patch by supplying --version=1; this is meant for transition purposes. BinaryDelta can still apply version 1 patches. Since major/minor versioning wasn't around before, for version 2 patches I had to change the before and after hash property keys to make the patch gracefully fail on older versions of BinaryDelta.

After this, I'm thinking of adding a verbose option and improve the current logging.