### PR TITLE
Fix for Skip This Updates button not working in XPC branch

### DIFF
--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -43,7 +43,7 @@
             // Don't tell the user about the permission error for scheduled update checks
             [self abortUpdateWithError:nil];
         } else {
-            [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES includesSkippedUpdates:YES];
+            [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES includesSkippedUpdates:NO];
         }
     }];
 }


### PR DESCRIPTION
includesSkippedUpdates was set to YES in SPUScheduledUpdateDriver
This was causing the Skip This Version button to not work when a background update check ran.
This was introduced in 47f08be1a.