### PR TITLE
SPUDownloaderSession leaked because the NSURLSession wasn’t invalidated

### DIFF
--- a/Sparkle/SPUDownloaderSession.m
+++ b/Sparkle/SPUDownloaderSession.m
@@ -150,6 +150,7 @@
 -(void)cleanup
 {
     [self.download cancel];
+    [self.downloadSession invalidateAndCancel];
     self.download = nil;
     self.downloadSession = nil;
     [super cleanup];


### PR DESCRIPTION
NSURLSession has a special handling for it's delegate... Now the session is explicitly invalidated to avoid a retain cycle.

From the Apple documentation:

Important

The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you don’t invalidate the session, your app leaks memory until it exits.

