### PR TITLE
Add touch bar build support for Xcode 8.0 and earlier

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -800,6 +800,7 @@
 		C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSignApp.enc.dmg; sourceTree = "<group>"; };
 		E1545EC31E1D7E0200FAECE8 /* SUTouchBarButtonGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUTouchBarButtonGroup.h; sourceTree = "<group>"; };
 		E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUTouchBarButtonGroup.m; sourceTree = "<group>"; };
+		E19CA4901E2E7E4D009D4D18 /* SUTouchBarForwardDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUTouchBarForwardDeclarations.h; sourceTree = "<group>"; };
 		F8761EB01ADC5068000C9034 /* SUCodeSigningVerifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUCodeSigningVerifierTest.m; sourceTree = "<group>"; };
 		F8761EB21ADC50EB000C9034 /* SparkleTestCodeSignApp.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = SparkleTestCodeSignApp.zip; sourceTree = "<group>"; };
 		FA1941CA0D94A70100DD942E /* ConfigFrameworkDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ConfigFrameworkDebug.xcconfig; sourceTree = "<group>"; };
@@ -1182,6 +1183,7 @@
 				7205C4301E1215AD00E370AE /* SUUpdatePermissionResponse.m */,
 				E1545EC31E1D7E0200FAECE8 /* SUTouchBarButtonGroup.h */,
 				E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */,
+				E19CA4901E2E7E4D009D4D18 /* SUTouchBarForwardDeclarations.h */,
 			);
 			name = "User Interface";
 			sourceTree = "<group>";

--- a/Sparkle/SUAutomaticUpdateAlert.m
+++ b/Sparkle/SUAutomaticUpdateAlert.m
@@ -11,6 +11,7 @@
 #import "SUAppcastItem.h"
 #import "SUApplicationInfo.h"
 #import "SUHost.h"
+#import "SUTouchBarForwardDeclarations.h"
 #import "SUTouchBarButtonGroup.h"
 
 static NSString *const SUAutomaticUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDENTIFIER ".SUAutomaticUpdateAlert";
@@ -109,7 +110,7 @@ static NSString *const SUAutomaticUpdateAlertTouchBarIndentifier = @"" SPARKLE_B
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSTouchBar alloc] init];
+    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[SUAutomaticUpdateAlertTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUAutomaticUpdateAlertTouchBarIndentifier;
     touchBar.delegate = self;
@@ -119,7 +120,7 @@ static NSString *const SUAutomaticUpdateAlertTouchBarIndentifier = @"" SPARKLE_B
 - (NSTouchBarItem *)touchBar:(NSTouchBar * __unused)touchBar makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
 {
     if ([identifier isEqualToString:SUAutomaticUpdateAlertTouchBarIndentifier]) {
-        NSCustomTouchBarItem* item = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSCustomTouchBarItem* item = [(NSCustomTouchBarItem *)[NSClassFromString(@"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier];
         item.viewController = [[SUTouchBarButtonGroup alloc] initByReferencingButtons:@[self.installButton, self.laterButton, self.skipButton]];
         return item;
     }

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -11,6 +11,7 @@
 #import "SUHost.h"
 #import "SULocalizations.h"
 #import "SUApplicationInfo.h"
+#import "SUTouchBarForwardDeclarations.h"
 #import "SUTouchBarButtonGroup.h"
 
 static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDENTIFIER ".SUStatusController";
@@ -135,7 +136,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSTouchBar alloc] init];
+    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[ SUStatusControllerTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUStatusControllerTouchBarIndentifier;
     touchBar.delegate = self;
@@ -145,7 +146,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 - (NSTouchBarItem *)touchBar:(NSTouchBar * __unused)touchBar makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
 {
     if ([identifier isEqualToString:SUStatusControllerTouchBarIndentifier]) {
-        NSCustomTouchBarItem *item = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSCustomTouchBarItem *item = [(NSCustomTouchBarItem *)[NSClassFromString(@"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier];
         SUTouchBarButtonGroup *group = [[SUTouchBarButtonGroup alloc] initByReferencingButtons:@[self.actionButton,]];
         item.viewController = group;
         self.touchBarButton = group.buttons.firstObject;

--- a/Sparkle/SUTouchBarButtonGroup.h
+++ b/Sparkle/SUTouchBarButtonGroup.h
@@ -8,10 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class NSTouchBar;
-@class NSTouchBarItem;
-@class NSCustomTouchBarItem;
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SUTouchBarButtonGroup : NSViewController

--- a/Sparkle/SUTouchBarForwardDeclarations.h
+++ b/Sparkle/SUTouchBarForwardDeclarations.h
@@ -1,0 +1,91 @@
+//
+//  SUTouchBarForwardDeclarations.h
+//  Sparkle
+//
+//  Created by Yuxin Wang on 18/01/2017.
+//  Copyright © 2017 Sparkle Project. All rights reserved.
+//
+
+// Once Sparkle no longer supports OSX 10.12.0, this file can be deleted.
+
+#import <Foundation/Foundation.h>
+
+#if !defined(MAC_OS_X_VERSION_10_12_1)
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class NSTouchBar;
+@class NSTouchBarItem;
+@class NSCustomTouchBarItem;
+
+typedef NSString * NSTouchBarItemIdentifier NS_EXTENSIBLE_STRING_ENUM;
+typedef NSString * NSTouchBarCustomizationIdentifier NS_EXTENSIBLE_STRING_ENUM;
+
+@protocol NSTouchBarDelegate;
+
+NS_CLASS_AVAILABLE_MAC(10_12_2)
+@interface NSTouchBar : NSObject <NSCoding>
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+@property (copy, nullable) NSTouchBarCustomizationIdentifier customizationIdentifier;
+@property (copy) NSArray<NSTouchBarItemIdentifier> *customizationAllowedItemIdentifiers;
+@property (copy) NSArray<NSTouchBarItemIdentifier> *customizationRequiredItemIdentifiers;
+@property (copy) NSArray<NSTouchBarItemIdentifier> *defaultItemIdentifiers;
+@property (copy, readonly) NSArray<NSTouchBarItemIdentifier> *itemIdentifiers;
+@property (copy, nullable) NSTouchBarItemIdentifier principalItemIdentifier;
+@property (copy, nullable) NSTouchBarItemIdentifier escapeKeyReplacementItemIdentifier;
+@property (copy) NSSet<NSTouchBarItem *> *templateItems;
+@property (nullable, weak) id <NSTouchBarDelegate> delegate;
+- (nullable __kindof NSTouchBarItem *)itemForIdentifier:(NSTouchBarItemIdentifier)identifier;
+@property (readonly, getter=isVisible) BOOL visible;
+
+@end
+
+@protocol NSTouchBarDelegate<NSObject>
+@optional
+- (nullable NSTouchBarItem*)touchBar:(NSTouchBar*)touchBar
+               makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier;
+@end
+
+typedef float NSTouchBarItemPriority _NS_TYPED_EXTENSIBLE_ENUM;
+
+NS_CLASS_AVAILABLE_MAC(10_12_2)
+@interface NSTouchBarItem : NSObject <NSCoding>
+
+- (instancetype)initWithIdentifier:(NSTouchBarItemIdentifier)identifier NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (readonly, copy) NSTouchBarItemIdentifier identifier;
+@property NSTouchBarItemPriority visibilityPriority;
+@property (readonly, nullable) NSView *view;
+@property (readonly, nullable) NSViewController *viewController;
+@property (readonly, copy) NSString *customizationLabel;
+@property (readonly, getter=isVisible) BOOL visible;
+
+@end
+
+NS_CLASS_AVAILABLE_MAC(10_12_2)
+@interface NSCustomTouchBarItem : NSTouchBarItem
+
+@property (readwrite, strong) __kindof NSView *view;
+@property (readwrite, strong, nullable) __kindof NSViewController *viewController;
+@property (readwrite, copy, null_resettable) NSString *customizationLabel;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#elif MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12_1
+
+// When compiling against the 10.12.1 SDK or later, just provide forward
+// declarations to suppress the partial availability warnings.
+
+@class NSTouchBar;
+@protocol NSTouchBarDelegate;
+@class NSTouchBarItem;
+@class NSCustomTouchBarItem;
+
+#endif  // MAC_OS_X_VERSION_10_12_1

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -21,6 +21,7 @@
 #import "SUAppcastItem.h"
 #import "SUApplicationInfo.h"
 #import "SUSystemUpdateInfo.h"
+#import "SUTouchBarForwardDeclarations.h"
 #import "SUTouchBarButtonGroup.h"
 
 static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDENTIFIER ".SUUpdateAlert";
@@ -325,7 +326,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSTouchBar alloc] init];
+    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[SUUpdateAlertTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUUpdateAlertTouchBarIndentifier;
     touchBar.delegate = self;
@@ -335,7 +336,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 - (NSTouchBarItem *)touchBar:(NSTouchBar * __unused)touchBar makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
 {
     if ([identifier isEqualToString:SUUpdateAlertTouchBarIndentifier]) {
-        NSCustomTouchBarItem* item = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSCustomTouchBarItem* item = [(NSCustomTouchBarItem *)[NSClassFromString(@"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier];
         item.viewController = [[SUTouchBarButtonGroup alloc] initByReferencingButtons:@[self.installButton, self.laterButton, self.skipButton]];
         return item;
     }

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -13,6 +13,7 @@
 #import "SUConstants.h"
 #import "SULocalizations.h"
 #import "SUApplicationInfo.h"
+#import "SUTouchBarForwardDeclarations.h"
 #import "SUTouchBarButtonGroup.h"
 
 static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDENTIFIER ".SUUpdatePermissionPrompt";
@@ -169,7 +170,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSTouchBar alloc] init];
+    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[SUUpdatePermissionPromptTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUUpdatePermissionPromptTouchBarIndentifier;
     touchBar.delegate = self;
@@ -179,7 +180,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 - (NSTouchBarItem *)touchBar:(NSTouchBar * __unused)touchBar makeItemForIdentifier:(NSTouchBarItemIdentifier)identifier
 {
     if ([identifier isEqualToString:SUUpdatePermissionPromptTouchBarIndentifier]) {
-        NSCustomTouchBarItem* item = [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier];
+        NSCustomTouchBarItem* item = [(NSCustomTouchBarItem *)[NSClassFromString(@"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier];
         item.viewController = [[SUTouchBarButtonGroup alloc] initByReferencingButtons:@[self.checkButton, self.cancelButton]];
         return item;
     }


### PR DESCRIPTION
Added forward declarations for macOS SDK < 10.12.1 . So the touch bar still works if Sparkle is built with old SDKs. I've tested the build with Xcode8.0 .

I added two `osx_image` is Travis, both `xcode8` and `xcode8.2`, in another branch.
I don't know if it is a legal build matrix for Travis, since the build is still queued.