### PR TITLE
Fix header imports in `ui-seperation-and-xpc` branch

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -9,7 +9,7 @@
 #import "SPUAutomaticUpdateDriver.h"
 #import "SPUUpdateDriver.h"
 #import "SUHost.h"
-#import "SPUUpdaterDelegate.h"
+#import <Sparkle/SPUUpdaterDelegate.h>
 #import "SPUCoreBasedUpdateDriver.h"
 #import "SULog.h"
 #import "SUAppcastItem.h"

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -8,7 +8,7 @@
 
 #import "SPUBasicUpdateDriver.h"
 #import "SUAppcastDriver.h"
-#import "SPUUpdaterDelegate.h"
+#import <Sparkle/SPUUpdaterDelegate.h>
 #import <Sparkle/SUErrors.h>
 #import "SULog.h"
 #import "SULocalizations.h"

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -10,7 +10,7 @@
 #import "SPUDownloaderDelegate.h"
 #import "SPUDownloader.h"
 #import "SPUXPCServiceInfo.h"
-#import "SUAppcastItem.h"
+#import <Sparkle/SUAppcastItem.h>
 #import "SUFileManager.h"
 #import "SULocalizations.h"
 #import "SUHost.h"

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -10,7 +10,7 @@
 #import "SULog.h"
 #import "SPUMessageTypes.h"
 #import "SPUXPCServiceInfo.h"
-#import "SPUUpdaterDelegate.h"
+#import <Sparkle/SPUUpdaterDelegate.h>
 #import "SUAppcastItem.h"
 #import "SULog.h"
 #import "SULocalizations.h"

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -6,7 +6,7 @@
 //  Copyright 2006 Andy Matuschak. All rights reserved.
 //
 
-#import "SPUUpdater.h"
+#import <Sparkle/SPUUpdater.h>
 #import "SPUUpdaterDelegate.h"
 #import "SPUUpdaterSettings.h"
 #import "SUHost.h"

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import "SPUUpdaterSettings.h"
+#import <Sparkle/SPUUpdaterSettings.h>
 #import "SUHost.h"
 #import "SUConstants.h"
 

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -7,12 +7,12 @@
 //
 
 #import "SUAppcastDriver.h"
-#import "SUAppcast.h"
+#import <Sparkle/SUAppcast.h>
 #import "SUAppcastItem.h"
 #import <Sparkle/SUVersionComparisonProtocol.h>
 #import "SUStandardVersionComparator.h"
 #import "SUOperatingSystem.h"
-#import "SPUUpdaterDelegate.h"
+#import <Sparkle/SPUUpdaterDelegate.h>
 #import "SUHost.h"
 #import "SUConstants.h"
 

--- a/Sparkle/SparkleCore.h
+++ b/Sparkle/SparkleCore.h
@@ -14,7 +14,7 @@
 // This list should include the shared headers. It doesn't matter if some of them aren't shared (unless
 // there are name-space collisions) so we can list all of them to start with:
 
-#import "SUAppcast.h"
+#import <Sparkle/SUAppcast.h>
 #import "SUAppcastItem.h"
 #import "SUStandardVersionComparator.h"
 #import "SPUUpdater.h"


### PR DESCRIPTION
> Allows building Distribution scheme with Xcode 10.2

I was building `ui-seperation-and-xpc` branch and ran into the same issues described in #1371.

I’m not sure why these duplicate deceleration errors are suddenly appearing when building with newer Xcode, but this fixed them.
