### PR TITLE
Add delegate methods to suppress update alert.

### DIFF
--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -47,4 +47,15 @@
     return YES;
 }
 
+- (BOOL)shouldShowUpdateAlert {
+    id<SUUpdaterPrivate> updater = self.updater;
+    id<SUUpdaterDelegate> updaterDelegate = [updater delegate];
+
+    if ([updaterDelegate respondsToSelector:@selector(updaterShouldShowUpdateAlertForScheduledUpdate:)]) {
+        return [updaterDelegate updaterShouldShowUpdateAlertForScheduledUpdate:self.updater];
+    }
+
+    return [super shouldShowUpdateAlert];
+}
+
 @end

--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -47,15 +47,15 @@
     return YES;
 }
 
-- (BOOL)shouldShowUpdateAlert {
+- (BOOL)shouldShowUpdateAlertForItem:(SUAppcastItem *)item {
     id<SUUpdaterPrivate> updater = self.updater;
     id<SUUpdaterDelegate> updaterDelegate = [updater delegate];
 
-    if ([updaterDelegate respondsToSelector:@selector(updaterShouldShowUpdateAlertForScheduledUpdate:)]) {
-        return [updaterDelegate updaterShouldShowUpdateAlertForScheduledUpdate:self.updater];
+    if ([updaterDelegate respondsToSelector:@selector(updaterShouldShowUpdateAlertForScheduledUpdate:forItem:)]) {
+        return [updaterDelegate updaterShouldShowUpdateAlertForScheduledUpdate:self.updater forItem:item];
     }
 
-    return [super shouldShowUpdateAlert];
+    return [super shouldShowUpdateAlertForItem:item];
 }
 
 @end

--- a/Sparkle/SUUIBasedUpdateDriver.h
+++ b/Sparkle/SUUIBasedUpdateDriver.h
@@ -20,7 +20,7 @@
 - (void)showAlert:(NSAlert *)alert;
 - (IBAction)cancelDownload:(id)sender;
 - (void)installAndRestart:(id)sender;
-- (BOOL)shouldShowUpdateAlert;
+- (BOOL)shouldShowUpdateAlertForItem:(SUAppcastItem *)item;
 
 @end
 

--- a/Sparkle/SUUIBasedUpdateDriver.h
+++ b/Sparkle/SUUIBasedUpdateDriver.h
@@ -20,6 +20,7 @@
 - (void)showAlert:(NSAlert *)alert;
 - (IBAction)cancelDownload:(id)sender;
 - (void)installAndRestart:(id)sender;
+- (BOOL)shouldShowUpdateAlert;
 
 @end
 

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -56,6 +56,10 @@
     return self;
 }
 
+- (BOOL)shouldShowUpdateAlert {
+    return YES;
+}
+
 - (void)didFindValidUpdate
 {
     id<SUUpdaterPrivate> updater = self.updater;
@@ -64,12 +68,18 @@
     }
 
     if (self.automaticallyInstallUpdates) {
-        [self updateAlertFinishedWithChoice:SUInstallUpdateChoice];
+        [self updateAlertFinishedWithChoice:SUInstallUpdateChoice forItem:nil];
         return;
     }
 
-    self.updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:self.updateItem host:self.host completionBlock:^(SUUpdateAlertChoice choice) {
-        [self updateAlertFinishedWithChoice:choice];
+    if (![self shouldShowUpdateAlert]) {
+        [self abortUpdate];
+        return;
+    }
+
+    SUAppcastItem *updateItem = self.updateItem;
+    self.updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:updateItem host:self.host completionBlock:^(SUUpdateAlertChoice choice) {
+        [self updateAlertFinishedWithChoice:choice forItem:updateItem];
     }];
 
     id<SUVersionDisplay> versDisp = nil;
@@ -125,26 +135,40 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidBecomeActiveNotification object:NSApp];
 }
 
-- (void)updateAlertFinishedWithChoice:(SUUpdateAlertChoice)choice
+- (void)didDismissAlertPermanently:(BOOL)permanently forItem:(SUAppcastItem *)item {
+    if (item == nil) {
+        return;
+    }
+    id<SUUpdaterPrivate> updater = self.updater;
+    if ([updater.delegate respondsToSelector:@selector(updater:didDismissUpdateAlertPermanently:forItem:)]) {
+        [updater.delegate updater:self.updater didDismissUpdateAlertPermanently:permanently forItem:item];
+    }
+}
+
+- (void)updateAlertFinishedWithChoice:(SUUpdateAlertChoice)choice forItem:(SUAppcastItem *)item
 {
     self.updateAlert = nil;
     [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
     switch (choice) {
         case SUInstallUpdateChoice:
+            [self didDismissAlertPermanently:NO forItem:item];
             [self downloadUpdate];
             break;
 
         case SUOpenInfoURLChoice:
+            [self didDismissAlertPermanently:NO forItem:item];
             [[NSWorkspace sharedWorkspace] openURL:[self.updateItem infoURL]];
             [self abortUpdate];
             break;
 
         case SUSkipThisVersionChoice:
+            [self didDismissAlertPermanently:YES forItem:item];
             [self.host setObject:[self.updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
             [self abortUpdate];
             break;
 
         case SURemindMeLaterChoice:
+            [self didDismissAlertPermanently:NO forItem:item];
             [self abortUpdate];
             break;
     }

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -56,7 +56,7 @@
     return self;
 }
 
-- (BOOL)shouldShowUpdateAlert {
+- (BOOL)shouldShowUpdateAlertForItem:(SUAppcastItem *)__unused item {
     return YES;
 }
 
@@ -72,12 +72,12 @@
         return;
     }
 
-    if (![self shouldShowUpdateAlert]) {
+    SUAppcastItem *updateItem = self.updateItem;
+    if (![self shouldShowUpdateAlertForItem:updateItem]) {
         [self abortUpdate];
         return;
     }
 
-    SUAppcastItem *updateItem = self.updateItem;
     self.updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:updateItem host:self.host completionBlock:^(SUUpdateAlertChoice choice) {
         [self updateAlertFinishedWithChoice:choice forItem:updateItem];
     }];

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -124,7 +124,7 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 
  \return YES to allow the update prompt to be shown (the default behavior), or NO to suppress it.
  */
-- (BOOL)updaterShouldShowUpdateAlertForScheduledUpdate:(SUUpdater *)updater;
+- (BOOL)updaterShouldShowUpdateAlertForScheduledUpdate:(SUUpdater *)updater forItem:(SUAppcastItem *)item;
 
 /*!
  Called after the user dismisses the update alert.

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -118,6 +118,23 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 - (void)updater:(SUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)item;
 
 /*!
+ Called just before the scheduled update driver prompts the user to install an update.
+
+ \param updater The SUUpdater instance.
+
+ \return YES to allow the update prompt to be shown (the default behavior), or NO to suppress it.
+ */
+- (BOOL)updaterShouldShowUpdateAlertForScheduledUpdate:(SUUpdater *)updater;
+
+/*!
+ Called after the user dismisses the update alert.
+
+ \param updater The SUUpdater instance.
+ \param permanently YES if the alert will not appear again for this update; NO if it may reappear.
+ */
+- (void)updater:(SUUpdater *)updater didDismissUpdateAlertPermanently:(BOOL)permanently forItem:(SUAppcastItem *)item;
+
+/*!
  Called when a valid update is not found.
  
  \param updater The SUUpdater instance.


### PR DESCRIPTION
## Background

Users want to know when an update is available, but some of them find a popup window to be too obtrusive [1]. I would like to offer users to option to receive a more subtle update notification. For inspiration, VS Code shows this when a new update is available:

![image](https://user-images.githubusercontent.com/427546/53223746-3148f480-3627-11e9-9516-248bb6712988.png)

## Implementation

This commit adds two new delegate methods:

```
- (BOOL)updaterShouldShowUpdateAlertForScheduledUpdate:(SUUpdater *)updater;
```

This is called only for scheduled updates. The delegate may choose to suppress the update, in which case the update is immediately aborted. That allows the "Check for Updates" menu item to remain enabled.

A delegate that wishes to present its own UI would likely use this notification to trigger the behavior, having used `updater:didFindValidUpdate:` to record any relevant information about the appcast item such as its version number.

The second new delegate method is:

```
- (void)updater:(SUUpdater *)updater didDismissUpdateAlertPermanently:(BOOL)permanently forItem:(SUAppcastItem *)item;
```

This is useful because it informs the application when the user wants to skip an update. It can then clear its own notification about the update in response to the user's expressed preference.

All update drivers other than the scheduled update driver remain unaffected by this change.

#### Footnotes

1. https://gitlab.com/gnachman/iterm2/issues/7502#note_143351094
