### PR TITLE
Don't set chmod 0444 on public DSA key file

### DIFF
--- a/bin/generate_keys.sh
+++ b/bin/generate_keys.sh
@@ -11,7 +11,6 @@ openssl="/usr/bin/openssl"
 $openssl gendsa <($openssl dsaparam 4096) -out dsa_priv.pem
 chmod 0400 dsa_priv.pem
 $openssl dsa -in dsa_priv.pem -pubout -out dsa_pub.pem
-chmod 0444 dsa_pub.pem
 
 echo "
 Generated private and public keys: dsa_priv.pem and dsa_pub.pem.


### PR DESCRIPTION
Nothing inside an app/update bundle should be altered anyway, and these permissions will be lost by revision control systems. They also conflict with BinaryDelta's permissions validation.