### PR TITLE
Added a timer invalidation in a asynchronous callback.

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -351,6 +351,9 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         [self.userDriver showCanCheckForUpdates:YES];
         
         [self retrieveNextUpdateCheckInterval:^(NSTimeInterval updateCheckInterval) {
+            // This callback is asynchronous, so the timer may be set. Invalidate to make sure it isn't.
+            [self.updaterTimer invalidate];
+            
             // How long has it been since last we checked for an update?
             NSDate *lastCheckDate = [self lastUpdateCheckDate];
             if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }


### PR DESCRIPTION
The scheduleNextUpdateCheckFiringImmediately: method includes an asynchronous callback. It invalidates the timer before invoking the method with the callback (retrieveNextUpdateCheckInterval:), but doesn’t invalidate again inside the callback block.

The problem with this is that it is possible the timer is started during the delay. In release versions of an app, crashes have been seen due to an assertion that the NSTimer be nil when scheduling.

The proposed fix is to invalidate the timer in the callback, ensuring the NSTimer is nil before scheduling.