### PR TITLE
Update mdimporter modification dates after delta extractions

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		722954CA1D04EA6000ECF9CA /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0867D6A5FE840307C02AAC07 /* AppKit.framework */; };
 		722954CB1D04EA6900ECF9CA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		722954CC1D04EA7000ECF9CA /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
+		723A920E1D722438004A9DED /* SUSpotlightImporterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A920D1D722438004A9DED /* SUSpotlightImporterTest.swift */; };
 		723B252D1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
 		723B252E1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
 		723B252F1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
@@ -677,6 +678,7 @@
 		722954C21D04E66F00ECF9CA /* SUFileOperationConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUFileOperationConstants.h; sourceTree = "<group>"; };
 		722954C31D04E66F00ECF9CA /* SUFileOperationConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUFileOperationConstants.m; sourceTree = "<group>"; };
 		722954C81D04E89500ECF9CA /* ConfigFileop.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigFileop.xcconfig; sourceTree = "<group>"; };
+		723A920D1D722438004A9DED /* SUSpotlightImporterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUSpotlightImporterTest.swift; sourceTree = "<group>"; };
 		723B252B1CEAB3A600909873 /* bscommon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bscommon.c; sourceTree = "<group>"; };
 		723B252C1CEAB3A600909873 /* bscommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bscommon.h; sourceTree = "<group>"; };
 		7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBinaryDeltaCreate.m; sourceTree = "<group>"; };
@@ -1024,6 +1026,7 @@
 				5AF9DC3B1981DBEE001EA135 /* SUDSAVerifierTest.m */,
 				72A4A23F1BB6567D00E7820D /* SUFileManagerTest.swift */,
 				5AF6C74C1AEA40760014A3AB /* SUInstallerTest.m */,
+				723A920D1D722438004A9DED /* SUSpotlightImporterTest.swift */,
 				7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */,
 				14950074195FDF5900BC5B5B /* SUUpdaterTest.m */,
 				61227A150DB548B800AB99EA /* SUVersionComparisonTest.m */,
@@ -1727,6 +1730,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				723A920E1D722438004A9DED /* SUSpotlightImporterTest.swift in Sources */,
 				721CF1A71AD7643600D9AC09 /* bsdiff.c in Sources */,
 				721CF1A81AD7644100D9AC09 /* bspatch.c in Sources */,
 				721CF1A91AD7644C00D9AC09 /* sais.c in Sources */,

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -10,6 +10,7 @@
 #import "SUBinaryDeltaUnarchiver.h"
 #import "SUBinaryDeltaApply.h"
 #import "SUUnarchiver_Private.h"
+#import "SUFileManager.h"
 #import "SUHost.h"
 #import "SULog.h"
 
@@ -18,6 +19,41 @@
 + (BOOL)canUnarchivePath:(NSString *)path
 {
     return [[path pathExtension] isEqualToString:@"delta"];
+}
+
+// According to https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/MDImporters/Concepts/Troubleshooting.html
+// We should make sure mdimporter bundles have an up to date time in the event they were delta updated.
+// We used to invoke mdimport on the bundle but this is not a very good approach.
+// There's no need to do that for non-delta updates and for updates that contain no mdimporters.
+// Moreover, updating the timestamp on the mdimporter bundles is what developers have to do anyway when shipping their new update outside of Sparkle
+- (void)updateSpotlightImportersAtBundlePath:(NSString *)targetPath
+{
+    NSURL *targetURL = [NSURL fileURLWithPath:targetPath];
+    // Only recurse if it's actually a directory.  Don't recurse into a
+    // root-level symbolic link.
+    NSDictionary *rootAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:targetPath error:nil];
+    NSString *rootType = [rootAttributes objectForKey:NSFileType];
+    
+    if ([rootType isEqualToString:NSFileTypeDirectory]) {
+        // The NSDirectoryEnumerator will avoid recursing into any contained
+        // symbolic links, so no further type checks are needed.
+        NSDirectoryEnumerator *directoryEnumerator = [[NSFileManager defaultManager] enumeratorAtURL:targetURL includingPropertiesForKeys:nil options:(NSDirectoryEnumerationOptions)0 errorHandler:nil];
+        
+        NSMutableArray *filesToUpdate = [[NSMutableArray alloc] init];
+        for (NSURL *file in directoryEnumerator) {
+            if ([file.pathExtension isEqualToString:@"mdimporter"]) {
+                [filesToUpdate addObject:file];
+            }
+        }
+        
+        SUFileManager *fileManager = [SUFileManager defaultManager];
+        for (NSURL *file in filesToUpdate) {
+            NSError *error = nil;
+            if (![fileManager updateModificationAndAccessTimeOfItemAtURL:file error:&error]) {
+                SULog(@"Error: During delta unarchiving, failed to touch %@", error);
+            }
+        }
+    }
 }
 
 - (void)applyBinaryDelta
@@ -29,6 +65,8 @@
         NSError *applyDiffError = nil;
         BOOL success = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO, &applyDiffError);
         if (success) {
+            [self updateSpotlightImportersAtBundlePath:targetPath];
+            
             dispatch_async(dispatch_get_main_queue(), ^{
                 [self notifyDelegateOfSuccess];
             });

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -26,7 +26,7 @@
 // We used to invoke mdimport on the bundle but this is not a very good approach.
 // There's no need to do that for non-delta updates and for updates that contain no mdimporters.
 // Moreover, updating the timestamp on the mdimporter bundles is what developers have to do anyway when shipping their new update outside of Sparkle
-- (void)updateSpotlightImportersAtBundlePath:(NSString *)targetPath
++ (void)updateSpotlightImportersAtBundlePath:(NSString *)targetPath
 {
     NSURL *targetURL = [NSURL fileURLWithPath:targetPath];
     // Only recurse if it's actually a directory.  Don't recurse into a
@@ -65,7 +65,7 @@
         NSError *applyDiffError = nil;
         BOOL success = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO, &applyDiffError);
         if (success) {
-            [self updateSpotlightImportersAtBundlePath:targetPath];
+            [[self class] updateSpotlightImportersAtBundlePath:targetPath];
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 [self notifyDelegateOfSuccess];

--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -122,30 +122,9 @@
     }
 }
 
-+ (void)mdimportInstallationPath:(NSString *)installationPath
-{
-    // *** GETS CALLED ON NON-MAIN THREAD!
-
-    SULog(@"mdimporting");
-
-    NSTask *mdimport = [[NSTask alloc] init];
-    [mdimport setLaunchPath:@"/usr/bin/mdimport"];
-    [mdimport setArguments:@[installationPath]];
-    @try {
-        [mdimport launch];
-        [mdimport waitUntilExit];
-    }
-    @catch (NSException *launchException)
-    {
-        // No big deal.
-        SULog(@"Error: %@", [launchException description]);
-    }
-}
-
-+ (void)finishInstallationToPath:(NSString *)installationPath withResult:(BOOL)result error:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler
++ (void)finishInstallationToPath:(NSString *)__unused installationPath withResult:(BOOL)result error:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler
 {
     if (result) {
-        [self mdimportInstallationPath:installationPath];
         dispatch_async(dispatch_get_main_queue(), ^{
             completionHandler(nil);
         });

--- a/Tests/SUSpotlightImporterTest.swift
+++ b/Tests/SUSpotlightImporterTest.swift
@@ -1,0 +1,60 @@
+//
+//  SUSpotlightImporterTest.swift
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 8/27/16.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import XCTest
+
+class SUSpotlightImporterTest: XCTestCase
+{
+    func testUpdatingSpotlightBundles()
+    {
+        let fileManager = SUFileManager.defaultManager()
+        let tempDirectoryURL = try! fileManager.makeTemporaryDirectoryWithPreferredName("Sparkle Unit Test Data", appropriateForDirectoryURL: NSURL(fileURLWithPath: NSHomeDirectory()))
+        
+        let bundleDirectory = tempDirectoryURL.URLByAppendingPathComponent("bundle.app")
+        try! fileManager.makeDirectoryAtURL(bundleDirectory)
+        
+        let innerDirectory = bundleDirectory.URLByAppendingPathComponent("foo")
+        try! fileManager.makeDirectoryAtURL(innerDirectory)
+        try! NSData().writeToURL(bundleDirectory.URLByAppendingPathComponent("bar"), options: .AtomicWrite)
+        
+        let importerDirectory = innerDirectory.URLByAppendingPathComponent("baz.mdimporter")
+        
+        try! fileManager.makeDirectoryAtURL(importerDirectory)
+        try! fileManager.makeDirectoryAtURL(innerDirectory.URLByAppendingPathComponent("flag"))
+        
+        try! NSData().writeToURL(importerDirectory.URLByAppendingPathComponent("file"), options: .AtomicWrite)
+        
+        let oldFooDirectoryAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(innerDirectory.path!)
+        let oldBarFileAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(bundleDirectory.URLByAppendingPathComponent("bar").path!)
+        let oldImporterAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(importerDirectory.path!)
+        let oldFlagAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(innerDirectory.URLByAppendingPathComponent("flag").path!)
+        let oldFileInImporterAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(importerDirectory.URLByAppendingPathComponent("file").path!)
+        
+        sleep(1) // wait for clock to advance
+        
+        // Update spotlight bundles
+        SUBinaryDeltaUnarchiver.updateSpotlightImportersAtBundlePath(bundleDirectory.path!)
+        
+        let newFooDirectoryAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(innerDirectory.path!)
+        XCTAssertEqual((newFooDirectoryAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldFooDirectoryAttributes[NSFileModificationDate] as! NSDate), 0)
+        
+        let newBarFileAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(bundleDirectory.URLByAppendingPathComponent("bar").path!)
+        XCTAssertEqual((newBarFileAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldBarFileAttributes[NSFileModificationDate] as! NSDate), 0)
+        
+        let newImporterAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(importerDirectory.path!)
+        XCTAssertGreaterThan((newImporterAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldImporterAttributes[NSFileModificationDate] as! NSDate), 0)
+        
+        let newFlagAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(innerDirectory.URLByAppendingPathComponent("flag").path!)
+        XCTAssertEqual((newFlagAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldFlagAttributes[NSFileModificationDate] as! NSDate), 0)
+        
+        let newFileInImporterAttributes = try! NSFileManager.defaultManager().attributesOfItemAtPath(importerDirectory.URLByAppendingPathComponent("file").path!)
+        XCTAssertEqual((newFileInImporterAttributes[NSFileModificationDate] as! NSDate).timeIntervalSinceDate(oldFileInImporterAttributes[NSFileModificationDate] as! NSDate), 0)
+        
+        try! fileManager.removeItemAtURL(tempDirectoryURL)
+    }
+}

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -3,6 +3,7 @@
 //
 
 #import "SUUnarchiver.h"
+#import "SUBinaryDeltaUnarchiver.h"
 #import "SUPipedUnarchiver.h"
 #import "SUBinaryDeltaCommon.h"
 #import "SUFileManager.h"
@@ -35,3 +36,8 @@ static const char *SUAppleQuarantineIdentifier = "com.apple.quarantine";
 - (NSArray *)parseAppcastItemsFromXMLFile:(NSURL *)appcastFile error:(NSError *__autoreleasing*)errorp;
 @end
 
+@interface SUBinaryDeltaUnarchiver (Private)
+
++ (void)updateSpotlightImportersAtBundlePath:(NSString *)targetPath;
+
+@end


### PR DESCRIPTION
Developers are supposed to [update the modification date](https://developer.apple.com/library/mac/documentation/Carbon/Conceptual/MDImporters/Concepts/Troubleshooting.html) of their mdimporter bundles regardless of whether or not the update is distributed over Sparkle or on their website. The one edge case is if we do a delta extraction where we may update a file inside the mdimporter bundle but not update the modification date of the spotlight importer.

So to be on the safe side we update the modification dates after delta extractions, and remove our invocation to `mdimport` during the final step of installation.