### PR TITLE
Update German localization for informal style and changed terminology

### DIFF
--- a/Sparkle/de.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUAutomaticUpdateAlert.xib
@@ -84,7 +84,7 @@ DQ
                     <button id="17">
                         <rect key="frame" x="104" y="58" width="569" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <buttonCell key="cell" type="check" title="Aktualisierungen in Zukunft automatisch herunterladen und installieren" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="43">
+                        <buttonCell key="cell" type="check" title="Updates in Zukunft automatisch laden und installieren" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="43">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>

--- a/Sparkle/de.lproj/SUAutomaticUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUAutomaticUpdateAlert.xib
@@ -57,9 +57,9 @@
                         </connections>
                     </textField>
                     <button verticalHuggingPriority="750" id="15">
-                        <rect key="frame" x="462" y="12" width="215" height="32"/>
+                        <rect key="frame" x="472" y="13" width="205" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES"/>
-                        <buttonCell key="cell" type="push" title="Installieren und erneut starten" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="41">
+                        <buttonCell key="cell" type="push" title="Installieren und neu starten" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="41">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                             <string key="keyEquivalent" base64-UTF8="YES">
@@ -71,7 +71,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" id="30">
-                        <rect key="frame" x="102" y="12" width="132" height="32"/>
+                        <rect key="frame" x="101" y="13" width="142" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <buttonCell key="cell" type="push" title="Nicht installieren" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="44">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -82,7 +82,7 @@ DQ
                         </connections>
                     </button>
                     <button id="17">
-                        <rect key="frame" x="105" y="58" width="619" height="18"/>
+                        <rect key="frame" x="104" y="58" width="569" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <buttonCell key="cell" type="check" title="Aktualisierungen in Zukunft automatisch herunterladen und installieren" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="43">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -93,7 +93,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" id="16">
-                        <rect key="frame" x="265" y="12" width="197" height="32"/>
+                        <rect key="frame" x="275" y="13" width="197" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES"/>
                         <buttonCell key="cell" type="push" title="Beim Beenden installieren" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="42">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/Sparkle/de.lproj/SUUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUUpdateAlert.xib
@@ -22,7 +22,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window identifier="SUUpdateAlert" title="Softwareaktualisierung" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
+        <window identifier="SUUpdateAlert" title="Softwareupdate" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
@@ -190,7 +190,7 @@ DQ
                             <constraint firstAttribute="height" relation="lessThanOrEqual" constant="28" id="0AI-ue-a0r"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="yM1-TA-HfP"/>
                         </constraints>
-                        <buttonCell key="cell" type="check" title="Aktualisierungen in Zukunft automatisch herunterladen und installieren" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="175">
+                        <buttonCell key="cell" type="check" title="Updates in Zukunft automatisch laden und installieren" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="175">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>

--- a/Sparkle/de.lproj/SUUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUUpdateAlert.xib
@@ -22,7 +22,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window identifier="SUUpdateAlert" title="Software-Aktualisierung" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
+        <window identifier="SUUpdateAlert" title="Softwareaktualisierung" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>

--- a/Sparkle/de.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/de.lproj/SUUpdatePermissionPrompt.xib
@@ -59,7 +59,7 @@ Gw
                     <textField verticalHuggingPriority="750" id="32">
                         <rect key="frame" x="104" y="131" width="316" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Automatisch nach Aktualisierungen suchen?" id="178">
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Automatisch nach Updates suchen?" id="178">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/Sparkle/de.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/de.lproj/SUUpdatePermissionPrompt.xib
@@ -137,17 +137,17 @@ Gw
             </connections>
         </arrayController>
         <customView id="39" userLabel="MoreInfoView">
-            <rect key="frame" x="0.0" y="0.0" width="362" height="205"/>
+            <rect key="frame" x="0.0" y="0.0" width="362" height="191"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" id="46">
-                    <rect key="frame" x="1" y="128" width="358" height="70"/>
+                    <rect key="frame" x="1" y="128" width="358" height="56"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="183">
                         <font key="font" metaFont="smallSystem"/>
-                        <string key="title">Das anonymisierte Systemprofil unterstützt uns bei der zukünftigen Entwicklung. Bitte kontaktieren Sie uns, wenn Sie Fragen hierzu haben.
+                        <string key="title">Das anonymisierte Systemprofil unterstützt uns bei der zukünftigen Entwicklung. Bitte kontaktiere uns, wenn du Fragen hierzu hast.
 
-Diese Informationen würden an uns gesendet:</string>
+Diese Informationen würden an uns gesendet werden:</string>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -160,7 +160,7 @@ Diese Informationen würden an uns gesendet:</string>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="14" id="41">
-                                <rect key="frame" x="0.0" y="0.0" width="353" height="16"/>
+                                <rect key="frame" x="0.0" y="0.0" width="353" height="113"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -1,16 +1,16 @@
-"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde heruntergeladen und steht zur Verwendung bereit! Dies ist eine wichtige Aktualisierung. Möchten Sie %1$@ jetzt durch die neue Version ersetzen und neu starten?";
+"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde heruntergeladen und steht zur Installation bereit! Dies ist eine wichtige Aktualisierung. Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
-"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde heruntergeladen und steht zur Verwendung bereit! Möchten Sie %1$@ jetzt durch die neue Version ersetzen und neu starten?";
+"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde heruntergeladen und steht zur Installation bereit! Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, wenn es von einem Volumen ohne Schreibzugriff (z.B. Disk Image oder CD/DVD) gestartet wurde. Kopieren Sie %1$@ in den Programme Ordner, aktualisieren Sie es von dort.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, weil es von einem Ort ohne Schreibzugriff oder temporären Ort aus gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
 
-"%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zur Zeit die neueste verfügbare Version.";
+"%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar (Sie verwenden Version %3$@). Möchten Sie die neue Version jetzt herunterladen?";
+"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du die neue Version jetzt herunterladen?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ist verfügbar (Sie verwenden Version %3$@). Möchten Sie mehr über diese Aktualisierung erfahren?";
+"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du mehr über diese Aktualisierung erfahren?";
 
 "%@ downloaded" = "%@ heruntergeladen";
 
@@ -18,19 +18,19 @@
 
 "A new version of %@ is available!" = "Eine neue Version von %@ ist verfügbar!";
 
-"A new version of %@ is ready to install!" = "Eine neue Version von %@ ist zur Installation bereit!";
+"A new version of %@ is ready to install!" = "Eine neue Version von %@ steht zur Installation bereit!";
 
-"An error occurred in retrieving update information. Please try again later." = "Bei der Aktualisierung trat ein Fehler auf. Bitte versuchen Sie es später erneut.";
+"An error occurred in retrieving update information. Please try again later." = "Beim Herunterladen der Aktualisierungsinformationen trat ein Fehler auf. Bitte versuche es später erneut.";
 
-"An error occurred while downloading the update. Please try again later." = "Beim Herunterladen ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.";
+"An error occurred while downloading the update. Please try again later." = "Beim Herunterladen der Aktualisierung ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
-"An error occurred while extracting the archive. Please try again later." = "Beim Entpacken der Daten ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.";
+"An error occurred while extracting the archive. Please try again later." = "Beim Entpacken des Archivs ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
-"An error occurred while installing the update. Please try again later." = "Bei der Installation der Aktualisierung ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.";
+"An error occurred while installing the update. Please try again later." = "Beim Installieren der Aktualisierung ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
 "An error occurred while parsing the update feed." = "Beim Lesen der Aktualisierungsinformationen ist ein Fehler aufgetreten.";
 
-"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "Beim erneuten Starten von %1$@ ist ein Fehler aufgetreten. Die neue Version von %1$@ steht beim nächsten Programmstart zur Verfügung.";
+"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "Beim Neustart von %1$@ ist ein Fehler aufgetreten. Die neue Version von %1$@ steht beim nächsten Programmstart zur Verfügung.";
 
 "An important update to %@ is ready to install" = "Eine wichtige Aktualisierung von %@ steht zur Installation bereit";
 
@@ -41,10 +41,10 @@
 
 "Cancel Update" = "Aktualisierung abbrechen";
 
-"Checking for updates..." = "Suche nach Aktualisierungen …";
+"Checking for updates..." = "Nach Aktualisierungen suchen …";
 
 /* Take care not to overflow the status window. */
-"Downloading update..." = "Aktualisierung wird heruntergeladen …";
+"Downloading update..." = "Aktualisierung herunterladen …";
 
 /* Take care not to overflow the status window. */
 "Extracting update..." = "Aktualisierung entpacken …";
@@ -52,7 +52,7 @@
 /* the unit for gigabytes */
 "GB" = "GB";
 
-"Install and Relaunch" = "Installieren und erneut starten";
+"Install and Relaunch" = "Installieren und neu starten";
 
 /* Take care not to overflow the status window. */
 "Installing update..." = "Aktualisierung installieren …";
@@ -67,7 +67,7 @@
 
 "Ready to Install" = "Bereit zum Installieren";
 
-"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Soll %1$@ automatisch nach Aktualisierungen suchen? Sie können im %1$@-Menü auch manuell nach Aktualisierungen suchen.";
+"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Soll %1$@ automatisch nach Aktualisierungen suchen? Du kannst im %1$@-Menü auch manuell nach Aktualisierungen suchen.";
 
 "The update is improperly signed." = "Die Aktualisierung ist nicht ordnungsgemäß signiert.";
 
@@ -75,9 +75,9 @@
 
 "Updating %@" = "Aktualisierung von %@";
 
-"You already have the newest version of %@." = "Sie haben bereits die neueste Version von %@.";
+"You already have the newest version of %@." = "Du hast bereits die neueste Version von %@.";
 
-"You're up-to-date!" = "Sie sind auf dem neuesten Stand!";
+"You're up-to-date!" = "Du bist auf dem neuesten Stand!";
 
 /* Alternative name for "Install" button if we have a paid update or other update
 	without a download but with a URL. */

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -1,18 +1,18 @@
-"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde heruntergeladen und steht zur Installation bereit! Dies ist eine wichtige Aktualisierung. Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
+"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde geladen und steht zur Installation bereit! Dies ist ein wichtiges Update. Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
-"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde heruntergeladen und steht zur Installation bereit! Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
+"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde geladen und steht zur Installation bereit! Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, weil es von einem Ort ohne Schreibzugriff oder temporären Ort aus gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du die neue Version jetzt herunterladen?";
+"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du die neue Version jetzt laden?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du mehr über diese Aktualisierung erfahren?";
+"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du mehr über dieses Update erfahren?";
 
-"%@ downloaded" = "%@ heruntergeladen";
+"%@ downloaded" = "%@ geladen";
 
 "%@ of %@" = "%1$@ von %2$@";
 
@@ -20,19 +20,19 @@
 
 "A new version of %@ is ready to install!" = "Eine neue Version von %@ steht zur Installation bereit!";
 
-"An error occurred in retrieving update information. Please try again later." = "Beim Herunterladen der Aktualisierungsinformationen trat ein Fehler auf. Bitte versuche es später erneut.";
+"An error occurred in retrieving update information. Please try again later." = "Beim Laden der Updateinformationen trat ein Fehler auf. Bitte versuche es später erneut.";
 
-"An error occurred while downloading the update. Please try again later." = "Beim Herunterladen der Aktualisierung ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
+"An error occurred while downloading the update. Please try again later." = "Beim Laden des Updates ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
 "An error occurred while extracting the archive. Please try again later." = "Beim Entpacken des Archivs ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
-"An error occurred while installing the update. Please try again later." = "Beim Installieren der Aktualisierung ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
+"An error occurred while installing the update. Please try again later." = "Beim Installieren des Updates ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
-"An error occurred while parsing the update feed." = "Beim Lesen der Aktualisierungsinformationen ist ein Fehler aufgetreten.";
+"An error occurred while parsing the update feed." = "Beim Lesen der Updateinformationen ist ein Fehler aufgetreten.";
 
 "An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "Beim Neustart von %1$@ ist ein Fehler aufgetreten. Die neue Version von %1$@ steht beim nächsten Programmstart zur Verfügung.";
 
-"An important update to %@ is ready to install" = "Eine wichtige Aktualisierung von %@ steht zur Installation bereit";
+"An important update to %@ is ready to install" = "Ein wichtiges Update von %@ steht zur Installation bereit";
 
 /* the unit for bytes */
 "B" = "B";
@@ -41,13 +41,13 @@
 
 "Cancel Update" = "Aktualisierung abbrechen";
 
-"Checking for updates..." = "Nach Aktualisierungen suchen …";
+"Checking for updates..." = "Nach Updates suchen …";
 
 /* Take care not to overflow the status window. */
-"Downloading update..." = "Aktualisierung herunterladen …";
+"Downloading update..." = "Update laden …";
 
 /* Take care not to overflow the status window. */
-"Extracting update..." = "Aktualisierung entpacken …";
+"Extracting update..." = "Update entpacken …";
 
 /* the unit for gigabytes */
 "GB" = "GB";
@@ -55,7 +55,7 @@
 "Install and Relaunch" = "Installieren und neu starten";
 
 /* Take care not to overflow the status window. */
-"Installing update..." = "Aktualisierung installieren …";
+"Installing update..." = "Update installieren …";
 
 /* the unit for kilobytes */
 "KB" = "KB";
@@ -67,9 +67,9 @@
 
 "Ready to Install" = "Bereit zum Installieren";
 
-"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Soll %1$@ automatisch nach Aktualisierungen suchen? Du kannst im %1$@-Menü auch manuell nach Aktualisierungen suchen.";
+"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Soll %1$@ automatisch nach Updates suchen? Du kannst im %1$@-Menü auch manuell nach Updates suchen.";
 
-"The update is improperly signed." = "Die Aktualisierung ist nicht ordnungsgemäß signiert.";
+"The update is improperly signed." = "Das Update ist nicht ordnungsgemäß signiert.";
 
 "Update Error!" = "Fehler beim Aktualisieren!";
 


### PR DESCRIPTION
Apple switched to an informal style in its German localisations in macOS Sierra ([source](https://www.mactechnews.de/news/article/macOS-Sierra-redet-den-Nutzer-mit-Du-an-164371.html)).

Apple also seems to be using the words "Update" instead of "Aktualisierung" and "laden" instead of "herunterladen" (as seen in the App Store section in System Preferences). This might have been a recent change too, I am not sure.

I also made some slight changes to match the source strings better.