### PR TITLE
Use finishTasksAndInvalidate instead of invalidateAndCancel in SPUDownloader

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -115,7 +115,7 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 {
     [self enableAutomaticTermination];
     [self.download cancel];
-    [self.downloadSession invalidateAndCancel];
+    [self.downloadSession finishTasksAndInvalidate];
     self.download = nil;
     self.downloadSession = nil;
     self.delegate = nil;


### PR DESCRIPTION
`-cleanup` is only called when the task has finished, so it's safe to do this.
This silences a spurious warning logged by NSURLSession (or somewhere else internal):

```
Task <BB2AE4EF-8E93-44D7-9AB3-6EE9A9E3ACF8>.<1> load failed with error Error Domain=NSURLErrorDomain Code=-999 "cancelled" UserInfo={NSErrorFailingURLStringKey=https://example.com/appcast.xml, NSErrorFailingURLKey=https://example.com/appcast.xml, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDownloadTask <BB2AE4EF-8E93-44D7-9AB3-6EE9A9E3ACF8>.<1>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDownloadTask <BB2AE4EF-8E93-44D7-9AB3-6EE9A9E3ACF8>.<1>, NSLocalizedDescription=cancelled} [-999]
```