### PR TITLE
Improve Authorization Usage

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -172,16 +172,18 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
                        versionComparator:[SUStandardVersionComparator defaultComparator]
                        completionHandler:^(NSError *error) {
                            if (error) {
-                               SULog(@"Installation Error: %@", error);
                                NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
-                               if (underlyingError != nil) {
-                                   SULog(@"Installation Underlying Error: %@", underlyingError);
-                               }
-                               if (self.shouldShowUI) {
-                                   NSAlert *alert = [[NSAlert alloc] init];
-                                   alert.messageText = @"";
-                                   alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
-                                   [alert runModal];
+                               if (underlyingError == nil || underlyingError.code != SUInstallationCancelledError) {
+                                   SULog(@"Installation Error: %@", error);
+                                   if (underlyingError != nil) {
+                                       SULog(@"Installation Underlying Error: %@", underlyingError);
+                                   }
+                                   if (self.shouldShowUI) {
+                                       NSAlert *alert = [[NSAlert alloc] init];
+                                       alert.messageText = @"";
+                                       alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
+                                       [alert runModal];
+                                   }
                                }
                                exit(EXIT_FAILURE);
                            } else {

--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -173,6 +173,10 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
                        completionHandler:^(NSError *error) {
                            if (error) {
                                SULog(@"Installation Error: %@", error);
+                               NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
+                               if (underlyingError != nil) {
+                                   SULog(@"Installation Underlying Error: %@", underlyingError);
+                               }
                                if (self.shouldShowUI) {
                                    NSAlert *alert = [[NSAlert alloc] init];
                                    alert.messageText = @"";

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(OSStatus, SUError) {
     SURelaunchError = 4004,
     SUInstallationError = 4005,
     SUDowngradeError = 4006,
+    SUInstallationCancelledError = 4007,
     
     // System phase errors
     SUSystemPowerOffError = 5000

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -147,7 +147,7 @@
  * @return YES if the installer ran the package successfully, otherwise NO with a populated error object
  *
  * This method uses the system wide installer tool to run the provided package. This process does not show any UI, except for
- * an initial authorization prompt if the calling process does not have root privileges. In other words, root privileges are required to use this method.
+ * an initial authorization prompt if the calling process does not have root privileges. In other words, root privileges are required to use this method, and the file manager instance must have been created by allowing authorization.
  * An error can occur if the package is unable to be ran by the installer, or if the installer reports a non-zero exit status code.
  */
 - (BOOL)executePackageAtURL:(NSURL *)packageURL error:(NSError **)error;

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -140,4 +140,16 @@
  */
 - (BOOL)releaseItemFromQuarantineAtRootURL:(NSURL *)rootURL error:(NSError **)error;
 
+/**
+ * Runs an installer package (pkg) in a headless mode using /usr/sbin/installer
+ * @param packageURL A URL pointing to the package to execute. The item at this URL must exist.
+ * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
+ * @return YES if the installer ran the package successfully, otherwise NO with a populated error object
+ *
+ * This method uses the system wide installer tool to run the provided package. This process does not show any UI, except for
+ * an initial authorization prompt if the calling process does not have root privileges. In other words, root privileges are required to use this method.
+ * An error can occur if the package is unable to be ran by the installer, or if the installer reports a non-zero exit status code.
+ */
+- (BOOL)executePackageAtURL:(NSURL *)packageURL error:(NSError **)error;
+
 @end

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -15,36 +15,6 @@
 
 static char SUAppleQuarantineIdentifier[] = "com.apple.quarantine";
 
-// Authorization code based on generous contribution from Allan Odgaard. Thanks, Allan!
-static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authorization, const char *executablePath, AuthorizationFlags options, char *const *arguments)
-{
-    BOOL returnValue = YES;
-
-    FILE *pipe = NULL;
-#pragma clang diagnostic push
-    // In the future, we may have to look at SMJobBless API to avoid deprecation. See issue #558
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if (AuthorizationExecuteWithPrivileges(authorization, executablePath, options, arguments, &pipe) == errAuthorizationSuccess)
-#pragma clang diagnostic pop
-    {
-        pid_t childPid = fcntl(fileno(pipe), F_GETOWN, 0);
-        int status = 0;
-        pid_t pid = -1;
-        do {
-            pid = waitpid(childPid, &status, 0);
-        } while (pid == -1 && errno == EINTR);
-        
-        if (pid == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-            returnValue = NO;
-        }
-        fclose(pipe);
-    } else {
-        returnValue = NO;
-    }
-    
-    return returnValue;
-}
-
 static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
 
     char path[PATH_MAX] = {0};
@@ -106,29 +76,101 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
     return (_allowsAuthorization && _auth != NULL) ? self : [SUFileManager fileManagerAllowingAuthorization:NO];
 }
 
-// Acquires an authorization reference which is intended to be used for future authorized file operations
+// Acquires an authorization reference with root privileges which is intended to be used for authorized file operations
 - (BOOL)_acquireAuthorizationWithError:(NSError *__autoreleasing *)error
 {
     // No need to continue if we already acquired an authorization reference
     if (_auth != NULL) {
         return YES;
     }
-
+    
     if (!_allowsAuthorization) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: @"Unable to grant authorization to perform action because it is explicitly turned off" }];
         }
         return NO;
     }
-
-    OSStatus status = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &_auth);
-    if (status != errAuthorizationSuccess) {
+    
+    OSStatus createStatus = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &_auth);
+    if (createStatus != errAuthorizationSuccess) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed creating authorization reference with status code %d.", status] }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed creating authorization reference with status code %d.", createStatus] }];
         }
         _auth = NULL;
         return NO;
     }
+    
+    AuthorizationItem rightItems[] = {
+        // The right that allows us to run tools as root user
+        {.name = kAuthorizationRightExecute, .valueLength = 0, .value = NULL, .flags = 0}
+    };
+    
+    AuthorizationRights rights = {
+        .count = sizeof(rightItems) / sizeof(*rightItems),
+        .items = rightItems
+    };
+    
+    AuthorizationFlags flags =
+    (AuthorizationFlags)(kAuthorizationFlagDefaults | kAuthorizationFlagInteractionAllowed | kAuthorizationFlagExtendRights | kAuthorizationFlagPreAuthorize);
+    
+    // This will test if we can gain authorization for running utlities as root
+    OSStatus copyStatus = AuthorizationCopyRights(_auth, &rights, kAuthorizationEmptyEnvironment, flags, NULL);
+    if (copyStatus != errAuthorizationSuccess) {
+        if (error != NULL) {
+            if (copyStatus == errAuthorizationCanceled) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationCancelledError userInfo:@{ NSLocalizedDescriptionKey: @"Authorization access was cancelled by the user." }];
+            } else {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed granting authorization rights with status code %d.", copyStatus] }];
+            }
+        }
+        
+        AuthorizationFree(_auth, kAuthorizationFlagDefaults);
+        _auth = NULL;
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (BOOL)_authorizeAndExecutePath:(const char *)executablePath arguments:(char *const *)arguments error:(NSError * __autoreleasing *)error
+{
+    NSError *acquireError = nil;
+    if (![self _acquireAuthorizationWithError:&acquireError]) {
+        if (error != NULL) {
+            *error = acquireError;
+        }
+        return NO;
+    }
+    
+    FILE *pipe = NULL;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (AuthorizationExecuteWithPrivileges(_auth, executablePath, kAuthorizationFlagDefaults, arguments, &pipe) != errAuthorizationSuccess) {
+#pragma clang diagnostic pop
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:@"Failed to run authorization tool." }];
+        }
+        return NO;
+    }
+    
+    pid_t childPid = fcntl(fileno(pipe), F_GETOWN, 0);
+    int status = 0;
+    
+    pid_t waitResult;
+    do {
+        waitResult = waitpid(childPid, &status, 0);
+    } while (waitResult == -1 && errno == EINTR);
+    
+    fclose(pipe);
+    
+    if (waitResult == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Failed to execute authorized executable with result %d and status (%d, %d, %d, %d).", waitResult, status, WIFEXITED(status), WEXITSTATUS(status), errno] }];
+        }
+        return NO;
+    }
+    
     return YES;
 }
 
@@ -212,16 +254,13 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         }
         return NO;
     }
-
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
-    BOOL success = AuthorizationExecuteWithPrivilegesAndWait(_auth, XATTR_UTILITY_PATH, kAuthorizationFlagDefaults, (char *[]){ "-s", "-r", "-d", xattrName, path, NULL });
-
+    
+    NSError *executeError = nil;
+    BOOL success = [self _authorizeAndExecutePath:XATTR_UTILITY_PATH arguments:(char *[]){ "-s", "-r", "-d", xattrName, path, NULL } error:&executeError];
+    
     if (!success && error != NULL) {
         NSString *errorMessage = [NSString stringWithFormat:@"Authenticated extended attribute deletion for %@ failed on %@.", [NSString stringWithUTF8String:xattrName], rootURL.path.lastPathComponent];
-        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:errorMessage }];
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:errorMessage, NSUnderlyingErrorKey: executeError }];
     }
 
     return success;
@@ -400,11 +439,6 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
-
     char sourcePath[PATH_MAX] = {0};
     if (![sourceURL.path getFileSystemRepresentation:sourcePath maxLength:sizeof(sourcePath)]) {
         if (error != NULL) {
@@ -420,11 +454,12 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         }
         return NO;
     }
-
-    if (!AuthorizationExecuteWithPrivilegesAndWait(_auth, "/bin/cp", kAuthorizationFlagDefaults, (char *[]){ "-Rf", "--", sourcePath, destinationPath, NULL })) {
+    
+    NSError *executeError = nil;
+    if (![self _authorizeAndExecutePath:"/bin/cp" arguments:(char *[]){ "-Rf", "--", sourcePath, destinationPath, NULL } error:&executeError]) {
         if (error != NULL) {
             NSString *errorMessage = [NSString stringWithFormat:@"Failed to perform authenticated file copy for %@.", sourceURL.lastPathComponent];
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:errorMessage }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:errorMessage, NSUnderlyingErrorKey: executeError }];
         }
         return NO;
     }
@@ -513,10 +548,6 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
     char sourcePath[PATH_MAX] = {0};
     if (![sourceURL.path getFileSystemRepresentation:sourcePath maxLength:sizeof(sourcePath)]) {
         if (error != NULL) {
@@ -532,11 +563,12 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         }
         return NO;
     }
-
-    if (!AuthorizationExecuteWithPrivilegesAndWait(_auth, "/bin/mv", kAuthorizationFlagDefaults, (char *[]){ "-f", "--", sourcePath, destinationPath, NULL })) {
+    
+    NSError *executeError = nil;
+    if (![self _authorizeAndExecutePath:"/bin/mv" arguments:(char *[]){ "-f", "--", sourcePath, destinationPath, NULL } error:&executeError]) {
         if (error != NULL) {
             NSString *errorMessage = [NSString stringWithFormat:@"Failed to perform authenticated file move for %@.", sourceURL.lastPathComponent];
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:errorMessage }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey:errorMessage, NSUnderlyingErrorKey: executeError }];
         }
         return NO;
     }
@@ -682,15 +714,13 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
     if (written < 0 || written >= 100) {
         return NO; // No custom error, because it's too unlikely to ever happen
     }
-
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
-    BOOL success = AuthorizationExecuteWithPrivilegesAndWait(_auth, "/usr/sbin/chown", kAuthorizationFlagDefaults, (char *[]){ "-R", userAndGroup, targetPath, NULL });
+    
+    NSError *executeError = nil;
+    BOOL success = [self _authorizeAndExecutePath:"/usr/sbin/chown" arguments:(char *[]){ "-R", userAndGroup, targetPath, NULL } error:&executeError];
+    
     if (!success && error != NULL) {
         NSString *errorMessage = [NSString stringWithFormat:@"Failed to change owner:group %@ on %@ with authentication.", [NSString stringWithUTF8String:userAndGroup], targetURL.path.lastPathComponent];
-        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: errorMessage }];
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: executeError }];
     }
 
     return success;
@@ -742,15 +772,12 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         }
         return NO;
     }
-
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
-    BOOL success = AuthorizationExecuteWithPrivilegesAndWait(_auth, "/usr/bin/touch", kAuthorizationFlagDefaults, (char *[]){ "-h", "--", path, NULL });
+    
+    NSError *executeError = nil;
+    BOOL success = [self _authorizeAndExecutePath:"/usr/bin/touch" arguments:(char *[]){ "-h", "--", path, NULL } error:&executeError];
     if (!success && error != NULL) {
         NSString *errorMessage = [NSString stringWithFormat:@"Failed to update modification & access time on %@ with authentication.", targetURL.path.lastPathComponent];
-        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: errorMessage }];
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: executeError }];
     }
 
     return success;
@@ -795,16 +822,14 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         }
         return NO;
     }
-
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
-    BOOL success = AuthorizationExecuteWithPrivilegesAndWait(_auth, "/bin/mkdir", kAuthorizationFlagDefaults, (char *[]){ "--", path, NULL });
+    
+    NSError *executeError = nil;
+    BOOL success = [self _authorizeAndExecutePath:"/bin/mkdir" arguments:(char *[]){ "--", path, NULL } error:&executeError];
     if (!success && error != NULL) {
         NSString *errorMessage = [NSString stringWithFormat:@"Failed to make directory %@ with authentication.", url.path.lastPathComponent];
-        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: errorMessage }];
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: executeError }];
     }
+    
     return success;
 }
 
@@ -850,10 +875,6 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    if (![self _acquireAuthorizationWithError:error]) {
-        return NO;
-    }
-
     char path[PATH_MAX] = {0};
     if (![url.path getFileSystemRepresentation:path maxLength:sizeof(path)]) {
         if (error != NULL) {
@@ -861,11 +882,13 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         }
         return NO;
     }
-
-    BOOL success = AuthorizationExecuteWithPrivilegesAndWait(_auth, "/bin/rm", kAuthorizationFlagDefaults, (char *[]){ "-rf", "--", path, NULL });
+    
+    NSError *executeError = nil;
+    BOOL success = [self _authorizeAndExecutePath:"/bin/rm" arguments:(char *[]){ "-rf", "--", path, NULL } error:&executeError];
     if (!success && error != NULL) {
-        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to remove %@ with authentication.", url.path.lastPathComponent] }];
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAuthenticationFailure userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to remove %@ with authentication.", url.path.lastPathComponent], NSUnderlyingErrorKey: executeError }];
     }
+    
     return success;
 }
 
@@ -951,6 +974,43 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
 
     [self removeItemAtURL:tempDirectory error:NULL];
 
+    return success;
+}
+
+// Unlike other methods, authorization is required to execute this method successfully
+- (BOOL)executePackageAtURL:(NSURL *)packageURL error:(NSError * __autoreleasing *)error
+{
+    if (![self _itemExistsAtURL:packageURL]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to execute package %@ because the file does not exist.", packageURL.path.lastPathComponent] }];
+        }
+        return NO;
+    }
+    
+    const char *installerPath = "/usr/sbin/installer"; // Mac OS X 10.2+ command line installer tool
+    
+    char path[PATH_MAX] = {0};
+    if (![packageURL.path getFileSystemRepresentation:path maxLength:sizeof(path)]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Package to execute (%@) cannot be represented as a valid file name.", packageURL.path.lastPathComponent] }];
+        }
+        return NO;
+    }
+    
+    char * const arguments[] = {
+        "-pkg",
+        path,
+        "-target",
+        "/",
+        NULL
+    };
+    
+    NSError *executeError = nil;
+    BOOL success = [self _authorizeAndExecutePath:installerPath arguments:arguments error:&executeError];
+    if (!success && error != NULL) {
+        NSString* errorMessage = @"Failed to execute package installer.";
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{NSLocalizedDescriptionKey: errorMessage, NSUnderlyingErrorKey: executeError}];
+    }
     return success;
 }
 

--- a/Sparkle/SUGuidedPackageInstaller.m
+++ b/Sparkle/SUGuidedPackageInstaller.m
@@ -6,89 +6,8 @@
 //  Copyright 2010 Dragon Systems Software Limited. All rights reserved.
 //
 
-#import <sys/stat.h>
-#import <Security/Security.h>
-
 #import "SUGuidedPackageInstaller.h"
-
-static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authorization, const char* executablePath, AuthorizationFlags options, char* const* arguments)
-{
-	sig_t oldSigChildHandler = signal(SIGCHLD, SIG_DFL);
-	BOOL returnValue = YES;
-	
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    /* AuthorizationExecuteWithPrivileges used to support 10.4+; should be replaced with XPC or external process */
-	if (AuthorizationExecuteWithPrivileges(authorization, executablePath, options, arguments, NULL) == errAuthorizationSuccess)
-#pragma clang diagnostic pop
-	{
-		int status = 0;
-		pid_t pid = wait(&status);
-		if (pid == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
-			returnValue = NO;
-	}
-	else
-		returnValue = NO;
-	
-	signal(SIGCHLD, oldSigChildHandler);
-	return returnValue;
-}
-
-@implementation SUGuidedPackageInstaller (SUGuidedPackageInstallerAuthentication)
-
-+ (AuthorizationRef)authorizationForExecutable:(NSString*)executablePath
-{
-	SUParameterAssert(executablePath);
-	
-	// Get authorization using advice in Apple's Technical Q&A1172
-	
-	// ...create authorization without specific rights
-	AuthorizationRef auth = NULL;
-	OSStatus validAuth = AuthorizationCreate(NULL,
-											 kAuthorizationEmptyEnvironment, 
-											 kAuthorizationFlagDefaults,
-											 &auth);
-	// ...then extend authorization with desired rights
-	if ((validAuth == errAuthorizationSuccess) &&
-		(auth != NULL))
-	{		
-        char executableFileSystemRepresentation[PATH_MAX];
-        [executablePath getFileSystemRepresentation:executableFileSystemRepresentation maxLength:sizeof(executableFileSystemRepresentation)];
-		
-		// Prepare a right allowing script to execute with privileges
-        AuthorizationItem right = {
-            .name = kAuthorizationRightExecute,
-            .value = executableFileSystemRepresentation,
-            .valueLength = strlen(executableFileSystemRepresentation),
-        };
-		
-		// Package up the single right
-		AuthorizationRights rights;
-		memset(&rights,0,sizeof(rights));
-		rights.count = 1;
-		rights.items = &right;
-		
-		// Extend rights to run script
-		validAuth = AuthorizationCopyRights(auth,
-											&rights,
-											kAuthorizationEmptyEnvironment,
-                                            (AuthorizationFlags)
-											(kAuthorizationFlagPreAuthorize |
-											kAuthorizationFlagExtendRights |
-											kAuthorizationFlagInteractionAllowed),
-											NULL);
-		if (validAuth != errAuthorizationSuccess)
-		{
-			// Error, clean up authorization
-			(void) AuthorizationFree(auth,kAuthorizationFlagDefaults);
-			auth = NULL;
-		}
-	}
-	
-	return auth;
-}
-
-@end
+#import "SUFileManager.h"
 
 @implementation SUGuidedPackageInstaller
 
@@ -97,39 +16,8 @@ static BOOL AuthorizationExecuteWithPrivilegesAndWait(AuthorizationRef authoriza
     SUParameterAssert(packagePath);
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-
-        // Preflight
-        NSString* installerPath = @"/usr/sbin/installer"; // Mac OS X 10.2+ command line installer tool
-        NSError* error = nil;
-
-        // Create authorization for installer executable
-        BOOL validInstallation = NO;
-        AuthorizationRef auth = [self authorizationForExecutable:installerPath];
-        if (auth != NULL)
-        {
-            char pathBuffer[PATH_MAX] = {0};
-            [packagePath getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)];
-
-            // Permission was granted to execute the installer with privileges
-            char * const arguments[] = {
-                "-pkg",
-                pathBuffer,
-                "-target",
-                "/",
-                NULL
-            };
-            validInstallation = AuthorizationExecuteWithPrivilegesAndWait(auth,
-                                                                          [installerPath fileSystemRepresentation],
-                                                                          kAuthorizationFlagDefaults,
-                                                                          arguments);
-            // TODO: wait for communications pipe to close via fileno & CFSocketCreateWithNative
-            AuthorizationFree(auth,kAuthorizationFlagDefaults);
-        }
-        else
-        {
-            NSString* errorMessage = [NSString stringWithFormat:@"Sparkle Updater: Script authorization denied."];
-            error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:[NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey]];
-        }
+        NSError *error = nil;
+        BOOL validInstallation = [[SUFileManager fileManagerAllowingAuthorization:YES] executePackageAtURL:[NSURL fileURLWithPath:packagePath] error:&error];
 
         dispatch_async(dispatch_get_main_queue(), ^{
             [self finishInstallationToPath:destinationPath

--- a/Tests/SUFileManagerTest.swift
+++ b/Tests/SUFileManagerTest.swift
@@ -308,13 +308,6 @@ class SUFileManagerTest: XCTestCase
         }
     }
     
-    // This alone shouldn't prompt a password dialog and should always succeed
-    func testAcquireAuthorization()
-    {
-        let fileManager = SUFileManager(allowingAuthorization: true)
-        try! fileManager._acquireAuthorization()
-    }
-    
     func testAcquireBadAuthorization()
     {
         let fileManager = SUFileManager(allowingAuthorization: false)


### PR DESCRIPTION
This is aimed to resolve #816. I found a way to retrieve the child pid without having to create a wrapper tool, by using fcntl. For practical purposes, this is intended to fix issues (or report errors better) with the guided installer not working. In my fork, I ran into an issue where the installer aborting too early because the child wasn't properly waited, which this aims to fix.

The installer unit test should work if it's ran as root.