### PR TITLE
update Sparkle framework headers to use modules if modules are available

### DIFF
--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -9,7 +9,11 @@
 #ifndef SUAPPCAST_H
 #define SUAPPCAST_H
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 #import "SUExport.h"
 
 @class SUAppcastItem;

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -9,7 +9,11 @@
 #ifndef SUAPPCASTITEM_H
 #define SUAPPCASTITEM_H
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 #import "SUExport.h"
 
 SU_EXPORT @interface SUAppcastItem : NSObject

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -9,7 +9,11 @@
 #ifndef SUERRORS_H
 #define SUERRORS_H
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 #import "SUExport.h"
 
 /**

--- a/Sparkle/SUStandardVersionComparator.h
+++ b/Sparkle/SUStandardVersionComparator.h
@@ -9,7 +9,11 @@
 #ifndef SUSTANDARDVERSIONCOMPARATOR_H
 #define SUSTANDARDVERSIONCOMPARATOR_H
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 #import "SUExport.h"
 #import "SUVersionComparisonProtocol.h"
 

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -9,7 +9,11 @@
 #ifndef SUUPDATER_H
 #define SUUPDATER_H
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 #import "SUExport.h"
 #import "SUVersionComparisonProtocol.h"
 #import "SUVersionDisplayProtocol.h"

--- a/Sparkle/SUVersionComparisonProtocol.h
+++ b/Sparkle/SUVersionComparisonProtocol.h
@@ -9,7 +9,11 @@
 #ifndef SUVERSIONCOMPARISONPROTOCOL_H
 #define SUVERSIONCOMPARISONPROTOCOL_H
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "SUExport.h"
 
 /*!

--- a/Sparkle/SUVersionDisplayProtocol.h
+++ b/Sparkle/SUVersionDisplayProtocol.h
@@ -6,7 +6,11 @@
 //  Copyright 2009 Elgato Systems GmbH. All rights reserved.
 //
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 #import "SUExport.h"
 
 /*!

--- a/Sparkle/Sparkle.h
+++ b/Sparkle/Sparkle.h
@@ -9,7 +9,11 @@
 #ifndef SPARKLE_H
 #define SPARKLE_H
 
+#if __has_feature(modules)
+@import Cocoa;
+#else
 #import <Cocoa/Cocoa.h>
+#endif
 
 // This list should include the shared headers. It doesn't matter if some of them aren't shared (unless
 // there are name-space collisions) so we can list all of them to start with:


### PR DESCRIPTION
When using modules building sparkle can produce a number of warnings. 

While building module 'Sparkle' imported from SparkleUpdater.h:13:
In file included from <module-includes>:1:
SparkleMaster/Sparkle.framework/Headers/Sparkle.h:12:1: warning: treating #import as an import of module 'Cocoa' [-Wauto-import]
#import <Cocoa/Cocoa.h>
^~~~~~~~~~~~~~~~~~~~~~~
@import Cocoa;

Change the headers to conditionally use @import if modules are available otherwise fall back to the #import of the framework umbrella header.