### PR TITLE
Use bundle URLs

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -337,18 +337,17 @@
             return NO;
         }
     }
-    
-    BOOL updateIsCodeSigned = [SUCodeSigningVerifier bundleAtPathIsCodeSigned:installSourcePath];
+
+    BOOL updateIsCodeSigned = [SUCodeSigningVerifier bundleAtURLIsCodeSigned:newHost.bundle.bundleURL];
 
     if (dsaKeysMatch) {
         NSError *error = nil;
-        if (updateIsCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtPath:installSourcePath error:&error]) {
+        if (updateIsCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:newHost.bundle.bundleURL error:&error]) {
             SULog(@"The update archive has a valid DSA signature, but the app is also signed with Code Signing, which is corrupted: %@. The update will be rejected.", error);
             return NO;
         }
     } else {
-        NSString *hostBundlePath = host.bundlePath;
-        BOOL hostIsCodeSigned = [SUCodeSigningVerifier bundleAtPathIsCodeSigned:hostBundlePath];
+        BOOL hostIsCodeSigned = [SUCodeSigningVerifier bundleAtURLIsCodeSigned:host.bundle.bundleURL];
 
         NSString *dsaStatus = newPublicDSAKey ? @"has a new DSA key that doesn't match the previous one" : (publicDSAKey ? @"removes the DSA key" : @"isn't signed with a DSA key");
         if (!hostIsCodeSigned || !updateIsCodeSigned) {
@@ -358,7 +357,7 @@
         }
 
         NSError *error = nil;
-        if (![SUCodeSigningVerifier codeSignatureAtPath:hostBundlePath matchesSignatureAtPath:installSourcePath error:&error]) {
+        if (![SUCodeSigningVerifier codeSignatureAtBundleURL:host.bundle.bundleURL matchesSignatureAtBundleURL:newHost.bundle.bundleURL error:&error]) {
             SULog(@"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app: %@. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus, error);
             return NO;
         }
@@ -407,7 +406,7 @@
 
 - (void)extractUpdate
 {
-    SUUnarchiver *unarchiver = [SUUnarchiver unarchiverForPath:self.downloadPath updatingHostBundlePath:[[self.host bundle] bundlePath] withPassword:self.updater.decryptionPassword];
+    SUUnarchiver *unarchiver = [SUUnarchiver unarchiverForPath:self.downloadPath updatingHostBundlePath:self.host.bundlePath withPassword:self.updater.decryptionPassword];
     if (!unarchiver) {
         SULog(@"Error: No valid unarchiver for %@!", self.downloadPath);
         [self unarchiverDidFail:nil];

--- a/Sparkle/SUCodeSigningVerifier.h
+++ b/Sparkle/SUCodeSigningVerifier.h
@@ -12,9 +12,9 @@
 #import <Foundation/Foundation.h>
 
 @interface SUCodeSigningVerifier : NSObject
-+ (BOOL)codeSignatureAtPath:(NSString *)oldBundlePath matchesSignatureAtPath:(NSString *)newBundlePath error:(NSError  **)error;
-+ (BOOL)codeSignatureIsValidAtPath:(NSString *)bundlePath error:(NSError **)error;
-+ (BOOL)bundleAtPathIsCodeSigned:(NSString *)bundlePath;
++ (BOOL)codeSignatureAtBundleURL:(NSURL *)oldBundlePath matchesSignatureAtBundleURL:(NSURL *)newBundlePath error:(NSError  **)error;
++ (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundlePath error:(NSError **)error;
++ (BOOL)bundleAtURLIsCodeSigned:(NSURL *)bundlePath;
 @end
 
 #endif

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -122,7 +122,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 -(void)checkIfConfiguredProperly {
     BOOL hasPublicDSAKey = [self.host publicDSAKey] != nil;
     BOOL isMainBundle = [self.host.bundle isEqualTo:[NSBundle mainBundle]];
-    BOOL hostIsCodeSigned = [SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.host.bundlePath];
+    BOOL hostIsCodeSigned = [SUCodeSigningVerifier bundleAtURLIsCodeSigned:self.host.bundle.bundleURL];
     NSURL *feedURL = [self feedURL];
     BOOL servingOverHttps = [[[feedURL scheme] lowercaseString] isEqualToString:@"https"];
 

--- a/Tests/SUCodeSigningVerifierTest.m
+++ b/Tests/SUCodeSigningVerifierTest.m
@@ -16,6 +16,7 @@
 @interface SUCodeSigningVerifierTest : XCTestCase
 
 @property (copy) NSString *notSignedAppPath;
+@property (copy) NSString *notSignedAppURL;
 @property (copy) NSString *validSignedAppPath;
 @property (copy) NSString *invalidSignedAppPath;
 @property (copy) NSString *calculatorCopyPath;
@@ -25,6 +26,7 @@
 @implementation SUCodeSigningVerifierTest
 
 @synthesize notSignedAppPath = _notSignedAppPath;
+@synthesize notSignedAppURL = _notSignedAppURL;
 @synthesize validSignedAppPath = _validSignedAppPath;
 @synthesize invalidSignedAppPath = _invalidSignedAppPath;
 @synthesize calculatorCopyPath = _calculatorCopyPath;
@@ -54,6 +56,7 @@
     if ([[NSFileManager defaultManager] createDirectoryAtPath:tempDirPath withIntermediateDirectories:YES attributes:nil error:&error]) {
         if ([self unzip:zippedAppPath toPath:tempDirPath]) {
             self.notSignedAppPath = [tempDirPath stringByAppendingPathComponent:@"SparkleTestCodeSignApp.app"];
+            self.notSignedAppURL = [NSURL fileURLWithPath:self.notSignedAppPath];
             [self setupValidSignedApp];
             [self setupCalculatorCopy];
             [self setupInvalidSignedApp];
@@ -195,58 +198,58 @@
 
 - (void)testUnsignedApp
 {
-    XCTAssertFalse([SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.notSignedAppPath], @"App not expected to be code signed");
+    XCTAssertFalse([SUCodeSigningVerifier bundleAtURLIsCodeSigned:self.notSignedAppURL], @"App not expected to be code signed");
 
     NSError *error = nil;
-    XCTAssertFalse([SUCodeSigningVerifier codeSignatureIsValidAtPath:self.notSignedAppPath error:&error], @"signature should not be valid as it's not code signed");
+    XCTAssertFalse([SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:self.notSignedAppURL error:&error], @"signature should not be valid as it's not code signed");
     XCTAssertNotNil(error, @"error should not be nil");
 }
 
 - (void)testValidSignedApp
 {
-    XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.validSignedAppPath], @"App expected to be code signed");
+    XCTAssertTrue([SUCodeSigningVerifier bundleAtURLIsCodeSigned:self.validSignedAppPath], @"App expected to be code signed");
 
     NSError *error = nil;
-    XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtPath:self.validSignedAppPath error:&error], @"signature should be valid");
+    XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:self.validSignedAppPath error:&error], @"signature should be valid");
     XCTAssertNil(error, @"error should be nil");
 }
 
 - (void)testValidSignedCalculatorApp
 {
     NSString *appPath = CALCULATOR_PATH;
-    XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:appPath], @"App expected to be code signed");
+    XCTAssertTrue([SUCodeSigningVerifier bundleAtURLIsCodeSigned:appPath], @"App expected to be code signed");
 
     NSError *error = nil;
-    XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtPath:appPath error:&error], @"signature should be valid");
+    XCTAssertTrue([SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:appPath error:&error], @"signature should be valid");
     XCTAssertNil(error, @"error should be nil");
 }
 
 - (void)testValidMatchingSelf
 {
     NSError *error = nil;
-    XCTAssertTrue([SUCodeSigningVerifier codeSignatureAtPath:CALCULATOR_PATH matchesSignatureAtPath:CALCULATOR_PATH error:&error], @"Our valid signed app expected to having matching signature to itself");
+    XCTAssertTrue([SUCodeSigningVerifier codeSignatureAtBundleURL:CALCULATOR_PATH matchesSignatureAtBundleURL:CALCULATOR_PATH error:&error], @"Our valid signed app expected to having matching signature to itself");
 }
 
 - (void)testValidMatching
 {
     // We can't test our own app because matching with ad-hoc signed apps understandably does not succeed
     NSError *error = nil;
-    XCTAssertTrue([SUCodeSigningVerifier codeSignatureAtPath:CALCULATOR_PATH matchesSignatureAtPath:self.calculatorCopyPath error:&error], @"The calculator app is expected to have matching identity signature to its altered copy");
+    XCTAssertTrue([SUCodeSigningVerifier codeSignatureAtBundleURL:CALCULATOR_PATH matchesSignatureAtBundleURL:self.calculatorCopyPath error:&error], @"The calculator app is expected to have matching identity signature to its altered copy");
 }
 
 - (void)testInvalidMatching
 {
     NSString *appPath = CALCULATOR_PATH;
     NSError *error = nil;
-    XCTAssertFalse([SUCodeSigningVerifier codeSignatureAtPath:appPath matchesSignatureAtPath:self.validSignedAppPath error:&error], @"Calculator app bundle expected to have different signature than our valid signed app");
+    XCTAssertFalse([SUCodeSigningVerifier codeSignatureAtBundleURL:appPath matchesSignatureAtBundleURL:self.validSignedAppPath error:&error], @"Calculator app bundle expected to have different signature than our valid signed app");
 }
 
 - (void)testInvalidSignedApp
 {
-    XCTAssertTrue([SUCodeSigningVerifier bundleAtPathIsCodeSigned:self.invalidSignedAppPath], @"App expected to be code signed, but signature is invalid");
+    XCTAssertTrue([SUCodeSigningVerifier bundleAtURLIsCodeSigned:self.invalidSignedAppPath], @"App expected to be code signed, but signature is invalid");
 
     NSError *error = nil;
-    XCTAssertFalse([SUCodeSigningVerifier codeSignatureIsValidAtPath:self.invalidSignedAppPath error:&error], @"signature should not be valid");
+    XCTAssertFalse([SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:self.invalidSignedAppPath error:&error], @"signature should not be valid");
     XCTAssertNotNil(error, @"error should not be nil");
 }
 

--- a/Tests/SUCodeSigningVerifierTest.m
+++ b/Tests/SUCodeSigningVerifierTest.m
@@ -77,20 +77,19 @@
 - (void)setupValidSignedApp
 {
     NSError *error = nil;
-    NSString *tempDir = [self.notSignedAppURL URLByDeletingLastPathComponent];
-    NSString *signedAndValid = [tempDir URLByAppendingPathComponent:@"valid-signed.app"];
+    NSURL *tempDir = [self.notSignedAppURL URLByDeletingLastPathComponent];
+    NSURL *signedAndValid = [tempDir URLByAppendingPathComponent:@"valid-signed.app"];
 
-    if ([[NSFileManager defaultManager] fileExistsAtURL:signedAndValid]) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:signedAndValid.path]) {
         [[NSFileManager defaultManager] removeItemAtURL:signedAndValid error:NULL];
     }
 
-    if (![[NSFileManager defaultManager] copyItemAtURL:self.notSignedAppURL toPath:signedAndValid error:&error]) {
+    if (![[NSFileManager defaultManager] copyItemAtURL:self.notSignedAppURL toURL:signedAndValid error:&error]) {
         XCTFail("Failed to copy %@ to %@ with error: %@", self.notSignedAppURL, signedAndValid, error);
     }
 
     self.validSignedAppURL = signedAndValid;
-    self.validSignedAppURL = [NSURL fileURLWithPath:signedAndValid];
-
+    
     if (![self codesignAppURL:self.validSignedAppURL]) {
         XCTFail(@"Failed to codesign %@", self.validSignedAppURL);
     }
@@ -98,10 +97,10 @@
 
 - (void)setupCalculatorCopy
 {
-    NSString *tempDir = [self.notSignedAppURL URLByDeletingLastPathComponent];
-    NSString *calculatorCopy = [tempDir URLByAppendingPathComponent:@"calc.app"];
+    NSURL *tempDir = [self.notSignedAppURL URLByDeletingLastPathComponent];
+    NSURL *calculatorCopy = [tempDir URLByAppendingPathComponent:@"calc.app"];
 
-    if ([[NSFileManager defaultManager] fileExistsAtURL:calculatorCopy]) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:calculatorCopy.path]) {
         [[NSFileManager defaultManager] removeItemAtURL:calculatorCopy error:NULL];
     }
 
@@ -110,9 +109,9 @@
     NSError *copyError = nil;
     // Don't check the return value of this operation - seems like on 10.11 the API can say it fails even though the operation really succeeds,
     // which sounds like some kind of (SIP / attribute?) bug
-    [[NSFileManager defaultManager] copyItemAtURL:CALCULATOR_PATH toPath:calculatorCopy error:&copyError];
+    [[NSFileManager defaultManager] copyItemAtURL:[NSURL fileURLWithPath:CALCULATOR_PATH] toURL:calculatorCopy error:&copyError];
 
-    if (![[NSFileManager defaultManager] fileExistsAtURL:calculatorCopy]) {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:calculatorCopy.path]) {
         XCTFail(@"Copied calculator application does not exist");
     }
 
@@ -129,16 +128,16 @@
 - (void)setupInvalidSignedApp
 {
     NSError *error = nil;
-    NSString *tempDir = [self.notSignedAppURL URLByDeletingLastPathComponent];
-    NSString *signedAndInvalid = [tempDir URLByAppendingPathComponent:@"invalid-signed.app"];
+    NSURL *tempDir = [self.notSignedAppURL URLByDeletingLastPathComponent];
+    NSURL *signedAndInvalid = [tempDir URLByAppendingPathComponent:@"invalid-signed.app"];
 
-    if ([[NSFileManager defaultManager] fileExistsAtURL:signedAndInvalid]) {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:signedAndInvalid.path]) {
         [[NSFileManager defaultManager] removeItemAtURL:signedAndInvalid error:NULL];
     }
-    if ([[NSFileManager defaultManager] copyItemAtURL:self.notSignedAppURL toPath:signedAndInvalid error:&error]) {
+    if ([[NSFileManager defaultManager] copyItemAtURL:self.notSignedAppURL toURL:signedAndInvalid error:&error]) {
         self.invalidSignedAppURL = signedAndInvalid;
         if ([self codesignAppURL:self.invalidSignedAppURL]) {
-            NSString *fileInAppBundleToRemove = [self.invalidSignedAppURL URLByAppendingPathComponent:@"Contents/Resources/test_app_only_dsa_pub.pem"];
+            NSURL *fileInAppBundleToRemove = [self.invalidSignedAppURL URLByAppendingPathComponent:@"Contents/Resources/test_app_only_dsa_pub.pem"];
             if (![[NSFileManager defaultManager] removeItemAtURL:fileInAppBundleToRemove error:&error]) {
                 NSLog(@"Failed to remove %@ with error %@", fileInAppBundleToRemove, error);
             }
@@ -173,7 +172,7 @@
     return success;
 }
 
-- (BOOL)codesignAppURL:(NSString *)appPath
+- (BOOL)codesignAppURL:(NSURL *)appPath
 {
     BOOL success = NO;
     @try


### PR DESCRIPTION
Use bundle URLs instead of paths to avoid creation of temp bundle objects