### PR TITLE
Set output path for Set Get Version Info script phase

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -1628,6 +1628,7 @@
 			);
 			name = "Run Script: Set Git Version Info";
 			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1643,6 +1644,7 @@
 			);
 			name = "Run Script: Set Git Version Info";
 			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
This slightly reduces the amount of work during incremental builds. Without this Autoupdate.app would always have to get recopied into the framework. This would then cause the Sparkle framework to get recopied into the parent app.