### PR TITLE
Disallow automatic updates when user can't write to the bundle

### DIFF
--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -28,6 +28,7 @@ typedef struct {
 
 - (instancetype)initWithBundle:(NSBundle *)aBundle;
 @property (readonly, copy) NSString *bundlePath;
+@property (readonly) BOOL allowsAutomaticUpdates;
 @property (readonly, copy) NSString *appCachePath;
 @property (readonly, copy) NSString *installationPath;
 @property (readonly, copy) NSString *name;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -62,6 +62,17 @@
     return [self.bundle bundlePath];
 }
 
+- (BOOL)allowsAutomaticUpdates
+{
+    // Can we automatically update in the background without bugging the user (e.g, with a administrator password prompt)?
+    BOOL isWritableAtBundle = [[NSFileManager defaultManager] isWritableFileAtPath:self.bundlePath];
+    
+    // Does the developer want us to disable automatic updates?
+    NSNumber *developerAllowsAutomaticUpdates = [self objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
+    
+    return isWritableAtBundle && (developerAllowsAutomaticUpdates == nil || developerAllowsAutomaticUpdates.boolValue);
+}
+
 - (NSString *)appCachePath
 {
     NSArray *cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -64,13 +64,14 @@
 
 - (BOOL)allowsAutomaticUpdates
 {
-    // Can we automatically update in the background without bugging the user (e.g, with a administrator password prompt)?
-    BOOL isWritableAtBundle = [[NSFileManager defaultManager] isWritableFileAtPath:self.bundlePath];
-    
     // Does the developer want us to disable automatic updates?
     NSNumber *developerAllowsAutomaticUpdates = [self objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
+    if (developerAllowsAutomaticUpdates != nil && !developerAllowsAutomaticUpdates.boolValue) {
+        return NO;
+    }
     
-    return isWritableAtBundle && (developerAllowsAutomaticUpdates == nil || developerAllowsAutomaticUpdates.boolValue);
+    // Can we automatically update in the background without bugging the user (e.g, with a administrator password prompt)?
+    return [[NSFileManager defaultManager] isWritableFileAtPath:self.bundlePath];
 }
 
 - (NSString *)appCachePath

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -171,11 +171,7 @@
 
 - (BOOL)allowsAutomaticUpdates
 {
-    BOOL allowAutoUpdates = YES; // Defaults to YES.
-    if ([self.host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey])
-        allowAutoUpdates = [self.host boolForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
-
-    return allowAutoUpdates;
+    return self.host.allowsAutomaticUpdates;
 }
 
 - (void)windowDidLoad
@@ -201,6 +197,16 @@
         [self.window.contentView addConstraint:automaticallyInstallUpdatesButtonToDescriptionFieldConstraint];
         
         [self.releaseNotesContainerView removeFromSuperview];
+    }
+    
+    // When we show release notes, it looks ugly if the install buttons are not closer to the release notes view
+    // However when we don't show release notes, it looks ugly if the install buttons are too close to the description field. Shrugs.
+    if (showReleaseNotes && ![self allowsAutomaticUpdates]) {
+        NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
+        
+        [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
+        
+        [self.automaticallyInstallUpdatesButton removeFromSuperview];
     }
 
     [self.window center];

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -435,8 +435,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
 - (BOOL)automaticallyDownloadsUpdates
 {
-    // If the SUAllowsAutomaticUpdatesKey exists and is set to NO, return NO.
-    if ([self.host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey] && [self.host boolForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey] == NO) {
+    // If the host doesn't allow automatic updates, don't ever let them happen
+    if (!self.host.allowsAutomaticUpdates) {
         return NO;
     }
 


### PR DESCRIPTION
The automatic updates checkbox is also hidden in this scenario, and
we also update the layout constraints if the releasenotes are still visible

Fixes / works around issue #624