### PR TITLE
Use "class" property attribute where available

### DIFF
--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -21,7 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 * Creates a file manager that will not authorize for file operations
 * @return A new file manager instance
 */
+#if __has_feature(objc_class_property)
+@property (class, readonly) SUFileManager *defaultManager;
+#else
 + (instancetype)defaultManager;
+#endif
 
 /**
  * Creates a file manager that allows authorizing for file operations

--- a/Sparkle/SUOperatingSystem.h
+++ b/Sparkle/SUOperatingSystem.h
@@ -17,8 +17,18 @@ typedef struct {
 
 @interface SUOperatingSystem : NSObject
 
+#if __has_feature(objc_class_property)
+@property (class, readonly) NSOperatingSystemVersion operatingSystemVersion;
+#else
 + (NSOperatingSystemVersion)operatingSystemVersion;
+#endif
+
 + (BOOL)isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion)version;
+
+#if __has_feature(objc_class_property)
+@property (class, readonly) NSString *systemVersionString;
+#else
 + (NSString *)systemVersionString;
+#endif
 
 @end

--- a/Sparkle/SUStandardVersionComparator.h
+++ b/Sparkle/SUStandardVersionComparator.h
@@ -38,7 +38,11 @@ SU_EXPORT @interface SUStandardVersionComparator : NSObject <SUVersionComparison
  
     It is usually preferred to alloc/init new a comparator instead.
 */
+#if __has_feature(objc_class_property)
+@property (class, readonly) SUStandardVersionComparator *defaultComparator;
+#else
 + (SUStandardVersionComparator *)defaultComparator;
+#endif
 
 /*!
     Compares version strings through textual analysis.

--- a/Sparkle/SUUnarchiverProtocol.h
+++ b/Sparkle/SUUnarchiverProtocol.h
@@ -14,7 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)canUnarchivePath:(NSString *)path;
 
+#if __has_feature(objc_class_property)
+@property (class, readonly) BOOL unsafeIfArchiveIsNotValidated;
+#else
 + (BOOL)unsafeIfArchiveIsNotValidated;
+#endif
 
 - (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock;
 

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -37,7 +37,11 @@ SU_EXPORT @interface SUUpdater : NSObject
  
  This is equivalent to passing [NSBundle mainBundle] to SUUpdater::updaterForBundle:
  */
+#if __has_feature(objc_class_property)
+@property (class, readonly) SUUpdater* sharedUpdater;
+#else
 + (SUUpdater *)sharedUpdater;
+#endif
 
 /*!
  The shared updater for a specified bundle.

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -45,20 +45,20 @@ class SUAppcastTest: XCTestCase {
             
             // Test best appcast item & a delta update item
             var deltaItem: SUAppcastItem? = nil
-            let bestAppcastItem = SUBasicUpdateDriver.bestItem(fromAppcastItems: items, getDeltaItem: &deltaItem, withHostVersion: "1.0", comparator: SUStandardVersionComparator.default())
+            let bestAppcastItem = SUBasicUpdateDriver.bestItem(fromAppcastItems: items, getDeltaItem: &deltaItem, withHostVersion: "1.0", comparator: SUStandardVersionComparator.default)
 
             XCTAssertEqual(bestAppcastItem, items[1])
             XCTAssertEqual(deltaItem!.fileURL.lastPathComponent, "3.0_from_1.0.patch")
             
             // Test latest delta update item available
             var latestDeltaItem: SUAppcastItem? = nil
-            SUBasicUpdateDriver.bestItem(fromAppcastItems: items, getDeltaItem: &latestDeltaItem, withHostVersion: "2.0", comparator: SUStandardVersionComparator.default())
+            SUBasicUpdateDriver.bestItem(fromAppcastItems: items, getDeltaItem: &latestDeltaItem, withHostVersion: "2.0", comparator: SUStandardVersionComparator.default)
             
             XCTAssertEqual(latestDeltaItem!.fileURL.lastPathComponent, "3.0_from_2.0.patch")
             
             // Test a delta item that does not exist
             var nonexistantDeltaItem: SUAppcastItem? = nil
-            SUBasicUpdateDriver.bestItem(fromAppcastItems: items, getDeltaItem: &nonexistantDeltaItem, withHostVersion: "2.1", comparator: SUStandardVersionComparator.default())
+            SUBasicUpdateDriver.bestItem(fromAppcastItems: items, getDeltaItem: &nonexistantDeltaItem, withHostVersion: "2.1", comparator: SUStandardVersionComparator.default)
             
             XCTAssertNil(nonexistantDeltaItem)
         } catch let err as NSError {

--- a/Tests/SUFileManagerTest.swift
+++ b/Tests/SUFileManagerTest.swift
@@ -12,7 +12,7 @@ class SUFileManagerTest: XCTestCase
 {
     func makeTempFiles(_ testBlock: (SUFileManager, URL, URL, URL, URL, URL, URL) -> Void)
     {
-        let fileManager = SUFileManager.default()
+        let fileManager = SUFileManager.default
         
         let tempDirectoryURL = (try! fileManager.makeTemporaryDirectory(withPreferredName: "Sparkle Unit Test Data", appropriateForDirectoryURL: URL(fileURLWithPath: NSHomeDirectory())))
         
@@ -278,7 +278,7 @@ class SUFileManagerTest: XCTestCase
     
     func testAcquireBadAuthorization()
     {
-        let fileManager = SUFileManager.default()
+        let fileManager = SUFileManager.default
         XCTAssertNil(try? fileManager._acquireAuthorization())
     }
 }

--- a/Tests/SUSpotlightImporterTest.swift
+++ b/Tests/SUSpotlightImporterTest.swift
@@ -12,7 +12,7 @@ class SUSpotlightImporterTest: XCTestCase
 {
     func testUpdatingSpotlightBundles()
     {
-        let fileManager = SUFileManager.default()
+        let fileManager = SUFileManager.default
         let tempDirectoryURL = try! fileManager.makeTemporaryDirectory(withPreferredName: "Sparkle Unit Test Data", appropriateForDirectoryURL: URL(fileURLWithPath: NSHomeDirectory()))
         
         let bundleDirectory = tempDirectoryURL.appendingPathComponent("bundle.app")


### PR DESCRIPTION
Clang in Xcode 8+ supports this attribute to declare class accessors as class properties. They provide consistent semantics with Cocoa singletons and other accessors in both Objective-C and Swift.

More information: https://useyourloaf.com/blog/objective-c-class-properties/.

The preprocessor macro can be found here: [llvm-mirror/clang/lib/Lex/PPMacroExpansion.cpp#L1169](https://github.com/llvm-mirror/clang/blob/a38ba9770a70056f9fdd6c71f819e5db45a105e4/lib/Lex/PPMacroExpansion.cpp#L1169).