### PR TITLE
2 tiny fixes

### DIFF
--- a/Documentation/build-docs.sh
+++ b/Documentation/build-docs.sh
@@ -5,7 +5,7 @@ if [ "$ACTION" = "" ] ; then
         doxygen Documentation/Doxyfile
     else
         echo "warning: Doxygen not found in PATH"
-        echo "open Terminal and type this command `brew install doxygen` then click `enter/return` key. finally build this target again"
+        echo "open Terminal and type this command 'brew install doxygen' then click 'enter/return' key. finally build this target again"
     fi
 elif [ "$ACTION" = "clean" ] ; then
     rm -rf "$SRCROOT/Documentation/html"

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -69,7 +69,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 static NSMutableDictionary *sharedUpdaters = nil;
 static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaultsObservationContext";
 
-#ifdef DEBUG
+#if DEBUG
 + (void)load
 {
     // Debug builds have different configurations for update check intervals


### PR DESCRIPTION
- bogus debug build warning fixed (as DEBUG always defined from the .xcconfig files this warning always displayed, even in release builds)
- fixed docs build warning message to prevent execution of  embedded shell script line (xcode cannot display this way the correct error message as the underlying echo command will try to execute the embedded command samples)