### PR TITLE
Update button outlets for all xib files

### DIFF
--- a/Sparkle/ar.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/ar.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/ar.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/ar.lproj/SUUpdatePermissionPrompt.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/cs.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/cs.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/cs.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/cs.lproj/SUUpdatePermissionPrompt.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/da.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/da.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/da.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/da.lproj/SUUpdatePermissionPrompt.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/de.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/de.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/de.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/el.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/el.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/el.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/el.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/es.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/es.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/es.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/es.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/fr.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/fr.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/fr.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/fr.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/is.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/is.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/is.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/is.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/it.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/it.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/it.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/it.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/ja.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/ja.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/ja.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/ja.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/ko.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/ko.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/ko.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/ko.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/nb.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/nb.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/nb.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/nb.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/nl.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/nl.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/nl.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/nl.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/pl.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/pl.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/pl.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/pl.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/pt_BR.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/pt_BR.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/pt_BR.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/pt_BR.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/pt_PT.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/pt_PT.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/pt_PT.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/pt_PT.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/ro.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/ro.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/ro.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/ro.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/ru.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/ru.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/ru.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/ru.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/sk.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/sk.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/sk.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/sk.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/sl.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/sl.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/sl.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/sl.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/sv.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/sv.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/sv.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/sv.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/th.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/th.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/th.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/th.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/tr.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/tr.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/tr.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/tr.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/uk.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/uk.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/uk.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/uk.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/zh_CN.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/zh_CN.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/zh_CN.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/zh_CN.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>

--- a/Sparkle/zh_TW.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/zh_TW.lproj/SUAutomaticUpdateAlert.xib
@@ -6,6 +6,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUAutomaticUpdateAlert">
             <connections>
+                <outlet property="installButton" destination="15" id="VHi-SZ-6td"/>
+                <outlet property="laterButton" destination="16" id="AZg-1M-E8w"/>
                 <outlet property="skipButton" destination="30" id="LpO-Ax-F1B"/>
                 <outlet property="window" destination="5" id="22"/>
             </connections>

--- a/Sparkle/zh_TW.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/zh_TW.lproj/SUUpdatePermissionPrompt.xib
@@ -7,6 +7,8 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="cancelButton" destination="14" id="gmk-EB-rHf"/>
+                <outlet property="checkButton" destination="13" id="JAM-bi-JDs"/>
                 <outlet property="descriptionTextField" destination="33" id="133"/>
                 <outlet property="moreInfoButton" destination="71" id="132"/>
                 <outlet property="moreInfoView" destination="39" id="127"/>


### PR DESCRIPTION
This is a simple text replacement.

I noticed that ca.lproj, fi.lproj, he.lproj and no.lproj have only .strings files instead of .xib files.