### PR TITLE
Fix compilation issues on Xcode 10 with new build system

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -1870,6 +1870,7 @@
 			files = (
 			);
 			inputPaths = (
+				$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH,
 			);
 			name = "Run Script: Set Git Version Info";
 			outputPaths = (
@@ -1885,6 +1886,7 @@
 			files = (
 			);
 			inputPaths = (
+				$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH,
 			);
 			name = "Run Script: Set Git Version Info";
 			outputPaths = (


### PR DESCRIPTION
During WWDC I found some compilation issues with Xcode 10 under the new build system. I sat with an Apple engineer in the labs, and we found that this change was necessary because the scripts access the Info.plist file, which in the new parallel build system may not be ready. These changes ensure the dependency system is aware and times tasks in the correct order.