### PR TITLE
Allow updating to previous versions if newest appcast item is blocked due to phased rollout

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -23,7 +23,7 @@
 - (void)checkForUpdatesAtURL:(NSURL *)URL host:(SUHost *)host;
 
 - (BOOL)isItemNewer:(SUAppcastItem *)ui;
-+ (BOOL)hostSupportsItem:(SUAppcastItem *)ui;
+- (BOOL)hostSupportsItem:(SUAppcastItem *)ui;
 - (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui;
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui;
 - (void)appcastDidFinishLoading:(SUAppcast *)ac;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -96,20 +96,20 @@
     return comparator;
 }
 
-+ (SUAppcastItem *)bestItemFromAppcastItems:(NSArray *)appcastItems getDeltaItem:(SUAppcastItem * __autoreleasing *)deltaItem withHostVersion:(NSString *)hostVersion comparator:(id<SUVersionComparison>)comparator
+- (SUAppcastItem *)bestItemFromAppcastItems:(NSArray *)appcastItems getDeltaItem:(SUAppcastItem * __autoreleasing *)deltaItem
 {
     SUAppcastItem *item = nil;
     for(SUAppcastItem *candidate in appcastItems) {
-        if ([[self class] hostSupportsItem:candidate]) {
-            if (!item || [comparator compareVersion:item.versionString toVersion:candidate.versionString] == NSOrderedAscending) {
+        if ([self hostSupportsItem:candidate]) {
+            if (!item || [[self versionComparator] compareVersion:item.versionString toVersion:candidate.versionString] == NSOrderedAscending) {
                 item = candidate;
             }
         }
     }
 
     if (item && deltaItem) {
-        SUAppcastItem *deltaUpdateItem = [[item deltaUpdates] objectForKey:hostVersion];
-        if (deltaUpdateItem && [[self class] hostSupportsItem:deltaUpdateItem]) {
+        SUAppcastItem *deltaUpdateItem = [[item deltaUpdates] objectForKey:self.host.version];
+        if (deltaUpdateItem && [self hostSupportsItem:deltaUpdateItem]) {
             *deltaItem = deltaUpdateItem;
         }
     }
@@ -117,7 +117,7 @@
     return item;
 }
 
-+ (BOOL)hostSupportsItem:(SUAppcastItem *)ui
+- (BOOL)hostSupportsItem:(SUAppcastItem *)ui
 {
     BOOL osOK = [ui isMacOsUpdate];
 	if (([ui minimumSystemVersion] == nil || [[ui minimumSystemVersion] isEqualToString:@""]) &&
@@ -155,7 +155,7 @@
 
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui
 {
-    return ui && [[self class] hostSupportsItem:ui] && [self isItemNewer:ui] && ![self itemContainsSkippedVersion:ui];
+    return ui && [self hostSupportsItem:ui] && [self isItemNewer:ui] && ![self itemContainsSkippedVersion:ui];
 }
 
 - (void)appcastDidFinishLoading:(SUAppcast *)ac
@@ -186,7 +186,7 @@
     {
         // Find the best supported update
         SUAppcastItem *deltaUpdateItem = nil;
-        item = [[self class] bestItemFromAppcastItems:ac.items getDeltaItem:&deltaUpdateItem withHostVersion:self.host.version comparator:[self versionComparator]];
+        item = [self bestItemFromAppcastItems:ac.items getDeltaItem:&deltaUpdateItem];
 
         if (item && deltaUpdateItem) {
             self.nonDeltaUpdateItem = item;

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -31,7 +31,4 @@
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName;
 - (id)objectForKey:(NSString *)key;
 - (BOOL)boolForKey:(NSString *)key;
-
-- (NSNumber*)updateGroupIdentifier;
-- (NSNumber*)setNewUpdateGroupIdentifier;
 @end

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -246,22 +246,4 @@
     return [self objectForUserDefaultsKey:key] ? [self boolForUserDefaultsKey:key] : [self boolForInfoDictionaryKey:key];
 }
 
-- (NSNumber*)updateGroupIdentifier {
-    NSNumber* updateGroupIdentifier = [self objectForUserDefaultsKey:SUUpdateGroupIdentifierKey];
-    if(updateGroupIdentifier == nil) {
-        updateGroupIdentifier = [self setNewUpdateGroupIdentifier];
-    }
-
-    return updateGroupIdentifier;
-}
-
-- (NSNumber*)setNewUpdateGroupIdentifier {
-    unsigned int r = arc4random_uniform(UINT_MAX);
-    NSNumber* updateGroupIdentifier = @(r);
-
-    [self setObject:updateGroupIdentifier forUserDefaultsKey:SUUpdateGroupIdentifierKey];
-
-    return updateGroupIdentifier;
-}
-
 @end

--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -12,10 +12,9 @@
 
 #import "SUSystemUpdateInfo.h"
 #import "SUAppcastItem.h"
-#import "SUHost.h"
 
 @interface SUScheduledUpdateDriver ()
-
+- (BOOL)isItemReadyForPhasedRollout:(SUAppcastItem *)ui;
 @end
 
 @implementation SUScheduledUpdateDriver
@@ -28,28 +27,26 @@
     return self;
 }
 
-+ (BOOL)hostSupportsItem:(SUAppcastItem *)ui {
-    return [super hostSupportsItem:ui] && [self isItemReadyForUpdateGroup:ui];
+- (BOOL)hostSupportsItem:(SUAppcastItem *)ui {
+    return [super hostSupportsItem:ui] && [self isItemReadyForPhasedRollout:ui];
 }
 
-+ (BOOL)isItemReadyForUpdateGroup:(SUAppcastItem *)ui {
+- (BOOL)isItemReadyForPhasedRollout:(SUAppcastItem *)ui {
     if([ui isCriticalUpdate] || ![ui phasedRolloutInterval]) {
         return YES;
     }
 
     NSDate* itemReleaseDate = ui.date;
-    if(itemReleaseDate) {
-        NSTimeInterval timeSinceRelease = [[NSDate date] timeIntervalSinceDate:itemReleaseDate];
-
-        NSTimeInterval phasedRolloutInterval = [[ui phasedRolloutInterval] doubleValue];
-        NSTimeInterval timeToWaitForGroup = phasedRolloutInterval * [SUSystemUpdateInfo updateGroup];
-
-        if(timeSinceRelease < timeToWaitForGroup) {
-            return NO; // not this host's turn yet
-        }
+    if(!itemReleaseDate) {
+        return YES;
     }
 
-    return YES;
+    NSTimeInterval timeSinceRelease = [[NSDate date] timeIntervalSinceDate:itemReleaseDate];
+
+    NSTimeInterval phasedRolloutInterval = [[ui phasedRolloutInterval] doubleValue];
+    NSTimeInterval timeToWaitForGroup = phasedRolloutInterval * [SUSystemUpdateInfo updateGroupForHost:self.host];
+
+    return timeSinceRelease >= timeToWaitForGroup;
 }
 
 - (void)didFindValidUpdate
@@ -87,7 +84,7 @@
 }
 
 - (void)downloaderDidFinishWithTemporaryDownloadData:(SPUDownloadData * _Nullable) downloadData {
-    [SUSystemUpdateInfo setNewUpdateGroupIdentifier]; // use new update group next time
+    [SUSystemUpdateInfo setNewUpdateGroupIdentifierForHost:self.host]; // use new update group next time
     [super downloaderDidFinishWithTemporaryDownloadData:downloadData];
 }
 

--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -28,11 +28,11 @@
     return self;
 }
 
-- (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui {
-    return [self isItemReadyForUpdateGroup:ui] && [super itemContainsValidUpdate:ui];
++ (BOOL)hostSupportsItem:(SUAppcastItem *)ui {
+    return [super hostSupportsItem:ui] && [self isItemReadyForUpdateGroup:ui];
 }
 
-- (BOOL)isItemReadyForUpdateGroup:(SUAppcastItem *)ui {
++ (BOOL)isItemReadyForUpdateGroup:(SUAppcastItem *)ui {
     if([ui isCriticalUpdate] || ![ui phasedRolloutInterval]) {
         return YES;
     }
@@ -42,7 +42,7 @@
         NSTimeInterval timeSinceRelease = [[NSDate date] timeIntervalSinceDate:itemReleaseDate];
 
         NSTimeInterval phasedRolloutInterval = [[ui phasedRolloutInterval] doubleValue];
-        NSTimeInterval timeToWaitForGroup = phasedRolloutInterval * [SUSystemUpdateInfo updateGroupForHost:self.host];
+        NSTimeInterval timeToWaitForGroup = phasedRolloutInterval * [SUSystemUpdateInfo updateGroup];
 
         if(timeSinceRelease < timeToWaitForGroup) {
             return NO; // not this host's turn yet
@@ -87,7 +87,7 @@
 }
 
 - (void)downloaderDidFinishWithTemporaryDownloadData:(SPUDownloadData * _Nullable) downloadData {
-    [self.host setNewUpdateGroupIdentifier]; // use new update group next time
+    [SUSystemUpdateInfo setNewUpdateGroupIdentifier]; // use new update group next time
     [super downloaderDidFinishWithTemporaryDownloadData:downloadData];
 }
 

--- a/Sparkle/SUSystemUpdateInfo.h
+++ b/Sparkle/SUSystemUpdateInfo.h
@@ -15,7 +15,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SUSystemUpdateInfo : NSObject
 
 + (BOOL)systemAllowsAutomaticUpdatesForHost:(SUHost *)host;
-+ (NSUInteger)updateGroupForHost:(SUHost *)host;
+
++ (NSUInteger)updateGroup;
++ (NSNumber*)updateGroupIdentifier;
++ (NSNumber*)setNewUpdateGroupIdentifier;
 
 @end
 

--- a/Sparkle/SUSystemUpdateInfo.h
+++ b/Sparkle/SUSystemUpdateInfo.h
@@ -16,9 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)systemAllowsAutomaticUpdatesForHost:(SUHost *)host;
 
-+ (NSUInteger)updateGroup;
-+ (NSNumber*)updateGroupIdentifier;
-+ (NSNumber*)setNewUpdateGroupIdentifier;
++ (NSUInteger)updateGroupForHost:(SUHost*)host;
++ (NSNumber*)updateGroupIdentifierForHost:(SUHost*)host;
++ (NSNumber*)setNewUpdateGroupIdentifierForHost:(SUHost*)host;
 
 @end
 

--- a/Sparkle/SUSystemUpdateInfo.m
+++ b/Sparkle/SUSystemUpdateInfo.m
@@ -59,25 +59,25 @@
 }
 
 #define NUM_UPDATE_GROUPS 7
-+ (NSUInteger)updateGroup {
-    NSNumber* updateGroupIdentifier = [self updateGroupIdentifier];
++ (NSUInteger)updateGroupForHost:(SUHost*)host {
+    NSNumber* updateGroupIdentifier = [self updateGroupIdentifierForHost:host];
     return ([updateGroupIdentifier unsignedIntValue] % NUM_UPDATE_GROUPS);
 }
 
-+ (NSNumber*)updateGroupIdentifier {
-    NSNumber* updateGroupIdentifier = [[NSUserDefaults standardUserDefaults] objectForKey:SUUpdateGroupIdentifierKey];
++ (NSNumber*)updateGroupIdentifierForHost:(SUHost*)host {
+    NSNumber* updateGroupIdentifier = [host objectForInfoDictionaryKey:SUUpdateGroupIdentifierKey];
     if(updateGroupIdentifier == nil) {
-        updateGroupIdentifier = [self setNewUpdateGroupIdentifier];
+        updateGroupIdentifier = [self setNewUpdateGroupIdentifierForHost:host];
     }
 
     return updateGroupIdentifier;
 }
 
-+ (NSNumber*)setNewUpdateGroupIdentifier {
++ (NSNumber*)setNewUpdateGroupIdentifierForHost:(SUHost*)host {
     unsigned int r = arc4random_uniform(UINT_MAX);
     NSNumber* updateGroupIdentifier = @(r);
 
-    [[NSUserDefaults standardUserDefaults] setObject:updateGroupIdentifier forKey:SUUpdateGroupIdentifierKey];
+    [host setObject:updateGroupIdentifier forUserDefaultsKey:SUUpdateGroupIdentifierKey];
 
     return updateGroupIdentifier;
 }

--- a/Sparkle/SUSystemUpdateInfo.m
+++ b/Sparkle/SUSystemUpdateInfo.m
@@ -59,9 +59,27 @@
 }
 
 #define NUM_UPDATE_GROUPS 7
-+ (NSUInteger)updateGroupForHost:(SUHost *)host {
-    NSNumber* updateGroupIdentifier = [host updateGroupIdentifier];
++ (NSUInteger)updateGroup {
+    NSNumber* updateGroupIdentifier = [self updateGroupIdentifier];
     return ([updateGroupIdentifier unsignedIntValue] % NUM_UPDATE_GROUPS);
+}
+
++ (NSNumber*)updateGroupIdentifier {
+    NSNumber* updateGroupIdentifier = [[NSUserDefaults standardUserDefaults] objectForKey:SUUpdateGroupIdentifierKey];
+    if(updateGroupIdentifier == nil) {
+        updateGroupIdentifier = [self setNewUpdateGroupIdentifier];
+    }
+
+    return updateGroupIdentifier;
+}
+
++ (NSNumber*)setNewUpdateGroupIdentifier {
+    unsigned int r = arc4random_uniform(UINT_MAX);
+    NSNumber* updateGroupIdentifier = @(r);
+
+    [[NSUserDefaults standardUserDefaults] setObject:updateGroupIdentifier forKey:SUUpdateGroupIdentifierKey];
+
+    return updateGroupIdentifier;
 }
 
 @end

--- a/Sparkle/SUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SUUserInitiatedUpdateDriver.m
@@ -93,7 +93,7 @@
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui
 {
     // We don't check to see if this update's been skipped, because the user explicitly *asked* if he had the latest version.
-    return [[self class] hostSupportsItem:ui] && [self isItemNewer:ui];
+    return [self hostSupportsItem:ui] && [self isItemNewer:ui];
 }
 
 @end

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -39,7 +39,7 @@ static const char *SUAppleQuarantineIdentifier = "com.apple.quarantine";
 
 @interface SUBasicUpdateDriver (Private)
 
-+ (SUAppcastItem *)bestItemFromAppcastItems:(NSArray *)appcastItems getDeltaItem:(SUAppcastItem *_Nullable __autoreleasing *_Nullable)deltaItem withHostVersion:(NSString *)hostVersion comparator:(id<SUVersionComparison>)comparator;
+- (SUAppcastItem *)bestItemFromAppcastItems:(NSArray *)appcastItems getDeltaItem:(SUAppcastItem *_Nullable __autoreleasing *_Nullable)deltaItem;
 
 @end
 


### PR DESCRIPTION
The current version of phased rollouts would not find other valid items if the latest one is not ready yet based on the phased rollout group. This PR changes this behavior by using the system's rollout group when finding valid appcast items.