### PR TITLE
Fix #1061 & #835: Sparkle clients polling too frequently

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -266,9 +266,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
 - (void)updateLastUpdateCheckDate
 {
-    [self setUpdateLastCheckedDate:[NSDate date]];
-    
     [self willChangeValueForKey:@"lastUpdateCheckDate"];
+    [self setUpdateLastCheckedDate:[NSDate date]];
     [self.host setObject:[self updateLastCheckedDate] forUserDefaultsKey:SULastCheckTimeKey];
     [self didChangeValueForKey:@"lastUpdateCheckDate"];
 }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -49,6 +49,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @property (strong) SUUpdateDriver *driver;
 @property (strong) SUHost *host;
 
+@property (copy) NSDate *updateLastCheckedDate;
+
 @end
 
 @implementation SUUpdater
@@ -61,6 +63,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize host;
 @synthesize sparkleBundle;
 @synthesize decryptionPassword;
+@synthesize updateLastCheckedDate;
 
 static NSMutableDictionary *sharedUpdaters = nil;
 static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaultsObservationContext";
@@ -253,13 +256,20 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
 - (NSDate *)lastUpdateCheckDate
 {
-    return [self.host objectForUserDefaultsKey:SULastCheckTimeKey];
+    if (![self updateLastCheckedDate])
+    {
+        [self setUpdateLastCheckedDate:[self.host objectForUserDefaultsKey:SULastCheckTimeKey]];
+    }
+    
+    return [self updateLastCheckedDate];
 }
 
 - (void)updateLastUpdateCheckDate
 {
+    [self setUpdateLastCheckedDate:[NSDate date]];
+    
     [self willChangeValueForKey:@"lastUpdateCheckDate"];
-    [self.host setObject:[NSDate date] forUserDefaultsKey:SULastCheckTimeKey];
+    [self.host setObject:[self updateLastCheckedDate] forUserDefaultsKey:SULastCheckTimeKey];
     [self didChangeValueForKey:@"lastUpdateCheckDate"];
 }
 


### PR DESCRIPTION
The SULastCheckTimeKey preference (a/k/a "default"), which is stored
in ~/Library/Preferences/….plist, was used to store the date of the
last update check.

That causes a problem if the storage is read-only (for example, if the
.plist file is “locked” (has the uchg or schg flag set) or if the
SULastCheckTimeKey key "exists in a domain that precedes the
application domain the search list"). The date would never be modified,
and the old date would cause a new update check to be queued at the end
of an update check. If application or bundle was up-to-date, or the
user had chosen to skip the update that was available, this would cause
update checks to happen as often as the computer and network would
allow, many times each second.

The new code uses an instance variable to store the value. The variable
is initially loaded from the “SULastCheckTimeKey” preference, and each
time the variable is modified its new value is stored to that
preference. However, the variable, not the preference, is used when
calculating whether enough time has passed since the last update check
to warrant another check. The variable will always (after the first
update check) have the "correct" value, and update checks will not be
done more frequently than desired.