### PR TITLE
Tool to generate appcasts automatically

### DIFF
--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -16,6 +16,7 @@ if [ "$ACTION" = "" ] ; then
     cp "$SRCROOT/CHANGELOG" "$SRCROOT/LICENSE" "$SRCROOT/Resources/SampleAppcast.xml" "$CONFIGURATION_BUILD_DIR/staging"
     cp -R "$SRCROOT/bin" "$CONFIGURATION_BUILD_DIR/staging"
     cp "$CONFIGURATION_BUILD_DIR/BinaryDelta" "$CONFIGURATION_BUILD_DIR/staging/bin"
+    cp "$CONFIGURATION_BUILD_DIR/generate_appcast" "$CONFIGURATION_BUILD_DIR/staging/bin"
     cp -R "$CONFIGURATION_BUILD_DIR/Sparkle Test App.app" "$CONFIGURATION_BUILD_DIR/staging"
     cp -R "$CONFIGURATION_BUILD_DIR/Sparkle.framework" "$CONFIGURATION_BUILD_DIR/staging"
 

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				5AE13FAA1E0D7E2F000D2C2C /* PBXTargetDependency */,
 				14950064195FB8A600BC5B5B /* PBXTargetDependency */,
 				14950066195FB8A600BC5B5B /* PBXTargetDependency */,
 				14950068195FB8A600BC5B5B /* PBXTargetDependency */,
@@ -72,9 +73,30 @@
 		55C14FC7136F05E100649790 /* Sparkle.strings in Resources */ = {isa = PBXBuildFile; fileRef = 61AAE8220A321A7F00D8810D /* Sparkle.strings */; };
 		55E6F33319EC9F6C00005E76 /* SUErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E6F33219EC9F6C00005E76 /* SUErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5A4094481C74EA5200983BE0 /* SUAppcastTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA4DCD01C73E5510078F128 /* SUAppcastTest.swift */; };
+		5A5AC5361E0C6CA300998119 /* Unarchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5AC5351E0C6CA300998119 /* Unarchive.swift */; };
+		5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5AC5371E0C6D3000998119 /* FeedXML.swift */; };
 		5A6D31EE1BF53245009C5157 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		5A6D31EF1BF5325F009C5157 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
+		5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA96C571E0AE0DB00CA4346 /* main.swift */; };
+		5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AAD00511E0BE6BE00AF411E /* ArchiveItem.swift */; };
+		5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E20FD68CC7005AE3F6 /* SUBinaryDeltaCommon.m */; };
+		5AAD00671E0C2D9B00AF411E /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
+		5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
+		5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
+		5AAD006A1E0C2DB500AF411E /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
+		5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AAD006B1E0C2DBF00AF411E /* libxar.tbd */; };
 		5AD0FA7F1C73F2E2004BCEFF /* testappcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */; };
+		5AE13F781E0C9B12000D2C2C /* DSASignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE13F771E0C9B12000D2C2C /* DSASignature.swift */; };
+		5AE13FA01E0D4F65000D2C2C /* Appcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE13F9F1E0D4F65000D2C2C /* Appcast.swift */; };
+		5AE13FA11E0D7168000D2C2C /* SUUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A8C09CA790200B7442F /* SUUnarchiver.m */; };
+		5AE13FA21E0D716F000D2C2C /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
+		5AE13FA41E0D71D1000D2C2C /* SUFileOperationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 722954C31D04E66F00ECF9CA /* SUFileOperationConstants.m */; };
+		5AE13FA51E0D71F5000D2C2C /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
+		5AE13FA61E0D7275000D2C2C /* SUStandardVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A225A30D1C4AC000430CCD /* SUStandardVersionComparator.m */; };
+		5AE13FB51E0D9F32000D2C2C /* SUDiskImageUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6102FE490E07803800F85D09 /* SUDiskImageUnarchiver.m */; };
+		5AE13FB61E0D9F39000D2C2C /* SUPipedUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6129C0B90E0B79810062CE76 /* SUPipedUnarchiver.m */; };
+		5AE13FB71E0D9F42000D2C2C /* SUUnarchiverNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 722589D91E0B19F4005EA0B9 /* SUUnarchiverNotifier.m */; };
+		5AE13FB81E0D9F8E000D2C2C /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		5AE459001C34118500E3BB47 /* SUUpdaterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 14950074195FDF5900BC5B5B /* SUUpdaterTest.m */; };
 		5AE459021C34118500E3BB47 /* SUVersionComparisonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 61227A150DB548B800AB99EA /* SUVersionComparisonTest.m */; };
 		5AE7E1111DC81AD3009C2C12 /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 5AE7E10E1DC81ACA009C2C12 /* AppIcon.icns */; };
@@ -303,6 +325,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 55C14BB6136EEF1500649790;
 			remoteInfo = Autoupdate;
+		};
+		5AE13FA71E0D7E1C000D2C2C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5AA96C541E0AE0DB00CA4346;
+			remoteInfo = Appcast;
+		};
+		5AE13FA91E0D7E2F000D2C2C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5AA96C541E0AE0DB00CA4346;
+			remoteInfo = Appcast;
 		};
 		5D06E8D50FD68C86005AE3F6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -539,8 +575,17 @@
 		55C14F05136EF6DB00649790 /* SULog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SULog.m; sourceTree = "<group>"; };
 		55C14F31136EFC2400649790 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		55E6F33219EC9F6C00005E76 /* SUErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUErrors.h; sourceTree = "<group>"; };
+		5A5AC5351E0C6CA300998119 /* Unarchive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Unarchive.swift; sourceTree = "<group>"; };
+		5A5AC5371E0C6D3000998119 /* FeedXML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedXML.swift; sourceTree = "<group>"; };
 		5AA4DCD01C73E5510078F128 /* SUAppcastTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUAppcastTest.swift; sourceTree = "<group>"; };
+		5AA96C571E0AE0DB00CA4346 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		5AA96C5D1E0AE0F900CA4346 /* Appcast-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Appcast-Bridging-Header.h"; sourceTree = "<group>"; };
+		5AAD00511E0BE6BE00AF411E /* ArchiveItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveItem.swift; sourceTree = "<group>"; };
+		5AAD006B1E0C2DBF00AF411E /* libxar.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxar.tbd; path = usr/lib/libxar.tbd; sourceTree = SDKROOT; };
 		5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast.xml; sourceTree = "<group>"; };
+		5AE13F771E0C9B12000D2C2C /* DSASignature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DSASignature.swift; sourceTree = "<group>"; };
+		5AE13F9F1E0D4F65000D2C2C /* Appcast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Appcast.swift; sourceTree = "<group>"; };
+		5AE13FB31E0D9E07000D2C2C /* generate_appcast */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = generate_appcast; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AE7E10E1DC81ACA009C2C12 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		5AEF45D9189D1CC90030D7DC /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		5AF6C74C1AEA40760014A3AB /* SUInstallerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUInstallerTest.m; sourceTree = "<group>"; };
@@ -757,6 +802,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5AA96C521E0AE0DB00CA4346 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5D06E8CE0FD68C7C005AE3F6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -833,6 +886,7 @@
 			isa = PBXGroup;
 			children = (
 				5D06E8D00FD68C7C005AE3F6 /* BinaryDelta */,
+				5AE13FB31E0D9E07000D2C2C /* generate_appcast */,
 				55C14BB7136EEF1500649790 /* Autoupdate.app */,
 				61B5F90209C4CEE200B25A18 /* Sparkle Test App.app */,
 				612279D90DB5470200AB99EA /* Sparkle Unit Tests.xctest */,
@@ -846,6 +900,7 @@
 		0867D691FE84028FC02AAC07 /* Sparkle */ = {
 			isa = PBXGroup;
 			children = (
+				5AA96C561E0AE0DB00CA4346 /* generate_appcast */,
 				1495006D195FBBBD00BC5B5B /* Sparkle */,
 				14732BB81960EEB600593899 /* Resources */,
 				61227A100DB5484000AB99EA /* Tests */,
@@ -870,6 +925,7 @@
 				6117796E0D1112E000749C97 /* IOKit.framework */,
 				5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */,
 				5D1AF5890FD7678C0065DB48 /* libxar.1.dylib */,
+				5AAD006B1E0C2DBF00AF411E /* libxar.tbd */,
 				5D1AF58F0FD767AD0065DB48 /* libxml2.dylib */,
 				5D1AF5990FD767E50065DB48 /* libz.dylib */,
 				61B5F8F609C4CEB300B25A18 /* Security.framework */,
@@ -993,6 +1049,20 @@
 				55C14BD3136EEFCE00649790 /* Autoupdate.m */,
 			);
 			path = Autoupdate;
+			sourceTree = "<group>";
+		};
+		5AA96C561E0AE0DB00CA4346 /* generate_appcast */ = {
+			isa = PBXGroup;
+			children = (
+				5AA96C5D1E0AE0F900CA4346 /* Appcast-Bridging-Header.h */,
+				5AE13F9F1E0D4F65000D2C2C /* Appcast.swift */,
+				5AAD00511E0BE6BE00AF411E /* ArchiveItem.swift */,
+				5AE13F771E0C9B12000D2C2C /* DSASignature.swift */,
+				5A5AC5371E0C6D3000998119 /* FeedXML.swift */,
+				5AA96C571E0AE0DB00CA4346 /* main.swift */,
+				5A5AC5351E0C6CA300998119 /* Unarchive.swift */,
+			);
+			path = generate_appcast;
 			sourceTree = "<group>";
 		};
 		5D06E8D90FD68C95005AE3F6 /* Binary Delta */ = {
@@ -1328,6 +1398,7 @@
 			buildToolPath = bash;
 			buildWorkingDirectory = "";
 			dependencies = (
+				5AE13FA81E0D7E1C000D2C2C /* PBXTargetDependency */,
 				14732BCB1960F73500593899 /* PBXTargetDependency */,
 				1454BA1619637EDB00344E57 /* PBXTargetDependency */,
 				14732BCF1960F73500593899 /* PBXTargetDependency */,
@@ -1359,6 +1430,22 @@
 			productName = Autoupdate;
 			productReference = 55C14BB7136EEF1500649790 /* Autoupdate.app */;
 			productType = "com.apple.product-type.application";
+		};
+		5AA96C541E0AE0DB00CA4346 /* generate_appcast */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5AA96C5C1E0AE0DC00CA4346 /* Build configuration list for PBXNativeTarget "generate_appcast" */;
+			buildPhases = (
+				5AA96C511E0AE0DB00CA4346 /* Sources */,
+				5AA96C521E0AE0DB00CA4346 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = generate_appcast;
+			productName = Appcast;
+			productReference = 5AE13FB31E0D9E07000D2C2C /* generate_appcast */;
+			productType = "com.apple.product-type.tool";
 		};
 		5D06E8CF0FD68C7C005AE3F6 /* BinaryDelta */ = {
 			isa = PBXNativeTarget;
@@ -1481,10 +1568,15 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = SU;
-				LastSwiftUpdateCheck = 0720;
+				LastSwiftUpdateCheck = 0800;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Sparkle Project";
 				TargetAttributes = {
+					5AA96C541E0AE0DB00CA4346 = {
+						CreatedOnToolsVersion = 8.0;
+						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
+					};
 					612279D80DB5470200AB99EA = {
 						LastSwiftMigration = 0800;
 						TestTargetID = 8DC2EF4F0486A6940098B216;
@@ -1566,6 +1658,7 @@
 				1495005F195FB89400BC5B5B /* All */,
 				726B2B5C1C645FC900388755 /* UI Tests */,
 				722954B31D04ADAF00ECF9CA /* fileop */,
+				5AA96C541E0AE0DB00CA4346 /* generate_appcast */,
 			);
 		};
 /* End PBXProject section */
@@ -1726,6 +1819,33 @@
 				55C14F20136EF84300649790 /* SUStatusController.m in Sources */,
 				55C14F23136EF86700649790 /* SUSystemProfiler.m in Sources */,
 				55C14F2A136EF9A900649790 /* SUWindowController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5AA96C511E0AE0DB00CA4346 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AE13FA01E0D4F65000D2C2C /* Appcast.swift in Sources */,
+				5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */,
+				5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */,
+				5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */,
+				5AE13F781E0C9B12000D2C2C /* DSASignature.swift in Sources */,
+				5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */,
+				5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */,
+				5AAD006A1E0C2DB500AF411E /* sais.c in Sources */,
+				5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */,
+				5AAD00671E0C2D9B00AF411E /* SUBinaryDeltaCreate.m in Sources */,
+				5AE13FA51E0D71F5000D2C2C /* SUConstants.m in Sources */,
+				5AE13FB51E0D9F32000D2C2C /* SUDiskImageUnarchiver.m in Sources */,
+				5AE13FA21E0D716F000D2C2C /* SUFileManager.m in Sources */,
+				5AE13FA41E0D71D1000D2C2C /* SUFileOperationConstants.m in Sources */,
+				5AE13FB81E0D9F8E000D2C2C /* SULog.m in Sources */,
+				5AE13FB61E0D9F39000D2C2C /* SUPipedUnarchiver.m in Sources */,
+				5AE13FA61E0D7275000D2C2C /* SUStandardVersionComparator.m in Sources */,
+				5AE13FA11E0D7168000D2C2C /* SUUnarchiver.m in Sources */,
+				5AE13FB71E0D9F42000D2C2C /* SUUnarchiverNotifier.m in Sources */,
+				5A5AC5361E0C6CA300998119 /* Unarchive.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1904,6 +2024,16 @@
 			isa = PBXTargetDependency;
 			target = 55C14BB6136EEF1500649790 /* Autoupdate */;
 			targetProxy = 55C14F96136F044100649790 /* PBXContainerItemProxy */;
+		};
+		5AE13FA81E0D7E1C000D2C2C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5AA96C541E0AE0DB00CA4346 /* generate_appcast */;
+			targetProxy = 5AE13FA71E0D7E1C000D2C2C /* PBXContainerItemProxy */;
+		};
+		5AE13FAA1E0D7E2F000D2C2C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5AA96C541E0AE0DB00CA4346 /* generate_appcast */;
+			targetProxy = 5AE13FA91E0D7E2F000D2C2C /* PBXContainerItemProxy */;
 		};
 		5D06E8D60FD68C86005AE3F6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2263,6 +2393,37 @@
 			};
 			name = Release;
 		};
+		5AA96C591E0AE0DC00CA4346 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "generate_appcast/Appcast-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		5AA96C5A1E0AE0DC00CA4346 /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "generate_appcast/Appcast-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Coverage;
+		};
+		5AA96C5B1E0AE0DC00CA4346 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "generate_appcast/Appcast-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 		5D06E8D20FD68C7D005AE3F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D06E8F20FD68D21005AE3F6 /* ConfigBinaryDeltaDebug.xcconfig */;
@@ -2412,6 +2573,16 @@
 				55C14BBB136EEF1500649790 /* Debug */,
 				149B785F1B7D398100D7D62C /* Coverage */,
 				55C14BBC136EEF1500649790 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5AA96C5C1E0AE0DC00CA4346 /* Build configuration list for PBXNativeTarget "generate_appcast" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5AA96C591E0AE0DC00CA4346 /* Debug */,
+				5AA96C5A1E0AE0DC00CA4346 /* Coverage */,
+				5AA96C5B1E0AE0DC00CA4346 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -97,6 +97,10 @@
 		5AE13FB61E0D9F39000D2C2C /* SUPipedUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6129C0B90E0B79810062CE76 /* SUPipedUnarchiver.m */; };
 		5AE13FB71E0D9F42000D2C2C /* SUUnarchiverNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 722589D91E0B19F4005EA0B9 /* SUUnarchiverNotifier.m */; };
 		5AE13FB81E0D9F8E000D2C2C /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
+		5AE13FB91E0DA384000D2C2C /* SUBinaryDeltaUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E9380FD69271005AE3F6 /* SUBinaryDeltaUnarchiver.m */; };
+		5AE13FBA1E0DA389000D2C2C /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E00FD68CC7005AE3F6 /* SUBinaryDeltaApply.m */; };
+		5AE13FBB1E0DA391000D2C2C /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
+		5AE13FBD1E0DA39B000D2C2C /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE13FBC1E0DA39B000D2C2C /* libbz2.tbd */; };
 		5AE459001C34118500E3BB47 /* SUUpdaterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 14950074195FDF5900BC5B5B /* SUUpdaterTest.m */; };
 		5AE459021C34118500E3BB47 /* SUVersionComparisonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 61227A150DB548B800AB99EA /* SUVersionComparisonTest.m */; };
 		5AE7E1111DC81AD3009C2C12 /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 5AE7E10E1DC81ACA009C2C12 /* AppIcon.icns */; };
@@ -586,6 +590,7 @@
 		5AE13F771E0C9B12000D2C2C /* DSASignature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DSASignature.swift; sourceTree = "<group>"; };
 		5AE13F9F1E0D4F65000D2C2C /* Appcast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Appcast.swift; sourceTree = "<group>"; };
 		5AE13FB31E0D9E07000D2C2C /* generate_appcast */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = generate_appcast; sourceTree = BUILT_PRODUCTS_DIR; };
+		5AE13FBC1E0DA39B000D2C2C /* libbz2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = usr/lib/libbz2.tbd; sourceTree = SDKROOT; };
 		5AE7E10E1DC81ACA009C2C12 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		5AEF45D9189D1CC90030D7DC /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		5AF6C74C1AEA40760014A3AB /* SUInstallerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUInstallerTest.m; sourceTree = "<group>"; };
@@ -806,6 +811,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5AE13FBD1E0DA39B000D2C2C /* libbz2.tbd in Frameworks */,
 				5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -924,6 +930,7 @@
 				0867D69BFE84028FC02AAC07 /* Foundation.framework */,
 				6117796E0D1112E000749C97 /* IOKit.framework */,
 				5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */,
+				5AE13FBC1E0DA39B000D2C2C /* libbz2.tbd */,
 				5D1AF5890FD7678C0065DB48 /* libxar.1.dylib */,
 				5AAD006B1E0C2DBF00AF411E /* libxar.tbd */,
 				5D1AF58F0FD767AD0065DB48 /* libxml2.dylib */,
@@ -1830,12 +1837,15 @@
 				5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */,
 				5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */,
 				5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */,
+				5AE13FBB1E0DA391000D2C2C /* bspatch.c in Sources */,
 				5AE13F781E0C9B12000D2C2C /* DSASignature.swift in Sources */,
 				5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */,
 				5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */,
 				5AAD006A1E0C2DB500AF411E /* sais.c in Sources */,
+				5AE13FBA1E0DA389000D2C2C /* SUBinaryDeltaApply.m in Sources */,
 				5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */,
 				5AAD00671E0C2D9B00AF411E /* SUBinaryDeltaCreate.m in Sources */,
+				5AE13FB91E0DA384000D2C2C /* SUBinaryDeltaUnarchiver.m in Sources */,
 				5AE13FA51E0D71F5000D2C2C /* SUConstants.m in Sources */,
 				5AE13FB51E0D9F32000D2C2C /* SUDiskImageUnarchiver.m in Sources */,
 				5AE13FA21E0D716F000D2C2C /* SUFileManager.m in Sources */,

--- a/generate_appcast/Appcast-Bridging-Header.h
+++ b/generate_appcast/Appcast-Bridging-Header.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+#import "SUStandardVersionComparator.h"
+#import "SUConstants.h"
+#import "SUErrors.h"
+#import "SUUnarchiver.h"
+#import "SUBinaryDeltaUnarchiver.h"
+#import "SUBinaryDeltaCreate.h"

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -1,0 +1,109 @@
+//
+//  Created by Kornel on 23/12/2016.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+
+func makeError(code: SUError, _ description: String) -> NSError {
+    return NSError(domain: SUSparkleErrorDomain, code: Int(OSStatus(code.rawValue)), userInfo: [
+        NSLocalizedDescriptionKey: description,
+        ]);
+}
+
+func makeAppcast(archivesSourceDir: URL, privateKey: SecKey) throws -> [String:[ArchiveItem]] {
+    let comparator = SUStandardVersionComparator();
+
+    let allUpdates = (try unarchiveUpdates(archivesSourceDir: archivesSourceDir))
+        .sorted(by: {
+            .orderedDescending == comparator.compareVersion($0.version, toVersion:$1.version)
+        })
+
+    if allUpdates.count == 0 {
+        throw makeError(code: .noUpdateError, "No usable archives found in \(archivesSourceDir.path)");
+    }
+
+    var updatesByAppcast:[String:[ArchiveItem]] = [:];
+
+    let group = DispatchGroup();
+
+    for update in allUpdates {
+        group.enter();
+        DispatchQueue.global().async {
+            do {
+                update.dsaSignature = try dsaSignature(path: update.archivePath, privateKey: privateKey);
+            } catch {
+                print(update, error);
+            }
+            group.leave();
+        }
+
+        let appcastFile = update.feedURL?.lastPathComponent ?? "appcast.xml";
+        if updatesByAppcast[appcastFile] == nil {
+            updatesByAppcast[appcastFile] = [];
+        }
+        updatesByAppcast[appcastFile]!.append(update);
+    }
+
+    for (_, updates) in updatesByAppcast {
+        var latestUpdatePerOS:[String:ArchiveItem] = [:];
+
+        for update in updates {
+            // items are ordered starting latest first
+            let os = update.minimumSystemVersion;
+            if latestUpdatePerOS[os] == nil {
+                latestUpdatePerOS[os] = update;
+            }
+        }
+
+        for (_,latestItem) in latestUpdatePerOS {
+            var numDeltas = 0;
+            let appBaseName = latestItem.appPath.deletingPathExtension().lastPathComponent;
+            for item in updates {
+                // No downgrades
+                if .orderedAscending != comparator.compareVersion(item.version, toVersion: latestItem.version) {
+                    continue;
+                }
+
+                let deltaBaseName = appBaseName + item.shortVersion + "-" + latestItem.shortVersion;
+                let deltaPath = archivesSourceDir.appendingPathComponent(deltaBaseName).appendingPathExtension("delta");
+
+                var delta:DeltaUpdate;
+                if !FileManager.default.fileExists(atPath: deltaPath.path) {
+                    do {
+                        delta = try DeltaUpdate.create(from: item, to: latestItem, archivePath: deltaPath);
+                    } catch {
+                        print("Could not create delta update", deltaPath.path, error);
+                        continue;
+                    }
+                } else {
+                    delta = DeltaUpdate(fromVersion: item.version, archivePath: deltaPath);
+                }
+
+                // Require delta to be a bit smaller
+                if delta.fileSize / 7 < latestItem.fileSize / 8 {
+                    // Max 3 deltas per version (arbitrary limit to reduce amount of work)
+                    numDeltas += 1;
+                    if numDeltas > 3 {
+                        break;
+                    }
+
+                    group.enter();
+                    DispatchQueue.global().async {
+                        do {
+                            delta.dsaSignature = try dsaSignature(path: deltaPath, privateKey: privateKey);
+                            latestItem.deltas.append(delta);
+                        } catch {
+                            print(delta.archivePath.lastPathComponent, error);
+                        }
+                        group.leave();
+                    }
+                }
+            }
+        }
+    }
+
+    group.wait();
+
+    return updatesByAppcast;
+}

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -65,7 +65,7 @@ func makeAppcast(archivesSourceDir: URL, privateKey: SecKey) throws -> [String:[
                     continue;
                 }
 
-                let deltaBaseName = appBaseName + item.shortVersion + "-" + latestItem.shortVersion;
+                let deltaBaseName = appBaseName + item.version + "-" + latestItem.version;
                 let deltaPath = archivesSourceDir.appendingPathComponent(deltaBaseName).appendingPathExtension("delta");
 
                 var delta:DeltaUpdate;

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -1,0 +1,120 @@
+//
+//  Created by Kornel on 22/12/2016.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+
+class DeltaUpdate {
+    let fromVersion: String;
+    let archivePath: URL;
+    var dsaSignature: String?;
+
+    init(fromVersion: String, archivePath: URL) {
+        self.archivePath = archivePath;
+        self.fromVersion = fromVersion;
+    }
+
+    var fileSize : Int64 {
+        let archiveFileAttributes = try! FileManager.default.attributesOfItem(atPath: self.archivePath.path);
+        return (archiveFileAttributes[.size] as! NSNumber).int64Value;
+    }
+
+    class func create(from: ArchiveItem, to: ArchiveItem, archivePath: URL) throws -> DeltaUpdate {
+        var applyDiffError: NSError? = nil;
+
+        if (!createBinaryDelta(from.appPath.path, to.appPath.path, archivePath.path, .beigeMajorVersion, true, &applyDiffError)) {
+            throw applyDiffError!;
+        }
+
+        return DeltaUpdate(fromVersion: from.version, archivePath: archivePath);
+    }
+}
+
+class ArchiveItem: CustomStringConvertible {
+    let version: String;
+    let _shortVersion: String?;
+    let minimumSystemVersion: String;
+    let archivePath: URL;
+    let appPath: URL;
+    let feedURL: URL?;
+    let archiveFileAttributes: [FileAttributeKey:Any];
+    var deltas: [DeltaUpdate];
+
+    var dsaSignature: String?;
+
+    init(version: String, shortVersion: String?, feedURL: URL?, minimumSystemVersion: String?, appPath: URL, archivePath: URL) throws {
+        self.version = version;
+        self._shortVersion = shortVersion;
+        self.feedURL = feedURL;
+        self.minimumSystemVersion = minimumSystemVersion ?? "10.7";
+        self.archivePath = archivePath;
+        self.appPath = appPath;
+        self.archiveFileAttributes = try FileManager.default.attributesOfItem(atPath: self.archivePath.path);
+        self.deltas = [];
+    }
+
+    convenience init(fromArchive archivePath: URL, unarchivedDir: URL) throws {
+        let items = try FileManager.default.contentsOfDirectory(atPath: unarchivedDir.path)
+            .filter({ !$0.hasPrefix(".") })
+            .map({ unarchivedDir.appendingPathComponent($0) })
+
+        let apps = items.filter({ $0.pathExtension == "app" });
+        if apps.count > 0 {
+            if apps.count > 1 {
+                throw makeError(code: .unarchivingError, "Too many apps in \(unarchivedDir.path) \(apps)");
+            }
+
+            let appPath = items[0];
+            guard let infoPlist = NSDictionary(contentsOf: appPath.appendingPathComponent("Contents/Info.plist")) else {
+                throw makeError(code: .unarchivingError, "No plist \(appPath.path)");
+            }
+            guard let version = infoPlist[kCFBundleVersionKey] as? String else {
+                throw makeError(code: .unarchivingError, "No Version \(kCFBundleVersionKey) \(appPath)");
+            }
+            let shortVersion = infoPlist["CFBundleShortVersionString"] as? String;
+
+            var feedURL:URL? = nil;
+            if let feedURLStr = infoPlist["SUFeedURL"] as? String {
+                feedURL = URL(string: feedURLStr);
+            }
+
+            try self.init(version: version,
+                           shortVersion: shortVersion,
+                           feedURL: feedURL,
+                           minimumSystemVersion: infoPlist["LSMinimumSystemVersion"] as? String,
+                           appPath: appPath,
+                           archivePath: archivePath);
+        } else {
+            throw makeError(code: .missingUpdateError, "No supported items in \(unarchivedDir) \(items) [note: only .app bundles are supported]");
+        }
+    }
+
+    var shortVersion: String {
+        return self._shortVersion ?? self.version;
+    }
+
+    var description : String {
+        return "\(self.archivePath) \(self.version)"
+    }
+
+    var archiveURL: URL {
+        if let relative = self.feedURL {
+            return URL(string: self.archivePath.lastPathComponent, relativeTo: relative)!
+        }
+        return URL(string: self.archivePath.lastPathComponent)!
+    }
+
+    var pubDate : String {
+        let date = self.archiveFileAttributes[.creationDate] as! Date;
+        let formatter = DateFormatter();
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss ZZ";
+        return formatter.string(from: date);
+    }
+
+    var fileSize : Int64 {
+        return (self.archiveFileAttributes[.size] as! NSNumber).int64Value;
+    }
+
+    let mimeType = "application/octet-stream";
+}

--- a/generate_appcast/DSASignature.swift
+++ b/generate_appcast/DSASignature.swift
@@ -1,0 +1,54 @@
+//
+//  Created by Kornel on 23/12/2016.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+
+func loadPrivateKey(privateKeyPath: URL) throws -> SecKey {
+    let data = try Data(contentsOf: privateKeyPath);
+
+    var cfitems: CFArray? = nil;
+    var format = SecExternalFormat.formatOpenSSL;
+    var type = SecExternalItemType.itemTypePrivateKey;
+
+    let status = SecItemImport(data as CFData, nil, &format, &type, SecItemImportExportFlags(rawValue: UInt32(0)), nil, nil, &cfitems);
+    if (status != errSecSuccess || cfitems == nil) {
+        print("Private DSA key could not be imported", status);
+        throw NSError(domain: SUSparkleErrorDomain, code: Int(OSStatus(SUError.signatureError.rawValue)), userInfo: nil);
+    }
+
+    if (format != SecExternalFormat.formatOpenSSL || type != SecExternalItemType.itemTypePrivateKey) {
+        throw makeError(code: .signatureError, "Not an OpensSSL private key \(format) \(type)");
+    }
+
+    return (cfitems as! NSArray)[0] as! SecKey;
+}
+
+func dsaSignature(path: URL, privateKey: SecKey) throws -> String {
+
+    var error: Unmanaged<CFError>?;
+
+    let stream = InputStream(fileAtPath:path.path)!;
+    let dataReadTransform = SecTransformCreateReadTransformWithReadStream(stream);
+
+    let dataDigestTransform = SecDigestTransformCreate(kSecDigestSHA1, 20, nil);
+    guard let dataSignTransform = SecSignTransformCreate(privateKey, &error) else {
+        print("can't use the key");
+        throw error!.takeRetainedValue();
+    }
+
+    let group = SecTransformCreateGroupTransform();
+    SecTransformConnectTransforms(dataReadTransform, kSecTransformOutputAttributeName, dataDigestTransform, kSecTransformInputAttributeName, group, &error);
+    if (error != nil) {
+        throw error!.takeRetainedValue();
+    }
+
+    SecTransformConnectTransforms(dataDigestTransform, kSecTransformOutputAttributeName, dataSignTransform, kSecTransformInputAttributeName, group, &error);
+    if (error != nil) {
+        throw error!.takeRetainedValue();
+    }
+
+    let result = SecTransformExecute(group, &error) as! Data;
+    return result.base64EncodedString();
+}

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -1,0 +1,162 @@
+//
+//  Created by Kornel on 22/12/2016.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+
+func findElement(name: String, parent: XMLElement) -> XMLElement? {
+    if let found = try? parent.nodes(forXPath: name) {
+        if found.count > 0 {
+            if let element = found[0] as? XMLElement {
+                return element;
+            }
+        }
+    }
+    return nil;
+}
+
+func findOrCreateElement(name: String, parent: XMLElement) -> XMLElement {
+    if let element = findElement(name: name, parent: parent) {
+        return element;
+    }
+    let element = XMLElement(name: name);
+    parent.addChild(element);
+    return element;
+}
+
+func text(_ text: String) -> XMLNode {
+    return XMLNode.text(withStringValue: text) as! XMLNode
+}
+
+func linebreak(_ element: XMLElement) {
+    element.addChild(text("\n"));
+}
+
+
+func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
+    let appBaseName = updates[0].appPath.deletingPathExtension().lastPathComponent;
+
+    let sparkleNS = "http://www.andymatuschak.org/xml-namespaces/sparkle";
+
+    var doc: XMLDocument;
+    do {
+        let options: XMLNode.Options = [
+            XMLNode.Options.nodeLoadExternalEntitiesNever,
+            XMLNode.Options.nodePreserveCDATA,
+            XMLNode.Options.nodePreserveWhitespace,
+            XMLNode.Options.nodePreservePrefixes,
+        ];
+        doc = try XMLDocument(contentsOf: appcastDestPath, options: Int(options.rawValue));
+    } catch {
+        let root = XMLElement(name: "rss");
+        root.addAttribute(XMLNode.attribute(withName: "xmlns:sparkle", stringValue: sparkleNS) as! XMLNode);
+        root.addAttribute(XMLNode.attribute(withName: "version", stringValue: "2.0") as! XMLNode);
+        doc = XMLDocument(rootElement: root);
+        doc.isStandalone = true;
+    }
+
+    var channel: XMLElement;
+
+    let rootNodes = try doc.nodes(forXPath: "/rss");
+    if rootNodes.count != 1 {
+        throw makeError(code: .appcastError, "Weird XML? \(appcastDestPath.path)");
+    }
+    let root = rootNodes[0] as! XMLElement
+    let channelNodes = try root.nodes(forXPath: "channel");
+    if channelNodes.count > 0 {
+        channel = channelNodes[0] as! XMLElement;
+    } else {
+        channel = XMLElement(name: "channel");
+        channel.addChild(XMLElement.element(withName: "title", stringValue: appBaseName) as! XMLElement);
+        root.addChild(channel);
+    }
+
+    var numItems = 0;
+    for update in updates {
+        var item: XMLElement;
+        let existingItems = try channel.nodes(forXPath: "item[enclosure[@sparkle:version=\"\(update.version)\"]]");
+        let createNewItem = existingItems.count == 0;
+
+        // Update all old items, but aim for less than 5 in new feeds
+        if createNewItem && numItems >= 5 {
+            continue;
+        }
+        numItems += 1;
+
+        if createNewItem {
+            item = XMLElement.element(withName: "item") as! XMLElement;
+            linebreak(channel);
+            channel.addChild(item);
+        } else {
+            item = existingItems[0] as! XMLElement;
+        }
+
+        if nil == findElement(name: "title", parent: item) {
+            linebreak(item);
+            item.addChild(XMLElement.element(withName: "title", stringValue: update.shortVersion) as! XMLElement);
+        }
+        if nil == findElement(name: "pubDate", parent: item) {
+            linebreak(item);
+            item.addChild(XMLElement.element(withName: "pubDate", stringValue: update.pubDate) as! XMLElement);
+        }
+
+        var minVer = findElement(name: "sparkle:minimumSystemVersion", parent: item);
+        if nil == minVer {
+            minVer = XMLElement.element(withName: "sparkle:minimumSystemVersion", uri: sparkleNS) as? XMLElement;
+            linebreak(item);
+            item.addChild(minVer!);
+        }
+        minVer?.setChildren([text(update.minimumSystemVersion)]);
+
+        var enclosure = findElement(name: "enclosure", parent: item);
+        if nil == enclosure {
+            enclosure = XMLElement.element(withName: "enclosure") as? XMLElement;
+            linebreak(item);
+            item.addChild(enclosure!);
+        }
+
+        var attributes = [
+            XMLNode.attribute(withName: "url", stringValue: update.archiveURL.absoluteString) as! XMLNode,
+            XMLNode.attribute(withName: "sparkle:version", uri: sparkleNS, stringValue: update.version) as! XMLNode,
+            XMLNode.attribute(withName: "length", stringValue: String(update.fileSize)) as! XMLNode,
+            XMLNode.attribute(withName: "type", stringValue: update.mimeType) as! XMLNode,
+        ];
+        if let sig = update.dsaSignature {
+            attributes.append(XMLNode.attribute(withName: "sparkle:dsaSignature", uri: sparkleNS, stringValue: sig) as! XMLNode);
+        }
+        enclosure!.attributes = attributes;
+
+        if update.deltas.count > 0 {
+            var deltas = findElement(name: "sparkle:deltas", parent: item);
+            if nil == deltas {
+                deltas = XMLElement.element(withName: "sparkle:deltas", uri: sparkleNS) as? XMLElement;
+                linebreak(item);
+                item.addChild(deltas!);
+            } else {
+                deltas!.setChildren([]);
+            }
+            for delta in update.deltas {
+                var attributes = [
+                    XMLNode.attribute(withName: "url", stringValue: URL(string: delta.archivePath.lastPathComponent, relativeTo: update.archiveURL)!.absoluteString) as! XMLNode,
+                    XMLNode.attribute(withName: "sparkle:version", uri: sparkleNS, stringValue: update.version) as! XMLNode,
+                    XMLNode.attribute(withName: "sparkle:deltaFrom", uri: sparkleNS, stringValue: delta.fromVersion) as! XMLNode,
+                    XMLNode.attribute(withName: "length", stringValue: String(delta.fileSize)) as! XMLNode,
+                    XMLNode.attribute(withName: "type", stringValue: "application/octet-stream") as! XMLNode,
+                    ];
+                if let sig = delta.dsaSignature {
+                    attributes.append(XMLNode.attribute(withName: "sparkle:dsaSignature", uri: sparkleNS, stringValue: sig) as! XMLNode);
+                }
+                linebreak(deltas!);
+                deltas!.addChild(XMLNode.element(withName: "enclosure", children: nil, attributes: attributes) as! XMLElement);
+            }
+        }
+        if createNewItem {
+            linebreak(item);
+            linebreak(channel);
+        }
+    }
+
+    let options = XMLNode.Options.nodeCompactEmptyElement;
+    try doc.xmlData(withOptions:Int(options.rawValue)).write(to: appcastDestPath);
+}

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -1,0 +1,95 @@
+//
+//  Created by Kornel on 22/12/2016.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+
+func unarchive(itemPath:URL, archiveDestDir: URL, callback: @escaping (Error?) -> Void) {
+    let fileManager = FileManager.default;
+    let tempDir = archiveDestDir.appendingPathExtension("tmp");
+    let itemCopy = tempDir.appendingPathComponent(itemPath.lastPathComponent);
+
+    _ = try? fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: [:]);
+
+    do {
+        try fileManager.linkItem(at: itemPath, to: itemCopy);
+        if let unarchiver = SUUnarchiver.unarchiver(forPath: itemCopy.path, updatingHostBundlePath:nil, decryptionPassword:nil) {
+            unarchiver.unarchive(completionBlock: { (error: Error?) in
+                if error != nil {
+                    callback(error);
+                    return;
+                }
+
+                _ = try? fileManager.removeItem(at: itemCopy);
+                do {
+                    try fileManager.moveItem(at: tempDir, to: archiveDestDir);
+                    callback(nil);
+                } catch {
+                    callback(error);
+                }
+            }, progressBlock: nil)
+        } else {
+            _ = try? fileManager.removeItem(at: itemCopy);
+            callback(makeError(code: .unarchivingError, "Can't create a hardlink to \(itemCopy)"));
+        }
+    } catch {
+        _ = try? fileManager.removeItem(at: tempDir);
+        callback(error);
+    }
+}
+
+func unarchiveUpdates(archivesSourceDir: URL) throws -> [ArchiveItem] {
+    let archivesDestDir = archivesSourceDir.appendingPathComponent(".tmp");
+
+    let group = DispatchGroup();
+
+    let fileManager = FileManager.default;
+
+    var unarchived:[ArchiveItem] = [];
+
+    let dir = try fileManager.contentsOfDirectory(atPath: archivesSourceDir.path);
+    var running = 0;
+    for item in dir.filter({ !$0.hasPrefix(".") && !$0.hasSuffix(".delta") && !$0.hasSuffix(".xml") }) {
+        let itemPath = archivesSourceDir.appendingPathComponent(item);
+        let archiveDestDir = archivesDestDir.appendingPathComponent(itemPath.lastPathComponent);
+
+        var isDir:ObjCBool = false;
+        if (fileManager.fileExists(atPath: itemPath.path, isDirectory: &isDir) && isDir.boolValue) {
+            continue;
+        }
+
+        let addItem = {
+            if let item = try? ArchiveItem(fromArchive: itemPath, unarchivedDir: archiveDestDir) {
+                objc_sync_enter(unarchived);
+                unarchived.append(item);
+                objc_sync_exit(unarchived);
+            }
+        }
+
+        if fileManager.fileExists(atPath: archiveDestDir.path) {
+            addItem();
+        } else {
+            group.enter();
+            unarchive(itemPath: itemPath, archiveDestDir: archiveDestDir) { (error: Error?) in
+                if let error = error {
+                    print("Could not unarchive", itemPath.path, error);
+                } else {
+                    addItem();
+                }
+                group.leave();
+            }
+        }
+
+        // Crude limit of concurrency
+        running += 1;
+        if running >= 8 {
+            running = 0;
+            group.wait();
+        }
+    }
+
+    group.wait();
+
+    return unarchived;
+}

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -1,0 +1,51 @@
+//
+//  main.swift
+//  Appcast
+//
+//  Created by Kornel on 20/12/2016.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+
+func main() {
+    let args = CommandLine.arguments;
+    if args.count < 3 {
+        let command = URL(fileURLWithPath: args[0]).lastPathComponent;
+        print("Generate appcast from a directory of Sparkle updates\nUsage: \(command) <private key path> <directory with update archives>\n",
+            " e.g. \(command) dsa_priv.pem archives/\n",
+            " Appcast files and deltas will be written to the archives directory.\n",
+            " Note that pkg-based updates are not supported.\n"
+        )
+        exit(1);
+    }
+
+    let privateKeyPath = URL(fileURLWithPath: args[1]);
+    let archivesSourceDir = URL(fileURLWithPath: "/Users/porneL/ImageOptim/imageoptim/archive", isDirectory:true);
+
+    do {
+        let privateKey = try loadPrivateKey(privateKeyPath: privateKeyPath);
+        do {
+            let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, privateKey: privateKey);
+
+            for (appcastFile, updates) in allUpdates {
+                let appcastDestPath = URL(fileURLWithPath: appcastFile, relativeTo: archivesSourceDir);
+                try writeAppcast(appcastDestPath:appcastDestPath, updates:updates);
+                print("Written", appcastDestPath.path, "based on", updates.count, "updates");
+            }
+        } catch {
+            print("Error generating appcast from directory", archivesSourceDir.path, "\n", error);
+            exit(1);
+        }
+    } catch {
+        print("Unable to load DSA private key from", privateKeyPath.path, "\n", error);
+        exit(1);
+    }
+}
+
+DispatchQueue.global().async(execute: {
+    main();
+    CFRunLoopStop(CFRunLoopGetMain());
+});
+
+CFRunLoopRun();

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -21,7 +21,7 @@ func main() {
     }
 
     let privateKeyPath = URL(fileURLWithPath: args[1]);
-    let archivesSourceDir = URL(fileURLWithPath: "/Users/porneL/ImageOptim/imageoptim/archive", isDirectory:true);
+    let archivesSourceDir = URL(fileURLWithPath: args[2], isDirectory:true);
 
     do {
         let privateKey = try loadPrivateKey(privateKeyPath: privateKeyPath);


### PR DESCRIPTION
One-stop-shop with convention-over-configuration to generate (and update) appcasts.

You give it private key and a directory of tarballs, and it'll figure out all versions from plists, generate delta updates, and dsa-sign everything.

* assumes all updates can be unarchived and contain .app bundles
* assumes `SUFeedURL` is present in the plist, and archives are served from the same directory

It's not clever architecturally, I just wanted get stuff done.

I'm compiling everything in instead of linking Sparkle.framework, since not all symbols are public and mixing and matching was a pain.
