### PR TITLE
BinaryDelta Verbosity/Improved Logging

### DIFF
--- a/Sparkle/SUBinaryDeltaApply.h
+++ b/Sparkle/SUBinaryDeltaApply.h
@@ -10,6 +10,6 @@
 #define SUBINARYDELTAAPPLY_H
 
 @class NSString;
-int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile);
+int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose);
 
 #endif

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -105,12 +105,12 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     
     NSString *beforeHash = hashOfTreeWithVersion(source, majorDiffVersion);
     if (!beforeHash) {
-        fprintf(stderr, "Unable to calculate hash of tree %s\n", [source fileSystemRepresentation]);
+        fprintf(stderr, "\nUnable to calculate hash of tree %s\n", [source fileSystemRepresentation]);
         return 1;
     }
 
     if (![beforeHash isEqualToString:expectedBeforeHash]) {
-        fprintf(stderr, "Source doesn't have expected hash (%s != %s).  Giving up.\n", [expectedBeforeHash UTF8String], [beforeHash UTF8String]);
+        fprintf(stderr, "\nSource doesn't have expected hash (%s != %s).  Giving up.\n", [expectedBeforeHash UTF8String], [beforeHash UTF8String]);
         return 1;
     }
 
@@ -119,11 +119,11 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
     
     if (!removeTree(destination)) {
-        fprintf(stderr, "Failed to remove %s\n", [destination fileSystemRepresentation]);
+        fprintf(stderr, "\nFailed to remove %s\n", [destination fileSystemRepresentation]);
         return 1;
     }
     if (!copyTree(source, destination)) {
-        fprintf(stderr, "Failed to copy %s to %s\n", [source fileSystemRepresentation], [destination fileSystemRepresentation]);
+        fprintf(stderr, "\nFailed to copy %s to %s\n", [source fileSystemRepresentation], [destination fileSystemRepresentation]);
         return 1;
     }
     
@@ -132,6 +132,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     if (verbose) {
         fprintf(stderr, "\nPatching...");
     }
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
     xar_file_t file;
     xar_iter_t iter = xar_iter_new();
     for (file = xar_file_first(x, iter); file; file = xar_file_next(iter)) {
@@ -139,34 +140,63 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         NSString *sourceFilePath = [source stringByAppendingPathComponent:path];
         NSString *destinationFilePath = [destination stringByAppendingPathComponent:path];
 
+        BOOL fileExisted = verbose && [fileManager attributesOfItemAtPath:destinationFilePath error:nil];
+        BOOL removedFile = NO;
+        
         const char *value;
         if (!xar_prop_get(file, DELETE_KEY, &value) ||
             (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_THEN_EXTRACT_OLD_KEY, &value))) {
             if (!removeTree(destinationFilePath)) {
-                fprintf(stderr, "%s or %s: failed to remove %s\n", DELETE_KEY, DELETE_THEN_EXTRACT_OLD_KEY, [destination fileSystemRepresentation]);
+                fprintf(stderr, "\n%s or %s: failed to remove %s\n", DELETE_KEY, DELETE_THEN_EXTRACT_OLD_KEY, [destination fileSystemRepresentation]);
                 return 1;
             }
-            if (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_KEY, &value))
+            if (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_KEY, &value)) {
+                if (verbose) {
+                    fprintf(stderr, "\n❌  %s (Removed)", [path fileSystemRepresentation]);
+                }
                 continue;
+            }
+            
+            removedFile = YES;
         }
 
         if (!xar_prop_get(file, BINARY_DELTA_KEY, &value)) {
             if (!applyBinaryDeltaToFile(x, file, sourceFilePath, destinationFilePath)) {
-                fprintf(stderr, "Unable to patch %s to destination %s\n", [sourceFilePath fileSystemRepresentation], [destinationFilePath fileSystemRepresentation]);
+                fprintf(stderr, "\nUnable to patch %s to destination %s\n", [sourceFilePath fileSystemRepresentation], [destinationFilePath fileSystemRepresentation]);
                 return 1;
+            }
+            
+            if (verbose) {
+                fprintf(stderr, "\n🔨  %s (Delta)", [path fileSystemRepresentation]);
             }
         } else if ((hasExtractKeyAvailable && !xar_prop_get(file, EXTRACT_KEY, &value)) ||
                    (!hasExtractKeyAvailable && xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value))) { // extract and permission modifications don't coexist
+            
             if (xar_extract_tofile(x, file, [destinationFilePath fileSystemRepresentation]) != 0) {
-                fprintf(stderr, "Unable to extract file to %s\n", [destinationFilePath fileSystemRepresentation]);
+                fprintf(stderr, "\nUnable to extract file to %s\n", [destinationFilePath fileSystemRepresentation]);
                 return 1;
             }
+            
+            if (verbose) {
+                if (fileExisted) {
+                    fprintf(stderr, "\n✏️  %s (Replaced)", [path fileSystemRepresentation]);
+                } else {
+                    fprintf(stderr, "\n✅  %s (Added)", [path fileSystemRepresentation]);
+                }
+            }
+        } else if (verbose && removedFile) {
+            fprintf(stderr, "\n❌  %s (Removed)", [path fileSystemRepresentation]);
         }
         
         if (!xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value)) {
-            if (!modifyPermissions(destinationFilePath, (mode_t)[[NSString stringWithUTF8String:value] intValue])) {
-                fprintf(stderr, "Unable to modify permissions (%s) on file %s\n", value, [destinationFilePath fileSystemRepresentation]);
+            mode_t mode = (mode_t)[[NSString stringWithUTF8String:value] intValue];
+            if (!modifyPermissions(destinationFilePath, mode)) {
+                fprintf(stderr, "\nUnable to modify permissions (%s) on file %s\n", value, [destinationFilePath fileSystemRepresentation]);
                 return 1;
+            }
+            
+            if (verbose) {
+                fprintf(stderr, "\n👮  %s (Mode: 0%o)", [path fileSystemRepresentation], mode);
             }
         }
     }
@@ -177,12 +207,12 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
     NSString *afterHash = hashOfTreeWithVersion(destination, majorDiffVersion);
     if (!afterHash) {
-        fprintf(stderr, "Unable to calculate hash of tree %s\n", [destination fileSystemRepresentation]);
+        fprintf(stderr, "\nUnable to calculate hash of tree %s\n", [destination fileSystemRepresentation]);
         return 1;
     }
 
     if (![afterHash isEqualToString:expectedAfterHash]) {
-        fprintf(stderr, "Destination doesn't have expected hash (%s != %s).  Giving up.\n", [expectedAfterHash UTF8String], [afterHash UTF8String]);
+        fprintf(stderr, "\nDestination doesn't have expected hash (%s != %s).  Giving up.\n", [expectedAfterHash UTF8String], [afterHash UTF8String]);
         removeTree(destination);
         return 1;
     }

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -153,7 +153,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
             }
             if (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_KEY, &value)) {
                 if (verbose) {
-                    fprintf(stderr, "\n❌  %s (Removed)", [path fileSystemRepresentation]);
+                    fprintf(stderr, "\n❌  %s %s", VERBOSE_DELETED, [path fileSystemRepresentation]);
                 }
                 continue;
             }
@@ -168,7 +168,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
             }
             
             if (verbose) {
-                fprintf(stderr, "\n🔨  %s (Delta)", [path fileSystemRepresentation]);
+                fprintf(stderr, "\n🔨  %s %s", VERBOSE_PATCHED, [path fileSystemRepresentation]);
             }
         } else if ((hasExtractKeyAvailable && !xar_prop_get(file, EXTRACT_KEY, &value)) ||
                    (!hasExtractKeyAvailable && xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value))) { // extract and permission modifications don't coexist
@@ -180,13 +180,13 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
             
             if (verbose) {
                 if (fileExisted) {
-                    fprintf(stderr, "\n✏️  %s (Replaced)", [path fileSystemRepresentation]);
+                    fprintf(stderr, "\n✏️  %s %s", VERBOSE_UPDATED, [path fileSystemRepresentation]);
                 } else {
-                    fprintf(stderr, "\n✅  %s (Added)", [path fileSystemRepresentation]);
+                    fprintf(stderr, "\n✅  %s %s", VERBOSE_ADDED, [path fileSystemRepresentation]);
                 }
             }
         } else if (verbose && removedFile) {
-            fprintf(stderr, "\n❌  %s (Removed)", [path fileSystemRepresentation]);
+            fprintf(stderr, "\n❌  %s %s", VERBOSE_DELETED, [path fileSystemRepresentation]);
         }
         
         if (!xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value)) {
@@ -197,7 +197,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
             }
             
             if (verbose) {
-                fprintf(stderr, "\n👮  %s (Mode: 0%o)", [path fileSystemRepresentation], mode);
+                fprintf(stderr, "\n👮  %s %s (0%o)", VERBOSE_MODIFIED, [path fileSystemRepresentation], mode);
             }
         }
     }

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -100,6 +100,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
 
     if (verbose) {
+        fprintf(stderr, "Applying version %u.%u patch...\n", majorDiffVersion, minorDiffVersion);
         fprintf(stderr, "Verifying source...");
     }
     

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -141,6 +141,7 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         NSString *sourceFilePath = [source stringByAppendingPathComponent:path];
         NSString *destinationFilePath = [destination stringByAppendingPathComponent:path];
 
+        // Don't use -[NSFileManager fileExistsAtPath:] because it will follow symbolic links
         BOOL fileExisted = verbose && [fileManager attributesOfItemAtPath:destinationFilePath error:nil];
         BOOL removedFile = NO;
         

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -25,7 +25,7 @@ static BOOL applyBinaryDeltaToFile(xar_t x, xar_file_t file, NSString *sourceFil
     return success;
 }
 
-int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile)
+int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose)
 {
     xar_t x = xar_open([patchFile fileSystemRepresentation], READ);
     if (!x) {
@@ -99,7 +99,10 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         return 1;
     }
 
-    fprintf(stdout, "Verifying source...  ");
+    if (verbose) {
+        fprintf(stderr, "Verifying source...");
+    }
+    
     NSString *beforeHash = hashOfTreeWithVersion(source, majorDiffVersion);
     if (!beforeHash) {
         fprintf(stderr, "Unable to calculate hash of tree %s\n", [source fileSystemRepresentation]);
@@ -111,7 +114,10 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         return 1;
     }
 
-    fprintf(stdout, "\nCopying files...  ");
+    if (verbose) {
+        fprintf(stderr, "\nCopying files...");
+    }
+    
     if (!removeTree(destination)) {
         fprintf(stderr, "Failed to remove %s\n", [destination fileSystemRepresentation]);
         return 1;
@@ -123,7 +129,9 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     
     BOOL hasExtractKeyAvailable = MAJOR_VERSION_IS_AT_LEAST(majorDiffVersion, SUBeigeMajorVersion);
 
-    fprintf(stdout, "\nPatching... ");
+    if (verbose) {
+        fprintf(stderr, "\nPatching...");
+    }
     xar_file_t file;
     xar_iter_t iter = xar_iter_new();
     for (file = xar_file_first(x, iter); file; file = xar_file_next(iter)) {
@@ -164,7 +172,9 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
     xar_close(x);
 
-    fprintf(stdout, "\nVerifying destination...  ");
+    if (verbose) {
+        fprintf(stderr, "\nVerifying destination...");
+    }
     NSString *afterHash = hashOfTreeWithVersion(destination, majorDiffVersion);
     if (!afterHash) {
         fprintf(stderr, "Unable to calculate hash of tree %s\n", [destination fileSystemRepresentation]);
@@ -177,6 +187,8 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         return 1;
     }
 
-    fprintf(stdout, "\nDone!\n");
+    if (verbose) {
+        fprintf(stderr, "\nDone!\n");
+    }
     return 0;
 }

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -31,6 +31,14 @@
 #define BEFORE_TREE_SHA1_OLD_KEY "before-sha1"
 #define AFTER_TREE_SHA1_OLD_KEY "after-sha1"
 
+#define VERBOSE_DELETED "Deleted" // file is deleted from the file system when applying a patch
+#define VERBOSE_REMOVED "Removed" // file is set to be removed when creating a patch
+#define VERBOSE_ADDED "Added" // file is added to the patch or file system
+#define VERBOSE_DIFFED "Diffed" // file is diffed when creating a patch
+#define VERBOSE_PATCHED "Patched" // file is patched when applying a patch
+#define VERBOSE_UPDATED "Updated" // file's contents are updated
+#define VERBOSE_MODIFIED "Modified" // file's metadata is modified
+
 #define MAJOR_VERSION_IS_AT_LEAST(actualMajor, expectedMajor) (actualMajor >= expectedMajor)
 
 // Each major version will be assigned a name of a color

--- a/Sparkle/SUBinaryDeltaCreate.h
+++ b/Sparkle/SUBinaryDeltaCreate.h
@@ -12,6 +12,6 @@
 #import "SUBinaryDeltaCommon.h"
 
 @class NSString;
-int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion);
+int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose);
 
 #endif

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -211,6 +211,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     }
 
     if (verbose) {
+        fprintf(stderr, "Creating version %u.%u patch...\n", majorVersion, minorVersion);
         fprintf(stderr, "Processing %s...", [source fileSystemRepresentation]);
     }
     

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -406,7 +406,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
                     if (originalInfo) {
                         fprintf(stderr, "\n✏️  %s %s", VERBOSE_UPDATED, [key fileSystemRepresentation]);
                     } else {
-                        fprintf(stderr, "\n✅  %s (%s)", VERBOSE_ADDED, [key fileSystemRepresentation]);
+                        fprintf(stderr, "\n✅  %s %s", VERBOSE_ADDED, [key fileSystemRepresentation]);
                     }
                 }
             }

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -367,7 +367,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
             xar_prop_set(newFile, DELETE_KEY, "true");
             
             if (verbose) {
-                fprintf(stderr, "\n❌  %s (Removed)", [key fileSystemRepresentation]);
+                fprintf(stderr, "\n❌  %s %s", VERBOSE_REMOVED, [key fileSystemRepresentation]);
             }
             continue;
         }
@@ -382,7 +382,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
                     xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [[NSString stringWithFormat:@"%u", [newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]] UTF8String]);
                     
                     if (verbose) {
-                        fprintf(stderr, "\n👮  %s (Mode: 0%o -> 0%o)", [key fileSystemRepresentation], [originalInfo[INFO_PERMISSIONS_KEY] unsignedShortValue], [newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]);
+                        fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, [key fileSystemRepresentation], [originalInfo[INFO_PERMISSIONS_KEY] unsignedShortValue], [newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]);
                     }
                 }
             } else {
@@ -404,9 +404,9 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
                 
                 if (verbose) {
                     if (originalInfo) {
-                        fprintf(stderr, "\n✏️  %s (Replaced)", [key fileSystemRepresentation]);
+                        fprintf(stderr, "\n✏️  %s %s", VERBOSE_UPDATED, [key fileSystemRepresentation]);
                     } else {
-                        fprintf(stderr, "\n✅  %s (Added)", [key fileSystemRepresentation]);
+                        fprintf(stderr, "\n✅  %s (%s)", VERBOSE_ADDED, [key fileSystemRepresentation]);
                     }
                 }
             }
@@ -431,7 +431,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         }
         
         if (verbose) {
-            fprintf(stderr, "\n🔨  %s (Delta)", [[operation relativePath] fileSystemRepresentation]);
+            fprintf(stderr, "\n🔨  %s %s", VERBOSE_DIFFED, [[operation relativePath] fileSystemRepresentation]);
         }
         
         xar_file_t newFile = xar_add_frompath(x, 0, [[operation relativePath] fileSystemRepresentation], [resultPath fileSystemRepresentation]);
@@ -443,7 +443,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
             xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [[NSString stringWithFormat:@"%u", [operation.permissions unsignedShortValue]] UTF8String]);
             
             if (verbose) {
-                fprintf(stderr, "\n👮  %s (Mode: 0%o -> 0%o)", [[operation relativePath] fileSystemRepresentation], operation.oldPermissions.unsignedShortValue, operation.permissions.unsignedShortValue);
+                fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, [[operation relativePath] fileSystemRepresentation], operation.oldPermissions.unsignedShortValue, operation.permissions.unsignedShortValue);
             }
         }
     }

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -11,68 +11,126 @@
 #import "SUBinaryDeltaCommon.h"
 #include <Foundation/Foundation.h>
 
+#define VERBOSE_FLAG @"--verbose"
+#define VERSION_FLAG @"--version"
+
 static void printUsage(void)
 {
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "BinaryDelta create [--version=<version>] <before-tree> <after-tree> <patch-file>\n");
-    fprintf(stderr, "BinaryDelta apply <before-tree> <after-tree> <patch-file>\n");
+    fprintf(stderr, "BinaryDelta create [--verbose --version=<version>] <before-tree> <after-tree> <patch-file>\n");
+    fprintf(stderr, "BinaryDelta apply [--verbose] <before-tree> <after-tree> <patch-file>\n");
+}
+
+static int runCreateCommand(NSArray *args)
+{
+    if (args.count < 3 || args.count > 5) {
+        printUsage();
+        return 1;
+    }
+    
+    if (args.count == 4 && ![args[0] isEqualToString:VERBOSE_FLAG] && ![args[0] hasPrefix:VERSION_FLAG]) {
+        printUsage();
+        return 1;
+    }
+    
+    if (args.count == 5 && ![args[1] isEqualToString:VERBOSE_FLAG] && ![args[1] hasPrefix:VERSION_FLAG]) {
+        printUsage();
+        return 1;
+    }
+    
+    BOOL verbose =
+        ((args.count == 4 && [args[0] isEqualToString:VERBOSE_FLAG]) ||
+        (args.count == 5 && [args[1] isEqualToString:VERBOSE_FLAG]));
+    
+    NSString *versionField = nil;
+    if (args.count == 4 && [args[0] hasPrefix:VERSION_FLAG]) {
+        versionField = args[0];
+    } else if (args.count == 5 && [args[1] hasPrefix:VERSION_FLAG]) {
+        versionField = args[1];
+    }
+    
+    NSArray *versionComponents = nil;
+    if (versionField) {
+        versionComponents = [versionField componentsSeparatedByString:@"="];
+        if (versionComponents.count != 2) {
+            printUsage();
+            return 1;
+        }
+    }
+    
+    SUBinaryDeltaMajorVersion patchVersion =
+        !versionComponents ?
+        LATEST_DELTA_DIFF_MAJOR_VERSION :
+        (SUBinaryDeltaMajorVersion)[[versionComponents[1] componentsSeparatedByString:@"."][0] intValue]; // ignore minor version if provided
+
+    NSArray *fileArgs = [args subarrayWithRange:NSMakeRange(args.count - 3, 3)];
+    
+    BOOL isDirectory;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:fileArgs[0] isDirectory:&isDirectory] || !isDirectory) {
+        fprintf(stderr, "Usage: before-tree must be a directory\n");
+        return 1;
+    }
+    
+    if (![[NSFileManager defaultManager] fileExistsAtPath:fileArgs[1] isDirectory:&isDirectory] || !isDirectory) {
+        fprintf(stderr, "Usage: after-tree must be a directory\n");
+        return 1;
+    }
+    
+    return createBinaryDelta(fileArgs[0], fileArgs[1], fileArgs[2], patchVersion, verbose);
+}
+
+static int runApplyCommand(NSArray *args)
+{
+    if (args.count < 3 || args.count > 4) {
+        printUsage();
+        return 1;
+    }
+    
+    if (args.count == 4 && ![args[0] isEqualToString:VERBOSE_FLAG]) {
+        printUsage();
+        return 1;
+    }
+    
+    BOOL verbose = (args.count == 4 && [args[0] isEqualToString:VERBOSE_FLAG]);
+    
+    NSArray *fileArgs = [args subarrayWithRange:NSMakeRange(args.count - 3, 3)];
+    
+    BOOL isDirectory;
+    if (![[NSFileManager defaultManager] fileExistsAtPath:fileArgs[0] isDirectory:&isDirectory] || !isDirectory) {
+        fprintf(stderr, "Usage: before-tree must be a directory\n");
+        return 1;
+    }
+    
+    if (![[NSFileManager defaultManager] fileExistsAtPath:fileArgs[2] isDirectory:&isDirectory] || isDirectory) {
+        fprintf(stderr, "Usage: patch-file must be a file %d\n", isDirectory);
+        return 1;
+    }
+    
+    return applyBinaryDelta(fileArgs[0], fileArgs[1], fileArgs[2], verbose);
 }
 
 int main(int __unused argc, char __unused *argv[])
 {
     @autoreleasepool {
         NSArray *args = [[NSProcessInfo processInfo] arguments];
-        if (args.count < 5 || args.count > 6) {
+        if (args.count < 3) {
             printUsage();
             return 1;
         }
 
         NSString *command = args[1];
+        NSArray *commandArguments = [args subarrayWithRange:NSMakeRange(2, args.count - 2)];
         
-        if (![command isEqualToString:@"create"] && args.count > 5) {
-            printUsage();
-            return 1;
-        }
-        
-        SUBinaryDeltaMajorVersion patchVersion;
-        NSString *versionField = ([command isEqualToString:@"create"] && args.count == 6) ? args[2] : nil;
-        if (!versionField) {
-            patchVersion = LATEST_DELTA_DIFF_MAJOR_VERSION;
-        } else {
-            NSArray *versionComponents = [versionField componentsSeparatedByString:@"="];
-            if (versionComponents.count != 2 || ![versionComponents[0] isEqualToString:@"--version"]) {
-                printUsage();
-                return 1;
-            }
-            // Ignore minor version if it's supplied
-            patchVersion = (SUBinaryDeltaMajorVersion)[[versionComponents[1] componentsSeparatedByString:@"."][0] intValue];
-        }
-        
-        NSString *oldPath = args[args.count - 3];
-        NSString *newPath = args[args.count - 2];
-        NSString *patchFile = args[args.count - 1];
-
-        BOOL isDirectory;
-        if (![[NSFileManager defaultManager] fileExistsAtPath:oldPath isDirectory:&isDirectory] || !isDirectory) {
-            fprintf(stderr, "Usage: before-tree must be a directory\n");
-            return 1;
-        }
-
         int result;
-        if ([command isEqualToString:@"apply"]) {
-            result = applyBinaryDelta(oldPath, newPath, patchFile);
-        } else if ([command isEqualToString:@"create"]) {
-            if (![[NSFileManager defaultManager] fileExistsAtPath:newPath isDirectory:&isDirectory] || !isDirectory) {
-                result = 1;
-                fprintf(stderr, "Usage: after-tree must be a directory\n");
-            } else {
-                result = createBinaryDelta(oldPath, newPath, patchFile, patchVersion);
-            }
+        if ([command isEqualToString:@"create"]) {
+            result = runCreateCommand(commandArguments);
+        } else if ([command isEqualToString:@"apply"]) {
+            result = runApplyCommand(commandArguments);
         } else {
             result = 1;
             printUsage();
         }
-
+        
         return result;
     }
 }

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -23,7 +23,7 @@
 static void printUsage(NSString *programName)
 {
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "%s create [--verbose --version=<version>] <before-tree> <after-tree> <patch-file>\n", [programName UTF8String]);
+    fprintf(stderr, "%s create [--verbose] [--version=<version>] <before-tree> <after-tree> <patch-file>\n", [programName UTF8String]);
     fprintf(stderr, "%s apply [--verbose] <before-tree> <after-tree> <patch-file>\n", [programName UTF8String]);
     fprintf(stderr, "%s version [<patch-file>]\n", [programName UTF8String]);
 }

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -10,31 +10,38 @@
 #include "SUBinaryDeltaCreate.h"
 #import "SUBinaryDeltaCommon.h"
 #include <Foundation/Foundation.h>
+#include <xar/xar.h>
 
 #define VERBOSE_FLAG @"--verbose"
 #define VERSION_FLAG @"--version"
 
-static void printUsage(void)
+#define CREATE_COMMAND @"create"
+#define APPLY_COMMAND @"apply"
+#define VERSION_COMMAND @"version"
+#define VERSION_ALTERNATE_COMMAND @"--version"
+
+static void printUsage(NSString *programName)
 {
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "BinaryDelta create [--verbose --version=<version>] <before-tree> <after-tree> <patch-file>\n");
-    fprintf(stderr, "BinaryDelta apply [--verbose] <before-tree> <after-tree> <patch-file>\n");
+    fprintf(stderr, "%s create [--verbose --version=<version>] <before-tree> <after-tree> <patch-file>\n", [programName UTF8String]);
+    fprintf(stderr, "%s apply [--verbose] <before-tree> <after-tree> <patch-file>\n", [programName UTF8String]);
+    fprintf(stderr, "%s version [<patch-file>]\n", [programName UTF8String]);
 }
 
-static int runCreateCommand(NSArray *args)
+static int runCreateCommand(NSString *programName, NSArray *args)
 {
     if (args.count < 3 || args.count > 5) {
-        printUsage();
+        printUsage(programName);
         return 1;
     }
     
     if (args.count == 4 && ![args[0] isEqualToString:VERBOSE_FLAG] && ![args[0] hasPrefix:VERSION_FLAG]) {
-        printUsage();
+        printUsage(programName);
         return 1;
     }
     
     if (args.count == 5 && ![args[1] isEqualToString:VERBOSE_FLAG] && ![args[1] hasPrefix:VERSION_FLAG]) {
-        printUsage();
+        printUsage(programName);
         return 1;
     }
     
@@ -53,7 +60,7 @@ static int runCreateCommand(NSArray *args)
     if (versionField) {
         versionComponents = [versionField componentsSeparatedByString:@"="];
         if (versionComponents.count != 2) {
-            printUsage();
+            printUsage(programName);
             return 1;
         }
     }
@@ -79,15 +86,15 @@ static int runCreateCommand(NSArray *args)
     return createBinaryDelta(fileArgs[0], fileArgs[1], fileArgs[2], patchVersion, verbose);
 }
 
-static int runApplyCommand(NSArray *args)
+static int runApplyCommand(NSString *programName, NSArray *args)
 {
     if (args.count < 3 || args.count > 4) {
-        printUsage();
+        printUsage(programName);
         return 1;
     }
     
     if (args.count == 4 && ![args[0] isEqualToString:VERBOSE_FLAG]) {
-        printUsage();
+        printUsage(programName);
         return 1;
     }
     
@@ -109,12 +116,57 @@ static int runApplyCommand(NSArray *args)
     return applyBinaryDelta(fileArgs[0], fileArgs[1], fileArgs[2], verbose);
 }
 
+static int runVersionCommand(NSString *programName, NSArray *args)
+{
+    if (args.count > 1) {
+        printUsage(programName);
+        return 1;
+    }
+    
+    if (args.count == 0) {
+        fprintf(stdout, "%u.%u\n", LATEST_DELTA_DIFF_MAJOR_VERSION, latestMinorVersionForMajorVersion(LATEST_DELTA_DIFF_MAJOR_VERSION));
+    } else {
+        NSString *patchFile = args[0];
+        xar_t x = xar_open([patchFile fileSystemRepresentation], READ);
+        if (!x) {
+            fprintf(stderr, "Unable to open patch %s\n", [patchFile fileSystemRepresentation]);
+            return 1;
+        }
+        
+        SUBinaryDeltaMajorVersion majorDiffVersion = FIRST_DELTA_DIFF_MAJOR_VERSION;
+        SUBinaryDeltaMinorVersion minorDiffVersion = FIRST_DELTA_DIFF_MINOR_VERSION;
+        
+        xar_subdoc_t subdoc;
+        for (subdoc = xar_subdoc_first(x); subdoc; subdoc = xar_subdoc_next(subdoc)) {
+            if (!strcmp(xar_subdoc_name(subdoc), BINARY_DELTA_ATTRIBUTES_KEY)) {
+                const char *value = 0;
+                
+                // available in version 2.0 or later
+                xar_subdoc_prop_get(subdoc, MAJOR_DIFF_VERSION_KEY, &value);
+                if (value)
+                    majorDiffVersion = (SUBinaryDeltaMajorVersion)[@(value) intValue];
+                
+                // available in version 2.0 or later
+                xar_subdoc_prop_get(subdoc, MINOR_DIFF_VERSION_KEY, &value);
+                if (value)
+                    minorDiffVersion = (SUBinaryDeltaMinorVersion)[@(value) intValue];
+            }
+        }
+        
+        fprintf(stdout, "%u.%u\n", majorDiffVersion, minorDiffVersion);
+    }
+    
+    return 0;
+}
+
 int main(int __unused argc, char __unused *argv[])
 {
     @autoreleasepool {
         NSArray *args = [[NSProcessInfo processInfo] arguments];
-        if (args.count < 3) {
-            printUsage();
+        NSString *programName = [args[0] lastPathComponent];
+        
+        if (args.count < 2) {
+            printUsage(programName);
             return 1;
         }
 
@@ -122,13 +174,15 @@ int main(int __unused argc, char __unused *argv[])
         NSArray *commandArguments = [args subarrayWithRange:NSMakeRange(2, args.count - 2)];
         
         int result;
-        if ([command isEqualToString:@"create"]) {
-            result = runCreateCommand(commandArguments);
-        } else if ([command isEqualToString:@"apply"]) {
-            result = runApplyCommand(commandArguments);
+        if ([command isEqualToString:CREATE_COMMAND]) {
+            result = runCreateCommand(programName, commandArguments);
+        } else if ([command isEqualToString:APPLY_COMMAND]) {
+            result = runApplyCommand(programName, commandArguments);
+        } else if ([command isEqualToString:VERSION_COMMAND] || [command isEqualToString:VERSION_ALTERNATE_COMMAND]) {
+            result = runVersionCommand(programName, commandArguments);
         } else {
             result = 1;
-            printUsage();
+            printUsage(programName);
         }
         
         return result;

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -39,13 +39,13 @@ static int runCreateCommand(NSArray *args)
     }
     
     BOOL verbose =
-        ((args.count == 4 && [args[0] isEqualToString:VERBOSE_FLAG]) ||
-        (args.count == 5 && [args[1] isEqualToString:VERBOSE_FLAG]));
+        ((args.count >= 4 && [args[0] isEqualToString:VERBOSE_FLAG]) ||
+        (args.count >= 5 && [args[1] isEqualToString:VERBOSE_FLAG]));
     
     NSString *versionField = nil;
-    if (args.count == 4 && [args[0] hasPrefix:VERSION_FLAG]) {
+    if (args.count >= 4 && [args[0] hasPrefix:VERSION_FLAG]) {
         versionField = args[0];
-    } else if (args.count == 5 && [args[1] hasPrefix:VERSION_FLAG]) {
+    } else if (args.count >= 5 && [args[1] hasPrefix:VERSION_FLAG]) {
         versionField = args[1];
     }
     

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -26,7 +26,7 @@
         NSString *sourcePath = [[self.updateHost bundle] bundlePath];
         NSString *targetPath = [[self.archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:[sourcePath lastPathComponent]];
 
-        int result = applyBinaryDelta(sourcePath, targetPath, self.archivePath);
+        int result = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO);
 		if (!result) {
 			dispatch_async(dispatch_get_main_queue(), ^{
 				[self notifyDelegateOfSuccess];

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -58,13 +58,13 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     }
     
     BOOL createdDiff =
-    (createBinaryDelta(sourceDirectory, destinationDirectory, diffFile, majorVersion) == 0);
+    (createBinaryDelta(sourceDirectory, destinationDirectory, diffFile, majorVersion, NO) == 0);
     
     if (createdDiff && afterDiffHandler != nil) {
         afterDiffHandler(fileManager, sourceDirectory, destinationDirectory);
     }
     
-    BOOL appliedDiff = (createdDiff && applyBinaryDelta(sourceDirectory, patchDirectory, diffFile) == 0);
+    BOOL appliedDiff = (createdDiff && applyBinaryDelta(sourceDirectory, patchDirectory, diffFile, NO) == 0);
     
     XCTAssertTrue([fileManager removeItemAtPath:sourceDirectory error:nil]);
     XCTAssertTrue([fileManager removeItemAtPath:destinationDirectory error:nil]);


### PR DESCRIPTION
Just added more logging when creating/applying patches to show what the program is doing when --verbose is supplied (no logging if it's not except for errors), redirected logging messages to stderr, and added a version option to obtain the version of BinaryDelta running and the version from a specified patch file.

![Diff screenshot](http://zgcoder.net/zfw/images/2015-04-19-18-44-40-EDT-40938.png)