### PR TITLE
Fix CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
-# 1.12.0
+# 1.11.0
 
+* Big improvements to code signing and DSA verification
+   - Sparkle now checks not only whether an update is correctly signed, but also whether the updated version will be able to verify future updates. Updates now must either use DSA keys correctly, or not try to use them at all. Same goes for Apple Code Signing.
+   - Rely on code signing and the DSA key in the new app instead of appcast. If the new app has a public DSA key, then the appcast item must have a DSA signature for the app, even if the app is code signed. (Zorg)
 * Deprecated serving over http without DSA (Zorg)
 * Removed extensions from shell scripts (Jake Petroules)
 * Improved Autoupdate application (Zorg)
@@ -17,12 +20,6 @@
 * Silenced warning about casting away const-ness and -Wassign-enum (Daniel Jalkut)
 * Rewritten test app so it works again, and from a local web server (Zorg)
 * Added script to generate a report comparing the Sparkle.strings files (Kevin Wojniak)
-
-# 1.11.0
-
-* Big improvements to code signing and DSA verification
-   - Sparkle now checks not only whether an update is correctly signed, but also whether the updated version will be able to verify future updates. Updates now must either use DSA keys correctly, or not try to use them at all. Same goes for Apple Code Signing.
-   - Rely on code signing and the DSA key in the new app instead of appcast. If the new app has a public DSA key, then the appcast item must have a DSA signature for the app, even if the app is code signed. (Zorg)
 * More verbose error message when DSA keys don't match (Kornel Lesiński)
 * Added delegate methods for pre-download and immediately post-failed-download (Isaac Greenspan)
 * Fix Lucida Grande is always used for release notes (LIU Dongyuan / 柳东原)


### PR DESCRIPTION
I suppose the changes about 1.12.0 in the CHANGELOG are just the changes which were added after some point of 1.11.0rc release and thus are belong to 1.11.0.

I've just removed `# 1.12.0` header and bring the change about the code signing and DSA verification (probably the most important change in 1.11.0) to the first position. No change in the sentences themselves.