### PR TITLE
Silence Xcode 10 "Messaging unqualified id" warning

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -87,5 +87,8 @@ CLANG_ENABLE_MODULES[sdk=macosx10.8] = NO
 // These should be removed once the conversion to ARC is complete
 WARNING_CFLAGS_EXTRA = -Wno-custom-atomic-properties -Wno-implicit-atomic-properties
 
+// Turn off -Wobjc-messaging-id on Xcode 10
+WARNING_CFLAGS_PER_SDK[sdk=macosx10.14] = -Wno-objc-messaging-id
+
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments $(WARNING_CFLAGS_EXTRA)
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments $(WARNING_CFLAGS_EXTRA) $(WARNING_CFLAGS_PER_SDK)


### PR DESCRIPTION
Silence "Messaging unqualified id" warning that's new in Xcode 10 (-Wobjc-messaging-id). This warning is added only when compiling against the 10.14 SDK.

This change should also be applied to the ui-separation-and-xpc branch.