### PR TITLE
Improvements to Autoupdate application

### DIFF
--- a/Sparkle/SUInstaller.h
+++ b/Sparkle/SUInstaller.h
@@ -18,7 +18,6 @@
 + (NSString *)installSourcePathInUpdateFolder:(NSString *)inUpdateFolder forHost:(SUHost *)host isPackage:(BOOL *)isPackagePtr isGuided:(BOOL *)isGuidedPtr;
 + (void)installFromUpdateFolder:(NSString *)updateFolder overHost:(SUHost *)host installationPath:(NSString *)installationPath versionComparator:(id<SUVersionComparison>)comparator completionHandler:(void (^)(NSError *))completionHandler;
 + (void)finishInstallationToPath:(NSString *)installationPath withResult:(BOOL)result error:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler;
-+ (NSString *)updateFolder;
 
 @end
 

--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -16,13 +16,6 @@
 
 @implementation SUInstaller
 
-static NSString *sUpdateFolder = nil;
-
-+ (NSString *)updateFolder
-{
-    return sUpdateFolder;
-}
-
 + (BOOL)isAliasFolderAtPath:(NSString *)path
 {
     NSNumber *aliasFlag = nil;
@@ -47,8 +40,6 @@ static NSString *sUpdateFolder = nil;
     NSString *fallbackPackagePath = nil;
     NSDirectoryEnumerator *dirEnum = [[NSFileManager defaultManager] enumeratorAtPath:inUpdateFolder];
     NSString *bundleFileNameNoExtension = [bundleFileName stringByDeletingPathExtension];
-
-    sUpdateFolder = inUpdateFolder;
 
     while ((currentFile = [dirEnum nextObject])) {
         NSString *currentPath = [inUpdateFolder stringByAppendingPathComponent:currentFile];


### PR DESCRIPTION
* Do all the installation work after the runloop is set up (hope this helps #441)
* TerminationListener only does termination listening now..
* Renamed folderpath to updateFolderPath. Likewise with some other variables. Since these are passed by command line arguments, updateFolderPath cannot be nil, so those checks for if folderpath is nil in the old code is removed
* Removed pointless global variable access [SUInstaller updateFolder]
* Old code does not handle if host path is not installation path *and* host path is not desired executable path. This does.

--

Would appreciate if the test app pull request is merged! I pretty much have to start with that branch in order to make and test any new changes.