### PR TITLE
Add Obj-C generics where applicable

### DIFF
--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -22,7 +22,12 @@ NS_ASSUME_NONNULL_BEGIN
 SU_EXPORT @interface SUAppcast : NSObject<NSURLDownloadDelegate>
 
 @property (copy, nullable) NSString *userAgentString;
+
+#if __has_feature(objc_generics)
+@property (copy, nullable) NSDictionary<NSString *, NSString *> *httpHeaders;
+#else
 @property (copy, nullable) NSDictionary *httpHeaders;
+#endif
 
 - (void)fetchAppcastFromURL:(NSURL *)url completionBlock:(void (^)(NSError *_Nullable))err;
 - (SUAppcast *)copyWithoutDeltaUpdates;

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -65,7 +65,7 @@
 
     if (self.httpHeaders) {
         for (NSString *key in self.httpHeaders) {
-            id value = [self.httpHeaders objectForKey:key];
+            NSString *value = [self.httpHeaders objectForKey:key];
             [request setValue:value forHTTPHeaderField:key];
         }
     }

--- a/Sparkle/SUSystemProfiler.h
+++ b/Sparkle/SUSystemProfiler.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUHost;
 @interface SUSystemProfiler : NSObject
 
-+ (NSArray *)systemProfileArrayForHost:(SUHost *)host;
++ (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host;
 
 @end
 

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -28,19 +28,19 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
 
 @implementation SUSystemProfiler
 
-+ (NSDictionary *)modelTranslationTable
++ (NSDictionary<NSString *, NSString *> *)modelTranslationTable
 {
     // Use explicit class to use the correct bundle even when subclassed
     NSString *path = [[NSBundle bundleForClass:[SUSystemProfiler class]] pathForResource:@"SUModelTranslation" ofType:@"plist"];
     return [[NSDictionary alloc] initWithContentsOfFile:path];
 }
 
-+ (NSArray *)systemProfileArrayForHost:(SUHost *)host
++ (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host
 {
-    NSDictionary *modelTranslation = [self modelTranslationTable];
+    NSDictionary<NSString *, NSString *> *modelTranslation = [self modelTranslationTable];
 
     // Gather profile information and append it to the URL.
-    NSMutableArray *profileArray = [NSMutableArray array];
+    NSMutableArray<NSDictionary<NSString *, NSString *> *> *profileArray = [NSMutableArray array];
     NSArray *profileDictKeys = @[@"key", @"displayKey", @"value", @"displayValue"];
     int error = 0;
     int value = 0;

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -160,7 +160,11 @@ SU_EXPORT @interface SUUpdater : NSObject
 
  The keys of this dictionary are HTTP header fields (NSString) and values are corresponding values (NSString)
  */
+#if __has_feature(objc_generics)
+@property (copy) NSDictionary<NSString *, NSString *> *httpHeaders;
+#else
 @property (copy) NSDictionary *httpHeaders;
+#endif
 
 /*!
  A property indicating whether or not the user's system profile information is sent when checking for updates.

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -210,7 +210,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     }
 
     if (shouldPrompt) {
-        NSArray *profileInfo = [SUSystemProfiler systemProfileArrayForHost:self.host];
+        NSArray<NSDictionary<NSString *, NSString *> *> *profileInfo = [SUSystemProfiler systemProfileArrayForHost:self.host];
         // Always say we're sending the system profile here so that the delegate displays the parameters it would send.
         if ([self.delegate respondsToSelector:@selector(feedParametersForUpdater:sendingSystemProfile:)]) {
             profileInfo = [profileInfo arrayByAddingObjectsFromArray:[self.delegate feedParametersForUpdater:self sendingSystemProfile:YES]];

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -64,7 +64,11 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
  
  \return An array of dictionaries with keys: "key", "value", "displayKey", "displayValue", the latter two being specifically for display to the user.
  */
+#if __has_feature(objc_generics)
+- (NSArray<NSDictionary<NSString *, NSString *> *> *)feedParametersForUpdater:(SUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
+#else
 - (NSArray *)feedParametersForUpdater:(SUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
+#endif
 
 /*!
  Returns a custom appcast URL.


### PR DESCRIPTION
Just some small generic changes I'm sync'ing. We've already been using generics in private files.

In headers that are exported, we test to see if generic support is available.