### PR TITLE
Test app cleanup

### DIFF
--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -53,7 +53,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     
     // Create a directory that'll be used for our web server listing
     NSURL *serverDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier];
-    if ([fileManager fileExistsAtPath:serverDirectoryURL.path]) {
+    if ([serverDirectoryURL checkResourceIsReachableAndReturnError:nil]) {
         NSError *removeServerDirectoryError = nil;
         
         if (![fileManager removeItemAtURL:serverDirectoryURL error:&removeServerDirectoryError]) {
@@ -81,7 +81,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     // Update bundle's version keys to latest version
     NSURL *infoURL = [[destinationBundleURL URLByAppendingPathComponent:@"Contents"] URLByAppendingPathComponent:@"Info.plist"];
     
-    BOOL infoFileExists = [fileManager fileExistsAtPath:infoURL.path];
+    BOOL infoFileExists = [infoURL checkResourceIsReachableAndReturnError:nil];
     assert(infoFileExists);
     
     NSMutableDictionary *infoDictionary = [[NSMutableDictionary alloc] initWithContentsOfURL:infoURL];

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -92,14 +92,15 @@ static NSString * const UPDATED_VERSION = @"2.0";
     assert(wroteInfoFile);
     
     // Change current working directory so web server knows where to list files
-    BOOL changedCurrentWorkingDirectory = [fileManager changeCurrentDirectoryPath:serverDirectoryURL.path];
-    assert(changedCurrentWorkingDirectory);
+    NSString *serverDirectoryPath = serverDirectoryURL.path;
+    assert(serverDirectoryPath != nil);
     
     // Create the archive for our update
     NSString *zipName = @"Sparkle_Test_App.zip";
     NSTask *dittoTask = [[NSTask alloc] init];
     dittoTask.launchPath = @"/usr/bin/ditto";
     dittoTask.arguments = @[@"-c", @"-k", @"--sequesterRsrc", @"--keepParent", destinationBundleURL.lastPathComponent, zipName];
+    dittoTask.currentDirectoryPath = serverDirectoryPath;
     [dittoTask launch];
     [dittoTask waitUntilExit];
     
@@ -175,7 +176,13 @@ static NSString * const UPDATED_VERSION = @"2.0";
     }
     
     // Finally start the server
-    self.serverTask = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/python" arguments:@[@"-m", @"SimpleHTTPServer", @"1337"]];
+    NSTask *serverTask = [[NSTask alloc] init];
+    serverTask.launchPath = @"/usr/bin/python";
+    assert([[NSFileManager defaultManager] fileExistsAtPath:serverTask.launchPath]);
+    serverTask.arguments = @[@"-m", @"SimpleHTTPServer", @"1337"];
+    serverTask.currentDirectoryPath = serverDirectoryPath;
+    [serverTask launch];
+    self.serverTask = serverTask;
     
     // Show the Settings window
     self.updateSettingsWindowController = [[SUUpdateSettingsWindowController alloc] init];

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -106,7 +106,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     
     assert(dittoTask.terminationStatus == 0);
     
-    [[NSFileManager defaultManager] removeItemAtURL:destinationBundleURL error:NULL];
+    [fileManager removeItemAtURL:destinationBundleURL error:NULL];
     
     // Don't ever do this at home, kids (seriously)
     // (that is, including the private key inside of your application)
@@ -178,7 +178,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     // Finally start the server
     NSTask *serverTask = [[NSTask alloc] init];
     serverTask.launchPath = @"/usr/bin/python";
-    assert([[NSFileManager defaultManager] fileExistsAtPath:serverTask.launchPath]);
+    assert([fileManager fileExistsAtPath:serverTask.launchPath]);
     serverTask.arguments = @[@"-m", @"SimpleHTTPServer", @"1337"];
     serverTask.currentDirectoryPath = serverDirectoryPath;
     [serverTask launch];


### PR DESCRIPTION
- When working with URLs, URL methods should be preferred vs converting to strings
- Changing the process working directory is not recommended by Apple docs