### PR TITLE
Add script to generate a report comparing the Sparkle.strings files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,5 @@ ci:
 	done
 
 check-localizations:
-	xcrun swiftc -sdk `xcrun --show-sdk-path` -o "$(TMPDIR)/CheckLocalizations" Sparkle/CheckLocalizations.swift
-	"$(TMPDIR)/CheckLocalizations" -root . -htmlPath "$(TMPDIR)/LocalizationsReport.htm"
+	./Sparkle/CheckLocalizations.swift -root . -htmlPath "$(TMPDIR)/LocalizationsReport.htm"
 	open "$(TMPDIR)/LocalizationsReport.htm"

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,8 @@ ci:
 			xcodebuild -sdk "macosx10.$$i" -scheme Distribution -configuration Debug test ; \
 		fi ; \
 	done
+
+check-localizations:
+	xcrun swiftc -sdk `xcrun --show-sdk-path` -o "$(TMPDIR)/CheckLocalizations" Sparkle/CheckLocalizations.swift
+	"$(TMPDIR)/CheckLocalizations" . "$(TMPDIR)/LocalizationsReport.htm"
+	open "$(TMPDIR)/LocalizationsReport.htm"

--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ ci:
 
 check-localizations:
 	xcrun swiftc -sdk `xcrun --show-sdk-path` -o "$(TMPDIR)/CheckLocalizations" Sparkle/CheckLocalizations.swift
-	"$(TMPDIR)/CheckLocalizations" . "$(TMPDIR)/LocalizationsReport.htm"
+	"$(TMPDIR)/CheckLocalizations" -root . -htmlPath "$(TMPDIR)/LocalizationsReport.htm"
 	open "$(TMPDIR)/LocalizationsReport.htm"

--- a/Sparkle/CheckLocalizations.swift
+++ b/Sparkle/CheckLocalizations.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+let args = NSProcessInfo.processInfo().arguments
+if args.count < 3 {
+    println("ERROR: Missing arguments.")
+    exit(1)
+}
+let sparkleRoot = args[1] as! String
+let htmlPath = args[2] as! String
+
+let enStringsPath = sparkleRoot + "/Sparkle/en.lproj/Sparkle.strings"
+let enStringsDict = NSDictionary(contentsOfFile: enStringsPath)
+if enStringsDict == nil {
+    println("ERROR: Invalid English strings.")
+    exit(1)
+}
+let enStringsDictKeys = enStringsDict!.allKeys
+
+let dirPath = sparkleRoot + "/Sparkle"
+let dirContents = NSFileManager.defaultManager().contentsOfDirectoryAtPath(dirPath, error: nil) as! [String]
+let css =
+    "body { font-family: sans-serif; font-size: 10pt; }" +
+    "h1 { font-size: 12pt; }"  +
+    ".missing { background-color: #FFBABA; color: #D6010E; }"  +
+    ".unused { background-color: #BDE5F8; color: #00529B; }" +
+    ".unlocalized { background-color: #FEEFB3; color: #9F6000; }"
+var html = "<!DOCTYPE html>\n<html><head><meta charset=\"UTF-8\">\n<title>Localizations</title>\n<style>\(css)</style>\n</head><body>\n"
+let locale = NSLocale.currentLocale()
+for dirEntry in dirContents {
+    if dirEntry.pathExtension != "lproj" || dirEntry == "en.lproj" {
+        continue
+    }
+    
+    let lang = locale.displayNameForKey(NSLocaleLanguageCode, value: dirEntry.stringByDeletingPathExtension)
+    html += "<h1>\(dirEntry) (\(lang!))</h1>\n"
+    
+    let stringsPath = dirPath.stringByAppendingPathComponent(dirEntry).stringByAppendingPathComponent("Sparkle.strings")
+    let stringsDict = NSDictionary(contentsOfFile: stringsPath)
+    if stringsDict == nil {
+        println("  ERROR: Invalid strings file \(dirEntry)")
+        continue
+    }
+    
+    var missing: [String] = []
+    var unlocalized: [String] = []
+    var unused: [String] = []
+    
+    for key in enStringsDictKeys {
+        let str = stringsDict?.objectForKey(key) as? String
+        if str == nil {
+            missing.append(key as! String)
+        } else if let enStr = enStringsDict?.objectForKey(key) as? String {
+            if enStr == str {
+                unlocalized.append(key as! String)
+            }
+        }
+    }
+
+    let stringsDictKeys = stringsDict!.allKeys
+    for key in stringsDictKeys {
+        if enStringsDict?.objectForKey(key) == nil {
+            unused.append(key as! String)
+        }
+    }
+    
+    let sorter = { (s1: String, s2: String) -> Bool in
+        return s1 < s2
+    }
+    missing.sort(sorter)
+    unlocalized.sort(sorter)
+    unused.sort(sorter)
+    
+    for key in missing {
+        html += "<span class=\"missing\">Missing \"\(key)\"</span><br/>\n"
+    }
+    for key in unlocalized {
+        html += "<span class=\"unlocalized\">Unlocalized \"\(key)\"</span><br/>\n"
+    }
+    for key in unused {
+        html += "<span class=\"unused\">Unused \"\(key)\"</span><br/>\n"
+    }
+}
+html += "</body></html>"
+
+var err: NSError?
+if !html.writeToFile(htmlPath, atomically: true, encoding: NSUTF8StringEncoding, error: &err) {
+    println("ERROR: Can't write report: \(err)")
+    exit(1)
+}

--- a/Sparkle/CheckLocalizations.swift
+++ b/Sparkle/CheckLocalizations.swift
@@ -12,21 +12,21 @@ func escapeHTML(str: String) -> String {
     die("NSXMLNode failure"); return ""
 }
 
-let args = NSProcessInfo.processInfo().arguments
-if args.count < 3 {
+let ud = NSUserDefaults.standardUserDefaults()
+let sparkleRoot = ud.objectForKey("root") as? String
+let htmlPath = ud.objectForKey("htmlPath") as? String
+if sparkleRoot == nil || htmlPath == nil {
     die("Missing arguments")
 }
-let sparkleRoot = args[1] as! String
-let htmlPath = args[2] as! String
 
-let enStringsPath = sparkleRoot + "/Sparkle/en.lproj/Sparkle.strings"
+let enStringsPath = sparkleRoot! + "/Sparkle/en.lproj/Sparkle.strings"
 let enStringsDict = NSDictionary(contentsOfFile: enStringsPath)
 if enStringsDict == nil {
     die("Invalid English strings")
 }
 let enStringsDictKeys = enStringsDict!.allKeys
 
-let dirPath = sparkleRoot + "/Sparkle"
+let dirPath = sparkleRoot! + "/Sparkle"
 let dirContents = NSFileManager.defaultManager().contentsOfDirectoryAtPath(dirPath, error: nil) as! [String]
 let css =
     "body { font-family: sans-serif; font-size: 10pt; }" +
@@ -93,6 +93,6 @@ for dirEntry in dirContents {
 html += "</body></html>"
 
 var err: NSError?
-if !html.writeToFile(htmlPath, atomically: true, encoding: NSUTF8StringEncoding, error: &err) {
+if !html.writeToFile(htmlPath!, atomically: true, encoding: NSUTF8StringEncoding, error: &err) {
     die("Can't write report: \(err)")
 }

--- a/Sparkle/CheckLocalizations.swift
+++ b/Sparkle/CheckLocalizations.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+func escapeHTML(str: String) -> String {
+    if let node = NSXMLNode.textWithStringValue(str) as? NSXMLNode {
+        return node.XMLString
+    }
+    return ""
+}
+
 let args = NSProcessInfo.processInfo().arguments
 if args.count < 3 {
     println("ERROR: Missing arguments.")
@@ -71,13 +78,13 @@ for dirEntry in dirContents {
     unused.sort(sorter)
     
     for key in missing {
-        html += "<span class=\"missing\">Missing \"\(key)\"</span><br/>\n"
+        html += "<span class=\"missing\">Missing \"\(escapeHTML(key))\"</span><br/>\n"
     }
     for key in unlocalized {
-        html += "<span class=\"unlocalized\">Unlocalized \"\(key)\"</span><br/>\n"
+        html += "<span class=\"unlocalized\">Unlocalized \"\(escapeHTML(key))\"</span><br/>\n"
     }
     for key in unused {
-        html += "<span class=\"unused\">Unused \"\(key)\"</span><br/>\n"
+        html += "<span class=\"unused\">Unused \"\(escapeHTML(key))\"</span><br/>\n"
     }
 }
 html += "</body></html>"

--- a/Sparkle/CheckLocalizations.swift
+++ b/Sparkle/CheckLocalizations.swift
@@ -1,16 +1,20 @@
 import Foundation
 
+func die(msg: String) {
+    println("ERROR: \(msg)")
+    exit(1)
+}
+
 func escapeHTML(str: String) -> String {
     if let node = NSXMLNode.textWithStringValue(str) as? NSXMLNode {
         return node.XMLString
     }
-    return ""
+    die("NSXMLNode failure"); return ""
 }
 
 let args = NSProcessInfo.processInfo().arguments
 if args.count < 3 {
-    println("ERROR: Missing arguments.")
-    exit(1)
+    die("Missing arguments")
 }
 let sparkleRoot = args[1] as! String
 let htmlPath = args[2] as! String
@@ -18,8 +22,7 @@ let htmlPath = args[2] as! String
 let enStringsPath = sparkleRoot + "/Sparkle/en.lproj/Sparkle.strings"
 let enStringsDict = NSDictionary(contentsOfFile: enStringsPath)
 if enStringsDict == nil {
-    println("ERROR: Invalid English strings.")
-    exit(1)
+    die("Invalid English strings")
 }
 let enStringsDictKeys = enStringsDict!.allKeys
 
@@ -44,7 +47,7 @@ for dirEntry in dirContents {
     let stringsPath = dirPath.stringByAppendingPathComponent(dirEntry).stringByAppendingPathComponent("Sparkle.strings")
     let stringsDict = NSDictionary(contentsOfFile: stringsPath)
     if stringsDict == nil {
-        println("  ERROR: Invalid strings file \(dirEntry)")
+        die("Invalid strings file \(dirEntry)")
         continue
     }
     
@@ -91,6 +94,5 @@ html += "</body></html>"
 
 var err: NSError?
 if !html.writeToFile(htmlPath, atomically: true, encoding: NSUTF8StringEncoding, error: &err) {
-    println("ERROR: Can't write report: \(err)")
-    exit(1)
+    die("Can't write report: \(err)")
 }

--- a/Sparkle/CheckLocalizations.swift
+++ b/Sparkle/CheckLocalizations.swift
@@ -1,3 +1,5 @@
+#!/usr/bin/xcrun swift
+
 import Foundation
 
 func die(msg: String) {


### PR DESCRIPTION
This is a Swift script that generates an HTML report comparing the localized strings files to the English version. It will show keys that are missing, unused, and unlocalized.

Already one benefit is it's revealing a bug where the key "You're up to date!" needs to be changed to "You're up-to-date!" in some files to pull in the localization.

This could be expanded to run in a special mode where it could check for unused localizations and report an error, which could be ran from the `ci` target to catch bugs with localization changes, but if that were to happen, it may need to be rewritten in a language that works on older Xcode versions (Python may do).