### PR TITLE
Improve BinaryDelta error handling & logging

### DIFF
--- a/Sparkle/SUBinaryDeltaApply.h
+++ b/Sparkle/SUBinaryDeltaApply.h
@@ -10,6 +10,6 @@
 #define SUBINARYDELTAAPPLY_H
 
 @class NSString;
-int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose);
+BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose, NSError * __autoreleasing *error);
 
 #endif

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -114,7 +114,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     
     NSString *beforeHash = hashOfTreeWithVersion(source, majorDiffVersion);
     if (!beforeHash) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to calculate hash of tree %@", source] }];
         }
@@ -122,7 +124,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     }
 
     if (![beforeHash isEqualToString:expectedBeforeHash]) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Source doesn't have expected hash (%@ != %@).  Giving up.", expectedBeforeHash, beforeHash] }];
         }
@@ -134,14 +138,18 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     }
     
     if (!removeTree(destination)) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to remove %@", destination] }];
         }
         return NO;
     }
     if (!copyTree(source, destination)) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to copy %@ to %@", source, destination] }];
         }
@@ -169,7 +177,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         if (!xar_prop_get(file, DELETE_KEY, &value) ||
             (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_THEN_EXTRACT_OLD_KEY, &value))) {
             if (!removeTree(destinationFilePath)) {
-                if (verbose) fprintf(stderr, "\n");
+                if (verbose) {
+                    fprintf(stderr, "\n");
+                }
                 if (error != NULL) {
                     *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@ or %@: failed to remove %@", @DELETE_KEY, @DELETE_THEN_EXTRACT_OLD_KEY, destination] }];
                 }
@@ -187,7 +197,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
 
         if (!xar_prop_get(file, BINARY_DELTA_KEY, &value)) {
             if (!applyBinaryDeltaToFile(x, file, sourceFilePath, destinationFilePath)) {
-                if (verbose) fprintf(stderr, "\n");
+                if (verbose) {
+                    fprintf(stderr, "\n");
+                }
                 if (error != NULL) {
                     *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to patch %@ to destination %@", sourceFilePath, destinationFilePath] }];
                 }
@@ -201,7 +213,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
                    (!hasExtractKeyAvailable && xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value))) { // extract and permission modifications don't coexist
             
             if (xar_extract_tofile(x, file, [destinationFilePath fileSystemRepresentation]) != 0) {
-                if (verbose) fprintf(stderr, "\n");
+                if (verbose) {
+                    fprintf(stderr, "\n");
+                }
                 if (error != NULL) {
                     *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to extract file to %@", destinationFilePath] }];
                 }
@@ -222,7 +236,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         if (!xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value)) {
             mode_t mode = (mode_t)[[NSString stringWithUTF8String:value] intValue];
             if (!modifyPermissions(destinationFilePath, mode)) {
-                if (verbose) fprintf(stderr, "\n");
+                if (verbose) {
+                    fprintf(stderr, "\n");
+                }
                 if (error != NULL) {
                     *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteNoPermissionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to modify permissions (%@) on file %@", @(value), destinationFilePath] }];
                 }
@@ -241,7 +257,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     }
     NSString *afterHash = hashOfTreeWithVersion(destination, majorDiffVersion);
     if (!afterHash) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to calculate hash of tree %@", destination] }];
         }
@@ -249,7 +267,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     }
 
     if (![afterHash isEqualToString:expectedAfterHash]) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination doesn't have expected hash (%@ != %@).  Giving up.", expectedAfterHash, afterHash] }];
         }

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -25,12 +25,14 @@ static BOOL applyBinaryDeltaToFile(xar_t x, xar_file_t file, NSString *sourceFil
     return success;
 }
 
-int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose)
+BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose, NSError * __autoreleasing *error)
 {
     xar_t x = xar_open([patchFile fileSystemRepresentation], READ);
     if (!x) {
-        fprintf(stderr, "Unable to open %s. Giving up.\n", [patchFile fileSystemRepresentation]);
-        return 1;
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to open %@. Giving up.", patchFile] }];
+        }
+        return NO;
     }
     
     SUBinaryDeltaMajorVersion majorDiffVersion = FIRST_DELTA_DIFF_MAJOR_VERSION;
@@ -80,13 +82,17 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
     
     if (majorDiffVersion < FIRST_DELTA_DIFF_MAJOR_VERSION) {
-        fprintf(stderr, "Unable to identify diff-version %u in delta.  Giving up.\n", majorDiffVersion);
-        return 1;
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadCorruptFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to identify diff-version %u in delta.  Giving up.", majorDiffVersion] }];
+        }
+        return NO;
     }
     
     if (majorDiffVersion > LATEST_DELTA_DIFF_MAJOR_VERSION) {
-        fprintf(stderr, "A later version is needed to apply this patch (on major version %u, but patch requests version %u).\n", LATEST_DELTA_DIFF_MAJOR_VERSION, majorDiffVersion);
-        return 1;
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A later version is needed to apply this patch (on major version %u, but patch requests version %u).", LATEST_DELTA_DIFF_MAJOR_VERSION, majorDiffVersion] }];
+        }
+        return NO;
     }
     
     BOOL usesNewTreeHash = MAJOR_VERSION_IS_AT_LEAST(majorDiffVersion, SUBeigeMajorVersion);
@@ -95,8 +101,10 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     NSString *expectedAfterHash = usesNewTreeHash ? expectedNewAfterHash : expectedAfterHashv1;
 
     if (!expectedBeforeHash || !expectedAfterHash) {
-        fprintf(stderr, "Unable to find before-sha1 or after-sha1 metadata in delta.  Giving up.\n");
-        return 1;
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadCorruptFileError userInfo:@{ NSLocalizedDescriptionKey: @"Unable to find before-sha1 or after-sha1 metadata in delta.  Giving up." }];
+        }
+        return NO;
     }
 
     if (verbose) {
@@ -106,13 +114,19 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     
     NSString *beforeHash = hashOfTreeWithVersion(source, majorDiffVersion);
     if (!beforeHash) {
-        fprintf(stderr, "\nUnable to calculate hash of tree %s\n", [source fileSystemRepresentation]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to calculate hash of tree %@", source] }];
+        }
+        return NO;
     }
 
     if (![beforeHash isEqualToString:expectedBeforeHash]) {
-        fprintf(stderr, "\nSource doesn't have expected hash (%s != %s).  Giving up.\n", [expectedBeforeHash UTF8String], [beforeHash UTF8String]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Source doesn't have expected hash (%@ != %@).  Giving up.", expectedBeforeHash, beforeHash] }];
+        }
+        return NO;
     }
 
     if (verbose) {
@@ -120,12 +134,18 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
     
     if (!removeTree(destination)) {
-        fprintf(stderr, "\nFailed to remove %s\n", [destination fileSystemRepresentation]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to remove %@", destination] }];
+        }
+        return NO;
     }
     if (!copyTree(source, destination)) {
-        fprintf(stderr, "\nFailed to copy %s to %s\n", [source fileSystemRepresentation], [destination fileSystemRepresentation]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to copy %@ to %@", source, destination] }];
+        }
+        return NO;
     }
     
     BOOL hasExtractKeyAvailable = MAJOR_VERSION_IS_AT_LEAST(majorDiffVersion, SUBeigeMajorVersion);
@@ -149,8 +169,11 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         if (!xar_prop_get(file, DELETE_KEY, &value) ||
             (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_THEN_EXTRACT_OLD_KEY, &value))) {
             if (!removeTree(destinationFilePath)) {
-                fprintf(stderr, "\n%s or %s: failed to remove %s\n", DELETE_KEY, DELETE_THEN_EXTRACT_OLD_KEY, [destination fileSystemRepresentation]);
-                return 1;
+                if (verbose) fprintf(stderr, "\n");
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@ or %@: failed to remove %@", @DELETE_KEY, @DELETE_THEN_EXTRACT_OLD_KEY, destination] }];
+                }
+                return NO;
             }
             if (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_KEY, &value)) {
                 if (verbose) {
@@ -164,8 +187,11 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
 
         if (!xar_prop_get(file, BINARY_DELTA_KEY, &value)) {
             if (!applyBinaryDeltaToFile(x, file, sourceFilePath, destinationFilePath)) {
-                fprintf(stderr, "\nUnable to patch %s to destination %s\n", [sourceFilePath fileSystemRepresentation], [destinationFilePath fileSystemRepresentation]);
-                return 1;
+                if (verbose) fprintf(stderr, "\n");
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to patch %@ to destination %@", sourceFilePath, destinationFilePath] }];
+                }
+                return NO;
             }
             
             if (verbose) {
@@ -175,8 +201,11 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
                    (!hasExtractKeyAvailable && xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value))) { // extract and permission modifications don't coexist
             
             if (xar_extract_tofile(x, file, [destinationFilePath fileSystemRepresentation]) != 0) {
-                fprintf(stderr, "\nUnable to extract file to %s\n", [destinationFilePath fileSystemRepresentation]);
-                return 1;
+                if (verbose) fprintf(stderr, "\n");
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to extract file to %@", destinationFilePath] }];
+                }
+                return NO;
             }
             
             if (verbose) {
@@ -193,8 +222,11 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
         if (!xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value)) {
             mode_t mode = (mode_t)[[NSString stringWithUTF8String:value] intValue];
             if (!modifyPermissions(destinationFilePath, mode)) {
-                fprintf(stderr, "\nUnable to modify permissions (%s) on file %s\n", value, [destinationFilePath fileSystemRepresentation]);
-                return 1;
+                if (verbose) fprintf(stderr, "\n");
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteNoPermissionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to modify permissions (%@) on file %@", @(value), destinationFilePath] }];
+                }
+                return NO;
             }
             
             if (verbose) {
@@ -209,18 +241,24 @@ int applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFil
     }
     NSString *afterHash = hashOfTreeWithVersion(destination, majorDiffVersion);
     if (!afterHash) {
-        fprintf(stderr, "\nUnable to calculate hash of tree %s\n", [destination fileSystemRepresentation]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to calculate hash of tree %@", destination] }];
+        }
+        return NO;
     }
 
     if (![afterHash isEqualToString:expectedAfterHash]) {
-        fprintf(stderr, "\nDestination doesn't have expected hash (%s != %s).  Giving up.\n", [expectedAfterHash UTF8String], [afterHash UTF8String]);
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination doesn't have expected hash (%@ != %@).  Giving up.", expectedAfterHash, afterHash] }];
+        }
         removeTree(destination);
-        return 1;
+        return NO;
     }
 
     if (verbose) {
         fprintf(stderr, "\nDone!\n");
     }
-    return 0;
+    return YES;
 }

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -145,7 +145,9 @@ NSData *hashOfFileContents(FTSENT *ent)
 NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
 {
     char pathBuffer[PATH_MAX] = {0};
-    [path getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)];
+    if (![path getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)]) {
+        return nil;
+    }
 
     char * const sourcePaths[] = {pathBuffer, 0};
     FTS *fts = fts_open(sourcePaths, FTS_PHYSICAL | FTS_NOCHDIR, compareFiles);

--- a/Sparkle/SUBinaryDeltaCreate.h
+++ b/Sparkle/SUBinaryDeltaCreate.h
@@ -12,6 +12,6 @@
 #import "SUBinaryDeltaCommon.h"
 
 @class NSString;
-int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose);
+BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose, NSError * __autoreleasing *error);
 
 #endif

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -221,30 +221,32 @@ static BOOL shouldChangePermissions(NSDictionary *originalInfo, NSDictionary *ne
     return YES;
 }
 
-int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose)
+BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose, NSError * __autoreleasing *error)
 {
-    if (majorVersion < FIRST_DELTA_DIFF_MAJOR_VERSION) {
-        fprintf(stderr, "Version provided (%u) is not valid\n", majorVersion);
-        return 1;
-    }
-    
-    if (majorVersion > LATEST_DELTA_DIFF_MAJOR_VERSION) {
-        fprintf(stderr, "This program is too old to create a version %u patch, or the version number provided is invalid\n", majorVersion);
-        return 1;
-    }
+    assert(source);
+    assert(destination);
+    assert(patchFile);
+    assert(majorVersion >= FIRST_DELTA_DIFF_MAJOR_VERSION && majorVersion <= LATEST_DELTA_DIFF_MAJOR_VERSION);
     
     SUBinaryDeltaMinorVersion minorVersion = latestMinorVersionForMajorVersion(majorVersion);
     
     NSMutableDictionary *originalTreeState = [NSMutableDictionary dictionary];
 
     char pathBuffer[PATH_MAX] = {0};
-    [source getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)];
+    if (![source getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve file system path representation from source %@", source] }];
+        }
+        return NO;
+    }
 
     char *sourcePaths[] = {pathBuffer, 0};
     FTS *fts = fts_open(sourcePaths, FTS_PHYSICAL | FTS_NOCHDIR, compareFiles);
     if (!fts) {
-        perror("fts_open");
-        return 1;
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"fts_open failed on source: %@", @(strerror(errno))] }];
+        }
+        return NO;
     }
 
     if (verbose) {
@@ -265,19 +267,28 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
 
         NSDictionary *info = infoForFile(ent);
         if (!info) {
-            fprintf(stderr, "\nFailed to retrieve info for file %s\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve info for file %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
         originalTreeState[key] = info;
         
         if (aclExists(ent)) {
-            fprintf(stderr, "\nDiffing ACLs are not supported. Detected ACL in before-tree on file %s\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing ACLs are not supported. Detected ACL in before-tree on file %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
         
         if (codeSignatureExtendedAttributeExists(ent)) {
-            fprintf(stderr, "\nDiffing code signed extended attributes are not supported. Detected extended attribute in before-tree on file %s\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing code signed extended attributes are not supported. Detected extended attribute in before-tree on file %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
     }
     fts_close(fts);
@@ -285,8 +296,11 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     NSString *beforeHash = hashOfTreeWithVersion(source, majorVersion);
 
     if (!beforeHash) {
-        fprintf(stderr, "\nFailed to generate hash for tree %s\n", [source fileSystemRepresentation]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to generate hash for tree %@", source] }];
+        }
+        return NO;
     }
 
     NSMutableDictionary *newTreeState = [NSMutableDictionary dictionary];
@@ -300,13 +314,21 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     }
 
     pathBuffer[0] = 0;
-    [destination getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)];
+    if (![destination getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)]) {
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve file system path representation from destination %@", destination] }];
+        }
+        return NO;
+    }
     
     sourcePaths[0] = pathBuffer;
     fts = fts_open(sourcePaths, FTS_PHYSICAL | FTS_NOCHDIR, compareFiles);
     if (!fts) {
-        perror("fts_open");
-        return 1;
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"fts_open failed on destination: %@", @(strerror(errno))] }];
+        }
+        return NO;
     }
 
 
@@ -322,8 +344,11 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
 
         NSDictionary *info = infoForFile(ent);
         if (!info) {
-            fprintf(stderr, "\nFailed to retrieve info from file %s\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve info from file %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
         
         // We should validate permissions and ACLs even if we don't store the info in the diff in the case of ACLs,
@@ -334,18 +359,27 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         
         mode_t permissions = [info[INFO_PERMISSIONS_KEY] unsignedShortValue];
         if (!IS_VALID_PERMISSIONS(permissions)) {
-            fprintf(stderr, "\nInvalid file permissions after-tree on file %s\nOnly permissions with modes 0755 and 0644 are supported\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid file permissions after-tree on file %@ (only permissions with modes 0755 and 0644 are supported)", @(ent->fts_path)] }];
+            }
+            return NO;
         }
         
         if (aclExists(ent)) {
-            fprintf(stderr, "\nDiffing ACLs are not supported. Detected ACL in after-tree on file %s\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing ACLs are not supported. Detected ACL in after-tree on file %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
         
         if (codeSignatureExtendedAttributeExists(ent)) {
-            fprintf(stderr, "\nDiffing code signed extended attributes are not supported. Detected extended attribute in after-tree on file %s\n", ent->fts_path);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing code signed extended attributes are not supported. Detected extended attribute in after-tree on file %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
         
         NSDictionary *oldInfo = originalTreeState[key];
@@ -372,8 +406,11 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
 
     NSString *afterHash = hashOfTreeWithVersion(destination, majorVersion);
     if (!afterHash) {
-        fprintf(stderr, "\nFailed to generate hash for tree %s\n", [destination fileSystemRepresentation]);
-        return 1;
+        if (verbose) fprintf(stderr, "\n");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to generate hash for tree %@", destination] }];
+        }
+        return NO;
     }
     
     if (verbose) {
@@ -479,8 +516,11 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     for (CreateBinaryDeltaOperation *operation in deltaOperations) {
         NSString *resultPath = [operation resultPath];
         if (!resultPath) {
-            fprintf(stderr, "\nFailed to create patch from source %s and destination %s\n", [[operation relativePath] fileSystemRepresentation], [resultPath fileSystemRepresentation]);
-            return 1;
+            if (verbose) fprintf(stderr, "\n");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to create patch from source %@ and destination %@", operation.relativePath, resultPath] }];
+            }
+            return NO;
         }
         
         if (verbose) {
@@ -511,5 +551,5 @@ int createBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         fprintf(stderr, "\nDone!\n");
     }
 
-    return 0;
+    return YES;
 }

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -267,7 +267,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
         NSDictionary *info = infoForFile(ent);
         if (!info) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve info for file %@", @(ent->fts_path)] }];
             }
@@ -276,7 +278,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         originalTreeState[key] = info;
         
         if (aclExists(ent)) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing ACLs are not supported. Detected ACL in before-tree on file %@", @(ent->fts_path)] }];
             }
@@ -284,7 +288,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         }
         
         if (codeSignatureExtendedAttributeExists(ent)) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing code signed extended attributes are not supported. Detected extended attribute in before-tree on file %@", @(ent->fts_path)] }];
             }
@@ -296,7 +302,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
     NSString *beforeHash = hashOfTreeWithVersion(source, majorVersion);
 
     if (!beforeHash) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to generate hash for tree %@", source] }];
         }
@@ -315,7 +323,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
     pathBuffer[0] = 0;
     if (![destination getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)]) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve file system path representation from destination %@", destination] }];
         }
@@ -344,7 +354,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
         NSDictionary *info = infoForFile(ent);
         if (!info) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to retrieve info from file %@", @(ent->fts_path)] }];
             }
@@ -359,7 +371,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         
         mode_t permissions = [info[INFO_PERMISSIONS_KEY] unsignedShortValue];
         if (!IS_VALID_PERMISSIONS(permissions)) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid file permissions after-tree on file %@ (only permissions with modes 0755 and 0644 are supported)", @(ent->fts_path)] }];
             }
@@ -367,7 +381,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         }
         
         if (aclExists(ent)) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing ACLs are not supported. Detected ACL in after-tree on file %@", @(ent->fts_path)] }];
             }
@@ -375,7 +391,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         }
         
         if (codeSignatureExtendedAttributeExists(ent)) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing code signed extended attributes are not supported. Detected extended attribute in after-tree on file %@", @(ent->fts_path)] }];
             }
@@ -406,7 +424,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
     NSString *afterHash = hashOfTreeWithVersion(destination, majorVersion);
     if (!afterHash) {
-        if (verbose) fprintf(stderr, "\n");
+        if (verbose) {
+            fprintf(stderr, "\n");
+        }
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to generate hash for tree %@", destination] }];
         }
@@ -516,7 +536,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
     for (CreateBinaryDeltaOperation *operation in deltaOperations) {
         NSString *resultPath = [operation resultPath];
         if (!resultPath) {
-            if (verbose) fprintf(stderr, "\n");
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
             if (error != NULL) {
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to create patch from source %@ and destination %@", operation.relativePath, resultPath] }];
             }

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -11,6 +11,7 @@
 #import "SUBinaryDeltaApply.h"
 #import "SUUnarchiver_Private.h"
 #import "SUHost.h"
+#import "SULog.h"
 #import "NTSynchronousTask.h"
 
 @implementation SUBinaryDeltaUnarchiver
@@ -26,13 +27,15 @@
         NSString *sourcePath = self.updateHostBundlePath;
         NSString *targetPath = [[self.archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:[sourcePath lastPathComponent]];
 
-        int result = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO);
-		if (!result) {
+        NSError *applyDiffError = nil;
+        BOOL success = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO, &applyDiffError);
+		if (success) {
 			dispatch_async(dispatch_get_main_queue(), ^{
 				[self notifyDelegateOfSuccess];
 			});
 		}
 		else {
+            SULog(@"Applying delta patch failed with error: %@", applyDiffError);
 			dispatch_async(dispatch_get_main_queue(), ^{
 				[self notifyDelegateOfFailure];
 			});

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -18,41 +18,41 @@
 
 + (BOOL)canUnarchivePath:(NSString *)path
 {
-	return [[path pathExtension] isEqualToString:@"delta"];
+    return [[path pathExtension] isEqualToString:@"delta"];
 }
 
 - (void)applyBinaryDelta
 {
-	@autoreleasepool {
+    @autoreleasepool {
         NSString *sourcePath = self.updateHostBundlePath;
         NSString *targetPath = [[self.archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:[sourcePath lastPathComponent]];
 
         NSError *applyDiffError = nil;
         BOOL success = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO, &applyDiffError);
-		if (success) {
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[self notifyDelegateOfSuccess];
-			});
-		}
-		else {
+        if (success) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self notifyDelegateOfSuccess];
+            });
+        }
+        else {
             SULog(@"Applying delta patch failed with error: %@", applyDiffError);
-			dispatch_async(dispatch_get_main_queue(), ^{
-				[self notifyDelegateOfFailure];
-			});
-		}
-	}
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self notifyDelegateOfFailure];
+            });
+        }
+    }
 }
 
 - (void)start
 {
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-		[self applyBinaryDelta];
-	});
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self applyBinaryDelta];
+    });
 }
 
 + (void)load
 {
-	[self registerImplementation:self];
+    [self registerImplementation:self];
 }
 
 @end


### PR DESCRIPTION
* Fix issue #608. From the framework, the error is logged via SULog. From the tool, the error is logged to stderr. Uses NSError handling for both.
* Move patch version validation for creating a binary diff into the BinaryDelta tool
* Add parameter assertions to createBinaryDelta and handle if -getFileSystemRepresentation:maxLength: fails