### PR TITLE
Replace awakeFromNib with windowDidLoad

### DIFF
--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -42,7 +42,7 @@
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@, %@>", [self class], [self.host bundlePath], [self.host installationPath]]; }
 
-- (void)awakeFromNib
+- (void)windowDidLoad
 {
     if ([self.host isBackgroundApplication]) {
         [[self window] setLevel:NSFloatingWindowLevel];

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -178,7 +178,7 @@
     return allowAutoUpdates;
 }
 
-- (void)awakeFromNib
+- (void)windowDidLoad
 {
     BOOL showReleaseNotes = [self showsReleaseNotes];
 

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -78,7 +78,7 @@
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], [self.host bundlePath]]; }
 
-- (void)awakeFromNib
+- (void)windowDidLoad
 {
 	if (![self shouldAskAboutProfile])
 	{


### PR DESCRIPTION
awakeFromNib should never be used; proper window loading methods
from the window controller should be used instead. awakeFromNib
can also be called multiple times in certain scenarios.