### PR TITLE
Prevent updating from running on first launch

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -221,7 +221,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
             [self resetUpdateCycle];
         }];
         // We start the update checks and register as observer for changes after the prompt finishes
-    } else {
+    } else if (hasLaunchedBefore) {
         // We check if the user's said they want updates, or they haven't said anything, and the default is set to checking.
         [self scheduleNextUpdateCheck];
     }


### PR DESCRIPTION
On first launch Sparkle will run if the shouldPrompt value is NO as a result of calling scheduleNextUpdateCheck.