### PR TITLE
Use bundleForClass instead of finding bundle by ID

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -419,7 +419,7 @@
         [updaterDelegate updater:self.updater willInstallUpdate:self.updateItem];
     }
 
-    NSBundle *sparkleBundle = [NSBundle bundleWithIdentifier:SUBundleIdentifier];
+    NSBundle *sparkleBundle = self.host.sparkleBundle;
 
     // Copy the relauncher into a temporary directory so we can get to it after the new version's installed.
     // Only the paranoid survive: if there's already a stray copy of relaunch there, we would have problems.
@@ -429,8 +429,9 @@
         // Only the paranoid survive: if there's already a stray copy of relaunch there, we would have problems.
         NSError *error = nil;
         [[NSFileManager defaultManager] createDirectoryAtPath:[targetPath stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:@{} error:&error];
-
-        if ([SUPlainInstaller copyPathWithAuthentication:relaunchPathToCopy overPath:targetPath temporaryName:nil error:&error]) {
+        
+        BOOL appendVersion = [[sparkleBundle infoDictionary][SUAppendVersionNumberKey] boolValue];
+        if ([SUPlainInstaller copyPathWithAuthentication:relaunchPathToCopy overPath:targetPath temporaryName:nil appendVersion:appendVersion error:&error]) {
             self.relaunchPath = targetPath;
         } else {
             [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:@{

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -14,6 +14,7 @@
 @interface SUHost : NSObject
 
 @property (strong, readonly) NSBundle *bundle;
+@property (strong, readonly) NSBundle *sparkleBundle;
 
 + (NSString *)systemVersionString;
 

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -25,7 +25,7 @@ typedef struct {
 
 @interface SUHost ()
 
-@property (strong, readwrite) NSBundle *bundle;
+@property (strong, readwrite) NSBundle *bundle, *sparkleBundle;
 @property (copy) NSString *defaultsDomain;
 @property (assign) BOOL usesStandardUserDefaults;
 
@@ -33,7 +33,7 @@ typedef struct {
 
 @implementation SUHost
 
-@synthesize bundle;
+@synthesize bundle, sparkleBundle;
 @synthesize defaultsDomain;
 @synthesize usesStandardUserDefaults;
 
@@ -45,6 +45,12 @@ typedef struct {
         self.bundle = aBundle;
         if (![self.bundle bundleIdentifier]) {
             SULog(@"Error: the bundle being updated at %@ has no %@! This will cause preference read/write to not work properly.", self.bundle, kCFBundleIdentifierKey);
+        }
+
+        self.sparkleBundle = [NSBundle bundleForClass:[self class]];
+        if (!self.sparkleBundle) {
+            SULog(@"Error: SUHost can't find Sparkle.framework it belongs to");
+            return nil;
         }
 
         self.defaultsDomain = [self.bundle objectForInfoDictionaryKey:SUDefaultsDomainKey];
@@ -91,7 +97,7 @@ typedef struct {
 
 - (NSString *)installationPath
 {
-    if ([[[NSBundle bundleWithIdentifier:SUBundleIdentifier] infoDictionary][SUNormalizeInstalledApplicationNameKey] boolValue]) {
+    if ([[self.sparkleBundle infoDictionary][SUNormalizeInstalledApplicationNameKey] boolValue]) {
         // We'll install to "#{CFBundleName}.app", but only if that path doesn't already exist. If we're "Foo 4.2.app," and there's a "Foo.app" in this directory, we don't want to overwrite it! But if there's no "Foo.app," we'll take that name.
         NSString *normalizedAppPath = [[[self.bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [self.bundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey], [[self.bundle bundlePath] pathExtension]]];
         if (![[NSFileManager defaultManager] fileExistsAtPath:[[[self.bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [self.bundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey], [[self.bundle bundlePath] pathExtension]]]]) {

--- a/Sparkle/SUPlainInstallerInternals.h
+++ b/Sparkle/SUPlainInstallerInternals.h
@@ -15,8 +15,8 @@
 
 @interface SUPlainInstaller (Internals)
 + (NSString *)temporaryNameForPath:(NSString *)path;
-+ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst temporaryName:(NSString *)tmp error:(NSError **)error;
-+ (void)_movePathToTrash:(NSString *)path;
++ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst temporaryName:(NSString *)tmp appendVersion:(BOOL)a error:(NSError **)error;
++ (void)_movePathToTrash:(NSString *)path appendVersion:(BOOL)a;
 + (BOOL)_removeFileAtPath:(NSString *)path error:(NSError **)error;
 + (BOOL)_removeFileAtPathWithForcedAuthentication:(NSString *)src error:(NSError **)error;
 @end

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -465,7 +465,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         return customUserAgentString;
     }
 
-    NSString *version = [[NSBundle bundleWithIdentifier:SUBundleIdentifier] objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
+    NSString *version = [self.host.sparkleBundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
     NSString *userAgent = [NSString stringWithFormat:@"%@/%@ Sparkle/%@", [self.host name], [self.host displayVersion], version ? version : @"?"];
     NSData *cleanedAgent = [userAgent dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
     return [[NSString alloc] initWithData:cleanedAgent encoding:NSASCIIStringEncoding];


### PR DESCRIPTION
It should prevent confusion when multiple copies of Sparkle are available
