### PR TITLE
Fix release note web view's contextual menu

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -33,9 +33,11 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 @end
 @protocol WebPolicyDelegate <NSObject>
 @end
+@protocol WebUIDelegate <NSObject>
+@end
 #endif
 
-@interface SUUpdateAlert () <WebFrameLoadDelegate, WebPolicyDelegate, NSTouchBarDelegate>
+@interface SUUpdateAlert () <WebFrameLoadDelegate, WebPolicyDelegate, WebUIDelegate, NSTouchBarDelegate>
 
 @property (strong) SUAppcastItem *updateItem;
 @property (strong) SUHost *host;
@@ -115,8 +117,9 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 - (void)endWithSelection:(SUUpdateAlertChoice)choice
 {
     [self.releaseNotesView stopLoading:self];
-    [self.releaseNotesView setFrameLoadDelegate:nil];
-    [self.releaseNotesView setPolicyDelegate:nil];
+    self.releaseNotesView.frameLoadDelegate = nil;
+    self.releaseNotesView.policyDelegate = nil;
+    self.releaseNotesView.UIDelegate = nil;
     [self.releaseNotesView removeFromSuperview]; // Otherwise it gets sent Esc presses (why?!) and gets very confused.
     [self close];
     self.completionBlock(choice);
@@ -152,6 +155,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     prefs.javaScriptEnabled = [self.host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
     self.releaseNotesView.frameLoadDelegate = self;
     self.releaseNotesView.policyDelegate = self;
+    self.releaseNotesView.UIDelegate = self;
     
     // Set the default font
     // "-apple-system-font" is a reference to the system UI font. "-apple-system" is the new recommended token, but for backward compatibility we can't use it.


### PR DESCRIPTION
I found "Reload" in release note's contextual menu does not reload contents, but opens the page in web browser app. I don't know how to fix it yet.

But I found the code added in 8ff6c147f26600c9dc15d6f76bed5730dda68af6 are intended to remove "Reload" from the menu. But it does not take effect nowadays due to missing assignment of UIDelegate.