### PR TITLE
Update modification & access time for new update

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -172,6 +172,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
                        versionComparator:[SUStandardVersionComparator defaultComparator]
                        completionHandler:^(NSError *error) {
                            if (error) {
+                               SULog(@"Installation Error: %@", error);
                                if (self.shouldShowUI) {
                                    NSAlert *alert = [[NSAlert alloc] init];
                                    alert.messageText = @"";

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -80,6 +80,19 @@
 - (BOOL)changeOwnerAndGroupOfItemAtRootURL:(NSURL *)targetURL toMatchURL:(NSURL *)matchURL error:(NSError **)error;
 
 /**
+ * Updates the modification and access time of an item at a specified target URL to the current time
+ * @param targetURL A URL pointing to the target item whose modification and access time to update. The item at this URL must exist.
+ * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
+ * @return YES if the target item's modification and access times have been updated, otherwise NO along with a populated error object
+ *
+ * This method updates the modification and access time of an item to the current time, ideal for letting the system know we installed a new file or
+ * application.
+ *
+ * This is not an atomic operation.
+ */
+- (BOOL)updateModificationAndAccessTimeOfItemAtURL:(NSURL *)targetURL error:(NSError **)error;
+
+/**
  * Releases Apple's quarantine extended attribute from the item at the specified root URL
  * @param rootURL A URL pointing to the item to release from Apple's quarantine. This will be applied recursively if the item is a directory. The item at this URL must exist.
  * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -60,7 +60,7 @@
         return NO;
     }
     
-    // Release our new app from quarantine and fix its owner and group IDs while it's at our temporary destination
+    // Release our new app from quarantine, fix its owner and group IDs, and update its modification time while it's at our temporary destination
     // We must leave moving the app to its destination as the final step in installing it, so that
     // it's not possible our new app can be left in an incomplete state at the final destination
     
@@ -85,6 +85,11 @@
         SULog(@"Failed to change owner and group of new app at %@ to match old app at %@", newTempURL.path, oldURL.path);
         [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
         return NO;
+    }
+    
+    if (![fileManager updateModificationAndAccessTimeOfItemAtURL:newTempURL error:error]) {
+        // Not a fatal error, but a pretty unfortunate one
+        SULog(@"Failed to update modification and access time of new app at %@", newTempURL.path);
     }
     
     // Decide on a destination name we should use for the older app when we move it around the file system

--- a/Tests/SUFileManagerTest.swift
+++ b/Tests/SUFileManagerTest.swift
@@ -169,6 +169,27 @@ class SUFileManagerTest: XCTestCase
         }
     }
     
+    func testUpdateFileModificationTime()
+    {
+        makeTempFiles() { fileManager, rootURL, ordinaryFileURL, directoryURL, fileInDirectoryURL in
+            XCTAssertNil(try? fileManager.updateModificationAndAccessTimeOfItemAtURL(rootURL.URLByAppendingPathComponent("does not exist")))
+            
+            let oldOrdinaryFileAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(ordinaryFileURL.path!)
+            let oldDirectoryAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(directoryURL.path!)
+            
+            sleep(1); // wait for clock to advance
+            
+            try! fileManager.updateModificationAndAccessTimeOfItemAtURL(ordinaryFileURL)
+            try! fileManager.updateModificationAndAccessTimeOfItemAtURL(directoryURL)
+            
+            let newOrdinaryFileAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(ordinaryFileURL.path!)
+            XCTAssertGreaterThan((newOrdinaryFileAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldOrdinaryFileAttributes[NSFileModificationDate] as! NSDate), 0)
+            
+            let newDirectoryAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(directoryURL.path!)
+            XCTAssertGreaterThan((newDirectoryAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldDirectoryAttributes[NSFileModificationDate] as! NSDate), 0)
+        }
+    }
+    
     func testFileExists()
     {
         makeTempFiles() { fileManager, rootURL, ordinaryFileURL, directoryURL, fileInDirectoryURL in


### PR DESCRIPTION
If we don't do this, Finder may not report the correct file size for the new update.
The system also may not register the new app in its database if we don't do this.

We may have been able to get away with not doing this before because we used to perform a copy
to install the update. However, now updates in some cases can be done with only move operations.

This should also be an alternative way of addressing issue #508