### PR TITLE
Ensure termListen is not deallocated before -[NSRunningApplication run]

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -204,9 +204,9 @@ int main(int __unused argc, const char __unused *argv[])
                                                                            shouldShowUI:shouldShowUI
                                                                                selfPath:[[NSBundle mainBundle] bundlePath]];
 
-        [termListen class];
         [[NSApplication sharedApplication] run];
-
+        // Ensure termListen is not deallocated by ARC before caling -[NSApplication run]
+        [termListen class];
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Related: Issue #441
I have no evidence that this is the cause of the issue, but from what we do know from the crash logs submitted, it looks like Sparkle crashes or errors on the main thread. It also looks like it might be from an object release rather than copying (which is done on a different thread) being the issue (see issue #417 also). I'm leaning towards this being an issue after the project was converted to ARC.