### PR TITLE
Dmg output

### DIFF
--- a/Sparkle/SUDiskImageUnarchiver.m
+++ b/Sparkle/SUDiskImageUnarchiver.m
@@ -140,7 +140,7 @@
         // Now that we've mounted it, we need to copy out its contents.
         manager = [[NSFileManager alloc] init];
         contents = [manager contentsOfDirectoryAtPath:mountPoint error:&error];
-		if (error)
+		if (contents == nil)
 		{
             SULog(@"Couldn't enumerate contents of archive mounted at %@: %@", mountPoint, error);
             goto reportError;

--- a/Sparkle/SUDiskImageUnarchiver.m
+++ b/Sparkle/SUDiskImageUnarchiver.m
@@ -10,6 +10,7 @@
 #import "SUUnarchiver_Private.h"
 #import "SULog.h"
 #include <CoreServices/CoreServices.h>
+#import "SUFileManager.h"
 
 @implementation SUDiskImageUnarchiver
 
@@ -84,7 +85,20 @@
             [arguments addObject:@"-stdinpass"];
         }
 
-        NSData *output = nil;
+        // We want to redirect hdiutil output to a temp file
+        // Note the file is not *critically* important because it's just used when hdiutil fails on error
+        
+        NSURL *tempDirectoryURL = [[SUFileManager defaultManager] makeTemporaryDirectoryWithPreferredName:@"dmg-temp-output" appropriateForDirectoryURL:[NSURL fileURLWithPath:NSTemporaryDirectory()] error:NULL];
+        
+        NSURL *outputFileURL = nil;
+        if (tempDirectoryURL != nil) {
+            NSURL *tempFileURL = [tempDirectoryURL URLByAppendingPathComponent:@"dmg-output.txt"];
+            // Create an empty file to ensure a file exists when we create a file handle for it later
+            if ([[NSData data] writeToURL:tempFileURL atomically:NO]) {
+                outputFileURL = tempFileURL;
+            }
+        }
+        
         NSInteger taskResult = -1;
 		@try
 		{
@@ -94,20 +108,20 @@
             task.arguments = arguments;
             
             NSPipe *inputPipe = [NSPipe pipe];
-            NSPipe *outputPipe = [NSPipe pipe];
+            // See https://github.com/sparkle-project/Sparkle/pull/874#issuecomment-242924887 for why we don't create a pipe
+            NSFileHandle *outputFileHandle = (outputFileURL != nil) ? [NSFileHandle fileHandleForWritingToURL:outputFileURL error:NULL] : nil;
             
             task.standardInput = inputPipe;
-            task.standardOutput = outputPipe;
+            task.standardOutput = outputFileHandle;
             
             [task launch];
             
             [inputPipe.fileHandleForWriting writeData:promptData];
             [inputPipe.fileHandleForWriting closeFile];
             
-            // Read data to end *before* waiting until the task ends so we don't deadlock if the stdout buffer becomes full if we haven't consumed from it
-            output = [outputPipe.fileHandleForReading readDataToEndOfFile];
-            
             [task waitUntilExit];
+            [outputFileHandle closeFile];
+            
             taskResult = task.terminationStatus;
         }
         @catch (NSException *)
@@ -117,7 +131,7 @@
 
 		if (taskResult != 0)
 		{
-            NSString *resultStr = output ? [[NSString alloc] initWithData:output encoding:NSUTF8StringEncoding] : nil;
+            NSString *resultStr = (outputFileURL != nil) ? [[NSString alloc] initWithContentsOfURL:outputFileURL encoding:NSUTF8StringEncoding error:NULL] : nil;
             SULog(@"hdiutil failed with code: %ld data: <<%@>>", (long)taskResult, resultStr);
             goto reportError;
         }
@@ -167,6 +181,10 @@
             }
         } else {
             SULog(@"Can't mount DMG %@", self.archivePath);
+        }
+        
+        if (tempDirectoryURL != nil) {
+            [[NSFileManager defaultManager] removeItemAtURL:tempDirectoryURL error:NULL];
         }
     }
 }


### PR DESCRIPTION
This redirects standard output to a temporary file.

See https://github.com/sparkle-project/Sparkle/pull/874#issuecomment-242924887

I still think this doesn't warrant holding onto NTSynchronousTask which uses runloop modes, notifications which I would rather stay away from.

Lastly, reading the output here isn't even *that* critical, so it could always get removed if this turns out to be a real headache.

cc @jkbullard (thanks for the feedback!)