### PR TITLE
Re-read SUHost Info dictionary when necessary

### DIFF
--- a/Sparkle/SUApplicationInfo.h
+++ b/Sparkle/SUApplicationInfo.h
@@ -10,11 +10,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SUHost;
+
 @interface SUApplicationInfo : NSObject
 
 + (BOOL)isBackgroundApplication:(NSApplication *)application;
 
-+ (NSImage *)bestIconForBundle:(NSBundle *)bundle;
++ (NSImage *)bestIconForHost:(SUHost *)host;
 
 @end
 

--- a/Sparkle/SUApplicationInfo.m
+++ b/Sparkle/SUApplicationInfo.m
@@ -8,6 +8,7 @@
 
 #import "SUApplicationInfo.h"
 #import "SUBundleIcon.h"
+#import "SUHost.h"
 
 @implementation SUApplicationInfo
 
@@ -16,16 +17,16 @@
     return (application.activationPolicy == NSApplicationActivationPolicyAccessory);
 }
 
-+ (NSImage *)bestIconForBundle:(NSBundle *)bundle
++ (NSImage *)bestIconForHost:(SUHost *)host
 {
-    NSURL *iconURL = [SUBundleIcon iconURLForBundle:bundle];
+    NSURL *iconURL = [SUBundleIcon iconURLForHost:host];
     
     NSImage *icon = (iconURL == nil) ? nil : [[NSImage alloc] initWithContentsOfURL:iconURL];
     // Use a default icon if none is defined.
     if (!icon) {
         // this asumption may not be correct (eg. even though we're not the main bundle, it could be still be a regular app)
         // but still better than nothing if no icon was included
-        BOOL isMainBundle = (bundle == [NSBundle mainBundle]);
+        BOOL isMainBundle = [host.bundle isEqualTo:[NSBundle mainBundle]];
         
         NSString *fileType = isMainBundle ? (__bridge NSString *)kUTTypeApplication : (__bridge NSString *)kUTTypeBundle;
         icon = [[NSWorkspace sharedWorkspace] iconForFileType:fileType];

--- a/Sparkle/SUAutomaticUpdateAlert.m
+++ b/Sparkle/SUAutomaticUpdateAlert.m
@@ -61,7 +61,7 @@
 
 - (NSImage *__nonnull)applicationIcon
 {
-    return [SUApplicationInfo bestIconForBundle:self.host.bundle];
+    return [SUApplicationInfo bestIconForHost:self.host];
 }
 
 - (NSString *__nonnull)titleText

--- a/Sparkle/SUBundleIcon.h
+++ b/Sparkle/SUBundleIcon.h
@@ -10,9 +10,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SUHost;
+
 @interface SUBundleIcon : NSObject
 
-+ (NSURL * _Nullable)iconURLForBundle:(NSBundle *)bundle;
++ (NSURL * _Nullable)iconURLForHost:(SUHost *)host;
 
 @end
 

--- a/Sparkle/SUBundleIcon.m
+++ b/Sparkle/SUBundleIcon.m
@@ -7,21 +7,23 @@
 //
 
 #import "SUBundleIcon.h"
+#import "SUHost.h"
 
 @implementation SUBundleIcon
 
-+ (NSURL *)iconURLForBundle:(NSBundle *)bundle
+// Note: To obtain the most current bundle icon file from the Info dictionary, this should take a SUHost, not a NSBundle
++ (NSURL *)iconURLForHost:(SUHost *)host
 {
-    NSString *resource = [bundle objectForInfoDictionaryKey:@"CFBundleIconFile"];
+    NSString *resource = [host objectForInfoDictionaryKey:@"CFBundleIconFile"];
     if (resource == nil || ![resource isKindOfClass:[NSString class]]) {
         return nil;
     }
     
-    NSURL *iconURL = [bundle URLForResource:resource withExtension:@"icns"];
+    NSURL *iconURL = [host.bundle URLForResource:resource withExtension:@"icns"];
     
     // The resource could already be containing the path extension, so try again without the extra extension
     if (iconURL == nil) {
-        iconURL = [bundle URLForResource:resource withExtension:nil];
+        iconURL = [host.bundle URLForResource:resource withExtension:nil];
     }
     return iconURL;
 }

--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -150,7 +150,7 @@
     NSBundle *bundle = host.bundle;
     assert(bundle != nil);
     
-    NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [bundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey], [[bundle bundlePath] pathExtension]]];
+    NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [host objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey], [[bundle bundlePath] pathExtension]]];
     
     return normalizedAppPath;
 }

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -186,12 +186,15 @@
     // Prevent malicious downgrades
     if (!allowDowngrades) {
         NSString *hostVersion = [self.host version];
+        
         NSBundle *bundle = [NSBundle bundleWithPath:self.bundlePath];
-        NSString *updateVersion = [bundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
+        SUHost *updateHost = [[SUHost alloc] initWithBundle:bundle];
+        NSString *updateVersion = [updateHost objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
+        
         id<SUVersionComparison> comparator = [[SUStandardVersionComparator alloc] init];
         if (!updateVersion || [comparator compareVersion:hostVersion toVersion:updateVersion] == NSOrderedDescending) {
             if (error != NULL) {
-                NSString *errorMessage = [NSString stringWithFormat:@"For security reasons, updates that downgrade version of the application are not allowed. Refusing to downgrade app from version %@ to %@. Aborting update.", hostVersion, [bundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey]];
+                NSString *errorMessage = [NSString stringWithFormat:@"For security reasons, updates that downgrade version of the application are not allowed. Refusing to downgrade app from version %@ to %@. Aborting update.", hostVersion, updateVersion];
                 
                 *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUDowngradeError userInfo:@{ NSLocalizedDescriptionKey: errorMessage }];
             }

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -66,7 +66,7 @@
 
 - (NSImage *)applicationIcon
 {
-    return [SUApplicationInfo bestIconForBundle:self.host.bundle];
+    return [SUApplicationInfo bestIconForHost:self.host];
 }
 
 - (void)beginActionWithTitle:(NSString *)aTitle maxProgressValue:(double)aMaxProgressValue statusText:(NSString *)aStatusText

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -314,7 +314,7 @@
     // are focused to inform the user since there is no dock icon to notify them.
     if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) { [NSApp activateIgnoringOtherApps:YES]; }
 
-    [alert setIcon:[SUApplicationInfo bestIconForBundle:self.host.bundle]];
+    [alert setIcon:[SUApplicationInfo bestIconForHost:self.host]];
     [alert runModal];
 
     if ([[updater delegate] respondsToSelector:@selector(updaterDidShowModalAlert:)])

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -221,7 +221,7 @@
 
 - (NSImage *)applicationIcon
 {
-    return [SUApplicationInfo bestIconForBundle:self.host.bundle];
+    return [SUApplicationInfo bestIconForHost:self.host];
 }
 
 - (NSString *)titleText

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -100,7 +100,7 @@
 
 - (NSImage *)icon
 {
-    return [SUApplicationInfo bestIconForBundle:self.host.bundle];
+    return [SUApplicationInfo bestIconForHost:self.host];
 }
 
 - (NSString *)promptDescription


### PR DESCRIPTION
Discussed a bit in #962. This is to sync more changes to master.

The decision I ended up making is re-reading the Info dictionary for a SUHost bundle only if the updater's lifetime is not tied to the lifetime of the bundle being updated. So if an app bundle is updating itself for instance, we can just rely on the cached info dictionary (common case). I had to change a couple of methods to accept a SUHost parameter rather than a NSBundle one.