### PR TITLE
builddir: use predefined BUILDDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all localizable-strings release build test travis
 
-BUILDDIR := $(shell mktemp -d "$(TMPDIR)/Sparkle.XXXXXX")
+ifndef BUILDDIR
+    BUILDDIR := $(shell mktemp -d "$(TMPDIR)/Sparkle.XXXXXX")
+endif
 
 localizable-strings:
 	rm -f Sparkle/en.lproj/Sparkle.strings


### PR DESCRIPTION
This commit allows user to control where Sparkle will be build

This can be useful when using Docker builder. Since BUILDIR is generated with a temp directory, it can be difficult for a script to know where to look for the final .framework. Instead exporting BUILDIR before compilation allows to determine where to look/link to Sparkle. 
Test:
export BUILDIR=$(pwd)
make release
unset BUILDIR
make release

