### PR TITLE
Add support for updates with flat packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,6 +5,7 @@ Copyright (c) 2015-2017 Mayur Pawashe.
 Copyright (c) 2014 C.W. Betts.
 Copyright (c) 2014 Petroules Corporation.
 Copyright (c) 2014 Big Nerd Ranch.
+Copyright (c) 2017 Andoni Morales Alastruey.
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -188,6 +188,9 @@
 		61F83F720DBFE140006FDD30 /* SUBasicUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */; };
 		61F83F740DBFE141006FDD30 /* SUBasicUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */; settings = {ATTRIBUTES = (); }; };
 		61FA52880E2D9EA400EF58AD /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* Sparkle.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		6A8FA7241E4602B500B02731 /* SUNoOpUnarchiver.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A8FA7231E4602B500B02731 /* SUNoOpUnarchiver.h */; };
+		6A8FA7271E460A6A00B02731 /* SUNoOpUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A8FA7251E4602FE00B02731 /* SUNoOpUnarchiver.m */; };
+		6A8FA7291E460A6B00B02731 /* SUNoOpUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A8FA7251E4602FE00B02731 /* SUNoOpUnarchiver.m */; };
 		7205C4311E1215AD00E370AE /* SUUpdatePermissionResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 7205C42F1E1215AD00E370AE /* SUUpdatePermissionResponse.h */; };
 		7205C4321E1215AD00E370AE /* SUUpdatePermissionResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 7205C4301E1215AD00E370AE /* SUUpdatePermissionResponse.m */; };
 		720767CF1E2DC37400F9A850 /* TerminationListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 720767CE1E2DC37400F9A850 /* TerminationListener.m */; };
@@ -731,6 +734,8 @@
 		61F614540E24A12D009F47E7 /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		61F83F6F0DBFE137006FDD30 /* SUBasicUpdateDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUBasicUpdateDriver.h; sourceTree = "<group>"; };
 		61F83F700DBFE137006FDD30 /* SUBasicUpdateDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUBasicUpdateDriver.m; sourceTree = "<group>"; };
+		6A8FA7231E4602B500B02731 /* SUNoOpUnarchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUNoOpUnarchiver.h; sourceTree = "<group>"; };
+		6A8FA7251E4602FE00B02731 /* SUNoOpUnarchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUNoOpUnarchiver.m; sourceTree = "<group>"; };
 		7205C42E1E11A6DA00E370AE /* SUInstallerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUInstallerProtocol.h; sourceTree = "<group>"; };
 		7205C42F1E1215AD00E370AE /* SUUpdatePermissionResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUUpdatePermissionResponse.h; sourceTree = "<group>"; };
 		7205C4301E1215AD00E370AE /* SUUpdatePermissionResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUUpdatePermissionResponse.m; sourceTree = "<group>"; };
@@ -1134,6 +1139,8 @@
 				722589D81E0B19F4005EA0B9 /* SUUnarchiverNotifier.h */,
 				722589D91E0B19F4005EA0B9 /* SUUnarchiverNotifier.m */,
 				722589D61E0AD86B005EA0B9 /* SUUnarchiverProtocol.h */,
+				6A8FA7231E4602B500B02731 /* SUNoOpUnarchiver.h */,
+				6A8FA7251E4602FE00B02731 /* SUNoOpUnarchiver.m */,
 			);
 			name = Unarchiving;
 			sourceTree = "<group>";
@@ -1413,6 +1420,7 @@
 				61A2279C0D1CEE7600430CCD /* SUSystemProfiler.h in Headers */,
 				72316BE31E0E1C7F0039EFD9 /* SUSystemUpdateInfo.h in Headers */,
 				E1545EC51E1D7E0200FAECE8 /* SUTouchBarButtonGroup.h in Headers */,
+				6A8FA7241E4602B500B02731 /* SUNoOpUnarchiver.h in Headers */,
 				61B93A3C0DD02D7000DCD2F8 /* SUUIBasedUpdateDriver.h in Headers */,
 				61299A8D09CA790200B7442F /* SUUnarchiver.h in Headers */,
 				722589DA1E0B19F4005EA0B9 /* SUUnarchiverNotifier.h in Headers */,
@@ -1890,6 +1898,7 @@
 			files = (
 				5AE13FA01E0D4F65000D2C2C /* Appcast.swift in Sources */,
 				5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */,
+				6A8FA7291E460A6B00B02731 /* SUNoOpUnarchiver.m in Sources */,
 				5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */,
 				5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */,
 				5AE13FBB1E0DA391000D2C2C /* bspatch.c in Sources */,
@@ -2032,6 +2041,7 @@
 				61B93A3D0DD02D7000DCD2F8 /* SUUIBasedUpdateDriver.m in Sources */,
 				61299A8E09CA790200B7442F /* SUUnarchiver.m in Sources */,
 				722589DB1E0B19F4005EA0B9 /* SUUnarchiverNotifier.m in Sources */,
+				6A8FA7271E460A6A00B02731 /* SUNoOpUnarchiver.m in Sources */,
 				61B5FCDE09C52A9F00B25A18 /* SUUpdateAlert.m in Sources */,
 				610134740DD250470049ACDF /* SUUpdateDriver.m in Sources */,
 				612DCBB00D488BC60015DBEA /* SUUpdatePermissionPrompt.m in Sources */,

--- a/Sparkle/SUNoOpUnarchiver.h
+++ b/Sparkle/SUNoOpUnarchiver.h
@@ -1,0 +1,25 @@
+//
+//  SUNoOpUnarchiver.h
+//  Sparkle
+//
+//  Created by Andoni Morales Alastruey on 4/2/17.
+//  Copyright © 2017 Sparkle Project. All rights reserved.
+//
+
+#ifndef SUNoOpUnarchiver_h
+#define SUNoOpUnarchiver_h
+
+#import <Foundation/Foundation.h>
+#import "SUUnarchiverProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SUNoOpUnarchiver : NSObject <SUUnarchiverProtocol>
+
+- (instancetype)initWithArchivePath:(NSString *)archivePath;
+@end
+
+NS_ASSUME_NONNULL_END
+
+
+#endif /* SUNoOpUnarchiver_h */

--- a/Sparkle/SUNoOpUnarchiver.m
+++ b/Sparkle/SUNoOpUnarchiver.m
@@ -1,0 +1,64 @@
+//
+//  SUNoOpUnarchiver.m
+//  Sparkle
+//
+//  Created by Andoni Morales Alastruey on 4/2/17.
+//  Copyright © 2017 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "SUNoOpUnarchiver.h"
+#import "SUUnarchiverNotifier.h"
+#import "SULog.h"
+#import "SUErrors.h"
+
+#include "AppKitPrevention.h"
+
+@interface SUNoOpUnarchiver ()
+
+@property (nonatomic, copy, readonly) NSString *archivePath;
+
+@end
+
+@implementation SUNoOpUnarchiver
+
+@synthesize archivePath = _archivePath;
+
++ (BOOL)canUnarchivePath:(NSString *)path
+{
+    NSArray<NSString *> *extensionsArray = @[@".pkg", @".mpkg"];
+
+    NSString *lastPathComponent = [path lastPathComponent];
+    for (NSString *currentExtension in extensionsArray)
+    {
+        if ([lastPathComponent hasSuffix:currentExtension]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
++ (BOOL)unsafeIfArchiveIsNotValidated
+{
+    return NO;
+}
+
+- (instancetype)initWithArchivePath:(NSString *)archivePath
+{
+    self = [super init];
+    if (self != nil) {
+        _archivePath = [archivePath copy];
+    }
+    return self;
+}
+
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock
+{
+    SUUnarchiverNotifier *notifier = [[SUUnarchiverNotifier alloc] initWithCompletionBlock:completionBlock progressBlock:progressBlock];
+    [notifier notifySuccess];
+}
+
+- (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], self.archivePath]; }
+
+@end

--- a/Sparkle/SUUnarchiver.m
+++ b/Sparkle/SUUnarchiver.m
@@ -11,6 +11,7 @@
 #import "SUPipedUnarchiver.h"
 #import "SUDiskImageUnarchiver.h"
 #import "SUBinaryDeltaUnarchiver.h"
+#import "SUNoOpUnarchiver.h"
 
 
 #include "AppKitPrevention.h"
@@ -29,6 +30,8 @@
         assert(hostPath != nil);
         NSString *nonNullHostPath = hostPath;
         return [[SUBinaryDeltaUnarchiver alloc] initWithArchivePath:path updateHostBundlePath:nonNullHostPath];
+    } else if ([SUNoOpUnarchiver canUnarchivePath:path]) {
+        return [[SUNoOpUnarchiver alloc] initWithArchivePath:path];
     }
     return nil;
 }


### PR DESCRIPTION
Flat packages are already archived and compressed so they
can be distrubuted as they are without the need to apply
and extra tar/zip archiving.
This commit adds a new unarchiver implementation that does
nothing with udpates using the .pkg or .mpkg extension

Fixes #54