### PR TITLE
Fixed some typos

### DIFF
--- a/Sparkle/he.lproj/Sparkle.strings
+++ b/Sparkle/he.lproj/Sparkle.strings
@@ -16,11 +16,13 @@
 
 "A new version of %@ is available!" = "גרסה חדשה של %@ זמינה!";
 
-"An error occurred during installation. Please try again later." = "שגיאה בהתקנה. אנא נסה שנית במועד מרוחר יותר.";
+"Cancel Update" = "בטל עדכון";
 
-"An error occurred in retrieving update information. Please try again later." = "שגיאה בקבלת מידע על עדכונים. אנא נסה שנית במועד מרוחר יותר.";
+"An error occurred during installation. Please try again later." = "שגיאה בהתקנה. אנא נסה שנית במועד מאוחר יותר.";
 
-"An error occurred while extracting the archive. Please try again later." = "שגיאה בפתיחת הקובת המקווץ. אנא נסה שנית במועד מרוחר יותר.";
+"An error occurred in retrieving update information. Please try again later." = "שגיאה בקבלת מידע על עדכונים. אנא נסה שנית במועד מאוחר יותר.";
+
+"An error occurred while extracting the archive. Please try again later." = "שגיאה בפתיחת הקובת המקווץ. אנא נסה שנית במועד מאוחר יותר.";
 
 "An error occurred while trying to download the file. Please try again later." = "שגיאה בהורדת הקובץ. אנא נסה שנית במועד מאוחר יותר.";
 


### PR DESCRIPTION
Fixed typos in the following keys:
"An error occurred during installation. Please try again later."
"An error occurred in retrieving update information. Please try again later."
Added missing key that fell back to English:
"Cancel Update" = "בטל עדכון"; (Inside alert when using a button to let user check for updates)