### PR TITLE
Improve Host Signing Verification

### DIFF
--- a/Sparkle/SUCodeSigningVerifier.h
+++ b/Sparkle/SUCodeSigningVerifier.h
@@ -12,10 +12,9 @@
 #import <Foundation/Foundation.h>
 
 @interface SUCodeSigningVerifier : NSObject
-+ (BOOL)codeSignatureMatchesHostAndIsValidAtPath:(NSString *)applicationPath error:(NSError **)error;
-+ (BOOL)codeSignatureIsValidAtPath:(NSString *)applicationPath error:(NSError **)error;
-+ (BOOL)hostApplicationIsCodeSigned;
-+ (BOOL)applicationAtPathIsCodeSigned:(NSString *)applicationPath;
++ (BOOL)codeSignatureAtPath:(NSString *)oldBundlePath matchesSignatureAtPath:(NSString *)newBundlePath error:(NSError  **)error;
++ (BOOL)codeSignatureIsValidAtPath:(NSString *)bundlePath error:(NSError **)error;
++ (BOOL)bundleAtPathIsCodeSigned:(NSString *)bundlePath;
 @end
 
 #endif

--- a/Sparkle/SUCodeSigningVerifier.m
+++ b/Sparkle/SUCodeSigningVerifier.m
@@ -59,6 +59,8 @@
     
     // Note that kSecCSCheckNestedCode may not work with pre-Mavericks code signing.
     // See https://github.com/sparkle-project/Sparkle/issues/376#issuecomment-48824267 and https://developer.apple.com/library/mac/technotes/tn2206
+    // Aditionally, there are several reasons to stay away from deep verification and to prefer DSA signing the download archive instead.
+    // See https://github.com/sparkle-project/Sparkle/pull/523#commitcomment-17549302 and https://github.com/sparkle-project/Sparkle/issues/543
     SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, requirement, &cfError);
     
@@ -113,8 +115,7 @@ finally:
         goto finally;
     }
     
-    // Note that kSecCSCheckNestedCode may not work with pre-Mavericks code signing.
-    // See https://github.com/sparkle-project/Sparkle/issues/376#issuecomment-48824267 and https://developer.apple.com/library/mac/technotes/tn2206
+    // See in -codeSignatureAtPath:matchesSignatureAtPath:error: for why kSecCSCheckNestedCode is not passed
     SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, NULL, &cfError);
     

--- a/Sparkle/SUCodeSigningVerifier.m
+++ b/Sparkle/SUCodeSigningVerifier.m
@@ -13,53 +13,60 @@
 
 @implementation SUCodeSigningVerifier
 
-+ (BOOL)codeSignatureMatchesHostAndIsValidAtPath:(NSString *)applicationPath error:(NSError *__autoreleasing *)error
++ (BOOL)codeSignatureAtPath:(NSString *)oldBundlePath matchesSignatureAtPath:(NSString *)newBundlePath error:(NSError *__autoreleasing *)error
 {
     OSStatus result;
     SecRequirementRef requirement = NULL;
     SecStaticCodeRef staticCode = NULL;
-    SecCodeRef hostCode = NULL;
+    SecStaticCodeRef oldCode = NULL;
     NSBundle *newBundle;
+    NSBundle *oldBundle;
     CFErrorRef cfError = NULL;
     if (error) {
         *error = nil;
     }
-
-    result = SecCodeCopySelf(kSecCSDefaultFlags, &hostCode);
-    if (result != noErr) {
-        SULog(@"Failed to copy host code %d", result);
+    
+    oldBundle = [NSBundle bundleWithPath:oldBundlePath];
+    if (!oldBundle) {
+        SULog(@"Failed to load NSBundle for original");
+        result = -1;
         goto finally;
     }
-
-    result = SecCodeCopyDesignatedRequirement(hostCode, kSecCSDefaultFlags, &requirement);
+    
+    result = SecStaticCodeCreateWithPath((__bridge CFURLRef)[oldBundle bundleURL], kSecCSDefaultFlags, &oldCode);
+    if (result == errSecCSUnsigned) {
+        return NO;
+    }
+    
+    result = SecCodeCopyDesignatedRequirement(oldCode, kSecCSDefaultFlags, &requirement);
     if (result != noErr) {
         SULog(@"Failed to copy designated requirement. Code Signing OSStatus code: %d", result);
         goto finally;
     }
-
-    newBundle = [NSBundle bundleWithPath:applicationPath];
+    
+    newBundle = [NSBundle bundleWithPath:newBundlePath];
     if (!newBundle) {
         SULog(@"Failed to load NSBundle for update");
         result = -1;
         goto finally;
     }
-
+    
     result = SecStaticCodeCreateWithPath((__bridge CFURLRef)[newBundle bundleURL], kSecCSDefaultFlags, &staticCode);
     if (result != noErr) {
         SULog(@"Failed to get static code %d", result);
         goto finally;
     }
-
+    
     // Note that kSecCSCheckNestedCode may not work with pre-Mavericks code signing.
     // See https://github.com/sparkle-project/Sparkle/issues/376#issuecomment-48824267 and https://developer.apple.com/library/mac/technotes/tn2206
-	SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
+    SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, requirement, &cfError);
-
+    
     if (cfError) {
         NSError *tmpError = CFBridgingRelease(cfError);
         if (error) *error = tmpError;
     }
-
+    
     if (result != noErr) {
         if (result == errSecCSUnsigned) {
             SULog(@"The host app is signed, but the new version of the app is not signed using Apple Code Signing. Please ensure that the new app is signed and that archiving did not corrupt the signature.");
@@ -70,20 +77,20 @@
                 SULog(@"Code signature of the new version doesn't match the old version: %@. Please ensure that old and new app is signed using exactly the same certificate.", requirementString);
                 CFRelease(requirementString);
             }
-
-            [self logSigningInfoForCode:hostCode label:@"host info"];
+            
+            [self logSigningInfoForCode:oldCode label:@"old info"];
             [self logSigningInfoForCode:staticCode label:@"new info"];
         }
     }
-
+    
 finally:
-    if (hostCode) CFRelease(hostCode);
+    if (oldCode) CFRelease(oldCode);
     if (staticCode) CFRelease(staticCode);
     if (requirement) CFRelease(requirement);
     return (result == noErr);
 }
 
-+ (BOOL)codeSignatureIsValidAtPath:(NSString *)applicationPath error:(NSError *__autoreleasing *)error
++ (BOOL)codeSignatureIsValidAtPath:(NSString *)bundlePath error:(NSError *__autoreleasing *)error
 {
     OSStatus result;
     SecStaticCodeRef staticCode = NULL;
@@ -92,39 +99,39 @@ finally:
     if (error) {
         *error = nil;
     }
-
-    newBundle = [NSBundle bundleWithPath:applicationPath];
+    
+    newBundle = [NSBundle bundleWithPath:bundlePath];
     if (!newBundle) {
         SULog(@"Failed to load NSBundle");
         result = -1;
         goto finally;
     }
-
+    
     result = SecStaticCodeCreateWithPath((__bridge CFURLRef)[newBundle bundleURL], kSecCSDefaultFlags, &staticCode);
     if (result != noErr) {
         SULog(@"Failed to get static code %d", result);
         goto finally;
     }
-
+    
     // Note that kSecCSCheckNestedCode may not work with pre-Mavericks code signing.
     // See https://github.com/sparkle-project/Sparkle/issues/376#issuecomment-48824267 and https://developer.apple.com/library/mac/technotes/tn2206
-	SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
+    SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, NULL, &cfError);
-
+    
     if (cfError) {
         NSError *tmpError = CFBridgingRelease(cfError);
         if (error) *error = tmpError;
     }
-
+    
     if (result != noErr) {
         if (result == errSecCSUnsigned) {
-            SULog(@"Error: The app is not signed using Apple Code Signing. %@", applicationPath);
+            SULog(@"Error: The app is not signed using Apple Code Signing. %@", bundlePath);
         }
         if (result == errSecCSReqFailed) {
             [self logSigningInfoForCode:staticCode label:@"new info"];
         }
     }
-
+    
 finally:
     if (staticCode) CFRelease(staticCode);
     return (result == noErr);
@@ -150,37 +157,23 @@ static id valueOrNSNull(id value) {
     }
 }
 
-+ (BOOL)hostApplicationIsCodeSigned
-{
-    OSStatus result;
-    SecCodeRef hostCode = NULL;
-    result = SecCodeCopySelf(kSecCSDefaultFlags, &hostCode);
-    if (result != 0) return NO;
-
-    SecRequirementRef requirement = NULL;
-    result = SecCodeCopyDesignatedRequirement(hostCode, kSecCSDefaultFlags, &requirement);
-    if (hostCode) CFRelease(hostCode);
-    if (requirement) CFRelease(requirement);
-    return (result == 0);
-}
-
-+ (BOOL)applicationAtPathIsCodeSigned:(NSString *)applicationPath
++ (BOOL)bundleAtPathIsCodeSigned:(NSString *)bundlePath
 {
     OSStatus result;
     SecStaticCodeRef staticCode = NULL;
     NSBundle *newBundle;
-
-    newBundle = [NSBundle bundleWithPath:applicationPath];
+    
+    newBundle = [NSBundle bundleWithPath:bundlePath];
     if (!newBundle) {
         SULog(@"Failed to load NSBundle");
-    	return NO;
+        return NO;
     }
-
+    
     result = SecStaticCodeCreateWithPath((__bridge CFURLRef)[newBundle bundleURL], kSecCSDefaultFlags, &staticCode);
     if (result == errSecCSUnsigned) {
-    	return NO;
+        return NO;
     }
-
+    
     SecRequirementRef requirement = NULL;
     result = SecCodeCopyDesignatedRequirement(staticCode, kSecCSDefaultFlags, &requirement);
     if (staticCode) {
@@ -190,7 +183,7 @@ static id valueOrNSNull(id value) {
         CFRelease(requirement);
     }
     if (result == errSecCSUnsigned) {
-    	return NO;
+        return NO;
     }
     return (result == 0);
 }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -122,7 +122,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 -(void)checkIfConfiguredProperly {
     BOOL hasPublicDSAKey = [self.host publicDSAKey] != nil;
     BOOL isMainBundle = [self.host.bundle isEqualTo:[NSBundle mainBundle]];
-    BOOL hostIsCodeSigned = [SUCodeSigningVerifier hostApplicationIsCodeSigned];
+    BOOL hostIsCodeSigned = [SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.host.bundlePath];
     NSURL *feedURL = [self feedURL];
     BOOL servingOverHttps = [[[feedURL scheme] lowercaseString] isEqualToString:@"https"];
 

--- a/Tests/SUCodeSigningVerifierTest.m
+++ b/Tests/SUCodeSigningVerifierTest.m
@@ -159,7 +159,7 @@
 
 - (void)testUnsignedApp
 {
-    XCTAssertFalse([SUCodeSigningVerifier applicationAtPathIsCodeSigned:self.notSignedAppPath], @"App not expected to be code signed");
+    XCTAssertFalse([SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.notSignedAppPath], @"App not expected to be code signed");
 
     NSError *error = nil;
     XCTAssertFalse([SUCodeSigningVerifier codeSignatureIsValidAtPath:self.notSignedAppPath error:&error], @"signature should not be valid as it's not code signed");
@@ -168,7 +168,7 @@
 
 - (void)testValidSignedApp
 {
-    XCTAssertTrue([SUCodeSigningVerifier applicationAtPathIsCodeSigned:self.validSignedAppPath], @"App expected to be code signed");
+    XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.validSignedAppPath], @"App expected to be code signed");
 
     NSError *error = nil;
     XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtPath:self.validSignedAppPath error:&error], @"signature should be valid");
@@ -178,7 +178,7 @@
 - (void)testValidSignedCalculatorApp
 {
     NSString *appPath = @"/Applications/Calculator.app";
-    XCTAssertTrue([SUCodeSigningVerifier applicationAtPathIsCodeSigned:appPath], @"App expected to be code signed");
+    XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:appPath], @"App expected to be code signed");
 
     NSError *error = nil;
     XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtPath:appPath error:&error], @"signature should be valid");
@@ -187,7 +187,7 @@
 
 - (void)testInvalidSignedApp
 {
-    XCTAssertTrue([SUCodeSigningVerifier applicationAtPathIsCodeSigned:self.invalidSignedAppPath], @"App expected to be code signed, but signature is invalid");
+    XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.invalidSignedAppPath], @"App expected to be code signed, but signature is invalid");
 
     NSError *error = nil;
     XCTAssertFalse([SUCodeSigningVerifier codeSignatureIsValidAtPath:self.invalidSignedAppPath error:&error], @"signature should not be valid");

--- a/Tests/SUCodeSigningVerifierTest.m
+++ b/Tests/SUCodeSigningVerifierTest.m
@@ -11,11 +11,14 @@
 #import "SUCodeSigningVerifier.h"
 #import "SUFileManager.h"
 
+#define CALCULATOR_PATH @"/Applications/Calculator.app"
+
 @interface SUCodeSigningVerifierTest : XCTestCase
 
 @property (copy) NSString *notSignedAppPath;
 @property (copy) NSString *validSignedAppPath;
 @property (copy) NSString *invalidSignedAppPath;
+@property (copy) NSString *calculatorCopyPath;
 
 @end
 
@@ -24,6 +27,7 @@
 @synthesize notSignedAppPath = _notSignedAppPath;
 @synthesize validSignedAppPath = _validSignedAppPath;
 @synthesize invalidSignedAppPath = _invalidSignedAppPath;
+@synthesize calculatorCopyPath = _calculatorCopyPath;
 
 - (void)setUp
 {
@@ -51,6 +55,7 @@
         if ([self unzip:zippedAppPath toPath:tempDirPath]) {
             self.notSignedAppPath = [tempDirPath stringByAppendingPathComponent:@"SparkleTestCodeSignApp.app"];
             [self setupValidSignedApp];
+            [self setupCalculatorCopy];
             [self setupInvalidSignedApp];
         }
         else {
@@ -81,15 +86,46 @@
     if ([[NSFileManager defaultManager] fileExistsAtPath:signedAndValid]) {
         [[NSFileManager defaultManager] removeItemAtPath:signedAndValid error:NULL];
     }
-    if ([[NSFileManager defaultManager] copyItemAtPath:self.notSignedAppPath toPath:signedAndValid error:&error]) {
-        self.validSignedAppPath = signedAndValid;
-        if (![self codesignAppPath:self.validSignedAppPath]) {
-            NSLog(@"Failed to codesign %@", self.validSignedAppPath);
-        }
+    
+    if (![[NSFileManager defaultManager] copyItemAtPath:self.notSignedAppPath toPath:signedAndValid error:&error]) {
+        XCTFail("Failed to copy %@ to %@ with error: %@", self.notSignedAppPath, signedAndValid, error);
     }
-    else {
-        NSLog(@"Failed to copy %@ to %@ with error %@", self.notSignedAppPath, signedAndValid, error);
+    
+    self.validSignedAppPath = signedAndValid;
+    
+    if (![self codesignAppPath:self.validSignedAppPath]) {
+        XCTFail(@"Failed to codesign %@", self.validSignedAppPath);
     }
+}
+
+- (void)setupCalculatorCopy
+{
+    NSString *tempDir = [self.notSignedAppPath stringByDeletingLastPathComponent];
+    NSString *calculatorCopy = [tempDir stringByAppendingPathComponent:@"calc.app"];
+    
+    if ([[NSFileManager defaultManager] fileExistsAtPath:calculatorCopy]) {
+        [[NSFileManager defaultManager] removeItemAtPath:calculatorCopy error:NULL];
+    }
+    
+    // Make a copy of the signed calculator app so we can match signatures later
+    // Matching signatures on ad-hoc signed apps does *not* work
+    NSError *copyError = nil;
+    // Don't check the return value of this operation - seems like on 10.11 the API can say it fails even though the operation really succeeds,
+    // which sounds like some kind of (SIP / attribute?) bug
+    [[NSFileManager defaultManager] copyItemAtPath:CALCULATOR_PATH toPath:calculatorCopy error:&copyError];
+    
+    if (![[NSFileManager defaultManager] fileExistsAtPath:calculatorCopy]) {
+        XCTFail(@"Copied calculator application does not exist");
+    }
+    
+    // Alter the signed copy slightly, this won't invalidate signature matching (although it will invalidate the integrity part of the signature)
+    // Which is what we want. If a user alters an app bundle, we should still be able to update as long as its identity is still valid
+    NSError *removeError = nil;
+    if (![[NSFileManager defaultManager] removeItemAtPath:[[calculatorCopy stringByAppendingPathComponent:@"Contents"] stringByAppendingPathComponent:@"PkgInfo"] error:&removeError]) {
+        XCTFail(@"Failed to remove file in calculator copy with error: %@", removeError);
+    }
+    
+    self.calculatorCopyPath = calculatorCopy;
 }
 
 - (void)setupInvalidSignedApp
@@ -177,12 +213,32 @@
 
 - (void)testValidSignedCalculatorApp
 {
-    NSString *appPath = @"/Applications/Calculator.app";
+    NSString *appPath = CALCULATOR_PATH;
     XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:appPath], @"App expected to be code signed");
 
     NSError *error = nil;
     XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtPath:appPath error:&error], @"signature should be valid");
     XCTAssertNil(error, @"error should be nil");
+}
+
+- (void)testValidMatchingSelf
+{
+    NSError *error = nil;
+    XCTAssertTrue([SUCodeSigningVerifier codeSignatureAtPath:CALCULATOR_PATH matchesSignatureAtPath:CALCULATOR_PATH error:&error], @"Our valid signed app expected to having matching signature to itself");
+}
+
+- (void)testValidMatching
+{
+    // We can't test our own app because matching with ad-hoc signed apps understandably does not succeed
+    NSError *error = nil;
+    XCTAssertTrue([SUCodeSigningVerifier codeSignatureAtPath:CALCULATOR_PATH matchesSignatureAtPath:self.calculatorCopyPath error:&error], @"The calculator app is expected to have matching identity signature to its altered copy");
+}
+
+- (void)testInvalidMatching
+{
+    NSString *appPath = CALCULATOR_PATH;
+    NSError *error = nil;
+    XCTAssertFalse([SUCodeSigningVerifier codeSignatureAtPath:appPath matchesSignatureAtPath:self.validSignedAppPath error:&error], @"Calculator app bundle expected to have different signature than our valid signed app");
 }
 
 - (void)testInvalidSignedApp


### PR DESCRIPTION
The code signature verification methods no longer assume the host is the application invoking the methods. This is mostly taken from my fork + I just added some unit tests. This should help resolve issues like #863