### PR TITLE
Improved app update validation

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -228,8 +228,14 @@
         return NO;
     }
     
-    NSString *newBundlePath = [SUInstaller appPathInUpdateFolder:extractedPath forHost:self.host];
+    BOOL isPackage = NO;
+    NSString *newBundlePath = [SUInstaller installSourcePathInUpdateFolder:extractedPath forHost:self.host isPackage:&isPackage isGuided:NULL];
     if (!newBundlePath) {
+        SULog(@"No suitable install is found in the update. The update will be rejected.");
+        return NO;
+    }
+    
+    if (isPackage) {
         return canValidateByDSASignature;
     }
     

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -249,7 +249,7 @@
     NSString *newPublicDSAKey = newHost.publicDSAKey;
     
     if (newPublicDSAKey != nil) {
-        if (![SUDSAVerifier validatePath:downloadedPath withEncodedDSASignature:DSASignature withPublicDSAKey:publicDSAKey]) {
+        if (![SUDSAVerifier validatePath:downloadedPath withEncodedDSASignature:DSASignature withPublicDSAKey:newPublicDSAKey]) {
             SULog(@"DSA signature validation failed. The update will be rejected.");
             return NO;
         }

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -231,7 +231,8 @@
         return (DSASignature != nil);
     }
     
-    BOOL canValidateByCodeSignature = [SUCodeSigningVerifier hostApplicationIsCodeSigned] && [SUCodeSigningVerifier applicationAtPathIsCodeSigned:newBundlePath];
+    BOOL isAppCodeSigned = [SUCodeSigningVerifier applicationAtPathIsCodeSigned:newBundlePath];
+    BOOL canValidateByCodeSignature = isAppCodeSigned && [SUCodeSigningVerifier hostApplicationIsCodeSigned];
 
     if (!DSASignature && !canValidateByCodeSignature) {
         SULog(@"The appcast item for the update has no DSA signature. The update will be rejected, because both DSA and Apple Code Signing verification failed.");
@@ -241,7 +242,7 @@
     NSError *error = nil;
     
     if (DSASignature) {
-        if (canValidateByCodeSignature && ![SUCodeSigningVerifier codeSignatureIsValidAtPath:newBundlePath error:&error]) {
+        if (isAppCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtPath:newBundlePath error:&error]) {
             SULog(@"The application to update has an invalid code signature: %@. The update will be rejected.", error);
             return NO;
         }

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -264,7 +264,7 @@
         }
     } else {
         if (![SUCodeSigningVerifier hostApplicationIsCodeSigned] || ![SUCodeSigningVerifier applicationAtPathIsCodeSigned:installSourcePath]) {
-            SULog(@"Public DSA keys differ and both apps are not code signed. The update will be rejected.");
+            SULog(@"Public DSA keys differ or are absent, and both apps are not code signed. The update will be rejected.");
             return NO;
         }
         

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -229,8 +229,8 @@
     }
     
     BOOL isPackage = NO;
-    NSString *newBundlePath = [SUInstaller installSourcePathInUpdateFolder:extractedPath forHost:self.host isPackage:&isPackage isGuided:NULL];
-    if (!newBundlePath) {
+    NSString *installSourcePath = [SUInstaller installSourcePathInUpdateFolder:extractedPath forHost:self.host isPackage:&isPackage isGuided:NULL];
+    if (!installSourcePath) {
         SULog(@"No suitable install is found in the update. The update will be rejected.");
         return NO;
     }
@@ -239,7 +239,7 @@
         return canValidateByDSASignature;
     }
     
-    BOOL isAppCodeSigned = [SUCodeSigningVerifier applicationAtPathIsCodeSigned:newBundlePath];
+    BOOL isAppCodeSigned = [SUCodeSigningVerifier applicationAtPathIsCodeSigned:installSourcePath];
     BOOL canValidateByCodeSignature = isAppCodeSigned && [SUCodeSigningVerifier hostApplicationIsCodeSigned];
 
     if (!canValidateByDSASignature && !canValidateByCodeSignature) {
@@ -250,12 +250,12 @@
     NSError *error = nil;
     
     if (canValidateByDSASignature) {
-        if (isAppCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtPath:newBundlePath error:&error]) {
+        if (isAppCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtPath:installSourcePath error:&error]) {
             SULog(@"The application to update has an invalid code signature: %@. The update will be rejected.", error);
             return NO;
         }
     } else {
-        if (![SUCodeSigningVerifier codeSignatureMatchesHostAndIsValidAtPath:newBundlePath error:&error]) {
+        if (![SUCodeSigningVerifier codeSignatureMatchesHostAndIsValidAtPath:installSourcePath error:&error]) {
             SULog(@"The update will be rejected, because DSA verification failed and the code signature from the original and updated application failed to match: %@", error);
             return NO;
         }

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -249,11 +249,6 @@
     NSString *newPublicDSAKey = newHost.publicDSAKey;
     
     if (newPublicDSAKey != nil) {
-        if (DSASignature == nil) {
-            SULog(@"No DSA signature is found in the appcast item. The update will be rejected.");
-            return NO;
-        }
-        
         if (![SUDSAVerifier validatePath:downloadedPath withEncodedDSASignature:DSASignature withPublicDSAKey:publicDSAKey]) {
             SULog(@"DSA signature validation failed. The update will be rejected.");
             return NO;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -264,7 +264,7 @@
         }
     } else {
         if (![SUCodeSigningVerifier hostApplicationIsCodeSigned] || ![SUCodeSigningVerifier applicationAtPathIsCodeSigned:installSourcePath]) {
-            SULog(@"Pubic DSA keys differ and both apps are not code signed. The update will be rejected.");
+            SULog(@"Public DSA keys differ and both apps are not code signed. The update will be rejected.");
             return NO;
         }
         

--- a/Sparkle/SUInstaller.h
+++ b/Sparkle/SUInstaller.h
@@ -15,7 +15,7 @@
 @class SUHost;
 @interface SUInstaller : NSObject
 
-+ (NSString *)appPathInUpdateFolder:(NSString *)updateFolder forHost:(SUHost *)host;
++ (NSString *)installSourcePathInUpdateFolder:(NSString *)inUpdateFolder forHost:(SUHost *)host isPackage:(BOOL *)isPackagePtr isGuided:(BOOL *)isGuidedPtr;
 + (void)installFromUpdateFolder:(NSString *)updateFolder overHost:(SUHost *)host installationPath:(NSString *)installationPath versionComparator:(id<SUVersionComparison>)comparator completionHandler:(void (^)(NSError *))completionHandler;
 + (void)finishInstallationToPath:(NSString *)installationPath withResult:(BOOL)result error:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler;
 + (NSString *)updateFolder;

--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -121,13 +121,6 @@ static NSString *sUpdateFolder = nil;
     return newAppDownloadPath;
 }
 
-+ (NSString *)appPathInUpdateFolder:(NSString *)updateFolder forHost:(SUHost *)host
-{
-    BOOL isPackage = NO;
-    NSString *path = [self installSourcePathInUpdateFolder:updateFolder forHost:host isPackage:&isPackage isGuided:nil];
-    return isPackage ? nil : path;
-}
-
 + (void)installFromUpdateFolder:(NSString *)inUpdateFolder overHost:(SUHost *)host installationPath:(NSString *)installationPath versionComparator:(id<SUVersionComparison>)comparator completionHandler:(void (^)(NSError *))completionHandler
 {
     BOOL isPackage = NO;


### PR DESCRIPTION
See discussion in issue #523

If an invalid DSA or invalid code signature is provided, the update will fail, regardless if one of these requirements is valid. The logic before is that the update will succeed if either a valid DSA or matched code signature is provided.

This still allows a code signature to change, be added, or be removed, as long as the DSA and the code signature (if provided) is valid. If no DSA is provided, then this is not possible, and the code signature from the host and update app must match.

I've not yet looked how feasible it'd be to create automated tests for this method, and also do not know how to run the pkg test with xctest.

[edit]: Shrug. It's also worth mentioning that code signature verification will be skipped if newBundlePath == nil, for example when the executable name changes as is the case with Sparkle's test application.