### PR TITLE
Don't touch Info.plist unless git version changes

### DIFF
--- a/Configurations/set-git-version-info.sh
+++ b/Configurations/set-git-version-info.sh
@@ -30,5 +30,11 @@ fi
 
 # and use it to set the CFBundleShortVersionString value
 export PATH="$PATH:/usr/libexec"
-PlistBuddy -c "Set :CFBundleShortVersionString '$version'" \
-    "$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH"
+
+if [ -f "$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH" ] ; then
+    oldversion=$(PlistBuddy -c "Print :CFBundleShortVersionString" "$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH")
+fi
+if [ "$version" != "$oldversion" ] ; then
+    PlistBuddy -c "Set :CFBundleShortVersionString '$version'" \
+        "$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH"
+fi


### PR DESCRIPTION
`PlistBuddy` always touches its output file, even if the value written is identical to the value already there. In such case, Xcode sees `Info.plist` as modified, therefore sees the entire target as modified and re-runs potentially expensive operations like copying frameworks or signing.

This PR avoids unnecessary build operations by checking the previous `CFBundleShortVersionString` if `Info.plist` already exists and only updating it if necessary.

This has only a tiny impact when building Sparkle itself, but makes a huge difference if it's built as part of a larger project (e.g. included as a git submodule). In my case, this simple change reduces noop (as far as it concerns Sparkle, i.e. when compiling changes elsewhere) build time by 1.6s, because without it, every build, even if Sparkle is unmodified, requires a) copying `Sparkle.framework` and b) re-signing it during copy. 