### PR TITLE
Update Xcode version for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode9
 before_install:
   - brew update
 script: make ci


### PR DESCRIPTION
You can already use `xcode9` image for Travis CI (cf. https://docs.travis-ci.com/user/languages/objective-c/)