### PR TITLE
Added initWithUpdaterDelegate:userDriverDelegate: to SPUStandardUpdaterController

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  A controller class that instantiates a SPUUpdater and allows binding UI to it.
  
- This class is meant to be instantiated in a nib. When doing so, the controller's updater targets the application's main bundle,
+ This class can be instantiated in a nib or created using initWithUpdaterDelegate:userDriverDelegate:. The controller's updater targets the application's main bundle
  and uses Sparkle's standard user interface. Typically, this class is used by sticking it as a custom NSObject subclass in an Interface Builder nib (probably in MainMenu).
  
  The controller creates an SPUUpdater instance and allows hooking up the check for updates action and menu item validation. It also allows hooking
@@ -66,6 +66,16 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
  You may access this property after your application has finished launching, or after your window controller has finished loading.
  */
 @property (nonatomic, readonly, nullable) id <SPUStandardUserDriverProtocol> userDriver;
+
+/*!
+ Use initWithUpdaterDelegate:userDriverDelegate: instead.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/*!
+ Create a new SPUStandardUpdaterController programmatically.
+ */
+- (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate;
 
 /*!
  Explicitly checks for updates and displays a progress dialog while doing so.

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -36,6 +36,22 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     // awakeFromNib might be called more than once; guard against that
     // We have to use awakeFromNib otherwise the delegate outlets may not be connected yet,
     // and we aren't a proper window or view controller, so we don't have a proper "did load" point
+    [self initializeUpdater];
+}
+
+- (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate
+{
+    if ((self = [super init])) {
+        _updaterDelegate = updaterDelegate;
+        _userDriverDelegate = userDriverDelegate;
+
+        [self initializeUpdater];
+    }
+    return self;
+}
+
+- (void)initializeUpdater
+{
     if (!self.initializedUpdater) {
         self.initializedUpdater = YES;
         


### PR DESCRIPTION
SPUStandardUpdaterController didn't have a way to cleanly create it outside of `awakeFromNib`.

This adds `initWithUpdaterDelegate:userDriverDelegate:` as an alternate to relying on `awakeFromNib`.

If an app is distributed to the Mac App Store you can't easily put SPUStandardUpdaterController in the nib (Apple rejects apps for referencing Sparkle in the app or nib). This would probably get through approval initially since this isn't the main Sparkle branch, but that isn't a good assumption for the future.