### PR TITLE
Run codesign when signing identity is a hyphen

### DIFF
--- a/Configurations/set-agent-signing.sh
+++ b/Configurations/set-agent-signing.sh
@@ -3,6 +3,6 @@
 AGENT_PATH="${TARGET_BUILD_DIR}"/"${CONTENTS_FOLDER_PATH}"/MacOS/"${SPARKLE_INSTALLER_PROGRESS_TOOL_NAME}".app
 
 #Only sign the agent app if we have code signing enabled (as we do with adhoc signatures in Debug builds for testing sandboxing)
-if [ ! -z "${CODE_SIGN_IDENTITY}" -a "${CODE_SIGN_IDENTITY}" != "-" ] ; then
+if [ ! -z "${CODE_SIGN_IDENTITY}" ] ; then
     codesign --verbose -f -s "${CODE_SIGN_IDENTITY}" "${AGENT_PATH}"
 fi

--- a/Configurations/set-ats-exceptions-test-app.sh
+++ b/Configurations/set-ats-exceptions-test-app.sh
@@ -7,6 +7,6 @@ DOWNLOADER_INFO_PLIST="${TARGET_BUILD_DIR}"/"${CONTENTS_FOLDER_PATH}"/XPCService
 #Only alter bundles if code signing is off, else we'll invalidate the signature on them
 #If code signing is enabled (as in debug mode), then we rely on another script for turning ATS exceptions on for these services
 #In release mode however, those services do not have ATS exceptions set up which is why we have to set up exceptions *here*
-if [ -z "${CODE_SIGN_IDENTITY}" -o "${CODE_SIGN_IDENTITY}" == "-" ] ; then
+if [ -z "${CODE_SIGN_IDENTITY}" ] ; then
     /usr/libexec/PlistBuddy -c "Set :NSAppTransportSecurity:NSAllowsArbitraryLoads YES" "${DOWNLOADER_INFO_PLIST}"
 fi


### PR DESCRIPTION
I'm sorry, my last shell script change wasn't totally correct (#1160). It was building in my main projects but then failed when building the UI test targets.

It turns out that using a hyphen (-) to sign creates an adhoc signature rather than not signing (this is new to me, oops!). The last fix for the incorrect conditional in the shell script is still correct, but the extra check for "-" needs to be removed.