### PR TITLE
Make sign_update work when Bash is not the default

### DIFF
--- a/bin/sign_update
+++ b/bin/sign_update
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 set -o pipefail
 if [ "$#" -ne 2 ]; then


### PR DESCRIPTION
The sign_update script fails when Bash is not the default shell. This patch fixes it and allows the script to run on a default Ubuntu system, for example.