### PR TITLE
Check for empty strings (as well as nil) in SUHost's -name method

### DIFF
--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -103,13 +103,13 @@
 
     // Allow host bundle to provide a custom name
     name = [self objectForInfoDictionaryKey:@"SUBundleName"];
-    if (name && ![name isEqualToString:@""]) return name;
+    if (name && name.length > 0) return name;
 
     name = [self.bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-	if (name && ![name isEqualToString:@""]) return name;
+	if (name && name.length > 0) return name;
 
     name = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
-	if (name && ![name isEqualToString:@""]) return name;
+	if (name && name.length > 0) return name;
 
     return [[[NSFileManager defaultManager] displayNameAtPath:[self.bundle bundlePath]] stringByDeletingPathExtension];
 }

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -103,13 +103,13 @@
 
     // Allow host bundle to provide a custom name
     name = [self objectForInfoDictionaryKey:@"SUBundleName"];
-    if (name) return name;
+    if (name && ![name isEqualToString:@""]) return name;
 
     name = [self.bundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-	if (name) return name;
+	if (name && ![name isEqualToString:@""]) return name;
 
     name = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
-	if (name) return name;
+	if (name && ![name isEqualToString:@""]) return name;
 
     return [[[NSFileManager defaultManager] displayNameAtPath:[self.bundle bundlePath]] stringByDeletingPathExtension];
 }


### PR DESCRIPTION
NSBundle's `-objectForInfoDictionaryKey:` returns an empty string instead of nil for `CFBundleDisplayName` in our case (at least on El Capitan Beta).