### PR TITLE
Remove <link> from SampleAppCast.xml

### DIFF
--- a/Resources/SampleAppcast.xml
+++ b/Resources/SampleAppcast.xml
@@ -2,7 +2,6 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
     <channel>
         <title>Your Great App's Changelog</title>
-        <link>http://you.com/app/appcast.xml</link>
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         <item>


### PR DESCRIPTION
Sparkle doesn’t use the channel’s link element. This resolves issue https://github.com/sparkle-project/Sparkle/issues/861.