### PR TITLE
Make "sign_update" work on pre-10.13 system

### DIFF
--- a/bin/sign_update
+++ b/bin/sign_update
@@ -6,4 +6,11 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 openssl=/usr/bin/openssl
-$openssl dgst -sha1 -binary < "$1" | $openssl dgst -sha1 -sign "$2" | $openssl enc -base64
+version=`$openssl version`
+if [[ $version =~ "OpenSSL 0.9" ]]; then
+	# pre-10.13 system: Fall back to OpenSSL DSS1 digest because it does not like the -sha1 option
+	$openssl dgst -sha1 -binary < "$1" | $openssl dgst -dss1 -sign "$2" | $openssl enc -base64
+else
+	# 10.13 and later: Use LibreSSL SHA1 digest
+	$openssl dgst -sha1 -binary < "$1" | $openssl dgst -sha1 -sign "$2" | $openssl enc -base64
+fi


### PR DESCRIPTION
Make "sign_update" work on pre-10.13 system by checking the OpenSSL version, using the older "-dss1" digest option again in that case. See https://github.com/sparkle-project/Sparkle/issues/1277 and https://github.com/sparkle-project/Sparkle/commit/0cb0b2f2c7b07b65231528991ac98dc384e51146