### PR TITLE
Switch to LZMA for the distribution archive

### DIFF
--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 if [ "$ACTION" = "" ] ; then
     # Sanity check that the Podspec version matches the Sparkle version
@@ -10,7 +10,7 @@ if [ "$ACTION" = "" ] ; then
     fi
 
     rm -rf "$CONFIGURATION_BUILD_DIR/staging"
-    rm -f "Sparkle-$CURRENT_PROJECT_VERSION.tar.bz2"
+    rm -f "Sparkle-$CURRENT_PROJECT_VERSION.tar.xz"
 
     mkdir -p "$CONFIGURATION_BUILD_DIR/staging"
     cp "$SRCROOT/CHANGELOG" "$SRCROOT/LICENSE" "$SRCROOT/Resources/SampleAppcast.xml" "$CONFIGURATION_BUILD_DIR/staging"
@@ -31,6 +31,6 @@ if [ "$ACTION" = "" ] ; then
 
     cd "$CONFIGURATION_BUILD_DIR/staging"
     # Sorted file list groups similar files together, which improves tar compression
-    find . \! -type d | rev | sort | rev | tar cjvf "../Sparkle-$CURRENT_PROJECT_VERSION.tar.bz2" --files-from=-
+    find . \! -type d | rev | sort | rev | tar cv --files-from=- | xz > "../Sparkle-$CURRENT_PROJECT_VERSION.tar.xz"
     rm -rf "$CONFIGURATION_BUILD_DIR/staging"
 fi

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ localizable-strings:
 
 release:
 	xcodebuild -scheme Distribution -configuration Release -derivedDataPath "$(BUILDDIR)" build
-	open -R "$(BUILDDIR)/Build/Products/Release/Sparkle-"*.tar.bz2
+	open -R "$(BUILDDIR)/Build/Products/Release/Sparkle-"*.tar.xz
 	cat Sparkle.podspec
 	@echo "Don't forget to update CocoaPods! pod trunk push"
 

--- a/Sparkle.podspec
+++ b/Sparkle.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   }
 
   s.platform = :osx, '10.7'
-  s.source   = { :http => "https://github.com/sparkle-project/Sparkle/releases/download/#{s.version}/Sparkle-#{s.version}.tar.bz2" }
+  s.source   = { :http => "https://github.com/sparkle-project/Sparkle/releases/download/#{s.version}/Sparkle-#{s.version}.tar.xz" }
   s.source_files = 'Sparkle.framework/Versions/A/Headers/*.h'
 
   s.public_header_files = 'Sparkle.framework/Versions/A/Headers/*.h'


### PR DESCRIPTION
7.3MB -> 4.3MB

Previous Sparkle distributions were around 4MB. The archive got much larger in 1.16 due to generate_appcast tool having a swift runtime.