### PR TITLE
Workaround for timing issue of termination detection.

### DIFF
--- a/Sparkle/Autoupdate/TerminationListener.m
+++ b/Sparkle/Autoupdate/TerminationListener.m
@@ -116,6 +116,11 @@
     if ([self terminated]) {
         [self invokeCompletionWithSuccess:YES];
     }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if ([self terminated]) {
+            [self invokeCompletionWithSuccess:YES];
+        }
+    });
 }
 
 static void noteExitKQueueCallback(CFFileDescriptorRef file, CFOptionFlags __unused callBackTypes, void *info)


### PR DESCRIPTION
part of #1079
I have no problem with this patch. But I have no idea that 2sec-delay is enough for every configuration.