### PR TITLE
New Spanish localisation

### DIFF
--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -1,43 +1,47 @@
-"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ se han descargado y están listos para utilizar. ¿Le gustaría instalar e iniciar %1$@ ahora?";
+"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "¡%1$@ %2$@ se ha descargado y está lista para usarse! Ésta es una actualización importante. ¿Te gustaría instalarla y volver a abrir %1$@ ahora?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ no se puede actualizar cuando se ejecuta desde un volumen de sólo lectura como imagen de disco o medio óptico. Mueva %1$@ a su carpeta de Aplicaciones y trate de iniciarlo desde allí.";
+"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "¡%1$@ %2$@ se ha descargado y está lista para usarse! ¿Te gustaría instalarla y volver a abrir %1$@ ahora?";
 
-"%@ %@ is currently the newest version available." = "%1$@ %2$@ es la última versión disponible.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ no se puede actualizar porque fue abierta desde una ubicación temporal o de solo lectura. Usa Finder para copiar %1$@ a la carpeta Aplicaciones, vuélvela a abrir desde ahí e inténtalo de nuevo.";
+
+"%@ %@ is currently the newest version available." = "%1$@ %2$@ es la versión más nueva disponible.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ está disponible (usted tiene la %3$@). ¿Desea descargarla ahora?";
+"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ya está disponible (tienes la %3$@). ¿Quisieras descargarla ahora?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ is now available--you have %3$@. Would you like to learn more about this update on the web?";
+"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ya está disponible--tú tienes la %3$@. ¿Quisieras aprender más acerca de esta actualización en la red?";
 
 "%@ downloaded" = "%@ descargado";
 
 "%@ of %@" = "%1$@ de %2$@";
 
-"A new version of %@ is available!" = "¡Hay una nueva versión de %@ !";
+"A new version of %@ is available!" = "¡Una nueva versión de %@ está disponible!";
 
-"A new version of %@ is ready to install!" = "¡Una versión nueva de %@ está lista para instalar!";
+"A new version of %@ is ready to install!" = "¡Una nueva versión de %@ está lista para instalarse!";
 
-"An error occurred in retrieving update information. Please try again later." = "Ocurrió un error al recopilar información sobre la actualización. Por favor, inténtelo de nuevo más tarde.";
+"An error occurred in retrieving update information. Please try again later." = "Ocurrió un error al recopilar información sobre la actualización. Por favor inténtalo de nuevo más tarde.";
 
-"An error occurred while downloading the update. Please try again later." = "Ocurrió un error mientras se descargaba la actualización. Por favor intente de nuevo más tarde.";
+"An error occurred while downloading the update. Please try again later." = "Ocurrió un error al descargar la actualización. Por favor inténtalo de nuevo más tarde.";
 
-"An error occurred while extracting the archive. Please try again later." = "Ocurrió un error al extraer el archivo. Por favor, inténtelo de nuevo más tarde.";
+"An error occurred while extracting the archive. Please try again later." = "Ocurrió un error al extraer el archivo. Por favor inténtalo de nuevo más tarde.";
 
-"An error occurred while installing the update. Please try again later." = "Ocurrió un error mientras se instalaba la actualización. Por favor intente de nuevo más tarde.";
+"An error occurred while installing the update. Please try again later." = "Ocurrió un error al instalar la actualización. Por favor inténtalo de nuevo más tarde.";
 
-"An error occurred while parsing the update feed." = "Ocurrió un error mientras se analizaba la entrada de la actualización.";
+"An error occurred while parsing the update feed." = "Ocurrió un error al analizar la información de la actualización.";
 
-"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "Ocurrió un error mientras se re-iniciaba %1$@, pero la nueva versión estará disponible la próxima vez que ejecute %1$@.";
+"An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "Ocurrió un error al volver a abrir %1$@, pero la nueva versión estará disponible la próxima vez que abras %1$@.";
+
+"An important update to %@ is ready to install" = "Una actualización importante para %@ está lista para instalarse";
 
 /* the unit for bytes */
-"B" = "O";
+"B" = "B";
 
 "Cancel" = "Cancelar";
 
 "Cancel Update" = "Cancelar actualización";
 
-"Checking for updates..." = "Buscando actualizaciones …";
+"Checking for updates..." = "Buscando actualizaciones…";
 
 /* Take care not to overflow the status window. */
 "Downloading update..." = "Descargando actualización…";
@@ -46,34 +50,40 @@
 "Extracting update..." = "Extrayendo actualización…";
 
 /* the unit for gigabytes */
-"GB" = "GO";
+"GB" = "GB";
 
-"Install and Relaunch" = "Instalar y volver a arrancar";
+"Install and Relaunch" = "Instalar y volver a abrir";
 
 /* Take care not to overflow the status window. */
 "Installing update..." = "Instalando actualización…";
 
 /* the unit for kilobytes */
-"KB" = "KO";
+"KB" = "KB";
+
+/* Alternative name for "Install" button if we have a paid update or other update
+	without a download but with a URL. */
+"Learn More..." = "Más información…";
 
 /* the unit for megabytes */
 "MB" = "MB";
 
-"OK" = "OK";
+/* OK button. */
+"OK" = "Aceptar";
 
-"Ready to Install" = "Preparado para instalar";
+/* Status message on progress window once download has finished. */
+"Ready to Install" = "Listo para instalarse";
 
-"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "¿Debería automáticamente %1$@ buscar las actualizaciones? Puede hacerlo también manualmente desde el menú %1$@.";
+/* Message that is optionally shown at startup to allow users to turn on/off update checks. */
+"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "¿Debería %1$@ buscar actualizaciones automáticamente? Siempre puedes buscar actualizaciones manualmente desde el menú %1$@.";
+
+"The update is improperly signed." = "La actualización está firmada incorrectamente.";
 
 "Update Error!" = "¡Error de actualización!";
 
 "Updating %@" = "Actualizando %@";
 
-"You already have the newest version of %@." = "Ya tiene la versión más reciente de %@.";
+/* 'Error' message when the user checks for updates but is already current or the feed doesn't contain any updates. (not necessarily shown in UI) */
+"You already have the newest version of %@." = "Ya tienes la versión más nueva de %@.";
 
-"You're up-to-date!" = "Ya tiene la versión más reciente";
-
-/* Alternative name for "Install" button if we have a paid update or other update
-	without a download but with a URL. */
-
-"Learn More..." = "Más información…";
+/* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
+"You're up-to-date!" = "¡Está actualizado!";


### PR DESCRIPTION
As discussed in #1259, I created new strings for the Spanish localisation.

I had to make some decisions. Hope these are okay with you:
- I refer to the app name and update using feminine pronouns. Makes most sense since application (aplicación), version (versión) and update (actualización) are all feminine nouns in Spanish.
- There's no ideal translation for relaunch, so I put it as "volver a abrir" (reopen).
- The most precise translations for feed (fuente) and parse (analizar sintácticamente) are technical terms that aren't used in common speech, so I used "información" (information) and analizar (analyse) instead.