### PR TITLE
BinaryDelta Code Signed Extended Attributes Validation

### DIFF
--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -16,6 +16,10 @@
 #define IS_VALID_PERMISSIONS(mode) \
     (((mode & PERMISSION_FLAGS) == 0755) || ((mode & PERMISSION_FLAGS) == 0644))
 
+#define APPLE_CODE_SIGN_XATTR_CODE_DIRECTORY_KEY "com.apple.cs.CodeDirectory"
+#define APPLE_CODE_SIGN_XATTR_CODE_REQUIREMENTS_KEY "com.apple.cs.CodeRequirements"
+#define APPLE_CODE_SIGN_XATTR_CODE_SIGNATURE_KEY "com.apple.cs.CodeSignature"
+
 #define BINARY_DELTA_ATTRIBUTES_KEY "binary-delta-attributes"
 #define MAJOR_DIFF_VERSION_KEY "major-version"
 #define MINOR_DIFF_VERSION_KEY "minor-version"

--- a/Sparkle/SUBinaryDeltaCommon.h
+++ b/Sparkle/SUBinaryDeltaCommon.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(uint16_t, SUBinaryDeltaMajorVersion)
 typedef NS_ENUM(uint16_t, SUBinaryDeltaMinorVersion)
 {
     SUAzureMinorVersion = 1,
-    SUBeigeMinorVersion = 0,
+    SUBeigeMinorVersion = 1,
 };
 
 #define FIRST_DELTA_DIFF_MAJOR_VERSION SUAzureMajorVersion

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -273,7 +273,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         }
         
         if (codeSignatureExtendedAttributeExists(ent)) {
-            fprintf(stderr, "\nDiffing code signed extended attributes is not supported yet. Detected extended attribute in before-tree on file %s\n", ent->fts_path);
+            fprintf(stderr, "\nDiffing code signed extended attributes are not supported. Detected extended attribute in before-tree on file %s\n", ent->fts_path);
             return 1;
         }
     }
@@ -335,7 +335,7 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         }
         
         if (codeSignatureExtendedAttributeExists(ent)) {
-            fprintf(stderr, "\nDiffing code signed extended attributes is not supported yet. Detected extended attribute in after-tree on file %s\n", ent->fts_path);
+            fprintf(stderr, "\nDiffing code signed extended attributes are not supported. Detected extended attribute in after-tree on file %s\n", ent->fts_path);
             return 1;
         }
         

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -124,6 +124,7 @@ static bool codeSignatureExtendedAttributeExists(const FTSENT *ent)
             if (strncmp("com.apple.cs.CodeDirectory", attribute, length) == 0 ||
                 strncmp("com.apple.cs.CodeRequirements", attribute, length) == 0 ||
                 strncmp("com.apple.cs.CodeSignature", attribute, length) == 0) {
+                free(buffer);
                 return true;
             }
             startCharacterIndex = characterIndex + 1;

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -323,6 +323,9 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         // We should validate permissions and ACLs even if we don't store the info in the diff in the case of ACLs,
         // or in the case of permissions if the patch version is 1
         
+        // We should also not allow files with code signed extended attributes since Apple doesn't recommend inserting these
+        // inside an application, and since we don't preserve extended attribitutes anyway
+        
         mode_t permissions = [info[INFO_PERMISSIONS_KEY] unsignedShortValue];
         if (!IS_VALID_PERMISSIONS(permissions)) {
             fprintf(stderr, "\nInvalid file permissions after-tree on file %s\nOnly permissions with modes 0755 and 0644 are supported\n", ent->fts_path);

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -121,9 +121,9 @@ static bool codeSignatureExtendedAttributeExists(const FTSENT *ent)
         if (buffer[characterIndex] == '\0') {
             char *attribute = &buffer[startCharacterIndex];
             size_t length = characterIndex - startCharacterIndex;
-            if (strncmp("com.apple.cs.CodeDirectory", attribute, length) == 0 ||
-                strncmp("com.apple.cs.CodeRequirements", attribute, length) == 0 ||
-                strncmp("com.apple.cs.CodeSignature", attribute, length) == 0) {
+            if (strncmp(APPLE_CODE_SIGN_XATTR_CODE_DIRECTORY_KEY, attribute, length) == 0 ||
+                strncmp(APPLE_CODE_SIGN_XATTR_CODE_REQUIREMENTS_KEY, attribute, length) == 0 ||
+                strncmp(APPLE_CODE_SIGN_XATTR_CODE_SIGNATURE_KEY, attribute, length) == 0) {
                 free(buffer);
                 return true;
             }


### PR DESCRIPTION
Apparently it is possible to code-sign any kind of non-mach-o binary file, such as a helper tool written in a scripting language that is marked as executable. The code signature information in this case is stored in the file's extended attributes. Unlike other kinds of extended attributes, these ones are important since they can invalidate the signature on an application if they're not present or if they're wrong, assuming these files are in a directory that should contain signed files.

The good news apparently is that Apple doesn't recommend using signed non-mach-o files inside an app and recommends inserting scripts in the app's Resources directory for example rather than making them executable and signing them. This means all we have to do is abort if we encounter files with a signed extended attribute, which is good because we don't preserve extended attributes in other circumstances anyway.

In the end, this pull request serves as a validation for not creating a diff when code-signed xattr files are around.