### PR TITLE
Fixing cut text in prompt window (French)

### DIFF
--- a/Sparkle/fr.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/fr.lproj/SUUpdatePermissionPrompt.xib
@@ -147,7 +147,7 @@ Gw
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">Les informations anonymes de profil système nous aident à planifier les futurs développements. Contactez-nous pour toute question à ce sujet.
 
-Ci-dessous figurent les informations qui seront transmises :</string>
+Ci-dessous figurent les informations transmises :</string>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/Sparkle/fr.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/fr.lproj/SUUpdatePermissionPrompt.xib
@@ -69,7 +69,7 @@ Gw
                         </connections>
                     </textField>
                     <button focusRingType="none" id="34">
-                        <rect key="frame" x="104" y="53" width="278" height="18"/>
+                        <rect key="frame" x="104" y="53" width="316" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Avec transmission anonyme de mon profil système" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" focusRingType="none" inset="2" id="180">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>


### PR DESCRIPTION
Made the checkbox wider in French since there's plenty of space.

Shortened the text a bit in MoreInfoView so it does not get cut when the view is squeezed to fit the prompt window. A rough literal translation of the change is like this: "Below is shown the information ~~that will be~~ transmitted:".

This problem was reported in #1275.