### PR TITLE
Amend to avoid gender issue

### DIFF
--- a/Sparkle/pt_BR.lproj/Sparkle.strings
+++ b/Sparkle/pt_BR.lproj/Sparkle.strings
@@ -86,4 +86,4 @@
 "You already have the newest version of %@." = "Você já possui a versão mais recente do %@.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You're up-to-date!" = "Você está atualizado!";
+"You're up-to-date!" = "O app está atualizado!";


### PR DESCRIPTION
Amend to avoid gender issue

Instead of addressing the user, which might cause gender issues, string has been adapted to include and refer to “app” (masculine, in accordance with Apple's terminology).

Would translate back as “The app is up-to-date!”