### PR TITLE
Disable the keyboard shortcut for the install button for scheduled updates to avoid accidental installs.

### DIFF
--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -56,4 +56,8 @@
     }
 }
 
+- (BOOL)shouldDisableKeyboardShortcutForInstallButton {
+    return YES;
+}
+   
 @end

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -85,10 +85,18 @@
     }
 
     // Only show the update alert if the app is active; otherwise, we'll wait until it is.
-    if ([NSApp isActive])
-        [[self.updateAlert window] makeKeyAndOrderFront:self];
-    else
+    if ([NSApp isActive]) {
+        NSWindow *window = [self.updateAlert window];
+        if ([self shouldDisableKeyboardShortcutForInstallButton]) {
+            [self.updateAlert disableKeyboardShortcutForInstallButton];
+        }
+        [window makeKeyAndOrderFront:self];
+    } else
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:NSApplicationDidBecomeActiveNotification object:NSApp];
+}
+
+- (BOOL)shouldDisableKeyboardShortcutForInstallButton {
+    return NO;
 }
 
 - (void)didNotFindUpdate

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, SUUpdateAlertChoice) {
 - (IBAction)installUpdate:sender;
 - (IBAction)skipThisVersion:sender;
 - (IBAction)remindMeLater:sender;
+- (void)disableKeyboardShortcutForInstallButton;
 
 @end
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -93,6 +93,9 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], [self.host bundlePath]]; }
 
+- (void)disableKeyboardShortcutForInstallButton {
+    self.installButton.keyEquivalent = @"";
+}
 
 - (void)endWithSelection:(SUUpdateAlertChoice)choice
 {


### PR DESCRIPTION
Scheduled updates open a key window at unpredictable times. Users find that they sometimes press <kbd>Enter</kbd> just as the window appears, causing an interruption in their work.

Example: https://gitlab.com/gnachman/iterm2/issues/5549

This commit removes the keyboard shortcut for scheduled updates, but preserves it for user-initiated updates.
