### PR TITLE
Only observe effectiveAppearance on 10.14 or later

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -219,7 +219,12 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     prefs.standardFontFamily = @"-apple-system-font";
     prefs.defaultFontSize = (int)[NSFont systemFontSize];
     [self adaptReleaseNotesAppearance];
-    [self.releaseNotesView addObserver:self forKeyPath:@"effectiveAppearance" options:0 context:nil];
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+    if (@available(macOS 10.14, *)) {
+        [self.releaseNotesView addObserver:self forKeyPath:@"effectiveAppearance" options:0 context:nil];
+    }
+#endif
     
     // Stick a nice big spinner in the middle of the web view until the page is loaded.
     NSRect frame = [[self.releaseNotesView superview] frame];
@@ -238,13 +243,21 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(__attribute__((unused)) NSDictionary<NSKeyValueChangeKey,id> *)change context:(__attribute__((unused)) void *)context {
-    if (object == self.releaseNotesView && [keyPath isEqualToString:@"effectiveAppearance"]) {
-        [self adaptReleaseNotesAppearance];
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+    if (@available(macOS 10.14, *)) {
+        if (object == self.releaseNotesView && [keyPath isEqualToString:@"effectiveAppearance"]) {
+            [self adaptReleaseNotesAppearance];
+        }
     }
+#endif
 }
 
 - (void)dealloc {
-    [self.releaseNotesView removeObserver:self forKeyPath:@"effectiveAppearance"];
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+    if (@available(macOS 10.14, *)) {
+        [self.releaseNotesView removeObserver:self forKeyPath:@"effectiveAppearance"];
+    }
+#endif
 }
 
 - (void)adaptReleaseNotesAppearance


### PR DESCRIPTION
We're seeing crashes like this on Touch Bar Macs running 10.12:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'An instance 0x60000033c980 of class WebView was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x600000436700> (
<NSKeyValueObservance 0x60000185afa0: Observer: 0x60000038a0e0, Key path: effectiveAppearance, Options: <New: NO, Old: NO, Prior: NO> Context: 0x0, Property: 0x60000185aee0>
)'
```

I'm not entirely sure why removeObserver: isn't being called in dealloc. I don't have a 10.12 machine on hand right now, so not observing effectiveAppearance at all seems like the safest path.