### PR TITLE
use modules when feature is available to suppress warnings

### DIFF
--- a/Sparkle/SUCodeSigningVerifier.h
+++ b/Sparkle/SUCodeSigningVerifier.h
@@ -9,7 +9,11 @@
 #ifndef SUCODESIGNINGVERIFIER_H
 #define SUCODESIGNINGVERIFIER_H
 
+#if __has_feature(modules)
+@import Foundation;
+#else
 #import <Foundation/Foundation.h>
+#endif
 #import "SUExport.h"
 
 SU_EXPORT @interface SUCodeSigningVerifier : NSObject


### PR DESCRIPTION
The header fails to check if modules are being used and always does #import which will generate a warning if modules are being used. Simply check if modules are being used and do @import if they are or fall back to #import of they are not.