### PR TITLE
File Operations Copy Fixes

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -170,6 +170,11 @@
 		721CF1AB1AD764EB00D9AC09 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */; };
 		7223E7631AD1AEFF008E3161 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
+		726F2CDE1BC9BE5B001971A4 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
+		726F2CDF1BC9C093001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
+		726F2CE01BC9C0EF001971A4 /* SUHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 61EF67550E25B58D00F754E0 /* SUHost.m */; };
+		726F2CE11BC9C100001971A4 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
+		726F2CE21BC9C133001971A4 /* SUSystemProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A2279B0D1CEE7600430CCD /* SUSystemProfiler.m */; };
 		7275F9C11B5F1F2900B1D19E /* SUFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7275F9BF1B5F1F2900B1D19E /* SUFileManager.h */; };
 		7275F9C21B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		7275F9C31B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
@@ -1473,6 +1478,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				726F2CE21BC9C133001971A4 /* SUSystemProfiler.m in Sources */,
+				726F2CE11BC9C100001971A4 /* SULog.m in Sources */,
+				726F2CE01BC9C0EF001971A4 /* SUHost.m in Sources */,
+				726F2CDF1BC9C093001971A4 /* SUConstants.m in Sources */,
+				726F2CDE1BC9BE5B001971A4 /* SUFileManager.m in Sources */,
 				5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */,
 				14652F7E19A9728A00959E44 /* bspatch.c in Sources */,
 				7223E7631AD1AEFF008E3161 /* sais.c in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -171,10 +171,11 @@
 		7223E7631AD1AEFF008E3161 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
 		726F2CDE1BC9BE5B001971A4 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
-		726F2CDF1BC9C093001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
-		726F2CE01BC9C0EF001971A4 /* SUHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 61EF67550E25B58D00F754E0 /* SUHost.m */; };
-		726F2CE11BC9C100001971A4 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
-		726F2CE21BC9C133001971A4 /* SUSystemProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A2279B0D1CEE7600430CCD /* SUSystemProfiler.m */; };
+		726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */; settings = {ASSET_TAGS = (); }; };
+		726F2CE61BC9C33D001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; settings = {ASSET_TAGS = (); }; };
+		726F2CE71BC9C3E2001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
+		726F2CE81BC9C48F001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
+		726F2CE91BC9C499001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		7275F9C11B5F1F2900B1D19E /* SUFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7275F9BF1B5F1F2900B1D19E /* SUFileManager.h */; };
 		7275F9C21B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		7275F9C31B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
@@ -574,6 +575,8 @@
 		7223E7621AD1AEFF008E3161 /* sais.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sais.h; sourceTree = "<group>"; };
 		7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBinaryDeltaCreate.m; sourceTree = "<group>"; };
 		7268AC641AD634E400C3E0C1 /* SUBinaryDeltaCreate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUBinaryDeltaCreate.h; sourceTree = "<group>"; };
+		726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUOperatingSystem.h; sourceTree = "<group>"; };
+		726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUOperatingSystem.m; sourceTree = "<group>"; };
 		7275F9BF1B5F1F2900B1D19E /* SUFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUFileManager.h; sourceTree = "<group>"; };
 		7275F9C01B5F1F2900B1D19E /* SUFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUFileManager.m; sourceTree = "<group>"; };
 		72A4A23F1BB6567D00E7820D /* SUFileManagerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUFileManagerTest.swift; sourceTree = "<group>"; };
@@ -959,6 +962,8 @@
 				14652F8319A9759F00959E44 /* SUExport.h */,
 				61EF67580E25C5B400F754E0 /* SUHost.h */,
 				61EF67550E25B58D00F754E0 /* SUHost.m */,
+				726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */,
+				726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */,
 				55C14F04136EF6DB00649790 /* SULog.h */,
 				55C14F05136EF6DB00649790 /* SULog.m */,
 			);
@@ -1090,6 +1095,7 @@
 				61EF67590E25C5B400F754E0 /* SUHost.h in Headers */,
 				618FA5010DAE88B40026945C /* SUInstaller.h in Headers */,
 				55C14F06136EF6DB00649790 /* SULog.h in Headers */,
+				726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */,
 				618FA5220DAE8E8A0026945C /* SUPackageInstaller.h in Headers */,
 				6102FE460E077FCE00F85D09 /* SUPipedUnarchiver.h in Headers */,
 				618FA5050DAE8AB80026945C /* SUPlainInstaller.h in Headers */,
@@ -1457,6 +1463,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				726F2CE71BC9C3E2001971A4 /* SUOperatingSystem.m in Sources */,
 				55C14BD4136EEFCE00649790 /* Autoupdate.m in Sources */,
 				F8761EB61ADC5E7A000C9034 /* SUCodeSigningVerifier.m in Sources */,
 				55C14F00136EF6B700649790 /* SUConstants.m in Sources */,
@@ -1478,10 +1485,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				726F2CE21BC9C133001971A4 /* SUSystemProfiler.m in Sources */,
-				726F2CE11BC9C100001971A4 /* SULog.m in Sources */,
-				726F2CE01BC9C0EF001971A4 /* SUHost.m in Sources */,
-				726F2CDF1BC9C093001971A4 /* SUConstants.m in Sources */,
+				726F2CE91BC9C499001971A4 /* SUOperatingSystem.m in Sources */,
+				726F2CE81BC9C48F001971A4 /* SUConstants.m in Sources */,
 				726F2CDE1BC9BE5B001971A4 /* SUFileManager.m in Sources */,
 				5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */,
 				14652F7E19A9728A00959E44 /* bspatch.c in Sources */,
@@ -1550,6 +1555,7 @@
 				618FA5060DAE8AB80026945C /* SUPlainInstaller.m in Sources */,
 				6101347C0DD2541A0049ACDF /* SUProbingUpdateDriver.m in Sources */,
 				61B93C0A0DD112FF00DCD2F8 /* SUScheduledUpdateDriver.m in Sources */,
+				726F2CE61BC9C33D001971A4 /* SUOperatingSystem.m in Sources */,
 				61A225A50D1C4AC000430CCD /* SUStandardVersionComparator.m in Sources */,
 				6196CFFA09C72149000DC222 /* SUStatusController.m in Sources */,
 				61A2279D0D1CEE7600430CCD /* SUSystemProfiler.m in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -171,14 +171,12 @@
 		7223E7631AD1AEFF008E3161 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
 		726F2CDE1BC9BE5B001971A4 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
-		726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */; settings = {ASSET_TAGS = (); }; };
-		726F2CE61BC9C33D001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; settings = {ASSET_TAGS = (); }; };
+		726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */; };
+		726F2CE61BC9C33D001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		726F2CE71BC9C3E2001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		726F2CE81BC9C48F001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
 		726F2CE91BC9C499001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
-		726F2CEA1BC9C708001971A4 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		726F2CEB1BC9C733001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
-		726F2CEC1BC9C74F001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		7275F9C11B5F1F2900B1D19E /* SUFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7275F9BF1B5F1F2900B1D19E /* SUFileManager.h */; };
 		7275F9C21B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		7275F9C31B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
@@ -199,7 +197,7 @@
 		767B61AC1972D488004E0C3C /* SUGuidedPackageInstaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 767B61AA1972D488004E0C3C /* SUGuidedPackageInstaller.h */; };
 		767B61AD1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */; };
 		767B61AE1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */; };
-		A5BF4F1D1BC7668B007A052A /* SUTestWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = A5BF4F1C1BC7668B007A052A /* SUTestWebServer.m */; settings = {ASSET_TAGS = (); }; };
+		A5BF4F1D1BC7668B007A052A /* SUTestWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = A5BF4F1C1BC7668B007A052A /* SUTestWebServer.m */; };
 		F8761EB11ADC5068000C9034 /* SUCodeSigningVerifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F8761EB01ADC5068000C9034 /* SUCodeSigningVerifierTest.m */; };
 		F8761EB31ADC50EB000C9034 /* SparkleTestCodeSignApp.zip in Resources */ = {isa = PBXBuildFile; fileRef = F8761EB21ADC50EB000C9034 /* SparkleTestCodeSignApp.zip */; };
 		F8761EB61ADC5E7A000C9034 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B078CD15A5FB6100600039 /* SUCodeSigningVerifier.m */; };
@@ -1529,9 +1527,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				726F2CEC1BC9C74F001971A4 /* SUOperatingSystem.m in Sources */,
 				726F2CEB1BC9C733001971A4 /* SUConstants.m in Sources */,
-				726F2CEA1BC9C708001971A4 /* SUFileManager.m in Sources */,
 				61B5F93009C4CFDC00B25A18 /* main.m in Sources */,
 				A5BF4F1D1BC7668B007A052A /* SUTestWebServer.m in Sources */,
 				72E45CF31B640CDD005C701A /* SUTestApplicationDelegate.m in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -176,6 +176,9 @@
 		726F2CE71BC9C3E2001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		726F2CE81BC9C48F001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
 		726F2CE91BC9C499001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
+		726F2CEA1BC9C708001971A4 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
+		726F2CEB1BC9C733001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
+		726F2CEC1BC9C74F001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		7275F9C11B5F1F2900B1D19E /* SUFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7275F9BF1B5F1F2900B1D19E /* SUFileManager.h */; };
 		7275F9C21B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		7275F9C31B5F1F2900B1D19E /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
@@ -1521,6 +1524,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				726F2CEC1BC9C74F001971A4 /* SUOperatingSystem.m in Sources */,
+				726F2CEB1BC9C733001971A4 /* SUConstants.m in Sources */,
+				726F2CEA1BC9C708001971A4 /* SUFileManager.m in Sources */,
 				61B5F93009C4CFDC00B25A18 /* main.m in Sources */,
 				72E45CF31B640CDD005C701A /* SUTestApplicationDelegate.m in Sources */,
 				72E45CF71B640DAE005C701A /* SUUpdateSettingsWindowController.m in Sources */,

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -452,16 +452,19 @@
     if (relaunchPathToCopy != nil) {
         NSString *targetPath = [self.host.appCachePath stringByAppendingPathComponent:[relaunchPathToCopy lastPathComponent]];
         
-        NSFileManager *fileManager = [[NSFileManager alloc] init];
+        SUFileManager *fileManager = [[SUFileManager alloc] initAllowingAuthorization:NO];
         NSError *error = nil;
+        
+        NSURL *relaunchURLToCopy = [NSURL fileURLWithPath:relaunchPathToCopy];
+        NSURL *targetURL = [NSURL fileURLWithPath:targetPath];
         
         // We only need to run our copy of the app by spawning a task
         // Since we are copying the app to a directory that is write-accessible, we don't need to muck with owner/group IDs
-        if ([self preparePathForRelaunchTool:targetPath error:&error] && [fileManager copyItemAtPath:relaunchPathToCopy toPath:targetPath error:&error]) {
+        if ([self preparePathForRelaunchTool:targetPath error:&error] && [fileManager copyItemAtURL:relaunchURLToCopy toURL:targetURL error:&error]) {
             // We probably don't need to release the quarantine, but we'll do it just in case it's necessary.
             // Perhaps in a sandboxed environment this matters more. Note that this may not be a fatal error.
             NSError *quarantineError = nil;
-            if (![[[SUFileManager alloc] initAllowingAuthorization:NO] releaseItemFromQuarantineAtRootURL:[NSURL fileURLWithPath:targetPath] error:&quarantineError]) {
+            if (![fileManager releaseItemFromQuarantineAtRootURL:targetURL error:&quarantineError]) {
                 SULog(@"Failed to release quarantine on %@ with error %@", targetPath, quarantineError);
             }
             self.relaunchPath = targetPath;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -9,6 +9,7 @@
 #import "SUBasicUpdateDriver.h"
 
 #import "SUHost.h"
+#import "SUOperatingSystem.h"
 #import "SUDSAVerifier.h"
 #import "SUInstaller.h"
 #import "SUStandardVersionComparator.h"
@@ -96,10 +97,10 @@
 
     // Check minimum and maximum System Version
     if ([ui minimumSystemVersion] != nil && ![[ui minimumSystemVersion] isEqualToString:@""]) {
-        minimumVersionOK = [[SUStandardVersionComparator defaultComparator] compareVersion:[ui minimumSystemVersion] toVersion:[SUHost systemVersionString]] != NSOrderedDescending;
+        minimumVersionOK = [[SUStandardVersionComparator defaultComparator] compareVersion:[ui minimumSystemVersion] toVersion:[SUOperatingSystem systemVersionString]] != NSOrderedDescending;
     }
     if ([ui maximumSystemVersion] != nil && ![[ui maximumSystemVersion] isEqualToString:@""]) {
-        maximumVersionOK = [[SUStandardVersionComparator defaultComparator] compareVersion:[ui maximumSystemVersion] toVersion:[SUHost systemVersionString]] != NSOrderedAscending;
+        maximumVersionOK = [[SUStandardVersionComparator defaultComparator] compareVersion:[ui maximumSystemVersion] toVersion:[SUOperatingSystem systemVersionString]] != NSOrderedAscending;
     }
 
     return minimumVersionOK && maximumVersionOK;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -452,7 +452,7 @@
     if (relaunchPathToCopy != nil) {
         NSString *targetPath = [self.host.appCachePath stringByAppendingPathComponent:[relaunchPathToCopy lastPathComponent]];
         
-        SUFileManager *fileManager = [[SUFileManager alloc] initAllowingAuthorization:NO];
+        SUFileManager *fileManager = [SUFileManager fileManagerAllowingAuthorization:NO];
         NSError *error = nil;
         
         NSURL *relaunchURLToCopy = [NSURL fileURLWithPath:relaunchPathToCopy];

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -461,7 +461,7 @@
             // We probably don't need to release the quarantine, but we'll do it just in case it's necessary.
             // Perhaps in a sandboxed environment this matters more. Note that this may not be a fatal error.
             NSError *quarantineError = nil;
-            if (![[[SUFileManager alloc] init] releaseItemFromQuarantineWithoutAuthenticationAtRootURL:[NSURL fileURLWithPath:targetPath] error:&quarantineError]) {
+            if (![[[SUFileManager alloc] initAllowingAuthorization:NO] releaseItemFromQuarantineAtRootURL:[NSURL fileURLWithPath:targetPath] error:&quarantineError]) {
                 SULog(@"Failed to release quarantine on %@ with error %@", targetPath, quarantineError);
             }
             self.relaunchPath = targetPath;

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -7,6 +7,7 @@
 //
 
 #include "SUBinaryDeltaCommon.h"
+#import "SUFileManager.h"
 #include <CommonCrypto/CommonDigest.h>
 #include <Foundation/Foundation.h>
 #include <fcntl.h>
@@ -220,7 +221,7 @@ BOOL removeTree(NSString *path)
 
 BOOL copyTree(NSString *source, NSString *dest)
 {
-    return [[NSFileManager defaultManager] copyItemAtPath:source toPath:dest error:nil];
+    return [[SUFileManager fileManagerAllowingAuthorization:NO] copyItemAtURL:[NSURL fileURLWithPath:source] toURL:[NSURL fileURLWithPath:dest] error:NULL];
 }
 
 BOOL modifyPermissions(NSString *path, mode_t desiredPermissions)

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -9,11 +9,21 @@
 #import <Foundation/Foundation.h>
 
 /**
- * A class used for performing file operations that may also perform authentication if permission is denied when trying to
+ * A class used for performing file operations that may also perform authentication if allowed and if permission is denied when trying to
  * perform them normally as the running user. All operations on this class may be used on thread other than the main thread.
  * This class provides basic file operations and stays away from including much application-level logic.
  */
 @interface SUFileManager : NSObject
+
+/**
+ * Initializes a file manager
+ * @param allowsAuthorization Specifies whether operations invoked on this instance are allowed to acquire authorization in order
+ *  to perform file operations when read or write access is denied
+ * @return A new file manager instance
+ * 
+ * This method just initializes the file manager. It doesn't acquire authorization immediately if allowsAuthorization is YES
+ */
+- (id)initAllowingAuthorization:(BOOL)allowsAuthorization;
 
 /**
  * Creates a temporary directory on the same volume as a provided URL
@@ -109,10 +119,5 @@
  * This is not an atomic operation.
  */
 - (BOOL)releaseItemFromQuarantineAtRootURL:(NSURL *)rootURL error:(NSError **)error;
-
-/**
- * Behaves as -releaseItemFromQuarantineAtRootURL:error: does, except without the capability of authenticating when permission is denied
- */
-- (BOOL)releaseItemFromQuarantineWithoutAuthenticationAtRootURL:(NSURL *)rootURL error:(NSError **)error;
 
 @end

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -16,14 +16,14 @@
 @interface SUFileManager : NSObject
 
 /**
- * Initializes a file manager
+ * Creates a file manager that allows or disallows authorizing for file operations
  * @param allowsAuthorization Specifies whether operations invoked on this instance are allowed to acquire authorization in order
  *  to perform file operations when read or write access is denied
  * @return A new file manager instance
  * 
- * This method just initializes the file manager. It doesn't acquire authorization immediately if allowsAuthorization is YES
+ * This method just creates the file manager. It doesn't acquire authorization immediately if allowsAuthorization is YES
  */
-- (id)initAllowingAuthorization:(BOOL)allowsAuthorization;
++ (instancetype)fileManagerAllowingAuthorization:(BOOL)allowsAuthorization;
 
 /**
  * Creates a temporary directory on the same volume as a provided URL

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -50,6 +50,17 @@
 - (BOOL)moveItemAtURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL error:(NSError **)error;
 
 /**
+ * Copies an item from a source to a destination
+ * @param sourceURL A URL pointing to the item to move. The item at this URL must exist.
+ * @param destinationURL A URL pointing to the destination the item will be moved at. An item must not already exist at this URL.
+ * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
+ * @return YES if the item was copied successfully, otherwise NO along with a populated error object
+ *
+ * This is not an atomic operation.
+ */
+- (BOOL)copyItemAtURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL error:(NSError **)error;
+
+/**
  * Moves an item at a specified URL to the running user's trash directory
  * @param url A URL pointing to the item to move to the trash. The item at this URL must exist.
  * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -310,9 +310,10 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
 /*
  * Copies an item from one location to another
  * This intentionally does *not* use copyfile() or any API that uses it such as NSFileManager's copy item method
- * This is because copyfile() fails to copy symbolic links from one network mount to another, which will affect copying apps
- * This failure has been reproduced on 10.11.0 and a VM running 10.8, so the issue has existed for a while.
- * For more info, see the bug report at http://openradar.appspot.com/radar?id=4925873463492608
+ * This is because copyfile() can fail to copy symbolic links from one network mount to another, which will affect copying apps
+ * This failure occurs because the system may think symbolic links on a SMB mount are zero bytes in size
+ * For more info, see bug reports at http://openradar.appspot.com/radar?id=4925873463492608
+ * and http://openradar.appspot.com/radar?id=5024037222744064
  */
 - (BOOL)copyItemAtURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL error:(NSError * __autoreleasing *)error
 {

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -7,7 +7,7 @@
 //
 
 #import "SUFileManager.h"
-#import "SUHost.h"
+#import "SUOperatingSystem.h"
 
 #include <sys/xattr.h>
 #include <sys/errno.h>
@@ -846,7 +846,7 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
     NSURL *trashURL = nil;
     BOOL canUseNewTrashAPI = YES;
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 1080
-    canUseNewTrashAPI = [SUHost isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 8, 0}];
+    canUseNewTrashAPI = [SUOperatingSystem isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 8, 0}];
     if (!canUseNewTrashAPI) {
         FSRef trashRef;
         if (FSFindFolder(kUserDomain, kTrashFolderType, kDontCreateFolder, &trashRef) == noErr) {

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -319,7 +319,7 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
     
     if (![self _itemExistsAtURL:destinationURL.URLByDeletingLastPathComponent]) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteFileExistsError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination parent directory to copy into (%@) does not exist.", destinationURL.URLByDeletingLastPathComponent.lastPathComponent] }];
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination parent directory to copy into (%@) does not exist.", destinationURL.URLByDeletingLastPathComponent.lastPathComponent] }];
         }
         return NO;
     }

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -55,7 +55,7 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
     BOOL _allowsAuthorization;
 }
 
-- (id)initAllowingAuthorization:(BOOL)allowsAuthorization
+- (instancetype)initAllowingAuthorization:(BOOL)allowsAuthorization
 {
     self = [super init];
     if (self != nil) {
@@ -63,6 +63,12 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
         _allowsAuthorization = allowsAuthorization;
     }
     return self;
+}
+
+
++ (instancetype)fileManagerAllowingAuthorization:(BOOL)allowsAuthorization
+{
+    return [[self alloc] initAllowingAuthorization:allowsAuthorization];
 }
 
 // Acquires an authorization reference which is intended to be used for future authorized file operations

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -317,6 +317,13 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
         return NO;
     }
     
+    if (![self _itemExistsAtURL:destinationURL.URLByDeletingLastPathComponent]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteFileExistsError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination parent directory to copy into (%@) does not exist.", destinationURL.URLByDeletingLastPathComponent.lastPathComponent] }];
+        }
+        return NO;
+    }
+    
     if ([self _itemExistsAtURL:destinationURL]) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteFileExistsError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination file to copy to (%@) already exists.", destinationURL.lastPathComponent] }];
@@ -444,14 +451,21 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
 {
     if (![self _itemExistsAtURL:sourceURL]) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Source file to move (%@) does not exist.", sourceURL.path.lastPathComponent] }];
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Source file to move (%@) does not exist.", sourceURL.lastPathComponent] }];
+        }
+        return NO;
+    }
+    
+    if (![self _itemExistsAtURL:destinationURL.URLByDeletingLastPathComponent]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination parent directory to move into (%@) does not exist.", destinationURL.URLByDeletingLastPathComponent.lastPathComponent] }];
         }
         return NO;
     }
     
     if ([self _itemExistsAtURL:destinationURL]) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteFileExistsError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination file to move (%@) already exists.", destinationURL.path.lastPathComponent] }];
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteFileExistsError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination file to move (%@) already exists.", destinationURL.lastPathComponent] }];
         }
         return NO;
     }

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -23,10 +23,6 @@ typedef struct {
 
 @property (strong, readonly) NSBundle *bundle;
 
-+ (NSOperatingSystemVersion)operatingSystemVersion;
-+ (BOOL)isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion)version;
-+ (NSString *)systemVersionString;
-
 - (instancetype)initWithBundle:(NSBundle *)aBundle;
 @property (readonly, copy) NSString *bundlePath;
 @property (readonly) BOOL allowsAutomaticUpdates;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -284,43 +284,4 @@
     return [self objectForUserDefaultsKey:key] ? [self boolForUserDefaultsKey:key] : [self boolForInfoDictionaryKey:key];
 }
 
-+ (NSOperatingSystemVersion)operatingSystemVersion
-{
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wselector"
-    // Xcode 5.1.1: operatingSystemVersion is clearly declared, must warn due to a compiler bug?
-    if (![NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)])
-#pragma clang diagnostic pop
-    {
-        NSOperatingSystemVersion version = { 0, 0, 0 };
-        NSURL *coreServices = [[NSFileManager defaultManager] URLForDirectory:NSCoreServiceDirectory inDomain:NSSystemDomainMask appropriateForURL:nil create:NO error:nil];
-        NSArray *components = [[NSDictionary dictionaryWithContentsOfURL:[coreServices URLByAppendingPathComponent:@"SystemVersion.plist"]][@"ProductVersion"] componentsSeparatedByString:@"."];
-        version.majorVersion = components.count > 0 ? [components[0] integerValue] : 0;
-        version.minorVersion = components.count > 1 ? [components[1] integerValue] : 0;
-        version.patchVersion = components.count > 2 ? [components[2] integerValue] : 0;
-        return version;
-    }
-#endif
-    return [[NSProcessInfo processInfo] operatingSystemVersion];
-}
-
-+ (BOOL)isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion)version
-{
-    const NSOperatingSystemVersion systemVersion = self.operatingSystemVersion;
-    if (systemVersion.majorVersion == version.majorVersion) {
-        if (systemVersion.minorVersion == version.minorVersion) {
-            return systemVersion.patchVersion >= version.patchVersion;
-        }
-        return systemVersion.minorVersion >= version.minorVersion;
-    }
-    return systemVersion.majorVersion >= version.majorVersion;
-}
-
-+ (NSString *)systemVersionString
-{
-    NSOperatingSystemVersion version = self.operatingSystemVersion;
-    return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion, (long)version.minorVersion, (long)version.patchVersion];
-}
-
 @end

--- a/Sparkle/SUOperatingSystem.h
+++ b/Sparkle/SUOperatingSystem.h
@@ -1,0 +1,16 @@
+//
+//  SUOperatingSystem.h
+//  Sparkle
+//
+//  Copyright © 2015 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SUOperatingSystem : NSObject
+
++ (NSOperatingSystemVersion)operatingSystemVersion;
++ (BOOL)isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion)version;
++ (NSString *)systemVersionString;
+
+@end

--- a/Sparkle/SUOperatingSystem.m
+++ b/Sparkle/SUOperatingSystem.m
@@ -1,0 +1,51 @@
+//
+//  SUOperatingSystem.m
+//  Sparkle
+//
+//  Copyright © 2015 Sparkle Project. All rights reserved.
+//
+
+#import "SUOperatingSystem.h"
+
+@implementation SUOperatingSystem
+
++ (NSOperatingSystemVersion)operatingSystemVersion
+{
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wselector"
+    // Xcode 5.1.1: operatingSystemVersion is clearly declared, must warn due to a compiler bug?
+    if (![NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)])
+#pragma clang diagnostic pop
+    {
+        NSOperatingSystemVersion version = { 0, 0, 0 };
+        NSURL *coreServices = [[NSFileManager defaultManager] URLForDirectory:NSCoreServiceDirectory inDomain:NSSystemDomainMask appropriateForURL:nil create:NO error:nil];
+        NSArray *components = [[NSDictionary dictionaryWithContentsOfURL:[coreServices URLByAppendingPathComponent:@"SystemVersion.plist"]][@"ProductVersion"] componentsSeparatedByString:@"."];
+        version.majorVersion = components.count > 0 ? [components[0] integerValue] : 0;
+        version.minorVersion = components.count > 1 ? [components[1] integerValue] : 0;
+        version.patchVersion = components.count > 2 ? [components[2] integerValue] : 0;
+        return version;
+    }
+#endif
+    return [[NSProcessInfo processInfo] operatingSystemVersion];
+}
+
++ (BOOL)isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion)version
+{
+    const NSOperatingSystemVersion systemVersion = self.operatingSystemVersion;
+    if (systemVersion.majorVersion == version.majorVersion) {
+        if (systemVersion.minorVersion == version.minorVersion) {
+            return systemVersion.patchVersion >= version.patchVersion;
+        }
+        return systemVersion.minorVersion >= version.minorVersion;
+    }
+    return systemVersion.majorVersion >= version.majorVersion;
+}
+
++ (NSString *)systemVersionString
+{
+    NSOperatingSystemVersion version = self.operatingSystemVersion;
+    return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion, (long)version.minorVersion, (long)version.patchVersion];
+}
+
+@end

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -42,7 +42,7 @@
         return NO;
     }
     
-    SUFileManager *fileManager = [[SUFileManager alloc] init];
+    SUFileManager *fileManager = [[SUFileManager alloc] initAllowingAuthorization:YES];
     
     // Create a temporary directory for our new app that resides on our destination's volume
     NSURL *tempNewDirectoryURL = [fileManager makeTemporaryDirectoryWithPreferredName:[installationURL.lastPathComponent.stringByDeletingPathExtension stringByAppendingString:@" (Incomplete Update)"] appropriateForDirectoryURL:installationURL.URLByDeletingLastPathComponent error:error];

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -42,7 +42,7 @@
         return NO;
     }
     
-    SUFileManager *fileManager = [[SUFileManager alloc] initAllowingAuthorization:YES];
+    SUFileManager *fileManager = [SUFileManager fileManagerAllowingAuthorization:YES];
     
     // Create a temporary directory for our new app that resides on our destination's volume
     NSURL *tempNewDirectoryURL = [fileManager makeTemporaryDirectoryWithPreferredName:[installationURL.lastPathComponent.stringByDeletingPathExtension stringByAppendingString:@" (Incomplete Update)"] appropriateForDirectoryURL:installationURL.URLByDeletingLastPathComponent error:error];

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -11,6 +11,7 @@
 #import "SUSystemProfiler.h"
 
 #import "SUHost.h"
+#import "SUOperatingSystem.h"
 #include <sys/sysctl.h>
 
 static NSString *const SUSystemProfilerApplicationNameKey = @"appName";
@@ -53,7 +54,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     size_t length = sizeof(value);
 
     // OS version
-    NSString *currentSystemVersion = [SUHost systemVersionString];
+    NSString *currentSystemVersion = [SUOperatingSystem systemVersionString];
     if (currentSystemVersion != nil) {
         [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerOperatingSystemVersionKey, @"OS Version", currentSystemVersion, currentSystemVersion] forKeys:profileDictKeys]];
     }

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -11,6 +11,7 @@
 #import "SUUpdateAlert.h"
 #import "SUUpdater_Private.h"
 #import "SUHost.h"
+#import "SUOperatingSystem.h"
 #import "SUStatusController.h"
 #import "SUConstants.h"
 
@@ -143,7 +144,7 @@
 
 - (NSString *)localizedStringFromByteCount:(long long)value
 {
-    if (![SUHost isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 8, 0}]) {
+    if (![SUOperatingSystem isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 8, 0}]) {
         if (value < 1000) {
             return [NSString stringWithFormat:@"%.0lf %@", value / 1.0,
                     SULocalizedString(@"B", @"the unit for bytes")];

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -8,6 +8,7 @@
 
 #import "SUTestApplicationDelegate.h"
 #import "SUUpdateSettingsWindowController.h"
+#import "SUFileManager.h"
 
 @interface SUTestApplicationDelegate ()
 
@@ -37,11 +38,11 @@ static NSString * const UPDATED_VERSION = @"2.0";
         [[NSApplication sharedApplication] terminate:nil];
     }
     
-    NSFileManager *fileManager = [NSFileManager defaultManager];
+    SUFileManager *fileManager = [[SUFileManager alloc] initAllowingAuthorization:NO];
     
     // Locate user's cache directory
     NSError *cacheError = nil;
-    NSURL *cacheDirectoryURL = [fileManager URLForDirectory:NSCachesDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:&cacheError];
+    NSURL *cacheDirectoryURL = [[NSFileManager defaultManager] URLForDirectory:NSCachesDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:&cacheError];
     
     if (cacheDirectoryURL == nil) {
         NSLog(@"Failed to locate cache directory with error: %@", cacheError);
@@ -62,7 +63,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     }
     
     NSError *createDirectoryError = nil;
-    if (![fileManager createDirectoryAtURL:serverDirectoryURL withIntermediateDirectories:YES attributes:nil error:&createDirectoryError]) {
+    if (![[NSFileManager defaultManager] createDirectoryAtURL:serverDirectoryURL withIntermediateDirectories:YES attributes:nil error:&createDirectoryError]) {
         NSLog(@"Failed creating directory at %@ with error %@", serverDirectoryURL.path, createDirectoryError);
         assert(NO);
     }
@@ -137,7 +138,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     
     // Obtain the file attributes to get the file size of our update later
     NSError *fileAttributesError = nil;
-    NSDictionary *archiveFileAttributes = [fileManager attributesOfItemAtPath:archiveURL.path error:&fileAttributesError];
+    NSDictionary *archiveFileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:archiveURL.path error:&fileAttributesError];
     if (archiveFileAttributes == nil) {
         NSLog(@"Failed to retrieve file attributes from archive with error %@", fileAttributesError);
         assert(NO);
@@ -178,7 +179,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     // Finally start the server
     NSTask *serverTask = [[NSTask alloc] init];
     serverTask.launchPath = @"/usr/bin/python";
-    assert([fileManager fileExistsAtPath:serverTask.launchPath]);
+    assert([[NSFileManager defaultManager] fileExistsAtPath:serverTask.launchPath]);
     serverTask.arguments = @[@"-m", @"SimpleHTTPServer", @"1337"];
     serverTask.currentDirectoryPath = serverDirectoryPath;
     [serverTask launch];

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -38,7 +38,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
         [[NSApplication sharedApplication] terminate:nil];
     }
     
-    SUFileManager *fileManager = [[SUFileManager alloc] initAllowingAuthorization:NO];
+    SUFileManager *fileManager = [SUFileManager fileManagerAllowingAuthorization:NO];
     
     // Locate user's cache directory
     NSError *cacheError = nil;

--- a/Tests/SUFileManagerTest.swift
+++ b/Tests/SUFileManagerTest.swift
@@ -36,6 +36,7 @@ class SUFileManagerTest: XCTestCase
     {
         makeTempFiles() { fileManager, rootURL, ordinaryFileURL, directoryURL, fileInDirectoryURL in
             XCTAssertNil(try? fileManager.moveItemAtURL(ordinaryFileURL, toURL: directoryURL))
+            XCTAssertNil(try? fileManager.moveItemAtURL(ordinaryFileURL, toURL: directoryURL.URLByAppendingPathComponent("foo").URLByAppendingPathComponent("bar")))
             XCTAssertNil(try? fileManager.moveItemAtURL(rootURL.URLByAppendingPathComponent("does not exist"), toURL: directoryURL))
             
             let newFileURL = (ordinaryFileURL.URLByDeletingLastPathComponent?.URLByAppendingPathComponent("new file"))!
@@ -82,6 +83,7 @@ class SUFileManagerTest: XCTestCase
     {
         makeTempFiles() { fileManager, rootURL, ordinaryFileURL, directoryURL, fileInDirectoryURL in
             XCTAssertNil(try? fileManager.copyItemAtURL(ordinaryFileURL, toURL: directoryURL))
+            XCTAssertNil(try? fileManager.copyItemAtURL(ordinaryFileURL, toURL: directoryURL.URLByAppendingPathComponent("foo").URLByAppendingPathComponent("bar")))
             XCTAssertNil(try? fileManager.copyItemAtURL(rootURL.URLByAppendingPathComponent("does not exist"), toURL: directoryURL))
             
             let newFileURL = (ordinaryFileURL.URLByDeletingLastPathComponent?.URLByAppendingPathComponent("new file"))!

--- a/Tests/SUFileManagerTest.swift
+++ b/Tests/SUFileManagerTest.swift
@@ -77,6 +77,26 @@ class SUFileManagerTest: XCTestCase
             try! fileManager.removeItemAtURL(directoryTrashURL)
         }
     }
+    
+    func testCopyFiles()
+    {
+        makeTempFiles() { fileManager, rootURL, ordinaryFileURL, directoryURL, fileInDirectoryURL in
+            XCTAssertNil(try? fileManager.copyItemAtURL(ordinaryFileURL, toURL: directoryURL))
+            XCTAssertNil(try? fileManager.copyItemAtURL(rootURL.URLByAppendingPathComponent("does not exist"), toURL: directoryURL))
+            
+            let newFileURL = (ordinaryFileURL.URLByDeletingLastPathComponent?.URLByAppendingPathComponent("new file"))!
+            try! fileManager.copyItemAtURL(ordinaryFileURL, toURL: newFileURL)
+            XCTAssertTrue(fileManager._itemExistsAtURL(ordinaryFileURL))
+            XCTAssertTrue(fileManager._itemExistsAtURL(newFileURL))
+            
+            let newDirectoryURL = (ordinaryFileURL.URLByDeletingLastPathComponent?.URLByAppendingPathComponent("new directory"))!
+            try! fileManager.copyItemAtURL(directoryURL, toURL: newDirectoryURL)
+            XCTAssertTrue(fileManager._itemExistsAtURL(directoryURL))
+            XCTAssertTrue(fileManager._itemExistsAtURL(newDirectoryURL))
+            XCTAssertTrue(fileManager._itemExistsAtURL(fileInDirectoryURL))
+            XCTAssertTrue(fileManager._itemExistsAtURL(newDirectoryURL.URLByAppendingPathComponent(fileInDirectoryURL.lastPathComponent!)))
+        }
+    }
 
     func testRemoveFiles()
     {


### PR DESCRIPTION
See issue #651 and [my open radar issue](http://openradar.appspot.com/23059163) for current issues sparkle has with copying items from different network mounted drives. Also made a small improvement to allowing/disallowing the authorization code from triggering.