### PR TITLE
Fix closeCheckingWindow called from background thread

### DIFF
--- a/Sparkle/SUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SUUserInitiatedUpdateDriver.m
@@ -27,6 +27,12 @@
 
 - (void)closeCheckingWindow
 {
+    if (![NSThread isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self closeCheckingWindow];
+        });
+        return;
+    }
 	if (self.checkingController)
 	{
         [[self.checkingController window] close];


### PR DESCRIPTION
Currently closeCheckingWindow is called from background thread (caused by [SPUDownloaderSession URLSession:downloadTask:didFinishDownloadingToURL] session delegate method called in background). Although it's surprisingly working well in most cases, sometimes it crashes.