### PR TITLE
Menu item validation

### DIFF
--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -71,6 +71,11 @@ SU_EXPORT @interface SUUpdater : NSObject
 - (IBAction)checkForUpdates:(id)sender;
 
 /*!
+   The menu item validation used for the -checkForUpdates: action
+ */
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem;
+
+/*!
     Checks for updates, but does not display any UI unless an update is found.
 
     This is meant for programmatically initating a check for updates. That is,

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -526,7 +526,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 - (BOOL)validateMenuItem:(NSMenuItem *)item
 {
     if ([item action] == @selector(checkForUpdates:)) {
-        return ![self updateInProgress];
+        return ![self updateInProgress] || [self.driver isInterruptible];
     }
     return YES;
 }

--- a/TestApplication/SUUpdateSettingsWindowController.m
+++ b/TestApplication/SUUpdateSettingsWindowController.m
@@ -29,4 +29,12 @@
     [self.updater checkForUpdates:nil];
 }
 
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+    if (menuItem.action == @selector(checkForUpdates:)) {
+        return [self.updater validateMenuItem:menuItem];
+    }
+    return YES;
+}
+
 @end


### PR DESCRIPTION
This just alters the menu item validation to match what Andy must have originally intended for.

Which is that if an update is downloaded automatically in the background, the user can initiate an update check that will abort that downloaded update, and check for the latest update from the server. The upside is that the newest update will be retrieved, but the downside is that the downloaded update will be wasted in this scenario (my [fork](https://github.com/zorgiepoo/Sparkle) makes the opposite decision).

Anyway, this is just a simple fix. I also made the menu item validation work on the test app's window controller.