### PR TITLE
Use contentsOfDirectory(at:...) instead of atPath:....

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -65,23 +65,22 @@ class ArchiveItem: CustomStringConvertible {
     }
 
     convenience init(fromArchive archivePath: URL, unarchivedDir: URL) throws {
-        let items = try FileManager.default.contentsOfDirectory(atPath: unarchivedDir.path)
-            .filter({ !$0.hasPrefix(".") })
-            .map({ unarchivedDir.appendingPathComponent($0) })
+        let resourceKeys = [URLResourceKey.typeIdentifierKey]
+        let items = try FileManager.default.contentsOfDirectory(at: unarchivedDir, includingPropertiesForKeys: resourceKeys, options: .skipsHiddenFiles)
 
-        let apps = items.filter({
-            if let resourceValues = try? $0.resourceValues(forKeys: [URLResourceKey.typeIdentifierKey]) {
+        let bundles = items.filter({
+            if let resourceValues = try? $0.resourceValues(forKeys: Set(resourceKeys)) {
                 return UTTypeConformsTo(resourceValues.typeIdentifier! as CFString, kUTTypeBundle)
             } else {
                 return false
             }
         });
-        if apps.count > 0 {
-            if apps.count > 1 {
-                throw makeError(code: .unarchivingError, "Too many bundles in \(unarchivedDir.path) \(apps)");
+        if bundles.count > 0 {
+            if bundles.count > 1 {
+                throw makeError(code: .unarchivingError, "Too many bundles in \(unarchivedDir.path) \(bundles)");
             }
 
-            let appPath = apps[0];
+            let appPath = bundles[0];
             guard let infoPlist = NSDictionary(contentsOf: appPath.appendingPathComponent("Contents/Info.plist")) else {
                 throw makeError(code: .unarchivingError, "No plist \(appPath.path)");
             }


### PR DESCRIPTION
And rename `apps` to `bundles`.

This removes the need for filtering based on starting with "." (hidden files), as well as the string/URL back-and-forth. Also pre-fetches `.typeIdentifierKey`.