### PR TITLE
Showing release notes with dark appearance according to the system theme

### DIFF
--- a/Resources/DarkAqua.css
+++ b/Resources/DarkAqua.css
@@ -1,0 +1,10 @@
+html {
+    color: white;
+    background: transparent;
+}
+:link {
+    color: #419CFF;
+}
+:link:active {
+    color: #FF1919;
+}

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		14950073195FCE4E00BC5B5B /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0867D6A5FE840307C02AAC07 /* AppKit.framework */; };
 		14958C6E19AEBC950061B14F /* signed-test-file.txt in Resources */ = {isa = PBXBuildFile; fileRef = 14958C6B19AEBC530061B14F /* signed-test-file.txt */; };
 		14958C6F19AEBC980061B14F /* test-pubkey.pem in Resources */ = {isa = PBXBuildFile; fileRef = 14958C6C19AEBC610061B14F /* test-pubkey.pem */; };
+		1EAA4C8B2132C7BF00604473 /* DarkAqua.css in Resources */ = {isa = PBXBuildFile; fileRef = 1EAA4C8A2132C7BF00604473 /* DarkAqua.css */; };
 		3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3772FEA813DE0B6B00F79537 /* SUVersionDisplayProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		55C14BEF136EF21700649790 /* SUStatus.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BD8136EF00C00649790 /* SUStatus.xib */; };
 		55C14C04136EF26100649790 /* SUUpdateAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BF0136EF26100649790 /* SUUpdateAlert.xib */; };
@@ -810,6 +811,7 @@
 		1A985A511C5C32BB0001163A /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1A985A521C5C32BC0001163A /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1A985A531C5C32BD0001163A /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		1EAA4C8A2132C7BF00604473 /* DarkAqua.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = DarkAqua.css; sourceTree = "<group>"; };
 		3772FEA813DE0B6B00F79537 /* SUVersionDisplayProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUVersionDisplayProtocol.h; sourceTree = "<group>"; };
 		4607BEA21948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		4607BEA41948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = nb; path = nb.lproj/SUUpdateAlert.xib; sourceTree = "<group>"; };
@@ -1489,6 +1491,7 @@
 				14732BBC1960EFB500593899 /* README.markdown */,
 				14732BB91960EEEE00593899 /* SampleAppcast.xml */,
 				615AE3CF0D64DC40001CA7BD /* SUModelTranslation.plist */,
+				1EAA4C8A2132C7BF00604473 /* DarkAqua.css */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2524,13 +2527,13 @@
 					};
 					726E07AC1CAF08D6001A286B = {
 						CreatedOnToolsVersion = 7.3;
-				};
+					};
 					726E07EE1CAF37BD001A286B = {
 						CreatedOnToolsVersion = 7.3;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
-			};
+							};
 						};
 					};
 					726E4A151C86C88F00C57C6A = {
@@ -2732,6 +2735,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61AAE8280A321A7F00D8810D /* Sparkle.strings in Resources */,
+				1EAA4C8B2132C7BF00604473 /* DarkAqua.css in Resources */,
 				615AE3D00D64DC40001CA7BD /* SUModelTranslation.plist in Resources */,
 				55C14BEF136EF21700649790 /* SUStatus.xib in Resources */,
 				55C14C04136EF26100649790 /* SUUpdateAlert.xib in Resources */,


### PR DESCRIPTION
This is done by applying a user stylesheet to get white text, making the background of the WebView transparent, and using a `NSBox` to display the dynamic dark background color.

Notes:

- All done in code so there is no need to change the IB files.
- Before this change, the spinner would appear invisible (white on white) while loading the release notes.
- The appearance of the release notes will unfortunately not adapt if the theme is changed while the window is open. That would probably involve adding a view in the hierarchy to handle calls to `effectiveAppearanceDidChange` by calling the method `adaptReleaseNotesAppearance` on the window controller.
- HTML files using custom colors might not appear at their greatest with this new background. Release note for some apps might need to be tweaked accordingly.

## Before

<img width="732" alt="capture d ecran 2018-08-26 a 06 27 55" src="https://user-images.githubusercontent.com/298045/44632307-3d891900-a946-11e8-998c-a70fbc2d0506.png">

## After

<img width="732" alt="capture d ecran 2018-08-26 a 15 56 00" src="https://user-images.githubusercontent.com/298045/44632504-a8881f00-a949-11e8-8a36-d3a91c4d8321.png">