### PR TITLE
Fix crash by accessing nil callback when replacing binary

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -548,13 +548,9 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             // Used later for relaunching
             // Compute this now before we set this installer property to nil
             NSString *installationPath = [self.installer installationPath];
-
-            void(^progressBlock)(double) = ^(double progress){
-                // not exactly sure what to do
-            };
             
             NSError *thirdStageError = nil;
-            if (![self.installer performFinalInstallationProgressBlock:progressBlock error:&thirdStageError]) {
+            if (![self.installer performFinalInstallationProgressBlock:nil error:&thirdStageError]) {
                 SULog(SULogLevelError, @"Failed to finalize installation with error: %@", thirdStageError);
                 
                 self.installer = nil;

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -548,9 +548,13 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             // Used later for relaunching
             // Compute this now before we set this installer property to nil
             NSString *installationPath = [self.installer installationPath];
+
+            void(^progressBlock)(double) = ^(double progress){
+                // not exactly sure what to do
+            };
             
             NSError *thirdStageError = nil;
-            if (![self.installer performFinalInstallationProgressBlock:nil error:&thirdStageError]) {
+            if (![self.installer performFinalInstallationProgressBlock:progressBlock error:&thirdStageError]) {
                 SULog(SULogLevelError, @"Failed to finalize installation with error: %@", thirdStageError);
                 
                 self.installer = nil;

--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -61,6 +61,8 @@
 
 - (BOOL)startInstallationToURL:(NSURL *)installationURL fromUpdateAtURL:(NSURL *)newURL withHost:(SUHost *)host progressBlock:(nullable void(^)(double))progress  error:(NSError * __autoreleasing *)error
 {
+
+#define _progress(a) if (progress) progress(a);
     if (installationURL == nil || newURL == nil) {
         // this really shouldn't happen but just in case
         SULog(SULogLevelError, @"Failed to perform installation because either installation URL (%@) or new URL (%@) is nil", installationURL, newURL);
@@ -70,7 +72,7 @@
         return NO;
     }
     
-    progress(1/10.0);
+    _progress(1/10.0);
     SUFileManager *fileManager = [[SUFileManager alloc] init];
 
     // Update the access time of our entire application before moving it into a temporary directory
@@ -92,7 +94,7 @@
         return NO;
     }
     
-    progress(2/10.0);
+    _progress(2/10.0);
 
     // Move the new app to our temporary directory
     NSString *newURLLastPathComponent = newURL.lastPathComponent;
@@ -103,7 +105,7 @@
         return NO;
     }
     
-    progress(3/10.0);
+    _progress(3/10.0);
 
     // Release our new app from quarantine
     NSError *quarantineError = nil;
@@ -112,7 +114,7 @@
         SULog(SULogLevelError, @"Failed to release quarantine at %@ with error %@", newTempURL.path, quarantineError);
     }
     
-    progress(4/10.0);
+    _progress(4/10.0);
 
     NSURL *oldURL = [NSURL fileURLWithPath:host.bundlePath];
     if (oldURL == nil) {
@@ -133,7 +135,7 @@
         return NO;
     }
     
-    progress(5/10.0);
+    _progress(5/10.0);
 
     NSError *touchError = nil;
     if (![fileManager updateModificationAndAccessTimeOfItemAtURL:newTempURL error:&touchError]) {
@@ -142,7 +144,7 @@
         SULog(SULogLevelError, @"Error: %@", touchError);
     }
     
-    progress(6/10.0);
+    _progress(6/10.0);
 
     // Decide on a destination name we should use for the older app when we move it around the file system
     NSString *oldDestinationName = oldURL.lastPathComponent.stringByDeletingPathExtension;
@@ -157,7 +159,7 @@
         return NO;
     }
     
-    progress(7/10.0);
+    _progress(7/10.0);
 
     // Move the old app to the temporary directory
     NSURL *oldTempURL = [tempOldDirectoryURL URLByAppendingPathComponent:oldDestinationNameWithPathExtension];
@@ -171,7 +173,7 @@
         return NO;
     }
     
-    progress(8/10.0);
+    _progress(8/10.0);
 
     // Move the new app to its final destination
     if (![fileManager moveItemAtURL:newTempURL toURL:installationURL error:error]) {
@@ -187,13 +189,13 @@
         return NO;
     }
     
-    progress(9/10.0);
+    _progress(9/10.0);
 
     // Cleanup
     [fileManager removeItemAtURL:tempOldDirectoryURL error:NULL];
     [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
     
-    progress(10/10.0);
+    _progress(10/10.0);
 
     return YES;
 }


### PR DESCRIPTION
Ref https://github.com/sparkle-project/Sparkle/issues/363

I was testing `ui-separation-and-xpc` branch and found one crash issue when AutoUpdate tries to update downloaded binary. 

I'm not exactly sure where I should send those progress value to UI, so I just made an empty callback to avoid the crash at this moment.