### PR TITLE
Support for getting the private key from keychain for signing deltas

### DIFF
--- a/generate_appcast/DSASignature.swift
+++ b/generate_appcast/DSASignature.swift
@@ -5,8 +5,8 @@
 
 import Foundation
 
-func loadPrivateKey(privateKeyPath: URL) throws -> SecKey {
-    let data = try Data(contentsOf: privateKeyPath);
+func loadPrivateKey(at privateKeyURL: URL) throws -> SecKey {
+    let data = try Data(contentsOf: privateKeyURL);
 
     var cfitems: CFArray? = nil;
     var format = SecExternalFormat.formatOpenSSL;
@@ -14,7 +14,7 @@ func loadPrivateKey(privateKeyPath: URL) throws -> SecKey {
 
     let status = SecItemImport(data as CFData, nil, &format, &type, SecItemImportExportFlags(rawValue: UInt32(0)), nil, nil, &cfitems);
     if (status != errSecSuccess || cfitems == nil) {
-        print("Private DSA key file", privateKeyPath, "exists, but it could not be read. SecItemImport error", status);
+        print("Private DSA key file", privateKeyURL.path, "exists, but it could not be read. SecItemImport error", status);
         throw NSError(domain: SUSparkleErrorDomain, code: Int(OSStatus(SUError.signatureError.rawValue)), userInfo: nil);
     }
 

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -10,37 +10,81 @@ import Foundation
 
 var verbose = false;
 
+func printUsage() {
+    let command = URL(fileURLWithPath: CommandLine.arguments.first!).lastPathComponent;
+    print("Generate appcast from a directory of Sparkle updates\n",
+        "Usage: \(command) < -f private key path | -k keychain_path -n key_name > <directory with update archives>\n",
+        " e.g. \(command) -f dsa_priv.pem archives/\n",
+        " Appcast files and deltas will be written to the archives directory.\n",
+        " Note that pkg-based updates are not supported.\n"
+    )
+}
+
 func main() {
     let args = CommandLine.arguments;
-    if args.count < 3 {
-        let command = URL(fileURLWithPath: args[0]).lastPathComponent;
-        print("Generate appcast from a directory of Sparkle updates\nUsage: \(command) <private key path> <directory with update archives>\n",
-            " e.g. \(command) dsa_priv.pem archives/\n",
-            " Appcast files and deltas will be written to the archives directory.\n",
-            " Note that pkg-based updates are not supported.\n"
-        )
-        exit(1);
-    }
 
-    let privateKeyURL = URL(fileURLWithPath: args[1]);
-    let archivesSourceDir = URL(fileURLWithPath: args[2], isDirectory:true);
+    let firstOption = args[1]
+    let privateKey: SecKey
+    
+    if firstOption == "-f" && args.count == 4 {
+        // private key specified by filename
+        let privateKeyURL = URL(fileURLWithPath: args[2])
+        
+        do {
+            privateKey = try loadPrivateKey(at: privateKeyURL)
+        } catch {
+            print("Unable to load DSA private key from", privateKeyURL.path, "\n", error)
+            exit(1)
+        }
+    }
+    else if (firstOption == "-n" || firstOption == "-k") && args.count == 6 {
+        // private key specified by keychain + key name
+        let keyName: String
+        let keychainURL: URL
+        
+        if firstOption == "-n" {
+            if args[3] != "-k" {
+                printUsage()
+                exit(1)
+            }
+            
+            keyName = args[2]
+            keychainURL = URL(fileURLWithPath: args[4])
+        }
+        else {
+            if args[3] != "-n" {
+                printUsage()
+                exit(1)
+            }
+            
+            keyName = args[4]
+            keychainURL = URL(fileURLWithPath: args[2])
+        }
+
+        do {
+            privateKey = try loadPrivateKey(named: keyName, fromKeychainAt: keychainURL)
+        } catch {
+            print("Unable to load DSA private key '\(keyName)' from keychain at", keychainURL.path, "\n", error)
+            exit(1)
+        }
+    }
+    else {
+        printUsage()
+        exit(1)
+    }
+    
+    let archivesSourceDir = URL(fileURLWithPath: args.last!, isDirectory: true)
 
     do {
-        let privateKey = try loadPrivateKey(at: privateKeyURL);
-        do {
-            let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, privateKey: privateKey, verbose:verbose);
-
-            for (appcastFile, updates) in allUpdates {
-                let appcastDestPath = URL(fileURLWithPath: appcastFile, relativeTo: archivesSourceDir);
-                try writeAppcast(appcastDestPath:appcastDestPath, updates:updates);
-                print("Written", appcastDestPath.path, "based on", updates.count, "updates");
-            }
-        } catch {
-            print("Error generating appcast from directory", archivesSourceDir.path, "\n", error);
-            exit(1);
+        let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, privateKey: privateKey, verbose:verbose);
+        
+        for (appcastFile, updates) in allUpdates {
+            let appcastDestPath = URL(fileURLWithPath: appcastFile, relativeTo: archivesSourceDir);
+            try writeAppcast(appcastDestPath:appcastDestPath, updates:updates);
+            print("Written", appcastDestPath.path, "based on", updates.count, "updates");
         }
     } catch {
-        print("Unable to load DSA private key from", privateKeyURL.path, "\n", error);
+        print("Error generating appcast from directory", archivesSourceDir.path, "\n", error);
         exit(1);
     }
 }

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -22,11 +22,11 @@ func main() {
         exit(1);
     }
 
-    let privateKeyPath = URL(fileURLWithPath: args[1]);
+    let privateKeyURL = URL(fileURLWithPath: args[1]);
     let archivesSourceDir = URL(fileURLWithPath: args[2], isDirectory:true);
 
     do {
-        let privateKey = try loadPrivateKey(privateKeyPath: privateKeyPath);
+        let privateKey = try loadPrivateKey(at: privateKeyURL);
         do {
             let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, privateKey: privateKey, verbose:verbose);
 
@@ -40,7 +40,7 @@ func main() {
             exit(1);
         }
     } catch {
-        print("Unable to load DSA private key from", privateKeyPath.path, "\n", error);
+        print("Unable to load DSA private key from", privateKeyURL.path, "\n", error);
         exit(1);
     }
 }


### PR DESCRIPTION
It's not safe to have private keys sitting on the disk in plaintext files, but so far this has been a requirement* for `generate_appcast`. This PR adds support for reading the private key directly from a keychain by extending the tool's CLI.

To load the key from file (old):

```
$ generate_appcast private.pem all_my_dmgs/
```

To load the key from file (new):

```
$ generate_appcast -f private.pem all_my_dmgs/
```

To load the key from keychain (new):

```
$ generate_appcast -n ~/Library/Keychains/login.keychain -n "My Sparkle Update Private Key" all_my_dmgs/
```

<sub>* Note: there is a workaround which involves extracting the previously stored key from the keychain, writing it to file, and passing that path to `generate_appcast`, but IMO that's an unnecessary roundtrip. </sub>