### PR TITLE
Don't show Autoupdate dock icon if we shouldn't show UI

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -130,11 +130,13 @@ static const NSTimeInterval SUInstallationTimeLimit = 5;
     [self.terminationListener startListeningWithCompletion:^{
         self.terminationListener = nil;
         
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SUInstallationTimeLimit * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            // Show app icon in the dock
-            ProcessSerialNumber psn = { 0, kCurrentProcess };
-            TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-        });
+        if (self.shouldShowUI) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SUInstallationTimeLimit * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                // Show app icon in the dock
+                ProcessSerialNumber psn = { 0, kCurrentProcess };
+                TransformProcessType(&psn, kProcessTransformToForegroundApplication);
+            });
+        }
         
          [self install];
     }];


### PR DESCRIPTION
I think this has been an issue for quite a while even before my refactoring of Autoupdate.m. And to note it looks like automatic updates hasn't been tested very much, which isn't good.