### PR TITLE
Dark Mode Release Notes Complement

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -253,7 +253,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     if (@available(macOS 10.14, *))
     {
         WebPreferences *prefs = [self.releaseNotesView preferences];
-        if ([self.releaseNotesView effectiveAppearance].name == NSAppearanceNameDarkAqua || [self.releaseNotesView effectiveAppearance].name == NSAppearanceNameAccessibilityHighContrastDarkAqua)
+        NSAppearanceName bestAppearance = [self.releaseNotesView.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+        if ([bestAppearance isEqualToString:NSAppearanceNameDarkAqua])
         {
             // Set user stylesheet adapted to light on dark
             prefs.userStyleSheetEnabled = YES;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -219,6 +219,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     prefs.standardFontFamily = @"-apple-system-font";
     prefs.defaultFontSize = (int)[NSFont systemFontSize];
     [self adaptReleaseNotesAppearance];
+    [self.releaseNotesView addObserver:self forKeyPath:@"effectiveAppearance" options:0 context:nil];
     
     // Stick a nice big spinner in the middle of the web view until the page is loaded.
     NSRect frame = [[self.releaseNotesView superview] frame];
@@ -234,6 +235,16 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 	{
         [[self.releaseNotesView mainFrame] loadHTMLString:[self.updateItem itemDescription] baseURL:nil];
     }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(__attribute__((unused)) NSDictionary<NSKeyValueChangeKey,id> *)change context:(__attribute__((unused)) void *)context {
+    if (object == self.releaseNotesView && [keyPath isEqualToString:@"effectiveAppearance"]) {
+        [self adaptReleaseNotesAppearance];
+    }
+}
+
+- (void)dealloc {
+    [self.releaseNotesView removeObserver:self forKeyPath:@"effectiveAppearance"];
 }
 
 - (void)adaptReleaseNotesAppearance

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -282,6 +282,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         {
             // Restore standard dark on light appearance
             [self.darkBackgroundView removeFromSuperview];
+            self.darkBackgroundView = nil;
             prefs.userStyleSheetEnabled = NO;
             self.releaseNotesView.drawsBackground = YES;
         }


### PR DESCRIPTION
Continuing from #1280:

* Now reacting to system appearance changes using KVO on the `effectiveAppearance` property of the release notes view.
* Better future-proofing for dark mode detection using `bestMatchFromAppearancesWithNames` instead of matching current appearance by name.
* Fixing issue where `darkBackgroundView` wouldn't be recreated when entering dark mode because it wasn't set to nil before.