### PR TITLE
Add support for the sparkle:os attribute in the enclosure tag

### DIFF
--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -27,6 +27,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject
 @property (strong, readonly) NSURL *fileURL;
 @property (nonatomic, readonly) uint64_t contentLength;
 @property (copy, readonly) NSString *versionString;
+@property (copy, readonly) NSString *osString;
 @property (copy, readonly) NSString *displayVersionString;
 @property (copy, readonly) NSDictionary *deltaUpdates;
 @property (strong, readonly) NSURL *infoURL;
@@ -37,6 +38,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject
 
 @property (getter=isDeltaUpdate, readonly) BOOL deltaUpdate;
 @property (getter=isCriticalUpdate, readonly) BOOL criticalUpdate;
+@property (getter=isOsxUpdate, readonly) BOOL osxUpdate;
 @property (getter=isInformationOnlyUpdate, readonly) BOOL informationOnlyUpdate;
 
 // Returns the dictionary provided in initWithDictionary; this might be useful later for extensions.

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -23,6 +23,7 @@
 @property (copy, readwrite) NSString *maximumSystemVersion;
 @property (strong, readwrite) NSURL *fileURL;
 @property (copy, readwrite) NSString *versionString;
+@property (copy, readwrite) NSString *osString;
 @property (copy, readwrite) NSString *displayVersionString;
 @property (copy, readwrite) NSDictionary *deltaUpdates;
 @property (strong, readwrite) NSURL *infoURL;
@@ -43,6 +44,7 @@
 @synthesize releaseNotesURL;
 @synthesize title;
 @synthesize versionString;
+@synthesize osString;
 @synthesize propertiesDictionary;
 
 - (BOOL)isDeltaUpdate
@@ -54,6 +56,17 @@
 - (BOOL)isCriticalUpdate
 {
     return [[self.propertiesDictionary objectForKey:SUAppcastElementTags] containsObject:SUAppcastElementCriticalUpdate];
+}
+
+- (BOOL)isOsxUpdate
+{
+    BOOL result = true;
+  
+    if (self.osString != nil && [self.osString caseInsensitiveCompare:SUAppcastAttributeValueOsx] != NSOrderedSame)
+    {
+        result = false;
+    }
+    return result;
 }
 
 - (BOOL)isInformationOnlyUpdate
@@ -150,8 +163,9 @@
         }
         if (enclosure) {
             self.DSASignature = [enclosure objectForKey:SUAppcastAttributeDSASignature];
+            self.osString = [enclosure objectForKey:SUAppcastAttributeOsType];
         }
-
+  
         self.versionString = newVersion;
         self.minimumSystemVersion = [dict objectForKey:SUAppcastElementMinimumSystemVersion];
         self.maximumSystemVersion = [dict objectForKey:SUAppcastElementMaximumSystemVersion];

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -115,12 +115,13 @@
 
 + (BOOL)hostSupportsItem:(SUAppcastItem *)ui
 {
+  BOOL osxSupported = [ui isOsxUpdate];
 	if (([ui minimumSystemVersion] == nil || [[ui minimumSystemVersion] isEqualToString:@""]) &&
-        ([ui maximumSystemVersion] == nil || [[ui maximumSystemVersion] isEqualToString:@""])) { return YES; }
+        ([ui maximumSystemVersion] == nil || [[ui maximumSystemVersion] isEqualToString:@""])) { return osxSupported; }
 
     BOOL minimumVersionOK = TRUE;
     BOOL maximumVersionOK = TRUE;
-    
+  
     id<SUVersionComparison> versionComparator = [[SUStandardVersionComparator alloc] init];
 
     // Check minimum and maximum System Version
@@ -131,7 +132,7 @@
         maximumVersionOK = [versionComparator compareVersion:[ui maximumSystemVersion] toVersion:[SUOperatingSystem systemVersionString]] != NSOrderedAscending;
     }
 
-    return minimumVersionOK && maximumVersionOK;
+    return minimumVersionOK && maximumVersionOK && osxSupported;
 }
 
 - (BOOL)isItemNewer:(SUAppcastItem *)ui

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -21,6 +21,8 @@ extern const NSTimeInterval SUDefaultUpdateCheckInterval;
 
 extern NSString *const SUBundleIdentifier;
 
+extern NSString *const SUAppcastAttributeValueOsx;
+
 // -----------------------------------------------------------------------------
 //	Notifications:
 // -----------------------------------------------------------------------------
@@ -64,6 +66,9 @@ extern NSString *const SUAppcastAttributeDeltaFrom;
 extern NSString *const SUAppcastAttributeDSASignature;
 extern NSString *const SUAppcastAttributeShortVersionString;
 extern NSString *const SUAppcastAttributeVersion;
+extern NSString *const SUAppcastAttributeOsType;
+
+
 
 extern NSString *const SUAppcastElementCriticalUpdate;
 extern NSString *const SUAppcastElementDeltas;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -21,6 +21,8 @@ const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);
 
 NSString *const SUBundleIdentifier = @SPARKLE_BUNDLE_IDENTIFIER;
 
+NSString *const SUAppcastAttributeValueOsx = @"osx";
+
 NSString *const SUTechnicalErrorInformationKey = @"SUTechnicalErrorInformation";
 
 NSString *const SUHasLaunchedBeforeKey = @"SUHasLaunchedBefore";
@@ -54,6 +56,7 @@ NSString *const SUAppcastAttributeDeltaFrom = @"sparkle:deltaFrom";
 NSString *const SUAppcastAttributeDSASignature = @"sparkle:dsaSignature";
 NSString *const SUAppcastAttributeShortVersionString = @"sparkle:shortVersionString";
 NSString *const SUAppcastAttributeVersion = @"sparkle:version";
+NSString *const SUAppcastAttributeOsType = @"sparkle:os";
 
 NSString *const SUAppcastElementCriticalUpdate = @"sparkle:criticalUpdate";
 NSString *const SUAppcastElementDeltas = @"sparkle:deltas";


### PR DESCRIPTION
This allows to use the same appcast xml file for winsparkle and sparkle. This feature is also already stated in the sparkle wiki here:

https://sparkle-project.org/documentation/publishing/#publishing-an-update

under "Alternate download locations for other operating systems"

But it was not implemented yet.

Behavior is as follows.
1. If no sparkle:os attribute was found -> assume its an osx update item
2. If sparkle:os attribute was found -> check if it contains "osx" as value. If it hasn't this item is not assumed to be an osx update item