### PR TITLE
Misc fixes

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -83,7 +83,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     self = [super init];
     if (bundle == nil) bundle = [NSBundle mainBundle];
 
-    self.sparkleBundle = [NSBundle bundleForClass:[self class]];
+    self.sparkleBundle = [NSBundle bundleForClass:[SUUpdater class]];
     if (!self.sparkleBundle) {
         SULog(@"Error: SUUpdater can't find Sparkle.framework it belongs to");
         return nil;

--- a/Sparkle/el.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/el.lproj/SUAutomaticUpdateAlert.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5037.3" systemVersion="13C44" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment version="1060" identifier="macosx"/>
+        <deployment identifier="macosx"/>
         <development version="5000" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5037.3"/>
     </dependencies>

--- a/Sparkle/el.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/el.lproj/SUUpdatePermissionPrompt.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5037.3" systemVersion="13C44" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment version="1060" identifier="macosx"/>
+        <deployment identifier="macosx"/>
         <development version="5000" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5037.3"/>
     </dependencies>


### PR DESCRIPTION
1. The change in SUUpdater.m is to support the cases where SUUpdater is subclassed from a different bundle.  In that case, using [self class] to try to determine the Sparkle Bundle is incorrect.  You must use [SUUpdater class] to ensure you're targeting the actual Sparkle bundle.

2. The other changes are just to get rid of some Xcode warnings which a a result of some .XIB's having their deployment target set to OSX 10.6 while the project is targeted at OSX 10.7.