### PR TITLE
Revert "For Debug builds, disabling timestamps in code signing means …

### DIFF
--- a/Configurations/ConfigCommonDebug.xcconfig
+++ b/Configurations/ConfigCommonDebug.xcconfig
@@ -10,7 +10,3 @@ SPARKLE_EXTRA_DEBUG = -DDEBUG
 OTHER_CFLAGS = $(SPARKLE_EXTRA_DEBUG)
 ONLY_ACTIVE_ARCH = YES
 COPY_PHASE_STRIP = NO
-
-// For Debug builds, we don't require timestamping because Apple's
-// server may be down or we may be off-network
-OTHER_CODE_SIGN_FLAGS = --timestamp=none


### PR DESCRIPTION
Reverts sparkle-project/Sparkle#584

The rationale behind Pull Request #584 was based on my flawed assumption that Sparkle code signs by default in its build settings. I was wrong about that. Since code signing is not done by default, I don't think it makes sense to bother with providing any default code signing options.