### PR TITLE
Warn a developer if they're using a debug version of Sparkle

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -59,6 +59,15 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 static NSMutableDictionary *sharedUpdaters = nil;
 static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaultsObservationContext";
 
+#ifdef DEBUG
++ (void)load
+{
+    // Debug builds have different configurations for update check intervals
+    // We're using NSLog instead of SULog here because we don't want to start Sparkle's logger here
+    NSLog(@"WARNING: This is running a Debug build of Sparkle; don't use this in production!");
+}
+#endif
+
 + (SUUpdater *)sharedUpdater
 {
     return [self updaterForBundle:[NSBundle mainBundle]];


### PR DESCRIPTION
Due to different values for min/default update check intervals, production apps should not use a debug version of Sparkle

---

Realized I had this branch I created long ago, and think it'd be a good idea to help issues like #759