### PR TITLE
Fix Test App crashing on systems earlier than 10.9

### DIFF
--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -120,7 +120,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     signUpdateTask.launchPath = signUpdatePath;
     
     NSURL *archiveURL = [serverDirectoryURL URLByAppendingPathComponent:zipName];
-    signUpdateTask.arguments = @[archiveURL, privateKeyPath];
+    signUpdateTask.arguments = @[archiveURL.path, privateKeyPath];
     
     NSPipe *outputPipe = [NSPipe pipe];
     signUpdateTask.standardOutput = outputPipe;


### PR DESCRIPTION
Passing a NSURL instance to a NSTask's arguments calls
-[NSURL fileSystemRepresentation] which is only available on 10.9+