### PR TITLE
expose CodesigningVerifier, add codesign info api

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -175,7 +175,7 @@
 		61A354550DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 61A354530DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.h */; settings = {ATTRIBUTES = (); }; };
 		61A354560DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A354540DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.m */; };
 		61AAE8280A321A7F00D8810D /* Sparkle.strings in Resources */ = {isa = PBXBuildFile; fileRef = 61AAE8220A321A7F00D8810D /* Sparkle.strings */; };
-		61B078CE15A5FB6100600039 /* SUCodeSigningVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B078CC15A5FB6100600039 /* SUCodeSigningVerifier.h */; };
+		61B078CE15A5FB6100600039 /* SUCodeSigningVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B078CC15A5FB6100600039 /* SUCodeSigningVerifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61B078CF15A5FB6100600039 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B078CD15A5FB6100600039 /* SUCodeSigningVerifier.m */; };
 		61B5F8ED09C4CE3C00B25A18 /* SUUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B5F8E309C4CE3C00B25A18 /* SUUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61B5F8EE09C4CE3C00B25A18 /* SUUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B5F8E409C4CE3C00B25A18 /* SUUpdater.m */; };
@@ -1447,9 +1447,9 @@
 				61F83F740DBFE141006FDD30 /* SUBasicUpdateDriver.h in Headers */,
 				5D06E9390FD69271005AE3F6 /* SUBinaryDeltaUnarchiver.h in Headers */,
 				72316BD91E0E17180039EFD9 /* SUBundleIcon.h in Headers */,
-				61B078CE15A5FB6100600039 /* SUCodeSigningVerifier.h in Headers */,
 				61299A5C09CA6D4500B7442F /* SUConstants.h in Headers */,
 				6102FE4A0E07803800F85D09 /* SUDiskImageUnarchiver.h in Headers */,
+				61B078CE15A5FB6100600039 /* SUCodeSigningVerifier.h in Headers */,
 				61299A2F09CA2DAB00B7442F /* SUDSAVerifier.h in Headers */,
 				34074B9F1FEABD5A001CB3A5 /* SPUDownloadData.h in Headers */,
 				55E6F33319EC9F6C00005E76 /* SUErrors.h in Headers */,

--- a/Sparkle/SUCodeSigningVerifier.h
+++ b/Sparkle/SUCodeSigningVerifier.h
@@ -10,11 +10,13 @@
 #define SUCODESIGNINGVERIFIER_H
 
 #import <Foundation/Foundation.h>
+#import "SUExport.h"
 
-@interface SUCodeSigningVerifier : NSObject
+SU_EXPORT @interface SUCodeSigningVerifier : NSObject
 + (BOOL)codeSignatureAtBundleURL:(NSURL *)oldBundlePath matchesSignatureAtBundleURL:(NSURL *)newBundlePath error:(NSError  **)error;
 + (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundlePath error:(NSError **)error;
 + (BOOL)bundleAtURLIsCodeSigned:(NSURL *)bundlePath;
++ (NSDictionary *)codeSignatureInfoAtBundleURL:(NSURL *)bundlePath;
 @end
 
 #endif

--- a/Sparkle/Sparkle.h
+++ b/Sparkle/Sparkle.h
@@ -28,5 +28,6 @@
 #import "SPUDownloaderProtocol.h"
 #import "SPUDownloaderSession.h"
 #import "SPUURLRequest.h"
+#import "SUCodeSigningVerifier.h"
 
 #endif


### PR DESCRIPTION
1. export CodesigningVerifier & CodesigningVerifier.h to Framework's Header
2. add api (NSDictionary *)codeSignatureInfoAtBundleURL:(NSURL *)bundlePath to main app to use for more **customized validate work** (teamid, etc), not just check if codesign in validate.
3. this change is base on **+ (void)logSigningInfoForCode:(SecStaticCodeRef)code label:(NSString*)label**.

Signed-off-by: sunuslee <sunuslee@gmail.com>