### PR TITLE
generate_appcast: if an .html file exists of the same name, create the releaseNotesLink

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -118,6 +118,22 @@ class ArchiveItem: CustomStringConvertible {
     var fileSize : Int64 {
         return (self.archiveFileAttributes[.size] as! NSNumber).int64Value;
     }
+    
+    var releaseNotesPath : URL {
+        let basename = self.archivePath.deletingPathExtension();
+        let releaseNotes = basename.appendingPathExtension("html");
+        return releaseNotes;
+    }
+
+    var releaseNotesURL : URL? {
+        guard let escapedFilename = self.releaseNotesPath.lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            return nil;
+        }
+        if let relative = self.feedURL {
+            return URL(string: escapedFilename, relativeTo: relative)
+        }
+        return URL(string: escapedFilename)
+    }
 
     let mimeType = "application/octet-stream";
 }

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -110,6 +110,19 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         }
         minVer?.setChildren([text(update.minimumSystemVersion)]);
 
+        let relElement = findElement(name: "sparkle:releaseNotesLink", parent: item);
+        if nil == relElement {
+            if FileManager.default.fileExists(atPath: update.releaseNotesPath.path) {
+                linebreak(item);
+                item.addChild(XMLElement.element(withName:"sparkle:releaseNotesLink", stringValue: (update.releaseNotesURL?.absoluteString)!) as! XMLElement);
+            }
+        } else {
+            if !FileManager.default.fileExists(atPath: update.releaseNotesPath.path) {
+                let childIndex = relElement?.index;
+                item.removeChild(at: childIndex!);
+            }
+        }
+        
         var enclosure = findElement(name: "enclosure", parent: item);
         if nil == enclosure {
             enclosure = XMLElement.element(withName: "enclosure") as? XMLElement;

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -50,7 +50,7 @@ func unarchiveUpdates(archivesSourceDir: URL) throws -> [ArchiveItem] {
 
     let dir = try fileManager.contentsOfDirectory(atPath: archivesSourceDir.path);
     var running = 0;
-    for item in dir.filter({ !$0.hasPrefix(".") && !$0.hasSuffix(".delta") && !$0.hasSuffix(".xml") }) {
+    for item in dir.filter({ !$0.hasPrefix(".") && !$0.hasSuffix(".delta") && !$0.hasSuffix(".xml") && !$0.hasSuffix(".html") }) {
         let itemPath = archivesSourceDir.appendingPathComponent(item);
         let archiveDestDir = archivesDestDir.appendingPathComponent(itemPath.lastPathComponent);
 


### PR DESCRIPTION
when generating the appcast, if an .html file exists of the same name as the archive, then it will be linked in as the `releaseNotesLink`.  If the file is later removed, the corresponding `releaseNotesLink` will also be removed. #1033