### PR TITLE
Alert driver

### DIFF
--- a/Sparkle/SUUIBasedUpdateDriver.h
+++ b/Sparkle/SUUIBasedUpdateDriver.h
@@ -17,7 +17,7 @@
 
 @interface SUUIBasedUpdateDriver : SUBasicUpdateDriver <SUUnarchiverDelegate>
 
-- (void)showModalAlert:(NSAlert *)alert;
+- (void)showAlert:(NSAlert *)alert;
 - (IBAction)cancelDownload:(id)sender;
 - (void)installAndRestart:(id)sender;
 

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -97,7 +97,7 @@
         alert.messageText = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
         alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
         [alert addButtonWithTitle:SULocalizedString(@"OK", nil)];
-        [self showModalAlert:alert];
+        [self showAlert:alert];
         [self abortUpdate];
     }
 }
@@ -253,7 +253,7 @@
     alert.messageText = SULocalizedString(@"Update Error!", nil);
     alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
     [alert addButtonWithTitle:SULocalizedString(@"Cancel Update", nil)];
-    [self showModalAlert:alert];
+    [self showAlert:alert];
     [super abortUpdateWithError:error];
 }
 
@@ -267,7 +267,7 @@
     [super abortUpdate];
 }
 
-- (void)showModalAlert:(NSAlert *)alert
+- (void)showAlert:(NSAlert *)alert
 {
     if ([[self.updater delegate] respondsToSelector:@selector(updaterWillShowModalAlert:)]) {
         [[self.updater delegate] updaterWillShowModalAlert:self.updater];

--- a/Sparkle/SUUpdateDriver.h
+++ b/Sparkle/SUUpdateDriver.h
@@ -22,6 +22,9 @@ extern NSString *const SUUpdateDriverFinishedNotification;
 - (instancetype)initWithUpdater:(SUUpdater *)updater;
 - (void)checkForUpdatesAtURL:(NSURL *)URL host:(SUHost *)host;
 - (void)abortUpdate;
+
+- (void)showAlert:(NSAlert *)alert;
+
 @property (getter=isInterruptible, readonly) BOOL interruptible;
 @property (readonly) BOOL finished;
 @property BOOL automaticallyInstallUpdates;

--- a/Sparkle/SUUpdateDriver.m
+++ b/Sparkle/SUUpdateDriver.m
@@ -8,6 +8,7 @@
 
 #import "SUUpdateDriver.h"
 #import "SUHost.h"
+#import "SULog.h"
 
 NSString *const SUUpdateDriverFinishedNotification = @"SUUpdateDriverFinished";
 
@@ -48,6 +49,12 @@ NSString *const SUUpdateDriverFinishedNotification = @"SUUpdateDriverFinished";
 {
     [self setValue:@YES forKey:@"finished"];
     [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdateDriverFinishedNotification object:self];
+}
+
+
+- (void)showAlert:(NSAlert *)alert {
+    // Only UI-based subclass shows the actual alert
+    SULog(@"ALERT: %@\n%@", alert.messageText, alert.informativeText);
 }
 
 @end

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -14,7 +14,7 @@
 #import "SUVersionComparisonProtocol.h"
 #import "SUVersionDisplayProtocol.h"
 
-@class SUUpdateDriver, SUAppcastItem, SUHost, SUAppcast;
+@class SUAppcastItem, SUAppcast;
 
 @protocol SUUpdaterDelegate;
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -105,10 +105,6 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         sharedUpdaters[[NSValue valueWithNonretainedObject:bundle]] = self;
         host = [[SUHost alloc] initWithBundle:bundle];
 
-        // Saving-the-developer-from-a-stupid-mistake-check:
-        // The check is async to give time to set a delegate, so that potentially-overriden feedURL works
-        [self performSelector:@selector(checkIfConfiguredProperly) withObject:nil afterDelay:0];
-
         // This runs the permission prompt if needed, but never before the app has finished launching because the runloop won't run before that
         [self performSelector:@selector(startUpdateCycle) withObject:nil afterDelay:0];
     }
@@ -366,6 +362,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         [self scheduleNextUpdateCheck];
         return;
     }
+
+    [self checkIfConfiguredProperly];
 
     NSURL *theFeedURL = [self parameterizedFeedURL];
     if (theFeedURL) // Use a NIL URL to cancel quietly.

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -40,9 +40,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 - (void)updateDriverDidFinish:(NSNotification *)note;
 @property (readonly, copy) NSURL *parameterizedFeedURL;
 
-- (void)notifyWillShowModalAlert;
-- (void)notifyDidShowModalAlert;
-
 @property (strong) SUUpdateDriver *driver;
 @property (strong) SUHost *host;
 
@@ -118,13 +115,11 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     return self;
 }
 
--(void)showModalAlertText:(NSString *)text informativeText:(NSString *)informativeText {
-    [self notifyWillShowModalAlert];
+-(void)showAlertText:(NSString *)text informativeText:(NSString *)informativeText {
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = text;
     alert.informativeText = informativeText;
-    [alert runModal];
-    [self notifyDidShowModalAlert];
+    [self.driver showAlert:alert];
 }
 
 -(void)checkIfConfiguredProperly {
@@ -134,10 +129,10 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     NSURL *feedURL = [self feedURL];
     BOOL servingOverHttps = [[[feedURL scheme] lowercaseString] isEqualToString:@"https"];
     if (!isMainBundle && !hasPublicDSAKey) {
-        [self showModalAlertText:@"Insecure update error!"
+        [self showAlertText:@"Insecure update error!"
                  informativeText:@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information."];
     } else if (isMainBundle && !(hasPublicDSAKey || hostIsCodeSigned)) {
-        [self showModalAlertText:@"Insecure update error!"
+        [self showAlertText:@"Insecure update error!"
                  informativeText:@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See Sparkle's documentation for more information."];
     } else if (isMainBundle && !hasPublicDSAKey && !servingOverHttps) {
         SULog(@"WARNING: Serving updates over HTTP without signing them with a DSA key is deprecated and may not be possible in a future release. Please serve your updates over https, or sign them with a DSA key, or do both. See Sparkle's documentation for more information.");
@@ -146,7 +141,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
     BOOL atsExceptionsExist = nil != [self.host objectForInfoDictionaryKey:@"NSAppTransportSecurity"];
     if (isMainBundle && !servingOverHttps && !atsExceptionsExist) {
-        [self showModalAlertText:@"Insecure feed URL is blocked in OS X 10.11"
+        [self showAlertText:@"Insecure feed URL is blocked in OS X 10.11"
                  informativeText:[NSString stringWithFormat:@"You must change the feed URL (%@) to use HTTPS or disable App Transport Security.\n\nFor more information:\nhttp://sparkle-project.org/documentation/app-transport-security/", [feedURL absoluteString]]];
     }
     if (!isMainBundle && !servingOverHttps) {
@@ -163,21 +158,6 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 }
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@, %@>", [self class], [self.host bundlePath], [self.host installationPath]]; }
-
-
-- (void)notifyWillShowModalAlert
-{
-    if ([self.delegate respondsToSelector:@selector(updaterWillShowModalAlert:)])
-        [self.delegate updaterWillShowModalAlert:self];
-}
-
-
-- (void)notifyDidShowModalAlert
-{
-    if ([self.delegate respondsToSelector:@selector(updaterDidShowModalAlert:)])
-        [self.delegate updaterDidShowModalAlert:self];
-}
-
 
 - (void)startUpdateCycle
 {


### PR DESCRIPTION
Checking of configuration in `SUUpdater` constructor can't be done properly, because at that point there's no delegate set yet. I've previously tried to work around that by deferring execution of the check, but in retrospect that wasn't a good idea, as it's non-deterministic.

To sort this out I've moved config check to be done later, right before actual update check, and the UI is driver-specific, so only the *UI* driver will show the alert as an actual modal dialog box. While it's not as eager and in-your-face as the previous setup, it's deterministic and doesn't complicate unit tests (we don't want modal dialogs popping up during unit tests :)
