### PR TITLE
Add UI tests to travis CI and add 10.12 as latest SDK to check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,14 @@ ci:
 			( rm -rf build && xcodebuild -sdk "macosx10.$$i" -scheme Distribution -configuration Coverage -derivedDataPath build ) || exit 1 ; \
 		fi ; \
 	done
-	for i in {10..11} ; do \
+	for i in {10..12} ; do \
 		if xcrun --sdk "macosx10.$$i" --show-sdk-path 2> /dev/null ; then \
 			( rm -rf build && xcodebuild -sdk "macosx10.$$i" -scheme Distribution -configuration Coverage -derivedDataPath build test ) || exit 1 ; \
+		fi ; \
+	done
+	for i in {11..12} ; do \
+		if xcrun --sdk "macosx10.$$i" --show-sdk-path 2> /dev/null ; then \
+			( rm -rf build && xcodebuild -sdk "macosx10.$$i" -scheme UITests -configuration Debug -derivedDataPath build test ) || exit 1 ; \
 		fi ; \
 	done
 


### PR DESCRIPTION
This may or may not work on Travis depending on it if allows the UI accessibility stuff. I just hope it doesn't hang..

Also, I noticed we have hardcoded versions for the SDKs and 10.12 wasn't included. Is it possible to do something a bit better so we don't forget to add new versions?