### PR TITLE
Improve 'read-only' error message

### DIFF
--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -2,7 +2,7 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde geladen und steht zur Installation bereit! Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, weil es von einem Ort ohne Schreibzugriff oder temporären Ort aus gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer .dmg Datei oder Laufwerk ohne Schreibzugriff gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -2,8 +2,7 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?";
 
-%1$@ can’t be updated when it was launched fom your Downloads folder, or when it's running from the .dmg or another read-only volume. Move %1$@ to Applications folder using Finder, relaunch it from there, and try again."
-
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can’t be updated if it was launched from your Downloads folder, or when it's running from the .dmg or another read-only volume. Move %1$@ to Applications folder using Finder, relaunch it from there, and try again.";
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -3,6 +3,7 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?";
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can’t be updated if it was launched from your Downloads folder, or when it's running from the .dmg or another read-only volume. Move %1$@ to Applications folder using Finder, relaunch it from there, and try again.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -2,7 +2,7 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can’t be updated when it’s running from a read-only volume like a disk image or an optical drive. Move %1$@ to Applications folder using Finder, relaunch it from there, and try again.";
+%1$@ can’t be updated when it was launched fom your Downloads folder, or when it's running from the .dmg or another read-only volume. Move %1$@ to Applications folder using Finder, relaunch it from there, and try again."
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 


### PR DESCRIPTION
Heya,

By far the most common cases we see for this error being shown are 
- running the app from ~/Downloads 
- running from a .dmg. 

I guess most apps no longer use physical media, so I'd like to update the error message to reflect that.

👋
Adrian

equinux