### PR TITLE
Don't bring up an authorized dialog during cleanup

### DIFF
--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -26,6 +26,15 @@
 + (instancetype)fileManagerAllowingAuthorization:(BOOL)allowsAuthorization;
 
 /**
+ * Returns a file manager that allows or disallows authorizing for file operations based on the current file manager
+ * @return A file manager instance that can perform authorized operations if the current file manager has already performed them.
+ *  If the current file manager instance hasn't yet performed authorized operations, then neither can the instance returned by this method
+ *
+ * This may return a newly created file manager or re-use the existing file manager depending on the current authorization rights.
+ */
+- (instancetype)fileManagerByPreservingAuthorizationRights;
+
+/**
  * Creates a temporary directory on the same volume as a provided URL
  * @param preferredName A name that may be used when creating the temporary directory. Note that in the uncommon case this name is used, the temporary directory will be created inside the directory pointed by appropriateURL
  * @param appropriateURL A URL to a directory that resides on the volume that the temporary directory will be created on. In the uncommon case, the temporary directory may be created inside this directory.

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -88,10 +88,16 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
     return self;
 }
 
-
 + (instancetype)fileManagerAllowingAuthorization:(BOOL)allowsAuthorization
 {
     return [[self alloc] initAllowingAuthorization:allowsAuthorization];
+}
+
+- (instancetype)fileManagerByPreservingAuthorizationRights
+{
+    // Check if we don't allow authorization, or that we haven't needed to authorize yet, to create or re-use a
+    // file manager instance with these restrictions
+    return (_allowsAuthorization && _auth != NULL) ? self : [SUFileManager fileManagerAllowingAuthorization:NO];
 }
 
 // Acquires an authorization reference which is intended to be used for future authorized file operations

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -139,15 +139,18 @@
         return NO;
     }
     
+    // From here on out, we don't really need to bring up authorization if we haven't done so prior
+    SUFileManager *constrainedFileManager = [fileManager fileManagerByPreservingAuthorizationRights];
+    
     // Cleanup: move the old app to the trash
     NSError *trashError = nil;
-    if (![fileManager moveItemAtURLToTrash:oldTempURL error:&trashError]) {
+    if (![constrainedFileManager moveItemAtURLToTrash:oldTempURL error:&trashError]) {
         SULog(@"Failed to move %@ to trash with error %@", oldTempURL, trashError);
     }
     
-    [fileManager removeItemAtURL:tempOldDirectoryURL error:NULL];
+    [constrainedFileManager removeItemAtURL:tempOldDirectoryURL error:NULL];
     
-    [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
+    [constrainedFileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
     
     return YES;
 }


### PR DESCRIPTION
If permissions are abnormal during cleanup or somewhere along the lines, it may be
possible to bring up authorization dialog that is not really needed. Prevent this from happening.

We would want to restrict authorization from being possible anyway when not needed.

This is intended to resolve #752 