### PR TITLE
New feature: didDownloadUpdate delegate method

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -417,6 +417,13 @@
         return;
     }
 
+    id<SUUpdaterDelegate> updaterDelegate = [self.updater delegate];
+    if ([updaterDelegate respondsToSelector:@selector(updater:didDownloadUpdate:tempPath:)])
+    {
+        NSString *installSourcePath = [SUInstaller installSourcePathInUpdateFolder:self.tempDir forHost:self.host isPackage:NULL isGuided:NULL];
+        [updaterDelegate updater:self.updater didDownloadUpdate:self.updateItem tempPath:installSourcePath];
+    }
+    
     if (![self.updater mayUpdateAndRestart])
     {
         [self abortUpdate];
@@ -425,7 +432,6 @@
 
     // Give the host app an opportunity to postpone the install and relaunch.
     static BOOL postponedOnce = NO;
-    id<SUUpdaterDelegate> updaterDelegate = [self.updater delegate];
     if (!postponedOnce && [updaterDelegate respondsToSelector:@selector(updater:shouldPostponeRelaunchForUpdate:untilInvoking:)])
     {
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[[self class] instanceMethodSignatureForSelector:@selector(installWithToolAndRelaunch:)]];

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -254,9 +254,33 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 - (void)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
 
 /*!
- Called immediately before installing the specified update.
+ Called after the update has been downloaded, but before relaunching and moving it to its final destination.
  
- Delegates can use this call to perform post-processing on the downloaded content.
+ Delegates can use this call to perform post-processing on the downloaded content.  For example:
+ \code
+    -   (void)updater:(SUUpdater *)updater
+    didDownloadUpdate:(SUAppcastItem *)item
+             tempPath:(NSString *)path
+    {
+        // locate a script called "postupdate.sh" in the downloaded version's resources folder
+        NSBundle *bundle = [NSBundle bundleWithPath:path];
+        NSString *scriptPath = [bundle pathForResource:@"postupdate" ofType:@"sh"];
+        if (scriptPath)
+        {
+            // execute the script
+            scriptPath = [NSString stringWithFormat:@"\"%@\"", scriptPath];
+            int exitCode = system([scriptPath cStringUsingEncoding:NSUTF8StringEncoding]);
+            if (exitCode)
+            {
+                // script failed
+            }
+        }
+        else
+        {
+            // the script was not in the downloaded version
+        }
+    }
+ \endcode
  
  \param updater The SUUpdater instance.
  \param item The appcast item corresponding to the update that is proposed to be installed.

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -254,6 +254,17 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 - (void)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
 
 /*!
+ Called immediately before installing the specified update.
+ 
+ Delegates can use this call to perform post-processing on the downloaded content.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that is proposed to be installed.
+ \param path The temporary location the product was downloaded into.
+ */
+- (void)updater:(SUUpdater *)updater didDownloadUpdate:(SUAppcastItem *)item tempPath:(NSString *)path;
+
+/*!
     Returns whether the relaunch should be delayed in order to perform other tasks.
 
     This is not called if the user didn't relaunch on the previous update,


### PR DESCRIPTION
I added this feature to solve my special use case and may be useful to others.

Use case: In order to avoid using a .pkg which would force the user to enter their admin password during the upgrade, I decided to package my updates a regular .zip bundle.  So Sparkle will download and put the files in the right place.  But the the package had an important post-flight script that needed to be ran, which won't happen now.  The way I solved this is by adding a "didDownloadUpdate" event to the delegate.  In my case, I check to see if there is a post-processing script in the downloaded bundle and execute it.  

An example is given in the comment block for the new delegate method.