### PR TITLE
Changes for Xcode 8

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -52,7 +52,6 @@ CLANG_WARN_OBJC_EXPLICIT_OWNERSHIP_TYPE = YES
 CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES
 CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
 CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES
-CLANG_WARN_OBJC_RECEIVER_WEAK = YES
 CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES
 CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
 CLANG_WARN_UNREACHABLE_CODE = YES
@@ -88,4 +87,4 @@ CLANG_ENABLE_MODULES[sdk=macosx10.8] = NO
 WARNING_CFLAGS_EXTRA = -Wno-custom-atomic-properties -Wno-implicit-atomic-properties
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-receiver-is-weak -Wno-arc-repeated-use-of-weak -Wno-auto-import $(WARNING_CFLAGS_EXTRA)
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import $(WARNING_CFLAGS_EXTRA)

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -128,7 +128,7 @@
         if (!attrName) {
             continue;
         }
-        [dictionary setObject:[attribute stringValue] forKey:attrName];
+        [dictionary setValue:[attribute stringValue] forKey:attrName];
     }
     return dictionary;
 }

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -128,7 +128,10 @@
         if (!attrName) {
             continue;
         }
-        [dictionary setValue:[attribute stringValue] forKey:attrName];
+        NSString *stringValue = [attribute stringValue];
+        if (stringValue) {
+            [dictionary setObject:stringValue forKey:attrName];
+        }
     }
     return dictionary;
 }

--- a/Sparkle/SUOperatingSystem.m
+++ b/Sparkle/SUOperatingSystem.m
@@ -20,11 +20,14 @@
     {
         NSOperatingSystemVersion version = { 0, 0, 0 };
         NSURL *coreServices = [[NSFileManager defaultManager] URLForDirectory:NSCoreServiceDirectory inDomain:NSSystemDomainMask appropriateForURL:nil create:NO error:nil];
-        NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfURL:[coreServices URLByAppendingPathComponent:@"SystemVersion.plist"]];
-        NSArray *components = [ [dictionary objectForKey: @"ProductVersion"] componentsSeparatedByString:@"."];
-        version.majorVersion = components.count > 0 ? [ [components objectAtIndex:0] integerValue] : 0;
-        version.minorVersion = components.count > 1 ? [ [components objectAtIndex:1] integerValue] : 0;
-        version.patchVersion = components.count > 2 ? [ [components objectAtIndex:2] integerValue] : 0;
+        NSURL *url = [coreServices URLByAppendingPathComponent:@"SystemVersion.plist"] ;
+        if (url) {
+            NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfURL:url];
+            NSArray *components = [ [dictionary objectForKey: @"ProductVersion"] componentsSeparatedByString:@"."];
+            version.majorVersion = components.count > 0 ? [ [components objectAtIndex:0] integerValue] : 0;
+            version.minorVersion = components.count > 1 ? [ [components objectAtIndex:1] integerValue] : 0;
+            version.patchVersion = components.count > 2 ? [ [components objectAtIndex:2] integerValue] : 0;
+        }
         return version;
     }
 #endif

--- a/Sparkle/SUOperatingSystem.m
+++ b/Sparkle/SUOperatingSystem.m
@@ -20,14 +20,13 @@
     {
         NSOperatingSystemVersion version = { 0, 0, 0 };
         NSURL *coreServices = [[NSFileManager defaultManager] URLForDirectory:NSCoreServiceDirectory inDomain:NSSystemDomainMask appropriateForURL:nil create:NO error:nil];
-        NSURL *url = [coreServices URLByAppendingPathComponent:@"SystemVersion.plist"] ;
-        if (url) {
-            NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfURL:url];
-            NSArray *components = [ [dictionary objectForKey: @"ProductVersion"] componentsSeparatedByString:@"."];
-            version.majorVersion = components.count > 0 ? [ [components objectAtIndex:0] integerValue] : 0;
-            version.minorVersion = components.count > 1 ? [ [components objectAtIndex:1] integerValue] : 0;
-            version.patchVersion = components.count > 2 ? [ [components objectAtIndex:2] integerValue] : 0;
-        }
+        NSURL *url = [coreServices URLByAppendingPathComponent:@"SystemVersion.plist"];
+        assert(url != nil);
+        NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfURL:url];
+        NSArray *components = [ [dictionary objectForKey: @"ProductVersion"] componentsSeparatedByString:@"."];
+        version.majorVersion = components.count > 0 ? [ [components objectAtIndex:0] integerValue] : 0;
+        version.minorVersion = components.count > 1 ? [ [components objectAtIndex:1] integerValue] : 0;
+        version.patchVersion = components.count > 2 ? [ [components objectAtIndex:2] integerValue] : 0;
         return version;
     }
 #endif

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -260,7 +260,7 @@
 {
     NSURL *requestURL = request.URL;
     NSString *scheme = requestURL.scheme;
-    BOOL whitelistedSafe = [@"http" isEqualToString:scheme] || [@"https" isEqualToString:scheme] || [@"about:blank" isEqualToString:requestURL.absoluteString];
+    BOOL whitelistedSafe = [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"] || [requestURL.absoluteString isEqualToString:@"about:blank"];
 
     // Do not allow redirects to dangerous protocols such as file://
     if (!whitelistedSafe) {

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -128,15 +128,15 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
     if (!hasPublicDSAKey) {
         if (!isMainBundle) {
-            [self showAlertText:NSLocalizedString(@"Insecure update error!", nil)
-                informativeText:NSLocalizedString(@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information.", nil)];
+            [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
+                informativeText:SULocalizedString(@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information.", nil)];
         } else {
             if (!hostIsCodeSigned) {
-                [self showAlertText:NSLocalizedString(@"Insecure update error!", nil)
-                    informativeText:NSLocalizedString(@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
+                [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
+                    informativeText:SULocalizedString(@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
             } else if (!servingOverHttps) {
-                [self showAlertText:NSLocalizedString(@"Insecure update error!", nil)
-                    informativeText:NSLocalizedString(@"For security reasons, you need to serve your updates over HTTPS and/or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
+                [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
+                    informativeText:SULocalizedString(@"For security reasons, you need to serve your updates over HTTPS and/or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
             }
         }
     }
@@ -145,8 +145,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (!servingOverHttps) {
         BOOL atsExceptionsExist = nil != [self.host objectForInfoDictionaryKey:@"NSAppTransportSecurity"];
         if (isMainBundle && !atsExceptionsExist) {
-            [self showAlertText:NSLocalizedString(@"Insecure feed URL is blocked in macOS 10.11", nil)
-                informativeText:[NSString stringWithFormat:NSLocalizedString(@"You must change the feed URL (%@) to use HTTPS or disable App Transport Security.\n\nFor more information:\nhttps://sparkle-project.org/documentation/app-transport-security/", nil), [feedURL absoluteString]]];
+            [self showAlertText:SULocalizedString(@"Insecure feed URL is blocked in macOS 10.11", nil)
+                informativeText:[NSString stringWithFormat:SULocalizedString(@"You must change the feed URL (%@) to use HTTPS or disable App Transport Security.\n\nFor more information:\nhttps://sparkle-project.org/documentation/app-transport-security/", nil), [feedURL absoluteString]]];
         } else if (!isMainBundle) {
             SULog(@"WARNING: Serving updates over HTTP may be blocked in macOS 10.11. Please change the feed URL (%@) to use HTTPS. For more information:\nhttps://sparkle-project.org/documentation/app-transport-security/", feedURL);
         }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -128,15 +128,15 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
     if (!hasPublicDSAKey) {
         if (!isMainBundle) {
-            [self showAlertText:@"Insecure update error!"
-                informativeText:@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information."];
+            [self showAlertText:NSLocalizedString(@"Insecure update error!", nil)
+                informativeText:NSLocalizedString(@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information.", nil)];
         } else {
             if (!hostIsCodeSigned) {
-                [self showAlertText:@"Insecure update error!"
-                    informativeText:@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information."];
+                [self showAlertText:NSLocalizedString(@"Insecure update error!", nil)
+                    informativeText:NSLocalizedString(@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
             } else if (!servingOverHttps) {
-                [self showAlertText:@"Insecure update error!"
-                    informativeText:@"For security reasons, you need to serve your updates over HTTPS and/or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information."];
+                [self showAlertText:NSLocalizedString(@"Insecure update error!", nil)
+                    informativeText:NSLocalizedString(@"For security reasons, you need to serve your updates over HTTPS and/or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
             }
         }
     }
@@ -145,8 +145,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (!servingOverHttps) {
         BOOL atsExceptionsExist = nil != [self.host objectForInfoDictionaryKey:@"NSAppTransportSecurity"];
         if (isMainBundle && !atsExceptionsExist) {
-            [self showAlertText:@"Insecure feed URL is blocked in macOS 10.11"
-                informativeText:[NSString stringWithFormat:@"You must change the feed URL (%@) to use HTTPS or disable App Transport Security.\n\nFor more information:\nhttps://sparkle-project.org/documentation/app-transport-security/", [feedURL absoluteString]]];
+            [self showAlertText:NSLocalizedString(@"Insecure feed URL is blocked in macOS 10.11", nil)
+                informativeText:[NSString stringWithFormat:NSLocalizedString(@"You must change the feed URL (%@) to use HTTPS or disable App Transport Security.\n\nFor more information:\nhttps://sparkle-project.org/documentation/app-transport-security/", nil), [feedURL absoluteString]]];
         } else if (!isMainBundle) {
             SULog(@"WARNING: Serving updates over HTTP may be blocked in macOS 10.11. Please change the feed URL (%@) to use HTTPS. For more information:\nhttps://sparkle-project.org/documentation/app-transport-security/", feedURL);
         }


### PR DESCRIPTION
This first change was necessary to build the Sparkle framework target in Xcode 8.0:

* In ConfigCommon.xcconfig, removed references to CLANG_WARN_OBJC_RECEIVER_WEAK and -Wno-receiver-is-weak, because apparently these had been deprecated and are now no longer recognized.  Unfortunately, I could not find any documentation on this, but it seems reasonable.

The remaining changes are to clear warnings from the static analyzer in Xcode 8.0:

* In SUAppcast.m, changed to method which can accept nil.
* In SUOperatingSystem.h, added a check for nil which probably never happens.
* In SUUpdateAlert.m, swapped receiver with parameter in -isEqualToString, 3 places, so that nonnull parameter could never be nil.
* In SUUpdater.m, added NSLocalizedString() wrappers around 8 recently-added (in the last few years, I think) user-facing warning strings.