### PR TITLE
Check if cocoapods is installed

### DIFF
--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -2,11 +2,13 @@
 set -e
 
 if [ "$ACTION" = "" ] ; then
-    # Sanity check that the Podspec version matches the Sparkle version
-    spec_version=$(printf "require 'cocoapods'\nspec = %s\nprint spec.version" "$(cat "$SRCROOT/Sparkle.podspec")" | LANG=en_US.UTF-8 ruby)
-    if [ "$spec_version" != "$CURRENT_PROJECT_VERSION" ] ; then
-        echo "podspec version '$spec_version' does not match the current project version '$CURRENT_PROJECT_VERSION'" >&2
-        exit 1
+    # If using cocoapods, sanity check that the Podspec version matches the Sparkle version
+    if [ -x "$(command -v pod)" ]; then
+        spec_version=$(printf "require 'cocoapods'\nspec = %s\nprint spec.version" "$(cat "$SRCROOT/Sparkle.podspec")" | LANG=en_US.UTF-8 ruby)
+        if [ "$spec_version" != "$CURRENT_PROJECT_VERSION" ] ; then
+            echo "podspec version '$spec_version' does not match the current project version '$CURRENT_PROJECT_VERSION'" >&2
+            exit 1
+        fi
     fi
 
     rm -rf "$CONFIGURATION_BUILD_DIR/staging"


### PR DESCRIPTION
Ensure cocoapods is installed before performing the release “sanity check” (#860)

Based on https://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script#677212