### PR TITLE
Handle additional permission denied code when copying files

### DIFF
--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -386,7 +386,9 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
         return YES;
     }
     
-    if (copyResult != permErr) {
+    // Note: I have recieved afpAccessDenied error in testing even when not copying from/to an AFP mount,
+    // when the error should have been a normal permission denied one
+    if (copyResult != permErr && copyResult != afpAccessDenied) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:copyResult userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to copy file (%@)", sourceURL.lastPathComponent] }];
         }


### PR DESCRIPTION
afpAccessDenied can be returned even when not using a AFP mount,
at least according to my testing.

Having an installation do a copy (because of different mounts) and auth
may not be a likely scenario, so this may not be hit often (if ever?).