### PR TITLE
Fixed an auto-synthesis warning

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -49,6 +49,7 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 @synthesize downloadFilename = _downloadFilename;
 @synthesize disabledAutomaticTermination = _disabledAutomaticTermination;
 @synthesize mode = _mode;
+@synthesize receivedExpectedBytes = _receivedExpectedBytes;
 
 - (instancetype)initWithDelegate:(id <SPUDownloaderDelegate>)delegate
 {


### PR DESCRIPTION
Silences a warning because a property is being auto-synthesized.
Eventually it would probably be good to turn off the auto-synthesize warning and allow all properties to be auto-synthesized by default (probably once fixes from Sparkle 1.x are no longer merged into 2.x).