### PR TITLE
For Debug builds, disabling timestamps in code signing means the buil…

### DIFF
--- a/Configurations/ConfigCommonDebug.xcconfig
+++ b/Configurations/ConfigCommonDebug.xcconfig
@@ -10,3 +10,7 @@ SPARKLE_EXTRA_DEBUG = -DDEBUG
 OTHER_CFLAGS = $(SPARKLE_EXTRA_DEBUG)
 ONLY_ACTIVE_ARCH = YES
 COPY_PHASE_STRIP = NO
+
+// For Debug builds, we don't require timestamping because Apple's
+// server may be down or we may be off-network
+OTHER_CODE_SIGN_FLAGS = --timestamp=none


### PR DESCRIPTION
…ds can take place without a network connection.