### PR TITLE
Add AppKit prevention guards to modules that shouldn't import it

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -732,6 +732,7 @@
 		7205C4331E12C23C00E370AE /* ConfigGenerateAppcast.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigGenerateAppcast.xcconfig; sourceTree = "<group>"; };
 		7205C4341E12C66D00E370AE /* ConfigGenerateAppcastRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigGenerateAppcastRelease.xcconfig; sourceTree = "<group>"; };
 		7205C4351E12CA7000E370AE /* ConfigGenerateAppcastDebug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigGenerateAppcastDebug.xcconfig; sourceTree = "<group>"; };
+		720767D01E2E3DD300F9A850 /* AppKitPrevention.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitPrevention.h; sourceTree = "<group>"; };
 		720B16421C66433D006985FB /* UITests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "UITests-Info.plist"; path = "UITests/UITests-Info.plist"; sourceTree = SOURCE_ROOT; };
 		720B16431C66433D006985FB /* SUTestApplicationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SUTestApplicationTest.swift; path = UITests/SUTestApplicationTest.swift; sourceTree = SOURCE_ROOT; };
 		7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUUnarchiverTest.swift; sourceTree = "<group>"; };
@@ -1036,6 +1037,7 @@
 		1495006D195FBBBD00BC5B5B /* Sparkle */ = {
 			isa = PBXGroup;
 			children = (
+				720767D01E2E3DD300F9A850 /* AppKitPrevention.h */,
 				61299B3909CB055000B7442F /* Appcast Support */,
 				55C14BD5136EEFD000649790 /* Autoupdate */,
 				089C1665FE841158C02AAC07 /* Framework Resources */,

--- a/Sparkle/AppKitPrevention.h
+++ b/Sparkle/AppKitPrevention.h
@@ -1,0 +1,16 @@
+//
+//  AppKitPrevention.h
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 1/17/17.
+//  Copyright © 2017 Sparkle Project. All rights reserved.
+//
+
+// #include (not #import) this header to prevent AppKit from being imported
+// Note this should be your LAST #include in your implementation file
+
+// If this error is triggered, you can have Xcode indicate to you which source file including this header caused the issue
+
+#ifdef _APPKITDEFINES_H
+#error This is a core or daemon-safe module and should NOT import AppKit
+#endif

--- a/Sparkle/AppKitPrevention.h
+++ b/Sparkle/AppKitPrevention.h
@@ -11,6 +11,10 @@
 
 // If this error is triggered, you can have Xcode indicate to you which source file including this header caused the issue
 
+// One may wonder for certain targets where AppKit is banned completely, why just not link AppKit instead.
+// Well, Xcode has thing called auto-linking that I don't trust very much.
+// Even after trying to disable the setting, I've had targets able to link to AppKit without AppKit being specified in the list of linked libraries.
+
 #ifdef _APPKITDEFINES_H
 #error This is a core or daemon-safe module and should NOT import AppKit
 #endif

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -12,6 +12,10 @@
 #import "SULocalizations.h"
 #import "SUErrors.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface NSXMLElement (SUAppcastExtensions)
 @property (readonly, copy) NSDictionary *attributesAsDictionary;
 @end

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -12,9 +12,8 @@
 #import "SULocalizations.h"
 #import "SUErrors.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface NSXMLElement (SUAppcastExtensions)
 @property (readonly, copy) NSDictionary *attributesAsDictionary;

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -10,9 +10,8 @@
 #import "SULog.h"
 #import "SUConstants.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUAppcastItem ()
 @property (copy, readwrite) NSString *title;

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -10,6 +10,10 @@
 #import "SULog.h"
 #import "SUConstants.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUAppcastItem ()
 @property (copy, readwrite) NSString *title;
 @property (copy, readwrite) NSString *dateString;

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -15,9 +15,8 @@
 #include <stdlib.h>
 #include <xar/xar.h>
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 static BOOL applyBinaryDeltaToFile(xar_t x, xar_file_t file, NSString *sourceFilePath, NSString *destinationFilePath)
 {

--- a/Sparkle/SUBinaryDeltaApply.m
+++ b/Sparkle/SUBinaryDeltaApply.m
@@ -15,6 +15,10 @@
 #include <stdlib.h>
 #include <xar/xar.h>
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 static BOOL applyBinaryDeltaToFile(xar_t x, xar_file_t file, NSString *sourceFilePath, NSString *destinationFilePath)
 {
     NSString *patchFile = temporaryFilename(@"apply-binary-delta");

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -18,9 +18,8 @@
 #include <sys/stat.h>
 #include <xar/xar.h>
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 int compareFiles(const FTSENT **a, const FTSENT **b)
 {

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -18,6 +18,10 @@
 #include <sys/stat.h>
 #include <xar/xar.h>
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 int compareFiles(const FTSENT **a, const FTSENT **b)
 {
     return strcoll((*a)->fts_name, (*b)->fts_name);

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -21,9 +21,8 @@
 #include <sys/xattr.h>
 #include <xar/xar.h>
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 extern int bsdiff(int argc, const char **argv);
 

--- a/Sparkle/SUBinaryDeltaCreate.m
+++ b/Sparkle/SUBinaryDeltaCreate.m
@@ -21,6 +21,10 @@
 #include <sys/xattr.h>
 #include <xar/xar.h>
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 extern int bsdiff(int argc, const char **argv);
 
 @interface CreateBinaryDeltaOperation : NSOperation

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -20,6 +20,10 @@
 #define VERSION_COMMAND @"version"
 #define VERSION_ALTERNATE_COMMAND @"--version"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 static void printUsage(NSString *programName)
 {
     fprintf(stderr, "Usage:\n");

--- a/Sparkle/SUBinaryDeltaTool.m
+++ b/Sparkle/SUBinaryDeltaTool.m
@@ -20,9 +20,7 @@
 #define VERSION_COMMAND @"version"
 #define VERSION_ALTERNATE_COMMAND @"--version"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+#include "AppKitPrevention.h"
 
 static void printUsage(NSString *programName)
 {

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -13,6 +13,10 @@
 #import "SULog.h"
 #import "SUFileManager.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUBinaryDeltaUnarchiver ()
 
 @property (nonatomic, copy, readonly) NSString *archivePath;

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -13,9 +13,8 @@
 #import "SULog.h"
 #import "SUFileManager.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUBinaryDeltaUnarchiver ()
 

--- a/Sparkle/SUBundleIcon.m
+++ b/Sparkle/SUBundleIcon.m
@@ -8,9 +8,8 @@
 
 #import "SUBundleIcon.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUBundleIcon
 

--- a/Sparkle/SUBundleIcon.m
+++ b/Sparkle/SUBundleIcon.m
@@ -8,6 +8,10 @@
 
 #import "SUBundleIcon.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUBundleIcon
 
 + (NSURL *)iconURLForBundle:(NSBundle *)bundle

--- a/Sparkle/SUCodeSigningVerifier.m
+++ b/Sparkle/SUCodeSigningVerifier.m
@@ -11,9 +11,8 @@
 #import "SUCodeSigningVerifier.h"
 #import "SULog.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUCodeSigningVerifier
 

--- a/Sparkle/SUCodeSigningVerifier.m
+++ b/Sparkle/SUCodeSigningVerifier.m
@@ -11,6 +11,10 @@
 #import "SUCodeSigningVerifier.h"
 #import "SULog.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUCodeSigningVerifier
 
 + (BOOL)codeSignatureAtBundleURL:(NSURL *)oldBundleURL matchesSignatureAtBundleURL:(NSURL *)newBundleURL error:(NSError *__autoreleasing *)error

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -13,6 +13,10 @@
 #define DEBUG 0
 #endif
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 // Define some minimum intervals to avoid DoS-like checking attacks
 const NSTimeInterval SUMinimumUpdateCheckInterval = DEBUG ? 60 : (60 * 60);
 const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -13,9 +13,7 @@
 #define DEBUG 0
 #endif
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+#include "AppKitPrevention.h"
 
 // Define some minimum intervals to avoid DoS-like checking attacks
 const NSTimeInterval SUMinimumUpdateCheckInterval = DEBUG ? 60 : (60 * 60);

--- a/Sparkle/SUDSAVerifier.m
+++ b/Sparkle/SUDSAVerifier.m
@@ -16,6 +16,10 @@
 #import "SULog.h"
 #include <CommonCrypto/CommonDigest.h>
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUDSAVerifier {
     SecKeyRef _secKey;
 }

--- a/Sparkle/SUDSAVerifier.m
+++ b/Sparkle/SUDSAVerifier.m
@@ -16,9 +16,8 @@
 #import "SULog.h"
 #include <CommonCrypto/CommonDigest.h>
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUDSAVerifier {
     SecKeyRef _secKey;

--- a/Sparkle/SUDiskImageUnarchiver.m
+++ b/Sparkle/SUDiskImageUnarchiver.m
@@ -10,9 +10,8 @@
 #import "SUUnarchiverNotifier.h"
 #import "SULog.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUDiskImageUnarchiver ()
 

--- a/Sparkle/SUDiskImageUnarchiver.m
+++ b/Sparkle/SUDiskImageUnarchiver.m
@@ -10,6 +10,10 @@
 #import "SUUnarchiverNotifier.h"
 #import "SULog.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUDiskImageUnarchiver ()
 
 @property (nonatomic, copy, readonly) NSString *archivePath;

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -15,6 +15,10 @@
 #include <sys/errno.h>
 #include <sys/time.h>
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 static char SUAppleQuarantineIdentifier[] = "com.apple.quarantine";
 
 static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -15,9 +15,8 @@
 #include <sys/errno.h>
 #include <sys/time.h>
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 static char SUAppleQuarantineIdentifier[] = "com.apple.quarantine";
 

--- a/Sparkle/SUGuidedPackageInstaller.m
+++ b/Sparkle/SUGuidedPackageInstaller.m
@@ -9,6 +9,10 @@
 #import "SUGuidedPackageInstaller.h"
 #import "SUFileManager.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUGuidedPackageInstaller ()
 
 @property (nonatomic, readonly, copy) NSString *packagePath;

--- a/Sparkle/SUGuidedPackageInstaller.m
+++ b/Sparkle/SUGuidedPackageInstaller.m
@@ -9,9 +9,8 @@
 #import "SUGuidedPackageInstaller.h"
 #import "SUFileManager.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUGuidedPackageInstaller ()
 

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -11,6 +11,10 @@
 #include <sys/mount.h> // For statfs for isRunningOnReadOnlyVolume
 #import "SULog.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 // This class should not rely on AppKit and should also be process independent
 // For example, it should not have code that tests writabilty to somewhere on disk,
 // as that may depend on the privileges of the process owner. Or code that depends on

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -11,9 +11,8 @@
 #include <sys/mount.h> // For statfs for isRunningOnReadOnlyVolume
 #import "SULog.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 // This class should not rely on AppKit and should also be process independent
 // For example, it should not have code that tests writabilty to somewhere on disk,

--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -15,9 +15,8 @@
 #import "SULog.h"
 #import "SUErrors.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUInstaller
 

--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -15,6 +15,10 @@
 #import "SULog.h"
 #import "SUErrors.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUInstaller
 
 + (BOOL)isAliasFolderAtPath:(NSString *)path

--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -13,6 +13,9 @@
 
 #include "SULog.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
 
 // -----------------------------------------------------------------------------
 //	Constants:

--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -13,9 +13,8 @@
 
 #include "SULog.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 // -----------------------------------------------------------------------------
 //	Constants:

--- a/Sparkle/SUOperatingSystem.m
+++ b/Sparkle/SUOperatingSystem.m
@@ -7,9 +7,8 @@
 
 #import "SUOperatingSystem.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED < 101000
 @interface NSProcessInfo ()

--- a/Sparkle/SUOperatingSystem.m
+++ b/Sparkle/SUOperatingSystem.m
@@ -7,6 +7,10 @@
 
 #import "SUOperatingSystem.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 #if __MAC_OS_X_VERSION_MAX_ALLOWED < 101000
 @interface NSProcessInfo ()
 - (NSOperatingSystemVersion)operatingSystemVersion;

--- a/Sparkle/SUPackageInstaller.m
+++ b/Sparkle/SUPackageInstaller.m
@@ -11,9 +11,8 @@
 #import "SUErrors.h"
 #import "SULog.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUPackageInstaller ()
 

--- a/Sparkle/SUPackageInstaller.m
+++ b/Sparkle/SUPackageInstaller.m
@@ -11,6 +11,10 @@
 #import "SUErrors.h"
 #import "SULog.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUPackageInstaller ()
 
 @property (nonatomic, readonly, copy) NSString *packagePath;

--- a/Sparkle/SUPipedUnarchiver.m
+++ b/Sparkle/SUPipedUnarchiver.m
@@ -11,6 +11,10 @@
 #import "SULog.h"
 #import "SUErrors.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUPipedUnarchiver ()
 
 @property (nonatomic, copy, readonly) NSString *archivePath;

--- a/Sparkle/SUPipedUnarchiver.m
+++ b/Sparkle/SUPipedUnarchiver.m
@@ -11,9 +11,8 @@
 #import "SULog.h"
 #import "SUErrors.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUPipedUnarchiver ()
 

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -14,9 +14,8 @@
 #import "SULog.h"
 #import "SUErrors.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUPlainInstaller ()
 

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -14,6 +14,10 @@
 #import "SULog.h"
 #import "SUErrors.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUPlainInstaller ()
 
 @property (nonatomic, readonly) SUHost *host;

--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -9,9 +9,8 @@
 #import "SUVersionComparisonProtocol.h"
 #import "SUStandardVersionComparator.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUStandardVersionComparator
 

--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -9,6 +9,10 @@
 #import "SUVersionComparisonProtocol.h"
 #import "SUStandardVersionComparator.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUStandardVersionComparator
 
 - (instancetype)init

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -14,6 +14,10 @@
 #import "SUOperatingSystem.h"
 #include <sys/sysctl.h>
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 static NSString *const SUSystemProfilerApplicationNameKey = @"appName";
 static NSString *const SUSystemProfilerApplicationVersionKey = @"appVersion";
 static NSString *const SUSystemProfilerCPU64bitKey = @"cpu64bit";

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -9,14 +9,12 @@
 
 #import <Foundation/Foundation.h>
 #import "SUSystemProfiler.h"
-
 #import "SUHost.h"
 #import "SUOperatingSystem.h"
 #include <sys/sysctl.h>
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 static NSString *const SUSystemProfilerApplicationNameKey = @"appName";
 static NSString *const SUSystemProfilerApplicationVersionKey = @"appVersion";

--- a/Sparkle/SUSystemUpdateInfo.m
+++ b/Sparkle/SUSystemUpdateInfo.m
@@ -11,6 +11,10 @@
 #import "SUConstants.h"
 #import "SUFileManager.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUSystemUpdateInfo
 
 + (BOOL)systemAllowsAutomaticUpdatesForHost:(SUHost *)host

--- a/Sparkle/SUSystemUpdateInfo.m
+++ b/Sparkle/SUSystemUpdateInfo.m
@@ -11,9 +11,8 @@
 #import "SUConstants.h"
 #import "SUFileManager.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUSystemUpdateInfo
 

--- a/Sparkle/SUUnarchiver.m
+++ b/Sparkle/SUUnarchiver.m
@@ -12,9 +12,8 @@
 #import "SUDiskImageUnarchiver.h"
 #import "SUBinaryDeltaUnarchiver.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUUnarchiver
 

--- a/Sparkle/SUUnarchiver.m
+++ b/Sparkle/SUUnarchiver.m
@@ -12,6 +12,10 @@
 #import "SUDiskImageUnarchiver.h"
 #import "SUBinaryDeltaUnarchiver.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUUnarchiver
 
 + (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword

--- a/Sparkle/SUUnarchiverNotifier.m
+++ b/Sparkle/SUUnarchiverNotifier.m
@@ -10,6 +10,10 @@
 #import "SULocalizations.h"
 #import "SUErrors.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUUnarchiverNotifier ()
 
 @property (nonatomic, readonly, copy) void (^completionBlock)(NSError * _Nullable);

--- a/Sparkle/SUUnarchiverNotifier.m
+++ b/Sparkle/SUUnarchiverNotifier.m
@@ -10,9 +10,8 @@
 #import "SULocalizations.h"
 #import "SUErrors.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUUnarchiverNotifier ()
 

--- a/Sparkle/SUUpdatePermissionResponse.m
+++ b/Sparkle/SUUpdatePermissionResponse.m
@@ -8,6 +8,10 @@
 
 #import "SUUpdatePermissionResponse.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @implementation SUUpdatePermissionResponse
 
 @synthesize automaticUpdateChecks = _automaticUpdateChecks;

--- a/Sparkle/SUUpdatePermissionResponse.m
+++ b/Sparkle/SUUpdatePermissionResponse.m
@@ -8,9 +8,8 @@
 
 #import "SUUpdatePermissionResponse.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @implementation SUUpdatePermissionResponse
 

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -13,6 +13,10 @@
 #import "SUHost.h"
 #import "SULog.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 @interface SUUpdateValidator ()
 
 @property (nonatomic, readonly) SUHost *host;

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -13,9 +13,8 @@
 #import "SUHost.h"
 #import "SULog.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 @interface SUUpdateValidator ()
 

--- a/fileop/SUFileOperationConstants.m
+++ b/fileop/SUFileOperationConstants.m
@@ -8,6 +8,10 @@
 
 #import "SUFileOperationConstants.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 char * const SUFileOpRemoveQuarantineCommand = "xattr-d-apple-quarantine";
 char * const SUFileOpCopyCommand = "cp";
 char * const SUFileOpMoveCommand = "mv";

--- a/fileop/SUFileOperationConstants.m
+++ b/fileop/SUFileOperationConstants.m
@@ -8,9 +8,8 @@
 
 #import "SUFileOperationConstants.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 char * const SUFileOpRemoveQuarantineCommand = "xattr-d-apple-quarantine";
 char * const SUFileOpCopyCommand = "cp";

--- a/fileop/fileop.m
+++ b/fileop/fileop.m
@@ -10,6 +10,10 @@
 #import "SUFileManager.h"
 #import "SUFileOperationConstants.h"
 
+#ifdef _APPKITDEFINES_H
+#error This is a "core" class and should NOT import AppKit
+#endif
+
 // If we fail, we exit with a unique status code
 // We don't try to NSLog because the logs can't be seen anywhere,
 // and we don't want to log to a file irresponsibly (especially as root),

--- a/fileop/fileop.m
+++ b/fileop/fileop.m
@@ -10,9 +10,8 @@
 #import "SUFileManager.h"
 #import "SUFileOperationConstants.h"
 
-#ifdef _APPKITDEFINES_H
-#error This is a "core" class and should NOT import AppKit
-#endif
+
+#include "AppKitPrevention.h"
 
 // If we fail, we exit with a unique status code
 // We don't try to NSLog because the logs can't be seen anywhere,


### PR DESCRIPTION
Just to synchronize more changes..

I'm not sure there's a better way to do this.

The internal update drivers and SUUpdate still need AppKit, which is inevitable for `master` branch.