### PR TITLE
Prepend app name to Autoupdate.app name

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -499,22 +499,29 @@
 
     // Copy the relauncher into a temporary directory so we can get to it after the new version's installed.
     // Only the paranoid survive: if there's already a stray copy of relaunch there, we would have problems.
-    NSString *const relaunchToolName = @"" SPARKLE_RELAUNCH_TOOL_NAME;
-    NSString *const relaunchToolSourcePath = [sparkleBundle pathForResource:relaunchToolName ofType:@"app"];
+    NSString *const relaunchToolSourceName = @"" SPARKLE_RELAUNCH_TOOL_NAME;
+    NSString *const relaunchToolSourcePath = [sparkleBundle pathForResource:relaunchToolSourceName ofType:@"app"];
     NSString *relaunchCopyTargetPath = nil;
     NSError *error = nil;
     BOOL copiedRelaunchPath = NO;
 
-    if (!relaunchToolName) {
+    if (!relaunchToolSourceName || ![relaunchToolSourceName length]) {
         SULog(SULogLevelError, @"SPARKLE_RELAUNCH_TOOL_NAME not configued");
     }
 
     if (!relaunchToolSourcePath) {
-        SULog(SULogLevelError, @"Sparkle.framework is damaged. %@ is missing", relaunchToolName);
+        SULog(SULogLevelError, @"Sparkle.framework is damaged. %@ is missing", relaunchToolSourceName);
     }
 
     if (relaunchToolSourcePath) {
-        relaunchCopyTargetPath = [[self appCachePath] stringByAppendingPathComponent:[relaunchToolSourcePath lastPathComponent]];
+        NSString *hostBundleBaseName = [[self.host.bundlePath lastPathComponent] stringByDeletingPathExtension];
+        if (!hostBundleBaseName) {
+            SULog(SULogLevelError, @"Unable to get bundlePath");
+            hostBundleBaseName = @"Sparkle";
+        }
+        NSString *relaunchCopyBaseName = [NSString stringWithFormat:@"%@ (Autoupdate).app", hostBundleBaseName];
+
+        relaunchCopyTargetPath = [[self appCachePath] stringByAppendingPathComponent:relaunchCopyBaseName];
 
         SUFileManager *fileManager = [SUFileManager defaultManager];
 


### PR DESCRIPTION
SPARKLE_RELAUNCH_TOOL_NAME config requires recompilation of Sparkle, so it's a lot of hassle.

I've realized that we don't need it. Since we're launching a copy of the Autoupdate.app, not the original in Sparkle.framework, we can rename it on the fly.

I've went for `$AppBundleName (Autoupdate).app`. It looks OK in the auth dialog.