### PR TITLE
Decouple and simplify installation code using protocols

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -679,6 +679,7 @@
 		61F614540E24A12D009F47E7 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUBasicUpdateDriver.h; sourceTree = "<group>"; };
 		61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBasicUpdateDriver.m; sourceTree = "<group>"; };
+		7205C42E1E11A6DA00E370AE /* SUInstallerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUInstallerProtocol.h; sourceTree = "<group>"; };
 		720B16421C66433D006985FB /* UITests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "UITests-Info.plist"; path = "UITests/UITests-Info.plist"; sourceTree = SOURCE_ROOT; };
 		720B16431C66433D006985FB /* SUTestApplicationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SUTestApplicationTest.swift; path = UITests/SUTestApplicationTest.swift; sourceTree = SOURCE_ROOT; };
 		7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUUnarchiverTest.swift; sourceTree = "<group>"; };
@@ -1105,6 +1106,7 @@
 				7275F9C01B5F1F2900B1D19E /* SUFileManager.m */,
 				767B61AA1972D488004E0C3C /* SUGuidedPackageInstaller.h */,
 				767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */,
+				7205C42E1E11A6DA00E370AE /* SUInstallerProtocol.h */,
 				618FA4FF0DAE88B40026945C /* SUInstaller.h */,
 				618FA5000DAE88B40026945C /* SUInstaller.m */,
 				618FA5200DAE8E8A0026945C /* SUPackageInstaller.h */,

--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -6,6 +6,7 @@
 #import "SUStandardVersionComparator.h"
 #import "SUStatusController.h"
 #import "SULog.h"
+#import "SUInstallerProtocol.h"
 
 #include <unistd.h>
 
@@ -154,32 +155,20 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
     }];
 }
 
-- (NSString *)installationPathForBundle:(NSBundle *)bundle
+- (void)showError:(NSError *)error
 {
-    if (SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME) {
-        // We'll install to "#{CFBundleName}.app", but only if that path doesn't already exist. If we're "Foo 4.2.app," and there's a "Foo.app" in this directory, we don't want to overwrite it! But if there's no "Foo.app," we'll take that name.
-        NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [bundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey], [[bundle bundlePath] pathExtension]]];
-        
-        if (![[NSFileManager defaultManager] fileExistsAtPath:normalizedAppPath]) {
-            return normalizedAppPath;
-        }
+    if (self.shouldShowUI) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"";
+        alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
+        [alert runModal];
     }
-    return [bundle bundlePath];
 }
 
 - (void)install
 {
     NSBundle *theBundle = [NSBundle bundleWithPath:self.hostPath];
     SUHost *host = [[SUHost alloc] initWithBundle:theBundle];
-    NSString *installationPath = [self installationPathForBundle:theBundle];
-    
-    if (self.shouldShowUI) {
-        self.statusController = [[SUStatusController alloc] initWithHost:host];
-        [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:Nil isDefault:NO];
-        [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"")
-                                   maxProgressValue: 0 statusText: @""];
-        [self.statusController showWindow:self];
-    }
     
     NSString *fileOperationToolPath = [[[[NSBundle mainBundle] executablePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:@""SPARKLE_FILEOP_TOOL_NAME];
     
@@ -187,36 +176,59 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
         SULog(@"Potential Installation Error: File operation tool path %@ is not found", fileOperationToolPath);
     }
     
-    [SUInstaller installFromUpdateFolder:self.updateFolderPath
-                                overHost:host
-                        installationPath:installationPath
-                   fileOperationToolPath:fileOperationToolPath
-                       versionComparator:[SUStandardVersionComparator defaultComparator]
-                       completionHandler:^(NSError *error) {
-                           if (error) {
-                               NSError *underlyingError = [error.userInfo objectForKey:NSUnderlyingErrorKey];
-                               if (underlyingError == nil || underlyingError.code != SUInstallationCancelledError) {
-                                   SULog(@"Installation Error: %@", error);
-                                   if (self.shouldShowUI) {
-                                       NSAlert *alert = [[NSAlert alloc] init];
-                                       alert.messageText = @"";
-                                       alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
-                                       [alert runModal];
-                                   }
-                               }
-                               exit(EXIT_FAILURE);
-                           } else {
-                               NSString *pathToRelaunch = nil;
-                               // If the installation path differs from the host path, we give higher precedence for it than
-                               // if the desired relaunch path differs from the host path
-                               if (![installationPath.pathComponents isEqualToArray:self.hostPath.pathComponents] || [self.relaunchPath.pathComponents isEqualToArray:self.hostPath.pathComponents]) {
-                                   pathToRelaunch = installationPath;
-                               } else {
-                                   pathToRelaunch = self.relaunchPath;
-                               }
-                               [self cleanupAndTerminateWithPathToRelaunch:pathToRelaunch];
-                           }
-                       }];
+    NSError *retrieveInstallerError = nil;
+    id<SUInstallerProtocol> installer = [SUInstaller installerForHost:host fileOperationToolPath:fileOperationToolPath updateDirectory:self.updateFolderPath error:&retrieveInstallerError];
+    if (installer == nil) {
+        SULog(@"Retrieved Installer Error: %@", retrieveInstallerError);
+        exit(EXIT_FAILURE);
+    }
+    
+    if (self.shouldShowUI && [installer canInstallSilently]) {
+        self.statusController = [[SUStatusController alloc] initWithHost:host];
+        [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:Nil isDefault:NO];
+        [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"")
+                                   maxProgressValue: 0 statusText: @""];
+        [self.statusController showWindow:self];
+    }
+    
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSError *initialInstallationError = nil;
+        if (![installer performInitialInstallation:&initialInstallationError]) {
+            SULog(@"Failed to perform initial installation with error: %@", initialInstallationError);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self showError:initialInstallationError];
+                exit(EXIT_FAILURE);
+            });
+            return;
+        }
+        
+        NSError *finalInstallationError = nil;
+        if (![installer performFinalInstallation:&finalInstallationError]) {
+            NSError *underlyingError = [finalInstallationError.userInfo objectForKey:NSUnderlyingErrorKey];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (underlyingError == nil || underlyingError.code != SUInstallationCancelledError) {
+                    SULog(@"Failed to perform final installation Error: %@", finalInstallationError);
+                    [self showError:finalInstallationError];
+                }
+                exit(EXIT_FAILURE);
+            });
+            return;
+        }
+        
+        NSString *installationPath = [installer installationPath];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSString *pathToRelaunch = nil;
+            // If the relaunch path is the same as the host bundle path, use the installation path from the installer which may be normalized
+            // Otherwise use the requested relaunch path in all other cases
+            if ([self.relaunchPath.pathComponents isEqualToArray:host.bundlePath.pathComponents]) {
+                pathToRelaunch = installationPath;
+            } else {
+                pathToRelaunch = self.relaunchPath;
+            }
+            [self cleanupAndTerminateWithPathToRelaunch:pathToRelaunch];
+        });
+    });
 }
 
 - (void)cleanupAndTerminateWithPathToRelaunch:(NSString *)relaunchPath

--- a/Sparkle/SUGuidedPackageInstaller.h
+++ b/Sparkle/SUGuidedPackageInstaller.h
@@ -19,16 +19,15 @@ A guided installation can be started by applications other than the application 
 - Replace the use of `AuthorizationExecuteWithPrivilegesAndWait`. This method remains because it is well supported and tested. Ideally a helper tool or XPC would be used.
 */
 
-#ifndef SUGUIDEDPACKAGEINSTALLER_H
-#define SUGUIDEDPACKAGEINSTALLER_H
-
 #import <Foundation/Foundation.h>
-#import "SUInstaller.h"
+#import "SUInstallerProtocol.h"
 
-@interface SUGuidedPackageInstaller : SUInstaller
+NS_ASSUME_NONNULL_BEGIN
 
-/*! Perform the guided installation */
-+ (void)performInstallationToPath:(NSString *)path fromPath:(NSString *)installerGuide host:(SUHost *)host fileOperationToolPath:(NSString *)fileOperationToolPath versionComparator:(id<SUVersionComparison>)comparator completionHandler:(void (^)(NSError *))completionHandler;
+@interface SUGuidedPackageInstaller : NSObject <SUInstallerProtocol>
+
+- (instancetype)initWithPackagePath:(NSString *)packagePath installationPath:(NSString *)installationPath fileOperationToolPath:(NSString *)fileOperationToolPath;
+
 @end
 
-#endif
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUGuidedPackageInstaller.m
+++ b/Sparkle/SUGuidedPackageInstaller.m
@@ -9,26 +9,46 @@
 #import "SUGuidedPackageInstaller.h"
 #import "SUFileManager.h"
 
+@interface SUGuidedPackageInstaller ()
+
+@property (nonatomic, readonly, copy) NSString *packagePath;
+@property (nonatomic, readonly, copy) NSString *installationPath;
+@property (nonatomic, readonly, copy) NSString *fileOperationToolPath;
+
+@end
+
 @implementation SUGuidedPackageInstaller
 
-+ (void)performInstallationToPath:(NSString *)destinationPath fromPath:(NSString *)packagePath host:(SUHost *)__unused host fileOperationToolPath:(NSString *)fileOperationToolPath versionComparator:(id<SUVersionComparison>)__unused comparator completionHandler:(void (^)(NSError *))completionHandler
+@synthesize packagePath = _packagePath;
+@synthesize installationPath = _installationPath;
+@synthesize fileOperationToolPath = _fileOperationToolPath;
+
+- (instancetype)initWithPackagePath:(NSString *)packagePath installationPath:(NSString *)installationPath fileOperationToolPath:(NSString *)fileOperationToolPath
 {
-    NSParameterAssert(packagePath);
+    self = [super init];
+    if (self != nil) {
+        _packagePath = [packagePath copy];
+        _installationPath = [installationPath copy];
+        _fileOperationToolPath = [fileOperationToolPath copy];
+    }
+    return self;
+}
+
+- (BOOL)performInitialInstallation:(NSError * __autoreleasing *)__unused error
+{
+    return YES;
+}
+
+- (BOOL)performFinalInstallation:(NSError * __autoreleasing *)error
+{
+    SUFileManager *fileManager = [SUFileManager fileManagerWithAuthorizationToolPath:self.fileOperationToolPath];
     
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        SUFileManager *fileManager = [SUFileManager fileManagerWithAuthorizationToolPath:fileOperationToolPath];
-        
-        NSError *error = nil;
-        BOOL validInstallation = [fileManager executePackageAtURL:[NSURL fileURLWithPath:packagePath] error:&error];
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self finishInstallationToPath:destinationPath
-                                withResult:validInstallation
-                                     error:error
-                         completionHandler:completionHandler];
-            
-        });
-    });
+    return [fileManager executePackageAtURL:[NSURL fileURLWithPath:self.packagePath] error:error];
+}
+
+- (BOOL)canInstallSilently
+{
+    return YES;
 }
 
 @end

--- a/Sparkle/SUInstaller.h
+++ b/Sparkle/SUInstaller.h
@@ -6,19 +6,21 @@
 //  Copyright 2008 Andy Matuschak. All rights reserved.
 //
 
-#ifndef SUINSTALLER_H
-#define SUINSTALLER_H
-
 #import <Foundation/Foundation.h>
 #import "SUVersionComparisonProtocol.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class SUHost;
+
+@protocol SUInstallerProtocol;
+
 @interface SUInstaller : NSObject
 
-+ (NSString *)installSourcePathInUpdateFolder:(NSString *)inUpdateFolder forHost:(SUHost *)host isPackage:(BOOL *)isPackagePtr isGuided:(BOOL *)isGuidedPtr;
-+ (void)installFromUpdateFolder:(NSString *)inUpdateFolder overHost:(SUHost *)host installationPath:(NSString *)installationPath fileOperationToolPath:(NSString *)fileOperationToolPath versionComparator:(id<SUVersionComparison>)comparator completionHandler:(void (^)(NSError *))completionHandler;
-+ (void)finishInstallationToPath:(NSString *)installationPath withResult:(BOOL)result error:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler;
++ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host fileOperationToolPath:(NSString *)fileOperationToolPath updateDirectory:(NSString *)updateDirectory error:(NSError **)error;
+
++ (nullable NSString *)installSourcePathInUpdateFolder:(NSString *)inUpdateFolder forHost:(SUHost *)host isPackage:(BOOL *)isPackagePtr isGuided:(nullable BOOL *)isGuidedPtr;
 
 @end
 
-#endif
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUInstallerProtocol.h
+++ b/Sparkle/SUInstallerProtocol.h
@@ -1,0 +1,36 @@
+//
+//  SUInstallerProtocol.h
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 12/26/16.
+//  Copyright © 2016 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SUInstallerProtocol <NSObject>
+
+// Any installation work can be done prior to user application being terminated and relaunched
+// Currently this is invoked after the user application is terminated, but this may change in the future.
+// No UI should occur during this stage (i.e, do not show package installer apps, etc..)
+// Should be able to be called from non-main thread
+- (BOOL)performInitialInstallation:(NSError **)error;
+
+// Any installation work after the user application has been terminated. This is where the final installation work can be done.
+// After this stage is done, the user application may be relaunched.
+// Should be able to be called from non-main thread
+- (BOOL)performFinalInstallation:(NSError **)error;
+
+// Indicates whether or not this installer can install the update silently in the background, without hindering the user
+// Should be thread safe
+- (BOOL)canInstallSilently;
+
+// The destination and installation path of the bundle being updated
+// Should be thread safe
+- (NSString *)installationPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUPackageInstaller.h
+++ b/Sparkle/SUPackageInstaller.h
@@ -6,13 +6,15 @@
 //  Copyright 2008 Andy Matuschak. All rights reserved.
 //
 
-#ifndef SUPACKAGEINSTALLER_H
-#define SUPACKAGEINSTALLER_H
-
 #import <Foundation/Foundation.h>
-#import "SUPlainInstaller.h"
+#import "SUInstallerProtocol.h"
 
-@interface SUPackageInstaller : SUPlainInstaller
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SUPackageInstaller : NSObject <SUInstallerProtocol>
+
+- (instancetype)initWithPackagePath:(NSString *)packagePath installationPath:(NSString *)installationPath;
+
 @end
 
-#endif
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUPackageInstaller.m
+++ b/Sparkle/SUPackageInstaller.m
@@ -9,33 +9,70 @@
 #import "SUPackageInstaller.h"
 #import "SUConstants.h"
 #import "SUErrors.h"
+#import "SULog.h"
+
+@interface SUPackageInstaller ()
+
+@property (nonatomic, readonly, copy) NSString *packagePath;
+@property (nonatomic, readonly, copy) NSString *installationPath;
+
+@end
 
 @implementation SUPackageInstaller
 
-+ (void)performInstallationToPath:(NSString *)installationPath fromPath:(NSString *)path host:(SUHost *)__unused host fileOperationToolPath:(NSString *)__unused fileOperationToolPath versionComparator:(id<SUVersionComparison>)__unused comparator completionHandler:(void (^)(NSError *))completionHandler
+static NSString *SUOpenUtilityPath = @"/usr/bin/open";
+
+@synthesize packagePath = _packagePath;
+@synthesize installationPath = _installationPath;
+
+- (instancetype)initWithPackagePath:(NSString *)packagePath installationPath:(NSString *)installationPath
+{
+    self = [super init];
+    if (self != nil) {
+        _packagePath = [packagePath copy];
+        _installationPath = [installationPath copy];
+    }
+    return self;
+}
+
+- (BOOL)performInitialInstallation:(NSError * __autoreleasing *)error
+{
+    if (![[NSFileManager defaultManager] fileExistsAtPath:SUOpenUtilityPath]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUMissingInstallerToolError userInfo:@{ NSLocalizedDescriptionKey: @"Couldn't find Apple's installer tool!" }];
+        }
+        return NO;
+    }
+    return YES;
+}
+
+- (BOOL)performFinalInstallation:(NSError * __autoreleasing *)error
 {
     // Run installer using the "open" command to ensure it is launched in front of current application.
     // -W = wait until the app has quit.
     // -n = Open another instance if already open.
     // -b = app bundle identifier
-    NSString *command = @"/usr/bin/open";
-    NSArray *args = @[@"-W", @"-n", @"-b", @"com.apple.installer", path];
-
-    if (![[NSFileManager defaultManager] fileExistsAtPath:command]) {
-        NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUMissingInstallerToolError userInfo:@{ NSLocalizedDescriptionKey: @"Couldn't find Apple's installer tool!" }];
-        [self finishInstallationToPath:installationPath withResult:NO error:error completionHandler:completionHandler];
-        return;
-    }
-
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSTask *installer = [NSTask launchedTaskWithLaunchPath:command arguments:args];
+    NSArray *args = @[@"-W", @"-n", @"-b", @"com.apple.installer", self.packagePath];
+    
+    // Known bug: if the installation fails or is canceled, Sparkle goes ahead and restarts, thinking everything is fine.
+    @try {
+        NSTask *installer = [NSTask launchedTaskWithLaunchPath:SUOpenUtilityPath arguments:args];
         [installer waitUntilExit];
+    }
+    @catch (NSException *exception) {
+        SULog(@"Error: Failed to launch package installer: %@", exception);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Package installer failed to launch." }];
+        }
+        return NO;
+    }
+    
+    return YES;
+}
 
-        // Known bug: if the installation fails or is canceled, Sparkle goes ahead and restarts, thinking everything is fine.
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self finishInstallationToPath:installationPath withResult:YES error:nil completionHandler:completionHandler];
-        });
-    });
+- (BOOL)canInstallSilently
+{
+    return NO;
 }
 
 @end

--- a/Sparkle/SUPlainInstaller.h
+++ b/Sparkle/SUPlainInstaller.h
@@ -6,19 +6,23 @@
 //  Copyright 2008 Andy Matuschak. All rights reserved.
 //
 
-#ifndef SUPLAININSTALLER_H
-#define SUPLAININSTALLER_H
-
 #import <Foundation/Foundation.h>
-#import "SUVersionComparisonProtocol.h"
-#import "SUInstaller.h"
+#import "SUInstallerProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @class SUHost;
 
-@interface SUPlainInstaller : SUInstaller
+@interface SUPlainInstaller : NSObject <SUInstallerProtocol>
 
-+ (void)performInstallationToPath:(NSString *)installationPath fromPath:(NSString *)path host:(SUHost *)host fileOperationToolPath:(NSString *)fileOperationToolPath versionComparator:(id<SUVersionComparison>)comparator completionHandler:(void (^)(NSError *))completionHandler;
+/*!
+ @param host The current (old) bundle host
+ @param bundlePath The path to the new bundle that will be installed.
+ @param installationPath The path the new bundlePath will be installed to.
+ @param fileOperationToolPath The path to the file operation tool for authorized operations.
+ */
+- (instancetype)initWithHost:(SUHost *)host bundlePath:(NSString *)bundlePath installationPath:(NSString *)installationPath fileOperationToolPath:(NSString *)fileOperationToolPath;
 
 @end
 
-#endif
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This also fixes a bug where the status progress window would be visible during interactive (non-guided) package installations. Possibly the last major refactor change to sync with my fork.