### PR TITLE
Remove brew update to reduce CI time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: objective-c
 osx_image: xcode9
-before_install:
-  - brew update
 script: make ci


### PR DESCRIPTION
By removing unrelated `brew update` which runs for about 5 minutes, Travis-CI time is now reduced to about 30 seconds. 