### PR TITLE
bsdiff fixes

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -177,6 +177,10 @@
 		721CF1AA1AD7647000D9AC09 /* libxar.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1AF5890FD7678C0065DB48 /* libxar.1.dylib */; };
 		721CF1AB1AD764EB00D9AC09 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */; };
 		7223E7631AD1AEFF008E3161 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
+		723B252D1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
+		723B252E1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
+		723B252F1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
+		723B25301CEAB3A600909873 /* bscommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 723B252C1CEAB3A600909873 /* bscommon.h */; };
 		7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
 		726F2CDE1BC9BE5B001971A4 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */; };
@@ -628,6 +632,8 @@
 		7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUUnarchiverTest.swift; sourceTree = "<group>"; };
 		7223E7611AD1AEFF008E3161 /* sais.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sais.c; sourceTree = "<group>"; };
 		7223E7621AD1AEFF008E3161 /* sais.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sais.h; sourceTree = "<group>"; };
+		723B252B1CEAB3A600909873 /* bscommon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bscommon.c; sourceTree = "<group>"; };
+		723B252C1CEAB3A600909873 /* bscommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bscommon.h; sourceTree = "<group>"; };
 		7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBinaryDeltaCreate.m; sourceTree = "<group>"; };
 		7268AC641AD634E400C3E0C1 /* SUBinaryDeltaCreate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUBinaryDeltaCreate.h; sourceTree = "<group>"; };
 		726B2B5D1C645FC900388755 /* UI Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UI Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -840,6 +846,8 @@
 		14732BB61960ECE800593899 /* bsdiff */ = {
 			isa = PBXGroup;
 			children = (
+				723B252B1CEAB3A600909873 /* bscommon.c */,
+				723B252C1CEAB3A600909873 /* bscommon.h */,
 				5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */,
 				5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */,
 				611142E810FB1BE5009810AA /* bspatch.h */,
@@ -1183,6 +1191,7 @@
 				7275F9C11B5F1F2900B1D19E /* SUFileManager.h in Headers */,
 				767B61AC1972D488004E0C3C /* SUGuidedPackageInstaller.h in Headers */,
 				61EF67590E25C5B400F754E0 /* SUHost.h in Headers */,
+				723B25301CEAB3A600909873 /* bscommon.h in Headers */,
 				618FA5010DAE88B40026945C /* SUInstaller.h in Headers */,
 				55C14F06136EF6DB00649790 /* SULog.h in Headers */,
 				726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */,
@@ -1616,6 +1625,7 @@
 				5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */,
 				14652F7E19A9728A00959E44 /* bspatch.c in Sources */,
 				7223E7631AD1AEFF008E3161 /* sais.c in Sources */,
+				723B252F1CEAB3A600909873 /* bscommon.c in Sources */,
 				14652F7D19A9726700959E44 /* SUBinaryDeltaApply.m in Sources */,
 				14652F7C19A9725300959E44 /* SUBinaryDeltaCommon.m in Sources */,
 				7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */,
@@ -1635,6 +1645,7 @@
 				721CF1A91AD7644C00D9AC09 /* sais.c in Sources */,
 				5A4094481C74EA5200983BE0 /* SUAppcastTest.swift in Sources */,
 				72D4DAA11AD7632900B211E2 /* SUBinaryDeltaCreate.m in Sources */,
+				723B252E1CEAB3A600909873 /* bscommon.c in Sources */,
 				142E0E0919A83AAC00E4312B /* SUBinaryDeltaTest.m in Sources */,
 				F8761EB11ADC5068000C9034 /* SUCodeSigningVerifierTest.m in Sources */,
 				5AF9DC3C1981DBEE001EA135 /* SUDSAVerifierTest.m in Sources */,
@@ -1692,6 +1703,7 @@
 				61EF67560E25B58D00F754E0 /* SUHost.m in Sources */,
 				618FA5020DAE88B40026945C /* SUInstaller.m in Sources */,
 				55C14F07136EF6DB00649790 /* SULog.m in Sources */,
+				723B252D1CEAB3A600909873 /* bscommon.c in Sources */,
 				726F2CE61BC9C33D001971A4 /* SUOperatingSystem.m in Sources */,
 				618FA5230DAE8E8A0026945C /* SUPackageInstaller.m in Sources */,
 				61D85D6D0E10B2ED00F9B4A9 /* SUPipedUnarchiver.m in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		142E0E0919A83AAC00E4312B /* SUBinaryDeltaTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 142E0E0819A83AAC00E4312B /* SUBinaryDeltaTest.m */; };
 		14652F7C19A9725300959E44 /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E20FD68CC7005AE3F6 /* SUBinaryDeltaCommon.m */; };
 		14652F7D19A9726700959E44 /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E00FD68CC7005AE3F6 /* SUBinaryDeltaApply.m */; };
-		14652F7E19A9728A00959E44 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; settings = {COMPILER_FLAGS = "-w"; }; };
+		14652F7E19A9728A00959E44 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
 		14652F8019A9740F00959E44 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		14652F8219A9746000959E44 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		14652F8419A978C200959E44 /* SUExport.h in Headers */ = {isa = PBXBuildFile; fileRef = 14652F8319A9759F00959E44 /* SUExport.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -81,9 +81,9 @@
 		5AF6C74F1AEA46D10014A3AB /* test.sparkle_guided.pkg in Resources */ = {isa = PBXBuildFile; fileRef = 5AF6C74E1AEA46D10014A3AB /* test.sparkle_guided.pkg */; };
 		5AF6C7541AEA49840014A3AB /* SUInstallerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6C74C1AEA40760014A3AB /* SUInstallerTest.m */; };
 		5AF9DC3C1981DBEE001EA135 /* SUDSAVerifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF9DC3B1981DBEE001EA135 /* SUDSAVerifierTest.m */; };
-		5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; settings = {COMPILER_FLAGS = "-w"; }; };
+		5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
 		5D06E8EA0FD68CDB005AE3F6 /* SUBinaryDeltaTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E30FD68CC7005AE3F6 /* SUBinaryDeltaTool.m */; };
-		5D06E8EB0FD68CE4005AE3F6 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; settings = {COMPILER_FLAGS = "-w"; }; };
+		5D06E8EB0FD68CE4005AE3F6 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
 		5D06E8EC0FD68CE4005AE3F6 /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E00FD68CC7005AE3F6 /* SUBinaryDeltaApply.m */; };
 		5D06E8ED0FD68CE4005AE3F6 /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E20FD68CC7005AE3F6 /* SUBinaryDeltaCommon.m */; };
 		5D06E8FD0FD68D6B005AE3F6 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */; };
@@ -171,9 +171,9 @@
 		720B16441C66433D006985FB /* UITests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 720B16421C66433D006985FB /* UITests-Info.plist */; };
 		720B16451C66433D006985FB /* SUTestApplicationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720B16431C66433D006985FB /* SUTestApplicationTest.swift */; };
 		7210C7681B9A9A1500EB90AC /* SUUnarchiverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */; };
-		721CF1A71AD7643600D9AC09 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; settings = {COMPILER_FLAGS = "-w"; }; };
-		721CF1A81AD7644100D9AC09 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; settings = {COMPILER_FLAGS = "-w"; }; };
-		721CF1A91AD7644C00D9AC09 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; settings = {COMPILER_FLAGS = "-w"; }; };
+		721CF1A71AD7643600D9AC09 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
+		721CF1A81AD7644100D9AC09 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
+		721CF1A91AD7644C00D9AC09 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		721CF1AA1AD7647000D9AC09 /* libxar.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1AF5890FD7678C0065DB48 /* libxar.1.dylib */; };
 		721CF1AB1AD764EB00D9AC09 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */; };
 		7223E7631AD1AEFF008E3161 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };

--- a/Vendor/bsdiff/bscommon.c
+++ b/Vendor/bsdiff/bscommon.c
@@ -1,0 +1,56 @@
+/*
+ *  bscommon.c
+ *  Sparkle
+ *
+ *  Created by Mayur Pawashe on 5/16/16.
+ */
+
+#include "bscommon.h"
+#include <stdlib.h>
+
+u_char *readfile(const char *filename, off_t *outSize)
+{
+    FILE *file = fopen(filename, "r");
+    if (file == NULL) {
+        return NULL;
+    }
+    
+    if (fseek(file, 0L, SEEK_END) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    
+    long offset = ftell(file);
+    if (offset == -1) {
+        fclose(file);
+        return NULL;
+    }
+    
+    size_t size = (size_t)offset;
+    
+    if (outSize != NULL) {
+        *outSize = (off_t)size;
+    }
+    
+    /* Allocate size + 1 bytes instead of newsize bytes to ensure
+     that we never try to malloc(0) and get a NULL pointer */
+    u_char *buffer = malloc(size + 1);
+    if (buffer == NULL) {
+        fclose(file);
+        return NULL;
+    }
+    
+    if (fseek(file, 0L, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+    
+    if (fread(buffer, 1, size, file) < size) {
+        fclose(file);
+        return NULL;
+    }
+    
+    fclose(file);
+    
+    return buffer;
+}

--- a/Vendor/bsdiff/bscommon.c
+++ b/Vendor/bsdiff/bscommon.c
@@ -42,11 +42,13 @@ u_char *readfile(const char *filename, off_t *outSize)
     
     if (fseek(file, 0L, SEEK_SET) != 0) {
         fclose(file);
+        free(buffer);
         return NULL;
     }
     
     if (fread(buffer, 1, size, file) < size) {
         fclose(file);
+        free(buffer);
         return NULL;
     }
     

--- a/Vendor/bsdiff/bscommon.h
+++ b/Vendor/bsdiff/bscommon.h
@@ -1,0 +1,16 @@
+/*
+ *  bscommon.h
+ *  Sparkle
+ *
+ *  Created by Mayur Pawashe on 5/16/16.
+ */
+
+#ifndef BS_COMMON_H
+#define BS_COMMON_H
+
+#include <sys/types.h>
+#include <stdio.h>
+
+u_char *readfile(const char *filename, off_t *outSize);
+
+#endif

--- a/Vendor/bsdiff/bsdiff.c
+++ b/Vendor/bsdiff/bsdiff.c
@@ -38,6 +38,8 @@ __FBSDID("$FreeBSD: src/usr.bin/bsdiff/bsdiff/bsdiff.c, v 1.1 2005/08/06 01:59:0
 #include <string.h>
 #include <unistd.h>
 
+#include "bscommon.h"
+
 #define MIN(x, y) (((x)<(y)) ? (x) : (y))
 
 /* matchlen(old, oldsize, new, newsize)
@@ -113,51 +115,6 @@ static void offtout(off_t x, u_char *buf)
 
     if (x < 0)
         buf[7] |= 0x80;
-}
-
-static u_char *readfile(const char *filename, off_t *outSize)
-{
-    FILE *file = fopen(filename, "r");
-    if (file == NULL) {
-        return NULL;
-    }
-    
-    if (fseek(file, 0L, SEEK_END) != 0) {
-        fclose(file);
-        return NULL;
-    }
-    
-    off_t size = ftell(file);
-    if (size == -1) {
-        fclose(file);
-        return NULL;
-    }
-    
-    if (outSize != NULL) {
-        *outSize = size;
-    }
-    
-    /* Allocate size + 1 bytes instead of newsize bytes to ensure
-     that we never try to malloc(0) and get a NULL pointer */
-    u_char *buffer = malloc(size + 1);
-    if (buffer == NULL) {
-        fclose(file);
-        return NULL;
-    }
-    
-    if (fseek(file, 0L, SEEK_SET) != 0) {
-        fclose(file);
-        return NULL;
-    }
-    
-    if (fread(buffer, 1, size, file) < size) {
-        fclose(file);
-        return NULL;
-    }
-    
-    fclose(file);
-    
-    return buffer;
 }
 
 int bsdiff(int argc, char *argv[]); // Added by AMM: suppresses a warning about the following not having a prototype.

--- a/Vendor/bsdiff/bsdiff.c
+++ b/Vendor/bsdiff/bsdiff.c
@@ -121,58 +121,68 @@ int bsdiff(int argc, char *argv[]); // Added by AMM: suppresses a warning about 
 
 int bsdiff(int argc, char *argv[])
 {
-    u_char *old,*new;           /* contents of old, new files */
-    off_t oldsize, newsize;     /* length of old, new files */
-    off_t *I,*V;                /* arrays used for suffix sort; I is ordering */
-    off_t scan;                 /* position of current match in old file */
+    u_char *old = NULL,*new = NULL;           /* contents of old, new files */
+    off_t oldsize = 0, newsize = 0;     /* length of old, new files */
+    off_t *I = NULL,*V = NULL;                /* arrays used for suffix sort; I is ordering */
+    off_t scan = 0;                 /* position of current match in old file */
     off_t pos = 0;              /* position of current match in new file */
-    off_t len;                  /* length of current match */
-    off_t lastscan;             /* position of previous match in old file */
-    off_t lastpos;              /* position of previous match in new file */
-    off_t lastoffset;           /* lastpos - lastscan */
-    off_t oldscore, scsc;       /* temp variables in match search */
-    off_t s, Sf, lenf, Sb, lenb;    /* temp vars in match extension */
-    off_t overlap, Ss, lens;
-    off_t i;
-    off_t dblen, eblen;         /* length of diff, extra sections */
-    u_char *db,*eb;             /* contents of diff, extra sections */
-    u_char buf[8];
-    u_char header[32];
-    FILE * pf;
+    off_t len = 0;                  /* length of current match */
+    off_t lastscan = 0;             /* position of previous match in old file */
+    off_t lastpos = 0;              /* position of previous match in new file */
+    off_t lastoffset = 0;           /* lastpos - lastscan */
+    off_t oldscore = 0, scsc = 0;       /* temp variables in match search */
+    off_t s = 0, Sf = 0, lenf = 0, Sb = 0, lenb = 0;    /* temp vars in match extension */
+    off_t overlap = 0, Ss = 0, lens = 0;
+    off_t i = 0;
+    off_t dblen = 0, eblen = 0;         /* length of diff, extra sections */
+    u_char *db = NULL,*eb = NULL;             /* contents of diff, extra sections */
+    u_char buf[8] = {0};
+    u_char header[32] = {0};
+    FILE * pf = NULL;
+    int exitstatus = -1;
 
-    if (argc != 4)
-        errx(1,"usage: %s oldfile newfile patchfile\n", argv[0]);
+    if (argc != 4) {
+        warnx("usage: %s oldfile newfile patchfile\n", argv[0]);
+        goto cleanup;
+    }
 
     old = readfile(argv[1], &oldsize);
     if (old == NULL) {
         warn("old file error: %s", argv[1]);
-        return -1;
+        goto cleanup;
     }
 
     if (((I = malloc((oldsize + 1) * sizeof(off_t))) == NULL) ||
-        ((V = malloc((oldsize + 1) * sizeof(off_t))) == NULL))
-        err(1, NULL);
+        ((V = malloc((oldsize + 1) * sizeof(off_t))) == NULL)) {
+        warn("Failed to allocate memory for I or V");
+        goto cleanup;
+    }
 
     /* Do a suffix sort on the old file. */
     I[0] = oldsize; sais(old, I+1, oldsize);
 
     free(V);
+    V = NULL;
     
     new = readfile(argv[2], &newsize);
     if (new == NULL) {
         warn("new file error: %s", argv[2]);
-        return -1;
+        goto cleanup;
     }
 
     if (((db = malloc(newsize + 1)) == NULL) ||
-        ((eb = malloc(newsize + 1)) == NULL))
-        err(1, NULL);
+        ((eb = malloc(newsize + 1)) == NULL)) {
+        warn("Failed to allocate memory for db or eb");
+        goto cleanup;
+    }
     dblen = 0;
     eblen = 0;
 
     /* Create the patch file */
-    if ((pf = fopen(argv[3], "w")) == NULL)
-        err(1, "%s", argv[3]);
+    if ((pf = fopen(argv[3], "w")) == NULL) {
+        warn("%s", argv[3]);
+        goto cleanup;
+    }
 
     /* Header is
         0    8     "BSDIFN40"
@@ -188,8 +198,10 @@ int bsdiff(int argc, char *argv[])
     offtout(0, header + 8);
     offtout(0, header + 16);
     offtout(newsize, header + 24);
-    if (fwrite(header, 32, 1, pf) != 1)
-        err(1, "fwrite(%s)", argv[3]);
+    if (fwrite(header, 32, 1, pf) != 1) {
+        warn("fwrite(%s)", argv[3]);
+        goto cleanup;
+    }
 
     /* Compute the differences, writing ctrl as we go */
     scan = 0;
@@ -305,16 +317,22 @@ int bsdiff(int argc, char *argv[])
              *      diff, in the old file
              */
             offtout(lenf, buf);
-            if (fwrite(buf, 8, 1, pf) != 1)
-                errx(1, "fwrite");
+            if (fwrite(buf, 8, 1, pf) != 1) {
+                warnx("fwrite");
+                goto cleanup;
+            }
 
             offtout((scan - lenb) - (lastscan + lenf), buf);
-            if (fwrite(buf, 8, 1, pf) != 1)
-                err(1, "fwrite");
+            if (fwrite(buf, 8, 1, pf) != 1) {
+                warn("fwrite");
+                goto cleanup;
+            }
 
             offtout((pos - lenb) - (lastpos + lenf), buf);
-            if (fwrite(buf, 8, 1, pf) != 1)
-                err(1, "fwrite");
+            if (fwrite(buf, 8, 1, pf) != 1) {
+                warn("fwrite");
+                goto cleanup;
+            }
 
             /* Update the variables describing the last match. Note that
              * 'lastscan' is set to the start of the current match _after_ the
@@ -327,37 +345,61 @@ int bsdiff(int argc, char *argv[])
     }
 
     /* Compute size of compressed ctrl data */
-    if ((len = ftello(pf)) == -1)
-        err(1, "ftello");
+    if ((len = ftello(pf)) == -1) {
+        warn("ftello");
+        goto cleanup;
+    }
     offtout(len - 32, header + 8);
 
     /* Write diff data */
-    if (dblen && fwrite(db, dblen, 1, pf) != 1)
-        err(1, "fwrite");
+    if (dblen && fwrite(db, dblen, 1, pf) != 1) {
+        warn("fwrite");
+        goto cleanup;
+    }
 
     /* Compute size of compressed diff data */
-    if ((newsize = ftello(pf)) == -1)
-        err(1, "ftello");
+    if ((newsize = ftello(pf)) == -1) {
+        warn("ftello");
+        goto cleanup;
+    }
     offtout(newsize - len, header + 16);
 
     /* Write extra data */
-    if (eblen && fwrite(eb, eblen, 1, pf) != 1)
-        err(1, "fwrite");
+    if (eblen && fwrite(eb, eblen, 1, pf) != 1) {
+        warn("fwrite");
+        goto cleanup;
+    }
 
     /* Seek to the beginning, write the header, and close the file */
-    if (fseeko(pf, 0, SEEK_SET))
-        err(1, "fseeko");
-    if (fwrite(header, 32, 1, pf) != 1)
-        err(1, "fwrite(%s)", argv[3]);
-    if (fclose(pf))
-        err(1, "fclose");
+    if (fseeko(pf, 0, SEEK_SET)) {
+        warn("fseeko");
+        goto cleanup;
+    }
+    if (fwrite(header, 32, 1, pf) != 1) {
+        warn("fwrite(%s)", argv[3]);
+        goto cleanup;
+    }
+    if (fclose(pf)) {
+        warn("fclose");
+        pf = NULL;
+        goto cleanup;
+    }
+    pf = NULL;
+    
+    exitstatus = 0;
+cleanup:
 
+    if (pf != NULL) {
+        fclose(pf);
+    }
+    
     /* Free the memory we used */
     free(db);
     free(eb);
     free(I);
+    free(V);
     free(old);
     free(new);
 
-    return 0;
+    return exitstatus;
 }

--- a/Vendor/bsdiff/bsdiff.c
+++ b/Vendor/bsdiff/bsdiff.c
@@ -84,7 +84,7 @@ static off_t search(off_t *I, u_char *old, off_t oldsize,
     }
 
     x = st + (en - st)/2;
-    if (memcmp(old + I[x], new, MIN(oldsize - I[x], newsize)) < 0) {
+    if (memcmp(old + I[x], new, (size_t)(MIN(oldsize - I[x], newsize))) < 0) {
         return search(I, old, oldsize, new, newsize, x, en, pos);
     } else {
         return search(I, old, oldsize, new, newsize, st, x, pos);
@@ -103,15 +103,15 @@ static void offtout(off_t x, u_char *buf)
     else
         y = x;
 
-    buf[0] = y % 256;
+    buf[0] = (u_char)(y % 256);
     y -= buf[0];
-    y = y/256; buf[1] = y%256; y -= buf[1];
-    y = y/256; buf[2] = y%256; y -= buf[2];
-    y = y/256; buf[3] = y%256; y -= buf[3];
-    y = y/256; buf[4] = y%256; y -= buf[4];
-    y = y/256; buf[5] = y%256; y -= buf[5];
-    y = y/256; buf[6] = y%256; y -= buf[6];
-    y = y/256; buf[7] = y%256;
+    y = y/256; buf[1] = (u_char)(y%256); y -= buf[1];
+    y = y/256; buf[2] = (u_char)(y%256); y -= buf[2];
+    y = y/256; buf[3] = (u_char)(y%256); y -= buf[3];
+    y = y/256; buf[4] = (u_char)(y%256); y -= buf[4];
+    y = y/256; buf[5] = (u_char)(y%256); y -= buf[5];
+    y = y/256; buf[6] = (u_char)(y%256); y -= buf[6];
+    y = y/256; buf[7] = (u_char)(y%256);
 
     if (x < 0)
         buf[7] |= 0x80;
@@ -152,14 +152,15 @@ int bsdiff(int argc, char *argv[])
         goto cleanup;
     }
 
-    if (((I = malloc((oldsize + 1) * sizeof(off_t))) == NULL) ||
-        ((V = malloc((oldsize + 1) * sizeof(off_t))) == NULL)) {
+    if (((I = malloc(((size_t)oldsize + 1) * sizeof(off_t))) == NULL) ||
+        ((V = malloc(((size_t)oldsize + 1) * sizeof(off_t))) == NULL)) {
         warn("Failed to allocate memory for I or V");
         goto cleanup;
     }
 
     /* Do a suffix sort on the old file. */
-    I[0] = oldsize; sais(old, I+1, oldsize);
+    I[0] = oldsize;
+    sais(old, I+1, (int)oldsize);
 
     free(V);
     V = NULL;
@@ -170,8 +171,8 @@ int bsdiff(int argc, char *argv[])
         goto cleanup;
     }
 
-    if (((db = malloc(newsize + 1)) == NULL) ||
-        ((eb = malloc(newsize + 1)) == NULL)) {
+    if (((db = malloc((size_t)newsize + 1)) == NULL) ||
+        ((eb = malloc((size_t)newsize + 1)) == NULL)) {
         warn("Failed to allocate memory for db or eb");
         goto cleanup;
     }
@@ -352,7 +353,7 @@ int bsdiff(int argc, char *argv[])
     offtout(len - 32, header + 8);
 
     /* Write diff data */
-    if (dblen && fwrite(db, dblen, 1, pf) != 1) {
+    if (dblen && fwrite(db, (size_t)dblen, 1, pf) != 1) {
         warn("fwrite");
         goto cleanup;
     }
@@ -365,7 +366,7 @@ int bsdiff(int argc, char *argv[])
     offtout(newsize - len, header + 16);
 
     /* Write extra data */
-    if (eblen && fwrite(eb, eblen, 1, pf) != 1) {
+    if (eblen && fwrite(eb, (size_t)eblen, 1, pf) != 1) {
         warn("fwrite");
         goto cleanup;
     }

--- a/Vendor/bsdiff/bspatch.c
+++ b/Vendor/bsdiff/bspatch.c
@@ -46,48 +46,48 @@ typedef void* stream_t;
 
 typedef struct
 {
-	stream_t (*open)(FILE*);
-	void (*close)(stream_t);
-	off_t (*read)(stream_t, void*, off_t);
+    stream_t (*open)(FILE*);
+    void (*close)(stream_t);
+    off_t (*read)(stream_t, void*, off_t);
 } io_funcs_t;
 
 static stream_t BSDIFF40_open(FILE *f)
 {
-	int bzerr = 0;
-	BZFILE *s = NULL;
+    int bzerr = 0;
+    BZFILE *s = NULL;
     if ((s = BZ2_bzReadOpen(&bzerr, f, 0, 0, NULL, 0)) == NULL) {
-		warnx("BZ2_bzReadOpen, bz2err = %d", bzerr);
+        warnx("BZ2_bzReadOpen, bz2err = %d", bzerr);
     }
-	return s;
+    return s;
 }
 
 static void BSDIFF40_close(stream_t s)
 {
-	int bzerr;
-	BZ2_bzReadClose(&bzerr, (BZFILE*)s);
+    int bzerr;
+    BZ2_bzReadClose(&bzerr, (BZFILE*)s);
 }
 
 static off_t BSDIFF40_read(stream_t s, void *buf, off_t len)
 {
-	int bzerr = 0, lenread = 0;
-	lenread = BZ2_bzRead(&bzerr, (BZFILE*)s, buf, (int)len);
+    int bzerr = 0, lenread = 0;
+    lenread = BZ2_bzRead(&bzerr, (BZFILE*)s, buf, (int)len);
     if (bzerr != BZ_OK && bzerr != BZ_STREAM_END) {
-		warnx("Corrupt patch\n");
+        warnx("Corrupt patch\n");
         lenread = -1;
     }
-	return lenread;
+    return lenread;
 }
 
 static io_funcs_t BSDIFF40_funcs = {
-	BSDIFF40_open,
-	BSDIFF40_close,
-	BSDIFF40_read
+    BSDIFF40_open,
+    BSDIFF40_close,
+    BSDIFF40_read
 };
 
 
 static stream_t BSDIFN40_open(FILE *f)
 {
-	return f;
+    return f;
 }
 
 static void BSDIFN40_close(stream_t __unused s)
@@ -96,13 +96,13 @@ static void BSDIFN40_close(stream_t __unused s)
 
 static off_t BSDIFN40_read(stream_t s, void *buf, off_t len)
 {
-	return (off_t)fread(buf, 1, (size_t)len, (FILE*)s);
+    return (off_t)fread(buf, 1, (size_t)len, (FILE*)s);
 }
 
 static io_funcs_t BSDIFN40_funcs = {
-	BSDIFN40_open,
-	BSDIFN40_close,
-	BSDIFN40_read
+    BSDIFN40_open,
+    BSDIFN40_close,
+    BSDIFN40_read
 };
 
 
@@ -112,35 +112,35 @@ typedef unsigned char u_char;
 
 static off_t offtin(u_char *buf)
 {
-	off_t y;
+    off_t y;
 
-	y=buf[7]&0x7F;
-	y=y*256;y+=buf[6];
-	y=y*256;y+=buf[5];
-	y=y*256;y+=buf[4];
-	y=y*256;y+=buf[3];
-	y=y*256;y+=buf[2];
-	y=y*256;y+=buf[1];
-	y=y*256;y+=buf[0];
+    y=buf[7]&0x7F;
+    y=y*256;y+=buf[6];
+    y=y*256;y+=buf[5];
+    y=y*256;y+=buf[4];
+    y=y*256;y+=buf[3];
+    y=y*256;y+=buf[2];
+    y=y*256;y+=buf[1];
+    y=y*256;y+=buf[0];
 
-	if(buf[7]&0x80) y=-y;
+    if(buf[7]&0x80) y=-y;
 
-	return y;
+    return y;
 }
 
 int bspatch(int argc,const char * const argv[])
 {
-	FILE * f = NULL, * cpf = NULL, * dpf = NULL, * epf = NULL;
-	stream_t cstream = NULL, dstream = NULL, estream = NULL;
-	ssize_t oldsize = 0,newsize = 0;
-	ssize_t bzctrllen = 0,bzdatalen = 0;
+    FILE * f = NULL, * cpf = NULL, * dpf = NULL, * epf = NULL;
+    stream_t cstream = NULL, dstream = NULL, estream = NULL;
+    ssize_t oldsize = 0,newsize = 0;
+    ssize_t bzctrllen = 0,bzdatalen = 0;
     u_char header[32] = {0},buf[8] = {0};
-	u_char *old = NULL, *new = NULL;
-	off_t oldpos = 0,newpos = 0;
+    u_char *old = NULL, *new = NULL;
+    off_t oldpos = 0,newpos = 0;
     off_t ctrl[3] = {0};
-	off_t lenread = 0;
-	off_t i = 0;
-	io_funcs_t * io = NULL;
+    off_t lenread = 0;
+    off_t i = 0;
+    io_funcs_t * io = NULL;
     int exitstatus = -1;
 
     if(argc!=4) {
@@ -148,101 +148,101 @@ int bspatch(int argc,const char * const argv[])
         goto cleanup;
     }
 
-	/* Open patch file */
+    /* Open patch file */
     if ((f = fopen(argv[3], "r")) == NULL) {
-		warn("fopen(%s)", argv[3]);
+        warn("fopen(%s)", argv[3]);
         goto cleanup;
     }
 
-	/*
-	File format:
-		0	8	"BSDIFF40" (bzip2) or "BSDIFN40" (raw)
-		8	8	X
-		16	8	Y
-		24	8	sizeof(newfile)
-		32	X	bzip2(control block)
-		32+X	Y	bzip2(diff block)
-		32+X+Y	???	bzip2(extra block)
-	with control block a set of triples (x,y,z) meaning "add x bytes
-	from oldfile to x bytes from the diff block; copy y bytes from the
-	extra block; seek forwards in oldfile by z bytes".
-	*/
+    /*
+    File format:
+        0   8   "BSDIFF40" (bzip2) or "BSDIFN40" (raw)
+        8   8   X
+        16  8   Y
+        24  8   sizeof(newfile)
+        32  X   bzip2(control block)
+        32+X    Y   bzip2(diff block)
+        32+X+Y  ??? bzip2(extra block)
+    with control block a set of triples (x,y,z) meaning "add x bytes
+    from oldfile to x bytes from the diff block; copy y bytes from the
+    extra block; seek forwards in oldfile by z bytes".
+    */
 
-	/* Read header */
-	if (fread(header, 1, 32, f) < 32) {
+    /* Read header */
+    if (fread(header, 1, 32, f) < 32) {
         if (feof(f)) {
-			warnx("Corrupt patch\n");
+            warnx("Corrupt patch\n");
         } else {
             warn("fread(%s)", argv[3]);
         }
         goto cleanup;
-	}
+    }
 
-	/* Check for appropriate magic */
-	if (memcmp(header, "BSDIFF40", 8) == 0)
-		io = &BSDIFF40_funcs;
-	else if (memcmp(header, "BSDIFN40", 8) == 0)
-		io = &BSDIFN40_funcs;
+    /* Check for appropriate magic */
+    if (memcmp(header, "BSDIFF40", 8) == 0)
+        io = &BSDIFF40_funcs;
+    else if (memcmp(header, "BSDIFN40", 8) == 0)
+        io = &BSDIFN40_funcs;
     else {
-		warnx("Corrupt patch\n");
+        warnx("Corrupt patch\n");
         goto cleanup;
     }
 
-	/* Read lengths from header */
-	bzctrllen=offtin(header+8);
-	bzdatalen=offtin(header+16);
-	newsize=offtin(header+24);
+    /* Read lengths from header */
+    bzctrllen=offtin(header+8);
+    bzdatalen=offtin(header+16);
+    newsize=offtin(header+24);
     if((bzctrllen<0) || (bzdatalen<0) || (newsize<0)) {
-		warnx("Corrupt patch\n");
+        warnx("Corrupt patch\n");
         goto cleanup;
     }
 
-	/* Close patch file and re-open it via libbzip2 at the right places */
+    /* Close patch file and re-open it via libbzip2 at the right places */
     if (fclose(f)) {
-		warn("fclose(%s)", argv[3]);
+        warn("fclose(%s)", argv[3]);
         f = NULL;
         goto cleanup;
     }
     f = NULL;
     
     if ((cpf = fopen(argv[3], "r")) == NULL) {
-		warn("fopen(%s)", argv[3]);
+        warn("fopen(%s)", argv[3]);
         goto cleanup;
     }
     if (fseeko(cpf, 32, SEEK_SET)) {
-		warn("fseeko(%s, %lld)", argv[3],
-		    (long long)32);
+        warn("fseeko(%s, %lld)", argv[3],
+            (long long)32);
         goto cleanup;
     }
-	cstream = io->open(cpf);
+    cstream = io->open(cpf);
     if (cstream == NULL) {
         warn("cstream open");
         goto cleanup;
     }
     if ((dpf = fopen(argv[3], "r")) == NULL) {
-		warn("fopen(%s)", argv[3]);
+        warn("fopen(%s)", argv[3]);
         goto cleanup;
     }
     if (fseeko(dpf, 32 + bzctrllen, SEEK_SET)) {
-		warn("fseeko(%s, %lld)", argv[3],
-		    (long long)(32 + bzctrllen));
+        warn("fseeko(%s, %lld)", argv[3],
+            (long long)(32 + bzctrllen));
         goto cleanup;
     }
-	dstream = io->open(dpf);
+    dstream = io->open(dpf);
     if (dstream == NULL) {
         warn("dstream open");
         goto cleanup;
     }
     if ((epf = fopen(argv[3], "r")) == NULL) {
-		warn("fopen(%s)", argv[3]);
+        warn("fopen(%s)", argv[3]);
         goto cleanup;
     }
     if (fseeko(epf, 32 + bzctrllen + bzdatalen, SEEK_SET)) {
-		warn("fseeko(%s, %lld)", argv[3],
-		    (long long)(32 + bzctrllen + bzdatalen));
+        warn("fseeko(%s, %lld)", argv[3],
+            (long long)(32 + bzctrllen + bzdatalen));
         goto cleanup;
     }
-	estream = io->open(epf);
+    estream = io->open(epf);
     if (estream == NULL) {
         warn("estream open");
         goto cleanup;
@@ -261,64 +261,64 @@ int bspatch(int argc,const char * const argv[])
         goto cleanup;
     }
 
-	oldpos=0;newpos=0;
-	while(newpos<newsize) {
-		/* Read control data */
-		for(i=0;i<=2;i++) {
-			lenread = io->read(cstream, buf, 8);
+    oldpos=0;newpos=0;
+    while(newpos<newsize) {
+        /* Read control data */
+        for(i=0;i<=2;i++) {
+            lenread = io->read(cstream, buf, 8);
             if (lenread < 8) {
-				warnx("Corrupt patch\n");
+                warnx("Corrupt patch\n");
                 goto cleanup;
             }
-			ctrl[i]=offtin(buf);
-		};
+            ctrl[i]=offtin(buf);
+        };
 
-		/* Sanity-check */
+        /* Sanity-check */
         if(newpos+ctrl[0]>newsize) {
-			warnx("Corrupt patch\n");
+            warnx("Corrupt patch\n");
             goto cleanup;
         }
 
-		/* Read diff string */
-		lenread = io->read(dstream, new + newpos, ctrl[0]);
+        /* Read diff string */
+        lenread = io->read(dstream, new + newpos, ctrl[0]);
         if (lenread < 0 || lenread < ctrl[0]) {
-			warnx("Corrupt patch\n");
+            warnx("Corrupt patch\n");
             goto cleanup;
         }
 
-		/* Add old data to diff string */
-		for(i=0;i<ctrl[0];i++)
-			if((oldpos+i>=0) && (oldpos+i<oldsize))
-				new[newpos+i]+=old[oldpos+i];
+        /* Add old data to diff string */
+        for(i=0;i<ctrl[0];i++)
+            if((oldpos+i>=0) && (oldpos+i<oldsize))
+                new[newpos+i]+=old[oldpos+i];
 
-		/* Adjust pointers */
-		newpos+=ctrl[0];
-		oldpos+=ctrl[0];
+        /* Adjust pointers */
+        newpos+=ctrl[0];
+        oldpos+=ctrl[0];
 
-		/* Sanity-check */
+        /* Sanity-check */
         if(newpos+ctrl[1]>newsize) {
-			warnx("Corrupt patch\n");
+            warnx("Corrupt patch\n");
             goto cleanup;
         }
 
-		/* Read extra string */
-		lenread = io->read(estream, new + newpos, ctrl[1]);
+        /* Read extra string */
+        lenread = io->read(estream, new + newpos, ctrl[1]);
         if (lenread < 0 || lenread < ctrl[1]) {
-			warnx("Corrupt patch\n");
+            warnx("Corrupt patch\n");
             goto cleanup;
         }
 
-		/* Adjust pointers */
-		newpos+=ctrl[1];
-		oldpos+=ctrl[2];
-	};
+        /* Adjust pointers */
+        newpos+=ctrl[1];
+        oldpos+=ctrl[2];
+    };
 
-	/* Clean up the bzip2 reads */
-	io->close(cstream);
+    /* Clean up the bzip2 reads */
+    io->close(cstream);
     cstream = NULL;
-	io->close(dstream);
+    io->close(dstream);
     dstream = NULL;
-	io->close(estream);
+    io->close(estream);
     estream = NULL;
     
     if (fclose(cpf) != 0) {
@@ -342,7 +342,7 @@ int bspatch(int argc,const char * const argv[])
     }
     epf = NULL;
 
-	/* Write the new file */
+    /* Write the new file */
     f = fopen(argv[2], "w");
     if (f == NULL) {
         warn("failed to write new file: %s", argv[2]);
@@ -363,8 +363,8 @@ int bspatch(int argc,const char * const argv[])
     
     exitstatus = 0;
 cleanup:
-	free(new);
-	free(old);
+    free(new);
+    free(old);
     
     if (f != NULL) {
         fclose(f);
@@ -394,5 +394,5 @@ cleanup:
         fclose(cpf);
     }
 
-	return exitstatus;
+    return exitstatus;
 }


### PR DESCRIPTION
1. Fix and don't hide compiler warnings for bspatch or bsdiff (can we please decide not to do this for files in the future?)
2. Use `FILE*` fread/fwrite functions instead of read() and write() to resolve #810
3. Change `err()`/`errx()` to use `warn()`/`warnx()`, cleanup, and return. Since we are invoking bsdiff/bspatch ourselves, we want to handle failures gracefully.