### PR TITLE
Don't install automatic updates if the system might shut off

### DIFF
--- a/Sparkle/SUAutomaticUpdateDriver.m
+++ b/Sparkle/SUAutomaticUpdateDriver.m
@@ -63,6 +63,7 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
 - (void)unarchiverDidFinish:(SUUnarchiver *)__unused ua
 {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillTerminate:) name:NSApplicationWillTerminateNotification object:nil];
+    [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self selector:@selector(systemWillPowerOff:) name:NSWorkspaceWillPowerOffNotification object:nil];
 
     // Sudden termination is available on 10.6+
     NSProcessInfo *processInfo = [NSProcessInfo processInfo];
@@ -103,6 +104,8 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
     if (self.willUpdateOnTermination)
     {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationWillTerminateNotification object:nil];
+        [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self name:NSWorkspaceWillPowerOffNotification object:nil];
+
         NSProcessInfo *processInfo = [NSProcessInfo processInfo];
         [processInfo enableSuddenTermination];
 
@@ -151,6 +154,7 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
         case SUInstallLaterChoice:
             self.postponingInstallation = YES;
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillTerminate:) name:NSApplicationWillTerminateNotification object:nil];
+            [[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self selector:@selector(systemWillPowerOff:) name:NSWorkspaceWillPowerOffNotification object:nil];
             // We're already waiting on quit, just indicate that we're idle.
             self.interruptible = YES;
             break;
@@ -170,6 +174,13 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
 
     self.showErrors = YES;
     [super installWithToolAndRelaunch:relaunch displayingUserInterface:showUI];
+}
+
+- (void)systemWillPowerOff:(NSNotification *)__unused note
+{
+    [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUSystemPowerOffError userInfo:@{
+        NSLocalizedDescriptionKey: SULocalizedString(@"The update will not be installed because the user requested for the system to power off", nil)
+    }]];
 }
 
 - (void)applicationWillTerminate:(NSNotification *)__unused note

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -38,7 +38,10 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUMissingInstallerToolError = 4003,
     SURelaunchError = 4004,
     SUInstallationError = 4005,
-    SUDowngradeError = 4006
+    SUDowngradeError = 4006,
+    
+    // System phase errors
+    SUSystemPowerOffError = 5000
 };
 
 #endif


### PR DESCRIPTION
Abort automatic updates before terminating the app if the system is about to shut or log off. This is particularly important for automatic updates because in response to the system shutting down and terminating our app, our response shouldn't be to spawn another application/process.

Incidentally, trying to install an automatic update while the system is powering off is a scenario that can very likely lead to incomplete/corrupt updates (unless #575 is incorporated) -- all it requires is users to hit a check box. But this isn't really about incomplete updates (nor can this issue hope to fully solve that), it's about doing less work so the user can power off faster.

If we get the power off notification, we let the delegate know about it. It may be possible some other application could cancel the shut down / log off process, so we should be able to continue even if that happens.