### PR TITLE
Delay check for -isRunningOnReadOnlyVolume until we know if update is available

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -21,6 +21,7 @@
 @property (strong, readonly) NSURLDownload *download;
 @property (copy, readonly) NSString *downloadPath;
 
+- (BOOL)verifyHostVolumeWritable;
 - (void)checkForUpdatesAtURL:(NSURL *)URL host:(SUHost *)host;
 
 - (BOOL)isItemNewer:(SUAppcastItem *)ui;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -43,14 +43,20 @@
 @synthesize tempDir;
 @synthesize relaunchPath;
 
+- (BOOL)verifyHostVolumeWritable
+{
+    if ([self.host isRunningOnReadOnlyVolume])
+    {
+        [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated when it's running from a read-only volume like a disk image or an optical drive. Move %1$@ to your Applications folder, relaunch it from there, and try again.", nil), [self.host name]] }]];
+        return NO;
+    }
+    
+    return YES;
+}
+
 - (void)checkForUpdatesAtURL:(NSURL *)URL host:(SUHost *)aHost
 {
     [super checkForUpdatesAtURL:URL host:aHost];
-	if ([aHost isRunningOnReadOnlyVolume])
-	{
-        [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated when it's running from a read-only volume like a disk image or an optical drive. Move %1$@ to your Applications folder, relaunch it from there, and try again.", nil), [aHost name]] }]];
-        return;
-    }
 
     SUAppcast *appcast = [[SUAppcast alloc] init];
 
@@ -190,6 +196,11 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterDidFindValidUpdateNotification
                                                         object:self.updater
                                                       userInfo:@{ SUUpdaterAppcastItemNotificationKey: self.updateItem }];
+    
+    if (![self verifyHostVolumeWritable]) {
+        return;
+    }
+    
     [self downloadUpdate];
 }
 

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -114,6 +114,10 @@
     [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
     switch (choice) {
         case SUInstallUpdateChoice:
+            if (![self verifyHostVolumeWritable]) {
+                return;
+            }
+            
             self.statusController = [[SUStatusController alloc] initWithHost:self.host];
             [self.statusController beginActionWithTitle:SULocalizedString(@"Downloading update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
             [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelDownload:) isDefault:NO];


### PR DESCRIPTION
This PR postpones the check for `-isRunningOnReadOnlyVolume` until
_after_ Sparkle has already discovered a valid update and the user has
chosen to download the update (either via the UI or via automatic
upgrade driver). I think there are at least two advantages to doing
this check later rather than sooner:
1. For apps that might be affected by Gatekeeper Path Randomization
   (#832), this change allows the app to still get delegate callbacks to
   know when an update is available (even if it can’t be applied). If it
   chooses, the app could then prompt the user to take some action. For
   example, moving the app out of ~/Downloads—or offering to do it on the
   user’s behalf via something like LetsMove.framework (which now works
   again in 10.12 beta 3). Without this PR, the update fails before
   the app has a chance to let the user know they’re missing out on an
   update.
2. This PR allows `-[SUUpdater checkForUpdateInformation]` to
   function properly even if app on read-only volume.
