### PR TITLE
Fix appcastDidFinishLoading: incomplete implementation warning

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -27,6 +27,7 @@
 - (BOOL)hostSupportsItem:(SUAppcastItem *)ui;
 - (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui;
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui;
+- (void)appcastDidFinishLoading:(SUAppcast *)ac;
 - (void)didFindValidUpdate;
 - (void)didNotFindUpdate;
 

--- a/Sparkle/SUUIBasedUpdateDriver.h
+++ b/Sparkle/SUUIBasedUpdateDriver.h
@@ -20,7 +20,6 @@
 - (void)showModalAlert:(NSAlert *)alert;
 - (IBAction)cancelDownload:(id)sender;
 - (void)installAndRestart:(id)sender;
-- (void)appcastDidFinishLoading:(SUAppcast *)ac;
 
 @end
 


### PR DESCRIPTION
`appcastDidFinishLoading:` was declared in `SUUIBasedUpdateDriver`, but defined and used in `SUUIBasedUpdateDriver`. This caused the following warning when building Sparkle:
```
SUUIBasedUpdateDriver.m:24:17: warning: method definition for 'appcastDidFinishLoading:' not found [-Wincomplete-implementation]
@implementation SUUIBasedUpdateDriver
                ^
In file included from SUUIBasedUpdateDriver.m:9:
SUUIBasedUpdateDriver.h:23:1: note: method 'appcastDidFinishLoading:' declared here
- (void)appcastDidFinishLoading:(SUAppcast *)ac;
^
```

This PR moves the declaration back to the base class where I think it belongs: it’s both defined and more importantly, *used* from the base class, so it seems the code currently only compiles & works thanks to Objective-C’s dynamic nature.