### PR TITLE
Remove unused temporaryName: parameter and supporting code.

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -431,7 +431,7 @@
         NSError *error = nil;
         [[NSFileManager defaultManager] createDirectoryAtPath:[targetPath stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:@{} error:&error];
                 
-        if ([SUPlainInstaller copyPathWithAuthentication:relaunchPathToCopy overPath:targetPath temporaryName:nil appendVersion:SPARKLE_APPEND_VERSION_NUMBER error:&error]) {
+        if ([SUPlainInstaller copyPathWithAuthentication:relaunchPathToCopy overPath:targetPath appendVersion:SPARKLE_APPEND_VERSION_NUMBER error:&error]) {
             self.relaunchPath = targetPath;
         } else {
             [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURelaunchError userInfo:@{

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -33,9 +33,8 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSError *error = nil;
         NSString *oldPath = [host bundlePath];
-        NSString *tempName = [self temporaryNameForPath:[host installationPath]];
 
-        BOOL result = [self copyPathWithAuthentication:path overPath:installationPath temporaryName:tempName appendVersion:SPARKLE_APPEND_VERSION_NUMBER error:&error];
+        BOOL result = [self copyPathWithAuthentication:path overPath:installationPath appendVersion:SPARKLE_APPEND_VERSION_NUMBER error:&error];
 
         if (result) {
             if ([SUCodeSigningVerifier applicationAtPathIsCodeSigned:installationPath]) {

--- a/Sparkle/SUPlainInstallerInternals.h
+++ b/Sparkle/SUPlainInstallerInternals.h
@@ -14,8 +14,7 @@
 #import "SUPlainInstaller.h"
 
 @interface SUPlainInstaller (Internals)
-+ (NSString *)temporaryNameForPath:(NSString *)path;
-+ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst temporaryName:(NSString *)tmp appendVersion:(BOOL)a error:(NSError **)error;
++ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst appendVersion:(BOOL)a error:(NSError **)error;
 + (void)_movePathToTrash:(NSString *)path appendVersion:(BOOL)a;
 + (BOOL)_removeFileAtPath:(NSString *)path error:(NSError **)error;
 + (BOOL)_removeFileAtPathWithForcedAuthentication:(NSString *)src error:(NSError **)error;

--- a/Sparkle/SUPlainInstallerInternals.m
+++ b/Sparkle/SUPlainInstallerInternals.m
@@ -85,28 +85,6 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
 
 @implementation SUPlainInstaller (Internals)
 
-+ (NSString *)temporaryNameForPath:(NSString *)path
-{
-    // Let's try to read the version number so the filename will be more meaningful.
-    NSString *postFix;
-    NSString *version;
-	if ((version = [[NSBundle bundleWithPath:path] objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey]) && ![version isEqualToString:@""])
-	{
-        NSMutableCharacterSet *validCharacters = [NSMutableCharacterSet alphanumericCharacterSet];
-        [validCharacters formUnionWithCharacterSet:[NSCharacterSet characterSetWithCharactersInString:@".-()"]];
-        postFix = [version stringByTrimmingCharactersInSet:[validCharacters invertedSet]];
-	}
-	else
-        postFix = @"old";
-    NSString *prefix = [[path stringByDeletingPathExtension] stringByAppendingFormat:@" (%@)", postFix];
-    NSString *tempDir = [prefix stringByAppendingPathExtension:[path pathExtension]];
-    // Now let's make sure we get a unique path.
-    unsigned int cnt = 2;
-    while ([[NSFileManager defaultManager] fileExistsAtPath:tempDir] && cnt <= 999)
-        tempDir = [NSString stringWithFormat:@"%@ %u.%@", prefix, cnt++, [path pathExtension]];
-    return [tempDir lastPathComponent];
-}
-
 + (NSString *)_temporaryCopyNameForPath:(NSString *)path appendVersion:(BOOL)appendVersion didFindTrash:(BOOL *)outDidFindTrash
 {
     // *** MUST BE SAFE TO CALL ON NON-MAIN THREAD!
@@ -464,7 +442,7 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
 	}
 }
 
-+ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst temporaryName:(NSString *)__unused tmp appendVersion:(BOOL)appendVersion error:(NSError *__autoreleasing *)error
++ (BOOL)copyPathWithAuthentication:(NSString *)src overPath:(NSString *)dst appendVersion:(BOOL)appendVersion error:(NSError *__autoreleasing *)error
 {
     FSRef srcRef, dstRef, dstDirRef, tmpDirRef;
     OSStatus err;


### PR DESCRIPTION
The temporaryName: parameter to SUPlainInstaller's copyPathWithAuthentication... method was not being used internally but was still mucking up the (already long) method signature for the method and related methods up the chain. Also remove related, no-longer-used temporaryNameForPath method.