### PR TITLE
Only check if new path is code signed

### DIFF
--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -32,14 +32,11 @@
         NSError *error = nil;
         NSString *oldPath = [host bundlePath];
         NSString *tempName = [self temporaryNameForPath:[host installationPath]];
-        BOOL hostIsCodeSigned = [SUCodeSigningVerifier applicationAtPathIsCodeSigned:oldPath];
 
         BOOL result = [self copyPathWithAuthentication:path overPath:installationPath temporaryName:tempName error:&error];
         
         if (result) {
-            // If the host is code signed, then the replacement should be be too (and the signature should be valid).
-            BOOL needToCheckCodeSignature = (hostIsCodeSigned || [SUCodeSigningVerifier applicationAtPathIsCodeSigned:installationPath]);
-            if (needToCheckCodeSignature) {
+            if ([SUCodeSigningVerifier applicationAtPathIsCodeSigned:installationPath]) {
                 result = [SUCodeSigningVerifier codeSignatureIsValidAtPath:installationPath error:&error];
             }
         }


### PR DESCRIPTION
If the original app is signed, and the update is not, this is actually fine if the DSA validation goes through. And this may be desirable for people that don't want to pay cash to code sign their application anymore.

See issue #523 where this change was brought in.