### PR TITLE
Adds an option to turn off hideOnDeactivate in SPUStandardUserDriver for foreground apps

### DIFF
--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -33,6 +33,11 @@ SU_EXPORT @interface SPUStandardUserDriver : NSObject <SPUUserDriver, SPUStandar
  */
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle delegate:(nullable id<SPUStandardUserDriverDelegate>)delegate;
 
+/*!
+ * Enable or disable hideOnDeactivate for standard update window.
+ */
+@property (nonatomic) BOOL hideOnDeactivate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -39,6 +39,7 @@
 @synthesize delegate = _delegate;
 @synthesize checkingController = _checkingController;
 @synthesize activeUpdateAlert = _activeUpdateAlert;
+@synthesize hideOnDeactivate = _hideOnDeactivate;
 @synthesize statusController = _statusController;
 
 #pragma mark Birth
@@ -50,6 +51,7 @@
         _host = [[SUHost alloc] initWithBundle:hostBundle];
         _delegate = delegate;
         _coreComponent = [[SPUUserDriverCoreComponent alloc] init];
+        _hideOnDeactivate = YES;
     }
     return self;
 }
@@ -88,12 +90,15 @@
     // Make sure the window is loaded in any case
     [self.activeUpdateAlert window];
     
+    if (!self.hideOnDeactivate) {
+        [self.activeUpdateAlert.window setHidesOnDeactivate:NO];
+    }
+    
     // If the app is a menubar app or the like, we need to focus it first and alter the
     // update prompt to behave like a normal window. Otherwise if the window were hidden
     // there may be no way for the application to be activated to make it visible again.
     if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) {
         [self.activeUpdateAlert.window setHidesOnDeactivate:NO];
-        
         [NSApp activateIgnoringOtherApps:YES];
     }
     


### PR DESCRIPTION
By default, SPUStandardUserDriver's update window disappears when moving focus to another app. Depending on your application, this might not be the desired behavior. This PR adds a boolean property that can be set to alter this behavior. Note that it still respects background apps, where the property has no effect.

Thank you for the time to review and please let me know if there might be a more appropriate way to address this issue.