### PR TITLE
Fix release build warning: skipping copy phase strip, binary is code signed

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -2232,6 +2232,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA1941CC0D94A70100DD942E /* ConfigCommonRelease.xcconfig */;
 			buildSettings = {
+				COPY_PHASE_STRIP = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Noticed this in our [Travis CI build log](https://travis-ci.org/matryer/bitbar/builds/138554729). Fixes a release build warning during copy phase, failing to strip debug symbols due to code signing. This is a default setting for project templates since Xcode 6.3 (see https://www.cocoanetics.com/2015/04/skipping-copy-phase-strip/). I confirmed that this gets added when creating a new project now.
