### PR TITLE
Fix flickering download progress status text

### DIFF
--- a/Sparkle/SUStatus.xib
+++ b/Sparkle/SUStatus.xib
@@ -10,6 +10,7 @@
             <connections>
                 <outlet property="actionButton" destination="12" id="34"/>
                 <outlet property="progressBar" destination="11" id="49"/>
+                <outlet property="statusTextField" destination="16" id="MiZ-Tn-yVg"/>
                 <outlet property="window" destination="5" id="25"/>
             </connections>
         </customObject>

--- a/Sparkle/SUStatusController.h
+++ b/Sparkle/SUStatusController.h
@@ -15,6 +15,7 @@
 @interface SUStatusController : SUWindowController
 @property (weak) IBOutlet NSButton *actionButton;
 @property (weak) IBOutlet NSProgressIndicator *progressBar;
+@property (weak) IBOutlet NSTextField *statusTextField;
 
 @property (copy) NSString *statusText;
 @property double progressValue;

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -11,6 +11,7 @@
 #import "SUAppcast.h"
 #import "SUAppcastItem.h"
 #import "SUVersionComparisonProtocol.h"
+#import "SUOperatingSystem.h"
 #import "SUStatusController.h"
 #import "SUHost.h"
 
@@ -28,6 +29,7 @@
 @synthesize host;
 @synthesize actionButton;
 @synthesize progressBar;
+@synthesize statusTextField;
 
 - (instancetype)initWithHost:(SUHost *)aHost
 {
@@ -51,6 +53,13 @@
     [[self window] center];
     [[self window] setFrameAutosaveName:@"SUStatusFrame"];
     [self.progressBar setUsesThreadedAnimation:YES];
+
+    if ([SUOperatingSystem isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 11, 0}]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+        [self.statusTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightRegular]];
+#pragma clang diagnostic pop
+    }
 }
 
 - (NSString *)windowTitle

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -167,8 +167,9 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
-    return [NSByteCountFormatter stringFromByteCount:value
-                                          countStyle:NSByteCountFormatterCountStyleFile];
+    NSByteCountFormatter *formatter = [[NSByteCountFormatter alloc] init];
+    [formatter setZeroPadsFractionDigits:YES];
+    return [formatter stringFromByteCount:value];
 #pragma clang diagnostic pop
 }
 


### PR DESCRIPTION
This PR fixes status text during download (e.g. "10MB of 22MB") so that it no longer distractingly jumps around and flickers. This was caused by two things:
1. Flicker on macOS >= 10.8 due to the use of NSByteCountFormatter's   default mode which isn't optimized for stable display and is not   suitable for rapidly updated values.
2. Smaller movements of text on macOS >= 10.11 due to the use of San   Francisco font's default variant, where digits don't have fixed   width.

The fix is to use appropriate APIs, i.e. use monospaced digits variant of the system font and make `NSByteCountFormatter` output more stable values (pre-10.8 manual formatting code was OK already and behaved like `setZeroPadsFractionDigits:YES`).

Let me show you:

_Before:_

![sparkle_before](https://cloud.githubusercontent.com/assets/145881/19837678/5b44a786-9ebf-11e6-97b7-dd453d995405.gif)
(Rapid jumping around when the text changes from “10.9” to “11” and then “11.1” rapidly, significantly shortening the label for a fraction of a second, wasn’t captured due to its short duration, but it’s actually the _more_ noticeable problem for a human eye.)

_After:_

![sparkle_after](https://cloud.githubusercontent.com/assets/145881/19837693/97952800-9ebf-11e6-8d86-2cd2a0067e47.gif)
