### PR TITLE
Silence Xcode 10 "Messaging unqualified id" warnings by specifying types

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ Secure and reliable software update framework for Cocoa developers.
 ## Requirements
 
 * Runtime: macOS 10.7 or greater
-* Build: Xcode 7 and 10.8 SDK or greater
+* Build: Xcode 7 and 10.11 SDK or greater
 * HTTPS server for serving updates (see [App Transport Security](http://sparkle-project.org/documentation/app-transport-security/))
 
 ## Usage

--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -232,7 +232,7 @@ int main(int __unused argc, const char __unused *argv[])
 {
     @autoreleasepool
     {
-        NSArray *args = [[NSProcessInfo processInfo] arguments];
+        NSArray<NSString *> *args = [[NSProcessInfo processInfo] arguments];
         if (args.count < 5 || args.count > 7) {
             return EXIT_FAILURE;
         }

--- a/Sparkle/SPUURLRequest.m
+++ b/Sparkle/SPUURLRequest.m
@@ -50,7 +50,7 @@ static NSString *SPUURLRequestNetworkServiceTypeKey = @"SPUURLRequestNetworkServ
 
 + (instancetype)URLRequestWithRequest:(NSURLRequest *)request
 {
-    return [[[self class] alloc] initWithURL:request.URL cachePolicy:request.cachePolicy timeoutInterval:request.timeoutInterval httpHeaderFields:request.allHTTPHeaderFields networkServiceType:request.networkServiceType];
+    return [(SPUURLRequest *)[[self class] alloc] initWithURL:request.URL cachePolicy:request.cachePolicy timeoutInterval:request.timeoutInterval httpHeaderFields:request.allHTTPHeaderFields networkServiceType:request.networkServiceType];
 }
 
 + (BOOL)supportsSecureCoding

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -22,12 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 SU_EXPORT @interface SUAppcast : NSObject
 
 @property (copy, nullable) NSString *userAgentString;
-
-#if __has_feature(objc_generics)
 @property (copy, nullable) NSDictionary<NSString *, NSString *> *httpHeaders;
-#else
-@property (copy, nullable) NSDictionary *httpHeaders;
-#endif
 
 - (void)fetchAppcastFromURL:(NSURL *)url inBackground:(BOOL)bg completionBlock:(void (^)(NSError *_Nullable))err;
 - (SUAppcast *)copyWithoutDeltaUpdates;

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -55,7 +55,7 @@
 
 - (BOOL)isCriticalUpdate
 {
-    return [[self.propertiesDictionary objectForKey:SUAppcastElementTags] containsObject:SUAppcastElementCriticalUpdate];
+    return [(NSArray *)[self.propertiesDictionary objectForKey:SUAppcastElementTags] containsObject:SUAppcastElementCriticalUpdate];
 }
 
 - (BOOL)isMacOsUpdate
@@ -97,7 +97,7 @@
 
             // Separate the url by underscores and take the last component, as that'll be closest to the end,
             // then we remove the extension. Hopefully, this will be the version.
-            NSArray *fileComponents = [[enclosure objectForKey:SURSSAttributeURL] componentsSeparatedByString:@"_"];
+            NSArray<NSString *> *fileComponents = [(NSString *)[enclosure objectForKey:SURSSAttributeURL] componentsSeparatedByString:@"_"];
             if ([fileComponents count] > 1) {
                 newVersion = [[fileComponents lastObject] stringByDeletingPathExtension];
             }

--- a/Sparkle/SUAutomaticUpdateAlert.m
+++ b/Sparkle/SUAutomaticUpdateAlert.m
@@ -110,7 +110,7 @@ static NSString *const SUAutomaticUpdateAlertTouchBarIndentifier = @"" SPARKLE_B
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
+    NSTouchBar *touchBar = [(NSTouchBar *)[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[SUAutomaticUpdateAlertTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUAutomaticUpdateAlertTouchBarIndentifier;
     touchBar.delegate = self;

--- a/Sparkle/SUBinaryDeltaCommon.m
+++ b/Sparkle/SUBinaryDeltaCommon.m
@@ -242,7 +242,7 @@ BOOL modifyPermissions(NSString *path, mode_t desiredPermissions)
         return NO;
     }
     mode_t newMode = ([permissions unsignedShortValue] & ~PERMISSION_FLAGS) | desiredPermissions;
-    int (*changeModeFunc)(const char *, mode_t) = [[attributes objectForKey:NSFileType] isEqualToString:NSFileTypeSymbolicLink] ? lchmod : chmod;
+    int (*changeModeFunc)(const char *, mode_t) = [(NSString *)[attributes objectForKey:NSFileType] isEqualToString:NSFileTypeSymbolicLink] ? lchmod : chmod;
     if (changeModeFunc([path fileSystemRepresentation], newMode) != 0) {
         return NO;
     }

--- a/Sparkle/SUDSAVerifier.m
+++ b/Sparkle/SUDSAVerifier.m
@@ -34,7 +34,7 @@
         return NO;
     }
 
-    SUDSAVerifier *verifier = [[self alloc] initWithPublicKeyData:[pkeyString dataUsingEncoding:NSUTF8StringEncoding]];
+    SUDSAVerifier *verifier = [(SUDSAVerifier *)[self alloc] initWithPublicKeyData:[pkeyString dataUsingEncoding:NSUTF8StringEncoding]];
 
     if (!verifier) {
         return NO;

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -71,12 +71,12 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
 
 + (instancetype)defaultManager
 {
-    return [[self alloc] initWithAuthorizationToolPath:nil];
+    return [(SUFileManager *)[self alloc] initWithAuthorizationToolPath:nil];
 }
 
 + (instancetype)fileManagerWithAuthorizationToolPath:(NSString *)authorizationToolPath
 {
-    return [[self alloc] initWithAuthorizationToolPath:authorizationToolPath];
+    return [(SUFileManager *)[self alloc] initWithAuthorizationToolPath:authorizationToolPath];
 }
 
 - (instancetype)fileManagerByPreservingAuthorizationRights
@@ -269,7 +269,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
     }
 
     if (isDirectory != NULL) {
-        *isDirectory = [[attributes objectForKey:NSFileType] isEqualToString:NSFileTypeDirectory];
+        *isDirectory = [(NSString *)[attributes objectForKey:NSFileType] isEqualToString:NSFileTypeDirectory];
     }
 
     return YES;
@@ -304,7 +304,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
 - (BOOL)_removeQuarantineWithAuthenticationAtRootURL:(NSURL *)rootURL error:(NSError *__autoreleasing *)error
 {
     // Because this is a system utility, it's fine to follow the symbolic link if one exists
-    if (![_fileManager fileExistsAtPath:@(XATTR_UTILITY_PATH)]) {
+    if (![_fileManager fileExistsAtPath:(NSString *)@(XATTR_UTILITY_PATH)]) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSLocalizedDescriptionKey: @"xattr utility does not exist on this system." }];
         }

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -161,7 +161,7 @@
 
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key
 {
-    return [[self objectForInfoDictionaryKey:key] boolValue];
+    return [(NSNumber *)[self objectForInfoDictionaryKey:key] boolValue];
 }
 
 - (id)objectForUserDefaultsKey:(NSString *)defaultName

--- a/Sparkle/SUOperatingSystem.m
+++ b/Sparkle/SUOperatingSystem.m
@@ -32,7 +32,7 @@
         NSURL *url = [coreServices URLByAppendingPathComponent:@"SystemVersion.plist"];
         assert(url != nil);
         NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfURL:url];
-        NSArray *components = [ [dictionary objectForKey: @"ProductVersion"] componentsSeparatedByString:@"."];
+        NSArray<NSString *> *components = [ (NSString *)[dictionary objectForKey: @"ProductVersion"] componentsSeparatedByString:@"."];
         version.majorVersion = components.count > 0 ? [ [components objectAtIndex:0] integerValue] : 0;
         version.minorVersion = components.count > 1 ? [ [components objectAtIndex:1] integerValue] : 0;
         version.patchVersion = components.count > 2 ? [ [components objectAtIndex:2] integerValue] : 0;

--- a/Sparkle/SUPipedUnarchiver.m
+++ b/Sparkle/SUPipedUnarchiver.m
@@ -100,7 +100,7 @@
         
         // Get the file size.
         NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:self.archivePath error:nil];
-        NSUInteger expectedLength = [[attributes objectForKey:NSFileSize] unsignedIntegerValue];
+        NSUInteger expectedLength = [(NSNumber *)[attributes objectForKey:NSFileSize] unsignedIntegerValue];
         if (expectedLength > 0) {
             NSFileHandle *archiveInput = [NSFileHandle fileHandleForReadingAtPath:self.archivePath];
             

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -136,7 +136,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
+    NSTouchBar *touchBar = [(NSTouchBar *)[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[ SUStatusControllerTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUStatusControllerTouchBarIndentifier;
     touchBar.delegate = self;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -263,7 +263,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     return finalString;
 }
 
-- (void)webView:(WebView *)sender didFinishLoadForFrame:frame
+- (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
 {
     if ([frame parentFrame] == nil) {
         self.webViewFinishedLoading = YES;
@@ -329,7 +329,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
+    NSTouchBar *touchBar = [(NSTouchBar *)[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[SUUpdateAlertTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUUpdateAlertTouchBarIndentifier;
     touchBar.delegate = self;

--- a/Sparkle/SUUpdatePermissionPrompt.h
+++ b/Sparkle/SUUpdatePermissionPrompt.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSInteger, SUPermissionPromptResult) {
 + (void)promptWithHost:(SUHost *)host systemProfile:(NSArray *)profile reply:(void (^)(SUUpdatePermissionResponse *))reply;
 
 - (IBAction)toggleMoreInfo:(id)sender;
-- (IBAction)finishPrompt:(id)sender;
+- (IBAction)finishPrompt:(NSButton *)sender;
 @end
 
 #endif

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -52,7 +52,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (BOOL)shouldAskAboutProfile
 {
-    return [[self.host objectForInfoDictionaryKey:SUEnableSystemProfilingKey] boolValue];
+    return [(NSNumber *)[self.host objectForInfoDictionaryKey:SUEnableSystemProfilingKey] boolValue];
 }
 
 - (instancetype)initWithHost:(SUHost *)aHost systemProfile:(NSArray *)profile reply:(void (^)(SUUpdatePermissionResponse *))reply
@@ -80,7 +80,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     }
 
     if (![NSApp modalWindow]) { // do not prompt if there is is another modal window on screen
-        SUUpdatePermissionPrompt *prompt = [[[self class] alloc] initWithHost:host systemProfile:profile reply:reply];
+        SUUpdatePermissionPrompt *prompt = [(SUUpdatePermissionPrompt *)[[self class] alloc] initWithHost:host systemProfile:profile reply:reply];
         NSWindow *window = [prompt window];
         if (window) {
             [NSApp runModalForWindow:window];
@@ -159,7 +159,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     [self.moreInfoView setHidden:!self.isShowingMoreInfo];
 }
 
-- (IBAction)finishPrompt:(id)sender
+- (IBAction)finishPrompt:(NSButton *)sender
 {
     SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) sendSystemProfile:self.shouldSendProfile];
     self.reply(response);
@@ -170,7 +170,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (NSTouchBar *)makeTouchBar
 {
-    NSTouchBar *touchBar = [[NSClassFromString(@"NSTouchBar") alloc] init];
+    NSTouchBar *touchBar = [(NSTouchBar *)[NSClassFromString(@"NSTouchBar") alloc] init];
     touchBar.defaultItemIdentifiers = @[SUUpdatePermissionPromptTouchBarIndentifier,];
     touchBar.principalItemIdentifier = SUUpdatePermissionPromptTouchBarIndentifier;
     touchBar.delegate = self;

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -160,11 +160,7 @@ SU_EXPORT @interface SUUpdater : NSObject
 
  The keys of this dictionary are HTTP header fields (NSString) and values are corresponding values (NSString)
  */
-#if __has_feature(objc_generics)
 @property (copy) NSDictionary<NSString *, NSString *> *httpHeaders;
-#else
-@property (copy) NSDictionary *httpHeaders;
-#endif
 
 /*!
  A property indicating whether or not the user's system profile information is sent when checking for updates.

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -88,7 +88,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (bundle == nil) bundle = [NSBundle mainBundle];
     id updater = [sharedUpdaters objectForKey:[NSValue valueWithNonretainedObject:bundle]];
     if (updater == nil) {
-        updater = [[[self class] alloc] initForBundle:bundle];
+        updater = [(SUUpdater *)[[self class] alloc] initForBundle:bundle];
     }
     return updater;
 }
@@ -315,7 +315,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     }
 
     // Do not use reachability for a preflight check. This can be deceptive and a bad idea. Apple does not recommend doing it.
-    SUUpdateDriver *theUpdateDriver = [[(automatic ? [SUAutomaticUpdateDriver class] : [SUScheduledUpdateDriver class])alloc] initWithUpdater:self];
+    SUUpdateDriver *theUpdateDriver = [(SUBasicUpdateDriver *)[(automatic ? [SUAutomaticUpdateDriver class] : [SUScheduledUpdateDriver class])alloc] initWithUpdater:self];
     
     [self checkForUpdatesWithDriver:theUpdateDriver];
 }
@@ -537,7 +537,7 @@ static NSString *escapeURLComponent(NSString *str) {
     const NSTimeInterval oneWeek = 60 * 60 * 24 * 7;
     sendingSystemProfile &= (-[lastSubmitDate timeIntervalSinceNow] >= oneWeek);
 
-    NSArray *parameters = @[];
+    NSArray<NSDictionary<NSString *, NSString *> *> *parameters = @[];
     if ([self.delegate respondsToSelector:@selector(feedParametersForUpdater:sendingSystemProfile:)]) {
         parameters = [parameters arrayByAddingObjectsFromArray:[self.delegate feedParametersForUpdater:self sendingSystemProfile:sendingSystemProfile]];
     }
@@ -550,7 +550,7 @@ static NSString *escapeURLComponent(NSString *str) {
 
     // Build up the parameterized URL.
     NSMutableArray *parameterStrings = [NSMutableArray array];
-    for (NSDictionary *currentProfileInfo in parameters) {
+    for (NSDictionary<NSString *, NSString *> *currentProfileInfo in parameters) {
         [parameterStrings addObject:[NSString stringWithFormat:@"%@=%@", escapeURLComponent([[currentProfileInfo objectForKey:@"key"] description]), escapeURLComponent([[currentProfileInfo objectForKey:@"value"] description])]];
     }
 

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -64,11 +64,7 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
  
  \return An array of dictionaries with keys: "key", "value", "displayKey", "displayValue", the latter two being specifically for display to the user.
  */
-#if __has_feature(objc_generics)
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)feedParametersForUpdater:(SUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
-#else
-- (NSArray *)feedParametersForUpdater:(SUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
-#endif
 
 /*!
  Returns a custom appcast URL.

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -30,7 +30,7 @@ static NSString * const UPDATED_VERSION = @"2.0";
     NSBundle *mainBundle = [NSBundle mainBundle];
     
     // Check if we are already up to date
-    if ([[mainBundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey] isEqualToString:UPDATED_VERSION]) {
+    if ([(NSString *)[mainBundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey] isEqualToString:UPDATED_VERSION]) {
         NSAlert *alreadyUpdatedAlert = [[NSAlert alloc] init];
         alreadyUpdatedAlert.messageText = @"Update succeeded!";
         alreadyUpdatedAlert.informativeText = @"This is the updated version of Sparkle Test App.\n\nDelete and rebuild the app to test updates again.";

--- a/TestApplication/SUTestWebServer.m
+++ b/TestApplication/SUTestWebServer.m
@@ -96,7 +96,7 @@
             NSString *requestLine = lines.count >= 3 ? [lines objectAtIndex:0] : nil;
             NSArray *parts = requestLine ? [requestLine componentsSeparatedByString:@" "] : nil;
             // Only process GET requests for existing files
-            if ([[parts objectAtIndex:0] isEqualToString:@"GET"]) {
+            if ([(NSString *)[parts objectAtIndex:0] isEqualToString:@"GET"]) {
                 // Use NSURL to strip out query parameters
                 NSString *path = [NSURL URLWithString:[parts objectAtIndex:1] relativeToURL:nil].path;
                 NSString *filePath = [self.workingDirectory stringByAppendingString:path];

--- a/fileop/fileop.m
+++ b/fileop/fileop.m
@@ -85,11 +85,11 @@ int main(int argc, const char *argv[])
         // This tool should be executed as root, so we should not try to authorize
         SUFileManager *fileManager = [SUFileManager defaultManager];
         
-        if ([command isEqualToString:@(SUFileOpRemoveQuarantineCommand)]) {
+        if ([command isEqualToString:(NSString *)@(SUFileOpRemoveQuarantineCommand)]) {
             if (![fileManager releaseItemFromQuarantineAtRootURL:fileURL error:NULL]) {
                 exit(SUQuarantineRemovalFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpCopyCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpCopyCommand)]) {
             if (destinationURL != nil) {
                 if (![fileManager copyItemAtURL:fileURL toURL:destinationURL error:NULL]) {
                     exit(SUCopyFailure);
@@ -97,7 +97,7 @@ int main(int argc, const char *argv[])
             } else {
                 exit(SUInvalidOrNoDestination | SUCopyFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpMoveCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpMoveCommand)]) {
             if (destinationURL != nil) {
                 if (![fileManager moveItemAtURL:fileURL toURL:destinationURL error:NULL]) {
                     exit(SUMoveFailure);
@@ -105,7 +105,7 @@ int main(int argc, const char *argv[])
             } else {
                 exit(SUInvalidOrNoDestination | SUMoveFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpChangeOwnerAndGroupCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpChangeOwnerAndGroupCommand)]) {
             if (destinationURL != nil) {
                 if (![fileManager changeOwnerAndGroupOfItemAtRootURL:fileURL toMatchURL:destinationURL error:NULL]) {
                     exit(SUChangeOwnerAndGroupFailure);
@@ -113,19 +113,19 @@ int main(int argc, const char *argv[])
             } else {
                 exit(SUInvalidOrNoDestination | SUChangeOwnerAndGroupFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpUpdateModificationAndAccessTimeCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpUpdateModificationAndAccessTimeCommand)]) {
             if (![fileManager updateModificationAndAccessTimeOfItemAtURL:fileURL error:NULL]) {
                 exit(SUTouchFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpMakeDirectoryCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpMakeDirectoryCommand)]) {
             if (![fileManager makeDirectoryAtURL:fileURL error:NULL]) {
                 exit(SUMakeDirectoryFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpRemoveCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpRemoveCommand)]) {
             if (![fileManager removeItemAtURL:fileURL error:NULL]) {
                 exit(SURemoveFailure);
             }
-        } else if ([command isEqualToString:@(SUFileOpInstallCommand)]) {
+        } else if ([command isEqualToString:(NSString *)@(SUFileOpInstallCommand)]) {
             // The one command that can *only* be run as the root user
             NSString *installerPath = @"/usr/sbin/installer";
             


### PR DESCRIPTION
Alternate fix for #1250. This explicitly casts the return types where the warnings are to silence them rather than disabling the warning.

If this approach is better I'll do the same thing in the ui-separation-and-xpc branch afterwards.