### PR TITLE
Correct old vs new version statement

### DIFF
--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -7,10 +7,10 @@
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ is now available—you have %3$@. Would you like to download it now?";
+"%@ %@ is now available (you have %@). Would you like to download it now?" = "%1$@ %2$@ is now available (you have %3$@). Would you like to download it now?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ is now available—you have %3$@. Would you like to learn more about this update on the web?";
+"%@ %@ is now available (you have %@). Would you like to learn more about this update on the web?" = "%1$@ %2$@ is now available (you have %3$@). Would you like to learn more about this update on the web?";
 
 "%@ downloaded" = "%@ downloaded";
 


### PR DESCRIPTION
The old syntax with single or double dash and no spaces on either side of the dash is very non-standard English (and Afrikaans; I cannot speak for other languages). I have changed it to bring it in line with the same string on WinSparkle, https://winsparkle.org/ (I was unable to locate the source file on Github, but this screenshot shows the difference in formulation.