### PR TITLE
Ability to trace application flow and customize logging.

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -260,6 +260,8 @@ int main(int __unused argc, const char __unused *argv[])
                                                                shouldShowUI:shouldShowUI];
         [application setDelegate:appInstaller];
         [application run];
+        
+        SUMaybeTrimLogFile();
     }
 
     return EXIT_SUCCESS;

--- a/Sparkle/SUAutomaticUpdateDriver.m
+++ b/Sparkle/SUAutomaticUpdateDriver.m
@@ -11,6 +11,7 @@
 #import "SUAutomaticUpdateAlert.h"
 #import "SUHost.h"
 #import "SUConstants.h"
+#import "SULog.h"
 
 // If the user hasn't quit in a week, ask them if they want to relaunch to get the latest bits. It doesn't matter that this measure of "one day" is imprecise.
 static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 24 * 7;
@@ -201,6 +202,13 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
         }
 
         [self abortUpdate];
+        
+        if ([error code] != SUNoUpdateError) {
+            SULog(@"Error: %@ %@ (URL %@)",
+                  error.localizedDescription,
+                  error.localizedFailureReason,
+                  error.userInfo[NSURLErrorFailingURLErrorKey]);
+        }
     }
 }
 

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -55,6 +55,11 @@ extern NSString *const SUAppendVersionNumberKey __attribute__((deprecated("This 
 extern NSString *const SUEnableAutomatedDowngradesKey __attribute__((deprecated("This key is obsolete. See SPARKLE_AUTOMATED_DOWNGRADES.")));
 extern NSString *const SUNormalizeInstalledApplicationNameKey __attribute__((deprecated("This key is obsolete. SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME.")));
 extern NSString *const SURelaunchToolNameKey __attribute__((deprecated("This key is obsolete. SPARKLE_RELAUNCH_TOOL_NAME.")));
+extern NSString *const SULogClearAtLaunchKey;
+extern NSString *const SULogMaxFileSizeKey;
+extern NSString *const SULogPersonalLogFileKey;
+extern NSString *const SULogTraceLoggingKey;
+extern NSString *const SULogTrimMaxFileSizeCoefficientKey;
 
 // -----------------------------------------------------------------------------
 //	Appcast keys::

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -52,6 +52,12 @@ NSString *const SUEnableAutomatedDowngradesKey = @"SUEnableAutomatedDowngrades";
 NSString *const SUNormalizeInstalledApplicationNameKey = @"SUNormalizeInstalledApplicationName";
 NSString *const SURelaunchToolNameKey = @"SURelaunchToolName";
 
+NSString *const SULogClearAtLaunchKey = @"SULogClearAtLaunch";
+NSString *const SULogMaxFileSizeKey = @"SULogMaxFileSize";
+NSString *const SULogPersonalLogFileKey = @"SULogPersonalLogFile";
+NSString *const SULogTraceLoggingKey = @"SULogTraceLogging";
+NSString *const SULogTrimMaxFileSizeCoefficientKey = @"SULogTrimMaxFileSizeCoefficient";
+
 NSString *const SUAppcastAttributeDeltaFrom = @"sparkle:deltaFrom";
 NSString *const SUAppcastAttributeDSASignature = @"sparkle:dsaSignature";
 NSString *const SUAppcastAttributeShortVersionString = @"sparkle:shortVersionString";

--- a/Sparkle/SULog.h
+++ b/Sparkle/SULog.h
@@ -27,6 +27,9 @@
 // -----------------------------------------------------------------------------
 
 void SUClearLog(void);
+void SULoadLogSettingsFromBundle(NSBundle *bundle);
 void SULog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+void SULogTrace(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+void SUMaybeTrimLogFile(void);
 
 #endif

--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -13,13 +13,53 @@
 
 #include "SULog.h"
 
+#include "SUHost.h"
+
 
 // -----------------------------------------------------------------------------
 //	Constants:
 // -----------------------------------------------------------------------------
 
-static NSString *const SULogFilePath = @"~/Library/Logs/SparkleUpdateLog.log";
+static NSString *const SULogDefaultFilePath = @"~/Library/Logs/SparkleUpdateLog.log";
+static NSString *const SULogFilePathTemplate = @"~/Library/Logs/SparkleUpdateLog-%@.log";
 
+static unsigned long long MaxLogFileSize = 1 * 1024 * 1024; // 1MB default
+static float TrimMaxFileSizeCoefficient = 0.75;
+static BOOL EnableTraceLogging = NO;
+static BOOL UsePersonalLogFile = NO;
+static BOOL ClearAtLaunch = YES;
+
+// -----------------------------------------------------------------------------
+//	Private prototypes:
+// -----------------------------------------------------------------------------
+
+NSString *SULogFilePath(void);
+NSString *SUCustomLogFilePath(void);
+
+// -----------------------------------------------------------------------------
+//	SUGetFilePath:
+//		Returns the log file path
+// -----------------------------------------------------------------------------
+
+NSString *SULogFilePath(void)
+{
+    return UsePersonalLogFile ? SUCustomLogFilePath() : SULogDefaultFilePath;
+}
+
+// -----------------------------------------------------------------------------
+//	SUCustomLogFilePath:
+//		Returns a path, unique for the application, in the user's logs dir
+// -----------------------------------------------------------------------------
+
+NSString *SUCustomLogFilePath(void)
+{
+    static NSString *filePath = nil;
+    if (filePath == nil) {
+        filePath = [NSString stringWithFormat:SULogFilePathTemplate,
+                    [[NSFileManager defaultManager] displayNameAtPath:[[NSBundle mainBundle] bundlePath]]];
+    }
+    return filePath;
+}
 
 // -----------------------------------------------------------------------------
 //	SUClearLog:
@@ -34,7 +74,7 @@ static NSString *const SULogFilePath = @"~/Library/Logs/SparkleUpdateLog.log";
 
 void SUClearLog(void)
 {
-    FILE *logfile = fopen([[SULogFilePath stringByExpandingTildeInPath] fileSystemRepresentation], "w");
+    FILE *logfile = fopen([[SULogFilePath() stringByExpandingTildeInPath] fileSystemRepresentation], "w");
     if (logfile) {
         fclose(logfile);
         SULog(@"===== %@ =====", [[NSFileManager defaultManager] displayNameAtPath:[[NSBundle mainBundle] bundlePath]]);
@@ -57,7 +97,9 @@ void SULog(NSString *format, ...)
     static BOOL loggedYet = NO;
     if (!loggedYet) {
         loggedYet = YES;
-        SUClearLog();
+        if (ClearAtLaunch) {
+            SUClearLog();
+        }
     }
 
     va_list ap;
@@ -65,7 +107,7 @@ void SULog(NSString *format, ...)
     NSString *theStr = [[NSString alloc] initWithFormat:format arguments:ap];
     NSLog(@"Sparkle: %@", theStr);
 
-    FILE *logfile = fopen([[SULogFilePath stringByExpandingTildeInPath] fileSystemRepresentation], "a");
+    FILE *logfile = fopen([[SULogFilePath() stringByExpandingTildeInPath] fileSystemRepresentation], "a");
     if (logfile) {
         theStr = [NSString stringWithFormat:@"%@: %@\n", [NSDate date], theStr];
         NSData *theData = [theStr dataUsingEncoding:NSUTF8StringEncoding];
@@ -75,4 +117,117 @@ void SULog(NSString *format, ...)
     va_end(ap);
 }
 
+// -----------------------------------------------------------------------------
+//	SULogTrace:
+//		Same like SULog, but logs only when tracing option is enabled
+//
+//	TAKES:
+//		format	-	NSLog/printf-style format string.
+//		...		-	More parameters depending on format string's contents.
+// -----------------------------------------------------------------------------
 
+void SULogTrace(NSString *format, ...) {
+    if (!EnableTraceLogging) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, format);
+    NSString *theStr = [[NSString alloc] initWithFormat:format arguments:ap];
+    
+    SULog(@"%@", theStr);
+    
+    va_end(ap);
+}
+
+// -----------------------------------------------------------------------------
+//	SUMaybeTrimLogFile:
+//      	Call this function to reduce log file size if it became bigger than
+//		defined MaxLogFileSize constant. Data is reduced up to DesiredLogFileSize
+//		and to the first character after its first new line character.
+// -----------------------------------------------------------------------------
+
+void SUMaybeTrimLogFile(void)
+{
+    NSString *logFilePath = [SULogFilePath() stringByExpandingTildeInPath];
+    NSError *error = nil;
+    
+    if (![[NSFileManager defaultManager] fileExistsAtPath:logFilePath]) {
+        return;
+    }
+    
+    unsigned long long logSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:logFilePath
+                                                                                   error:&error] fileSize];
+    
+    if (error != nil) {
+        NSLog(@"%@", error);
+        return;
+    }
+    
+    if (logSize < MaxLogFileSize) {
+        return;
+    }
+    
+    // Read contents from the log file
+    NSString *contents = [NSString stringWithContentsOfFile:logFilePath encoding:NSUTF8StringEncoding error:&error];
+    if (error != nil) {
+        NSLog(@"%@", error);
+    }
+    if (contents.length == 0) {
+        return;
+    }
+    
+    NSUInteger cropLength = (NSUInteger)((MaxLogFileSize * TrimMaxFileSizeCoefficient) * contents.length / logSize);
+    if (contents.length < cropLength) {
+        return;
+    }
+    
+    // Trim to desired size
+    NSString *newContents = [contents substringFromIndex:contents.length - cropLength];
+    if (newContents.length == 0) {
+        return;
+    }
+    // Trim to the first character after first new-line character, if possible
+    NSRange firstNewLineRange = [newContents rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];
+    if (firstNewLineRange.location != NSNotFound && firstNewLineRange.location + 1 < newContents.length) {
+        newContents = [newContents substringFromIndex:firstNewLineRange.location + 1];
+    }
+    
+    // Save results to the file (overwrite)
+    [newContents writeToFile:logFilePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    if (error != nil) {
+        NSLog(@"%@", error);
+    }
+}
+
+// -----------------------------------------------------------------------------
+//	SULoadLogSettingsFromBundle:
+//      	Loads logging settings from the given bundle
+// -----------------------------------------------------------------------------
+
+void SULoadLogSettingsFromBundle(NSBundle *bundle)
+{
+    SUHost *host = [[SUHost alloc] initWithBundle:bundle];
+    if (host == nil) {
+        return;
+    }
+    
+    if ([host objectForKey:SULogTraceLoggingKey] != nil) {
+        EnableTraceLogging = [host boolForKey:SULogTraceLoggingKey];
+    }
+    if ([host objectForKey:SULogPersonalLogFileKey] != nil) {
+        UsePersonalLogFile = [host boolForKey:SULogPersonalLogFileKey];
+    }
+    if ([host objectForKey:SULogClearAtLaunchKey]) {
+        ClearAtLaunch = [host boolForKey:SULogClearAtLaunchKey];
+    }
+    
+    NSNumber *fileSizeValue = [host objectForKey:SULogMaxFileSizeKey];
+    if (fileSizeValue != nil && [fileSizeValue isKindOfClass:[NSNumber class]]) {
+        MaxLogFileSize = [[host objectForKey:SULogMaxFileSizeKey] unsignedLongLongValue];
+    }
+    
+    NSNumber *trimCoefValue = [host objectForKey:SULogTrimMaxFileSizeCoefficientKey];
+    if (trimCoefValue != nil && [trimCoefValue isKindOfClass:[NSNumber class]]) {
+        TrimMaxFileSizeCoefficient = [trimCoefValue floatValue];
+    }
+}

--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -12,6 +12,7 @@
 #import "SUAppcast.h"
 #import "SUAppcastItem.h"
 #import "SUVersionComparisonProtocol.h"
+#import "SULog.h"
 
 @interface SUScheduledUpdateDriver ()
 
@@ -54,6 +55,12 @@
         }
 
         [self abortUpdate];
+        if ([error code] != SUNoUpdateError) {
+            SULog(@"Error: %@ %@ (URL %@)",
+                  error.localizedDescription,
+                  error.localizedFailureReason,
+                  error.userInfo[NSURLErrorFailingURLErrorKey]);
+        }
     }
 }
 

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -13,6 +13,7 @@
 #import "SUHost.h"
 #import "SUStatusController.h"
 #import "SUConstants.h"
+#import "SULog.h"
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED < 1080
 @interface NSByteCountFormatter : NSFormatter {
@@ -113,6 +114,7 @@
     [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
     switch (choice) {
         case SUInstallUpdateChoice:
+            SULogTrace(@"User chose: update");
             self.statusController = [[SUStatusController alloc] initWithHost:self.host];
             [self.statusController beginActionWithTitle:SULocalizedString(@"Downloading update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
             [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelDownload:) isDefault:NO];
@@ -121,16 +123,19 @@
             break;
 
         case SUOpenInfoURLChoice:
+            SULogTrace(@"User chose: see info");
             [[NSWorkspace sharedWorkspace] openURL:[self.updateItem infoURL]];
             [self abortUpdate];
             break;
 
         case SUSkipThisVersionChoice:
+            SULogTrace(@"User chose: skip this version");
             [self.host setObject:[self.updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
             [self abortUpdate];
             break;
 
         case SURemindMeLaterChoice:
+            SULogTrace(@"User chose: remind later");
             [self abortUpdate];
             break;
     }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -82,6 +82,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 {
     self = [super init];
     if (bundle == nil) bundle = [NSBundle mainBundle];
+    
+    SULoadLogSettingsFromBundle(bundle);
 
     self.sparkleBundle = [NSBundle bundleForClass:[self class]];
     if (!self.sparkleBundle) {
@@ -183,6 +185,10 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (!hasLaunchedBefore) {
         [self.host setBool:YES forUserDefaultsKey:SUHasLaunchedBeforeKey];
     }
+    
+    // Keep log file size in bounds
+    SUMaybeTrimLogFile();
+    SULogTrace(@"Sparkle module started. App version %@. Works with %@", [self.host version], [self feedURL]);
 
     if (shouldPrompt) {
         NSArray *profileInfo = [self.host systemProfile];
@@ -346,8 +352,13 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
 - (void)checkForUpdatesWithDriver:(SUUpdateDriver *)d
 {
-	if ([self updateInProgress]) { return; }
-	if (self.checkTimer) { [self.checkTimer invalidate]; self.checkTimer = nil; }		// Timer is non-repeating, may have invalidated itself, so we had to retain it.
+    SULogTrace(@"Requested for update via %@", NSStringFromClass([d class]));
+    
+    if ([self updateInProgress]) {
+        SULogTrace(@"Update check rejected: in progress");
+        return;
+    }
+    if (self.checkTimer) { [self.checkTimer invalidate]; self.checkTimer = nil; }		// Timer is non-repeating, may have invalidated itself, so we had to retain it.
 
     [self willChangeValueForKey:@"lastUpdateCheckDate"];
     [self.host setObject:[NSDate date] forUserDefaultsKey:SULastCheckTimeKey];
@@ -355,6 +366,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
     if( [self.delegate respondsToSelector: @selector(updaterMayCheckForUpdates:)] && ![self.delegate updaterMayCheckForUpdates: self] )
 	{
+        SULogTrace(@"Update check rejected: not allowed by delegate");
         [self scheduleNextUpdateCheck];
         return;
     }
@@ -364,15 +376,18 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     // If we're not given a driver at all, just schedule the next update check and bail.
     if (!self.driver)
     {
+        SULogTrace(@"Update check rejected: no driver is set");
         [self scheduleNextUpdateCheck];
         return;
     }
 
     NSURL *theFeedURL = [self parameterizedFeedURL];
-    if (theFeedURL) // Use a NIL URL to cancel quietly.
+    if (theFeedURL) { // Use a NIL URL to cancel quietly.
         [self.driver checkForUpdatesAtURL:theFeedURL host:self.host];
-    else
+    } else {
+        SULogTrace(@"Update check aborted: empty url");
         [self.driver abortUpdate];
+    }
 }
 
 - (void)registerAsObserver


### PR DESCRIPTION
Improves logging by adding constants for .plist file, for:
- SULogTraceLoggingKey - bool - enable tracing (default no)
- SULogPersonalLogFileKey - bool - when enabled, application outputs
  to its own log file (default no = use common log file)
- SULogClearAtLaunchKey - bool - indicates whether log file should
  be cleaned at app launch (default yes)
- SULogMaxFileSizeKey - int - defines maximum file size for the log file,
  on each start updater check if this value is exceeded and trims it (1MB default)
- SULogTrimMaxFileSizeCoefficientKey - float - the log file will be trimmed
  on this value (0.75 default)

SULog:
- Add SULogTrace() function which is used to trace some important steps
  in the user flow.
- SUMaybeTrimLogFile() checks file size and trims to desired size
- SULoadLogSettingsFromBundle() loads settings from the bundle or user defaults
