### PR TITLE
Fix unit tests

### DIFF
--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -17,7 +17,7 @@ class SUAppcastTest: XCTestCase {
         let testData = NSData(contentsOfFile: testFile)!
         
         do {
-            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data!) as! [SUAppcastItem];
+            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data) as! [SUAppcastItem];
             
             XCTAssertEqual(4, items.count);
             
@@ -72,7 +72,7 @@ class SUAppcastTest: XCTestCase {
         let testData = NSData(contentsOfFile: testFile)!
 
         do {
-            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data!) as! [SUAppcastItem];
+            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data) as! [SUAppcastItem];
 
             XCTAssertEqual(2, items.count);
 

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -40,7 +40,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     NSString *tmp2 = temporaryFilename(@"Sparklęエンジン");
     NSLog(@"Temporary files: %@, %@", tmp1, tmp2);
 #pragma clang diagnostic push
-//#pragma clang diagnostic ignored "-Wobjc-messaging-id"
+#pragma clang diagnostic ignored "-Wobjc-messaging-id"
     XCTAssertNotEqualObjects(tmp1, tmp2);
 #pragma clang diagnostic pop
     XCTAssert(YES, @"Pass");

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -27,7 +27,10 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     NSString *tmp1 = temporaryDirectory(@"Sparklęエンジン");
     NSString *tmp2 = temporaryDirectory(@"Sparklęエンジン");
     NSLog(@"Temporary directories: %@, %@", tmp1, tmp2);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-messaging-id"
     XCTAssertNotEqualObjects(tmp1, tmp2);
+#pragma clang diagnostic pop
     XCTAssert(YES, @"Pass");
 }
 
@@ -36,7 +39,10 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     NSString *tmp1 = temporaryFilename(@"Sparklęエンジン");
     NSString *tmp2 = temporaryFilename(@"Sparklęエンジン");
     NSLog(@"Temporary files: %@, %@", tmp1, tmp2);
+#pragma clang diagnostic push
+//#pragma clang diagnostic ignored "-Wobjc-messaging-id"
     XCTAssertNotEqualObjects(tmp1, tmp2);
+#pragma clang diagnostic pop
     XCTAssert(YES, @"Pass");
 }
 


### PR DESCRIPTION
This pull request includes a few fixes to quiet warnings I encountered on Xcode 10.1 running on Mojave 10.14.1, and includes a change to the behavior of SUFileManager's updateAccessTimeOfItemAtRootURL... to work around a subtle problem where the access time of a directory changes as a side-effect of asking for a child's fileSystemRepresentation. This fixes a breaking unit test "testUpdateFileAccessTime".