### PR TITLE
Fixed SPUDownloader leak

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -115,6 +115,7 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 {
     [self enableAutomaticTermination];
     [self.download cancel];
+    [self.downloadSession invalidateAndCancel];
     self.download = nil;
     self.downloadSession = nil;
     self.delegate = nil;


### PR DESCRIPTION
SPUDownloader was getting leaked because its NSURLSession wasn't ever invalidated. If NSURLSession isn't invalidated then its delegate keeps a strong reference.

Looks like the same fix will also need to be applied to master.