### PR TITLE
Updated XPC codesigning to enable hardened runtime.

### DIFF
--- a/bin/codesign_xpc
+++ b/bin/codesign_xpc
@@ -10,7 +10,7 @@ def sanitize(argument):
     return ('"' + argument + '"' if ' ' in argument else argument)
 
 def _codesign_service(identity, path, entitlements_path=None):
-    command = ["codesign", "-fs", identity, path] + ([] if entitlements_path is None else ["--entitlements", entitlements_path])
+    command = ["codesign", "-o", "runtime", "-fs", identity, path] + ([] if entitlements_path is None else ["--entitlements", entitlements_path])
     log_message(" ".join(map(sanitize, command)))
 
     process = subprocess.Popen(command, stdout=subprocess.PIPE)


### PR DESCRIPTION
This adds the `-o runtime` flag when calling `codesign` in the `codesign_xpc` script, enabling hardened runtime for XPCs.

I don't think this to be sufficient for notarization in the general case when Autoupdate and Updater.app are included in the framework. It is sufficient for me since I specifically remove these two from the framework in my build process and rely solely on XPCs.