### PR TITLE
Check existence of NSByteCountFormatter instead of comparing OS version

### DIFF
--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -128,7 +128,7 @@
 
 - (NSString *)localizedStringFromByteCount:(long long)value
 {
-    if (SUHost.operatingSystemVersion.minorVersion < 8) {
+    if (![NSByteCountFormatter class]) {
         if (value < 1000) {
             return [NSString stringWithFormat:@"%.0lf %@", value / 1.0,
                     SULocalizedString(@"B", @"the unit for bytes")];


### PR DESCRIPTION
The old code didn't look at the major version and is probably less efficient