### PR TITLE
Improved error when running from translocated location

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -61,7 +61,14 @@
     [super checkForUpdatesAtURL:URL host:aHost];
 	if ([aHost isRunningOnReadOnlyVolume])
 	{
-        [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.", nil), [aHost name]] }]];
+        if ([aHost isRunningTranslocated])
+        {
+            [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningTranslocated userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to.", nil), [aHost name], [aHost name]] }]];
+        }
+        else
+        {
+            [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.", nil), [aHost name]] }]];
+        }
         return;
     }
 

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -29,6 +29,7 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUNoUpdateError = 1001,
     SUAppcastError = 1002,
     SURunningFromDiskImageError = 1003,
+    SURunningTranslocated = 1004,
 
     // Download phase errors.
     SUTemporaryDirectoryError = 2000,

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -21,6 +21,7 @@
 @property (readonly) SUPublicKeys *publicKeys;
 
 @property (getter=isRunningOnReadOnlyVolume, readonly) BOOL runningOnReadOnlyVolume;
+@property (getter=isRunningTranslocated, readonly) BOOL runningTranslocated;
 @property (readonly, nonatomic, copy) NSString *publicDSAKeyFileKey;
 
 - (id)objectForInfoDictionaryKey:(NSString *)key;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -110,6 +110,13 @@
     return (statfs_info.f_flags & MNT_RDONLY) != 0;
 }
 
+- (BOOL)isRunningTranslocated
+{
+    NSString *path = [self.bundle bundlePath];
+    return [path rangeOfString:@"/AppTranslocation/"].location != NSNotFound;
+}
+
+
 - (NSString *__nullable)publicEDKey
 {
     return [self objectForInfoDictionaryKey:SUPublicEDKeyKey];

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer DMG Datei oder Laufwerk ohne Schreibzugriff gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
 
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Beenden Sie „%1$@“, bewegen Sie es in den Ordner „Programme“, starten Sie das Programm von dort erneut und versuchen Sie es noch einmal. „%2$@“ kann nicht aktualisiert werden, wenn das Programm von dem Ort ausgeführt wird, an den es heruntergeladen wurde.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.";
 
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ ne peut pas être mis à jour quand il fonctionne à partir d’un volume en lecture seule, comme une image disque ou un lecteur optique. Déplacez %1$@ dans votre dossier Applications, relancez-le à partir de là et réessayez.";
 
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Quittez %1$@ et déplacez-le dans le dossier Applications, relancez-le à partir de ce dossier et essayez à nouveau. %2$@ ne peut pas être mis à jour s'il est exécuté depuis le dossier dans lequel il a été téléchargé.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ est la version la plus récente disponible.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@は読み出し専用またはテンポラリな場所で開かれているためアップデートできません。%1$@をアプリケーションフォルダに移動し、そこから再起動したあとやり直してください。";
 
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "%1$@ を終了させ、アプリケーションフォルダに移動の上再度お試しください。この場所ではダウンロードされたアップデータを %2$@ に適用できません。";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@は現在入手できる最新バージョンです。";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/zh_CN.lproj/Sparkle.strings
+++ b/Sparkle/zh_CN.lproj/Sparkle.strings
@@ -2,6 +2,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "无法更新 %1$@，因为它运行于一个只读宗卷如磁盘映像或光盘。移动 %1$@ 到应用程序文件夹并再试一次。";
 
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "退出 %1$@，将其移至“应用程序”，并在那里重新启动，然后再试。如果在下载位置运行此程序，则无法对 %2$@ 进行更新。";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 是当前的最新版本。";
 
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ 可供下载，您现在的版本是 %3$@。要现在下载吗？";


### PR DESCRIPTION
Hi all,

For many, many years now, we've been running a private fork of Sparkle for our products, and we've found that the further we've diverged, the harder it has become to integrate fixes from upstream. This was particularly difficult when integrating changes to enable hardened runtime for the updater app. As such, we would like to switch to using the official Sparkle if at all possible. This will require us to port a few features back from our fork. I am still working my way though all the differences, and hopefully won't need to submit many pull requests.

This first pull request adds an error message that will appear if a user attempts to update an app translocated app. Because app translocation runs the app from a read-only volume, users will currently see an error informing them that the app is running from a read-only location, but some users found this to be confusing.

The pull request also contains translations for the error string in the languages we localize our apps for. Unfortunately, this is a small fraction of the languages supported by Sparkle.

This is my first time submitting a pull request to Sparkle, and I read the code of conduct, but I could not find any other requirements about submitting pull requests. If it is deficient in any way, I will be more than happy to rectify any issues.

Thank you in advance for reviewing this request.