### PR TITLE
Hide automatic updates checkbox for information only updates

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -171,7 +171,8 @@
 
 - (BOOL)allowsAutomaticUpdates
 {
-    return [SUSystemUpdateInfo systemAllowsAutomaticUpdatesForHost:self.host];
+    return [SUSystemUpdateInfo systemAllowsAutomaticUpdatesForHost:self.host]
+            && !self.updateItem.isInformationOnlyUpdate;
 }
 
 - (void)windowDidLoad


### PR DESCRIPTION
It's a bit of odd to show 'Automatically download and install updates in the future' checkbox if an update has only information but no downloads.
Even the checkbox can be hidden by SUAllowsAutomaticUpdatesKey, I think it would be better to be determined by appcast, instead of disabling auto downloads in host app permanently.