### PR TITLE
Properly import Foundation to fix errors when building as a module

### DIFF
--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -9,7 +9,7 @@
 #ifndef SUAPPCAST_H
 #define SUAPPCAST_H
 
-#import <Foundation/NSURLDownload.h>
+#import <Foundation/Foundation.h>
 #import "SUExport.h"
 
 @class SUAppcastItem;


### PR DESCRIPTION
I was seeing errors like

```
SUAppcast.h:19:18: Declaration of 'NSDictionary' must be imported from module 'Foundation.NSDictionary' before it is required
SUAppcastItem.h:16:28: Declaration of 'NSDate' must be imported from module 'Foundation.NSDate' before it is required
```

This PR addresses that, by importing the Foundation framework's umbrella header into `SUAppcast.h`.