### PR TITLE
Dsa existence

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -317,6 +317,12 @@
     SUHost *newHost = [[SUHost alloc] initWithBundle:newBundle];
     NSString *newPublicDSAKey = newHost.publicDSAKey;
     
+    // Downgrade in DSA security should not be possible
+    if (publicDSAKey != nil && newPublicDSAKey == nil) {
+        SULog(@"A public DSA key is found in the old bundle but no public DSA key is found in the new update. For security reasons, the update will be rejected.");
+        return NO;
+    }
+    
     BOOL dsaKeysMatch = (publicDSAKey == nil || newPublicDSAKey == nil) ? NO : [publicDSAKey isEqualToString:newPublicDSAKey];
     
     // If the new DSA key differs from the old, then this check is not a security measure, because the new key is not trusted.

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -34,6 +34,7 @@ typedef struct {
 @property (getter=isRunningOnReadOnlyVolume, readonly) BOOL runningOnReadOnlyVolume;
 @property (getter=isBackgroundApplication, readonly) BOOL backgroundApplication;
 @property (readonly, copy) NSString *publicDSAKey;
+@property (readonly, nonatomic, copy) NSString *publicDSAKeyFileKey;
 @property (readonly, copy) NSArray *systemProfile;
 
 - (id)objectForInfoDictionaryKey:(NSString *)key;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -168,7 +168,7 @@
     }
 
     // More likely, we've got a reference to a Resources file by filename:
-    NSString *keyFilename = [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey];
+    NSString *keyFilename = [self publicDSAKeyFileKey];
 	if (!keyFilename) {
         return nil;
     }
@@ -178,6 +178,11 @@
         return nil;
     }
     return [NSString stringWithContentsOfFile:keyPath encoding:NSASCIIStringEncoding error:nil];
+}
+
+- (NSString * __nullable)publicDSAKeyFileKey
+{
+    return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey];
 }
 
 - (NSArray *)systemProfile

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -127,16 +127,23 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     BOOL servingOverHttps = [[[feedURL scheme] lowercaseString] isEqualToString:@"https"];
 
     if (!hasPublicDSAKey) {
-        if (!isMainBundle) {
+        // If we failed to retrieve a DSA key but the bundle specifies a path to one, we should consider this a configuration failure
+        NSString *publicDSAKeyFileKey = [self.host publicDSAKeyFileKey];
+        if (publicDSAKeyFileKey != nil) {
             [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
-                informativeText:SULocalizedString(@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information.", nil)];
+                informativeText:[NSString stringWithFormat:SULocalizedString(@"For security reasons, the file indicated by the '%@' key needs to exist in the bundle's Resources.", nil), SUPublicDSAKeyFileKey]];
         } else {
-            if (!hostIsCodeSigned) {
+            if (!isMainBundle) {
                 [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
-                    informativeText:SULocalizedString(@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
-            } else if (!servingOverHttps) {
-                [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
-                    informativeText:SULocalizedString(@"For security reasons, you need to serve your updates over HTTPS and/or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
+                    informativeText:SULocalizedString(@"For security reasons, you need to sign your updates with a DSA key. See Sparkle's documentation for more information.", nil)];
+            } else {
+                if (!hostIsCodeSigned) {
+                    [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
+                        informativeText:SULocalizedString(@"For security reasons, you need to code sign your application or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
+                } else if (!servingOverHttps) {
+                    [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
+                        informativeText:SULocalizedString(@"For security reasons, you need to serve your updates over HTTPS and/or sign your updates with a DSA key. See https://sparkle-project.org/documentation/ for more information.", nil)];
+                }
             }
         }
     }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -131,7 +131,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         NSString *publicDSAKeyFileKey = [self.host publicDSAKeyFileKey];
         if (publicDSAKeyFileKey != nil) {
             [self showAlertText:SULocalizedString(@"Insecure update error!", nil)
-                informativeText:[NSString stringWithFormat:SULocalizedString(@"For security reasons, the file indicated by the '%@' key needs to exist in the bundle's Resources.", nil), SUPublicDSAKeyFileKey]];
+                informativeText:[NSString stringWithFormat:SULocalizedString(@"For security reasons, the file (%@) indicated by the '%@' key needs to exist in the bundle's Resources.", nil), publicDSAKeyFileKey, SUPublicDSAKeyFileKey]];
         } else {
             if (!isMainBundle) {
                 [self showAlertText:SULocalizedString(@"Insecure update error!", nil)


### PR DESCRIPTION
Two changes:

1. Alert developers from making a mistake of specifying a filename to a DSA public key in their bundle's Info.plist but not having the file actually exist in the bundle's resources.
2. Prevent upgrades that would result in a security downgrade by removing the public DSA key (this is a security related change).

I have seen developers make a mistake of not supplying a public key in their new update.