### PR TITLE
Download cleanup

### DIFF
--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -26,7 +26,6 @@ typedef struct {
 - (instancetype)initWithBundle:(NSBundle *)aBundle;
 @property (readonly, copy) NSString *bundlePath;
 @property (readonly) BOOL allowsAutomaticUpdates;
-@property (readonly, copy) NSString *appCachePath;
 @property (readonly, copy) NSString *installationPath;
 @property (readonly, copy) NSString *name;
 @property (readonly, copy) NSString *version;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -74,28 +74,6 @@
     return [[NSFileManager defaultManager] isWritableFileAtPath:self.bundlePath];
 }
 
-- (NSString *)appCachePath
-{
-    NSArray *cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *cachePath = nil;
-    if ([cachePaths count]) {
-        cachePath = [cachePaths objectAtIndex:0];
-    }
-    if (!cachePath) {
-        SULog(@"Failed to find user's cache directory! Using system default");
-        cachePath = NSTemporaryDirectory();
-    }
-
-    NSString *name = [self.bundle bundleIdentifier];
-    if (!name) {
-        name = [self name];
-    }
-
-    cachePath = [cachePath stringByAppendingPathComponent:name];
-    cachePath = [cachePath stringByAppendingPathComponent:@"Sparkle"];
-    return cachePath;
-}
-
 - (NSString *)installationPath
 {
     if (SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME) {

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -54,7 +54,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     assert(bundleIdentifier != nil);
     
     // Create a directory that'll be used for our web server listing
-    NSURL *serverDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier];
+    NSURL *serverDirectoryURL = [[cacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier] URLByAppendingPathComponent:@"ServerData"];
     if ([serverDirectoryURL checkResourceIsReachableAndReturnError:nil]) {
         NSError *removeServerDirectoryError = nil;
         


### PR DESCRIPTION
This is to improve/resolve issue #750 

If you apply just the first commit for the Test App, you can reproduce the issue that the 2nd commit fixes pretty easily. Just download an update and quit before deciding to install it. Do it again, and you'll see that data accumulates in the user's cache directory.