### PR TITLE
Custom updater icon

### DIFF
--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -244,6 +244,19 @@ int main(int __unused argc, const char __unused *argv[])
             [application activateIgnoringOtherApps:YES];
         }
         
+        NSBundle *theBundle = [NSBundle bundleWithPath:[args objectAtIndex:1]];
+        SUHost *host = [[SUHost alloc] initWithBundle:theBundle];
+        NSString *customIconPath = host.updaterCustomIconPath;
+        
+        if (customIconPath) {
+            NSImage *customIcon = [[NSImage alloc] initWithContentsOfFile:customIconPath];
+            
+            if (customIcon) {
+                [[NSApplication sharedApplication] setApplicationIconImage:customIcon];
+            }
+        }
+
+        
         AppInstaller *appInstaller = [[AppInstaller alloc] initWithHostPath:[args objectAtIndex:1]
                                                                relaunchPath:[args objectAtIndex:2]
                                                             parentProcessId:[[args objectAtIndex:3] intValue]

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -55,6 +55,7 @@ extern NSString *const SULastProfileSubmitDateKey;
 extern NSString *const SUPromptUserOnFirstLaunchKey;
 extern NSString *const SUDefaultsDomainKey;
 extern NSString *const SUEnableJavaScriptKey;
+extern NSString *const SUUpdaterCustomIconKey;
 extern NSString *const SUFixedHTMLDisplaySizeKey __attribute__((deprecated("This key is obsolete and has no effect.")));
 extern NSString *const SUAppendVersionNumberKey __attribute__((deprecated("This key is obsolete. See SPARKLE_APPEND_VERSION_NUMBER.")));
 extern NSString *const SUEnableAutomatedDowngradesKey __attribute__((deprecated("This key is obsolete. See SPARKLE_AUTOMATED_DOWNGRADES.")));

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -46,6 +46,7 @@ NSString *const SUUpdateGroupIdentifierKey = @"SUUpdateGroupIdentifier";
 NSString *const SULastProfileSubmitDateKey = @"SULastProfileSubmissionDate";
 NSString *const SUPromptUserOnFirstLaunchKey = @"SUPromptUserOnFirstLaunch";
 NSString *const SUEnableJavaScriptKey = @"SUEnableJavaScript";
+NSString *const SUUpdaterCustomIconKey = @"SUUpdaterCustomIcon";
 NSString *const SUFixedHTMLDisplaySizeKey = @"SUFixedHTMLDisplaySize";
 NSString *const SUDefaultsDomainKey = @"SUDefaultsDomain";
 NSString *const SUSparkleErrorDomain = @"SUSparkleErrorDomain";

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, copy) NSString *name;
 @property (readonly, copy) NSString *version;
 @property (readonly, copy) NSString *displayVersion;
+@property (readonly, copy, nullable) NSString *updaterCustomIconPath;
 @property (readonly) SUPublicKeys *publicKeys;
 
 @property (getter=isRunningOnReadOnlyVolume, readonly) BOOL runningOnReadOnlyVolume;

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -7,6 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class SUPublicKeys;
 
 @interface SUHost : NSObject
@@ -22,14 +24,16 @@
 
 @property (getter=isRunningOnReadOnlyVolume, readonly) BOOL runningOnReadOnlyVolume;
 @property (getter=isRunningTranslocated, readonly) BOOL runningTranslocated;
-@property (readonly, nonatomic, copy) NSString *publicDSAKeyFileKey;
+@property (readonly, nonatomic, copy, nullable) NSString *publicDSAKeyFileKey;
 
-- (id)objectForInfoDictionaryKey:(NSString *)key;
+- (nullable id)objectForInfoDictionaryKey:(NSString *)key;
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key;
-- (id)objectForUserDefaultsKey:(NSString *)defaultName;
-- (void)setObject:(id)value forUserDefaultsKey:(NSString *)defaultName;
+- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName;
+- (void)setObject:(nullable id)value forUserDefaultsKey:(NSString *)defaultName;
 - (BOOL)boolForUserDefaultsKey:(NSString *)defaultName;
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName;
-- (id)objectForKey:(NSString *)key;
+- (nullable id)objectForKey:(NSString *)key;
 - (BOOL)boolForKey:(NSString *)key;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -14,6 +14,8 @@
 
 #include "AppKitPrevention.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // This class should not rely on AppKit and should also be process independent
 // For example, it should not have code that tests writabilty to somewhere on disk,
 // as that may depend on the privileges of the process owner. Or code that depends on
@@ -24,9 +26,9 @@
 
 @property (strong, readwrite) NSBundle *bundle;
 @property (nonatomic, readonly) BOOL isMainBundle;
-@property (copy) NSString *defaultsDomain;
+@property (copy, nullable) NSString *defaultsDomain;
 @property (assign) BOOL usesStandardUserDefaults;
-@property (readonly, copy) NSString *publicDSAKey;
+@property (readonly, copy, nullable) NSString *publicDSAKey;
 
 @end
 
@@ -69,7 +71,7 @@
     return [self.bundle bundlePath];
 }
 
-- (NSString *__nonnull)name
+- (NSString *)name
 {
     NSString *name;
 
@@ -86,7 +88,7 @@
     return [[[NSFileManager defaultManager] displayNameAtPath:[self bundlePath]] stringByDeletingPathExtension];
 }
 
-- (NSString *__nonnull)version
+- (NSString *)version
 {
     NSString *version = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
     if (!version || [version isEqualToString:@""])
@@ -94,7 +96,7 @@
     return version;
 }
 
-- (NSString *__nonnull)displayVersion
+- (NSString *)displayVersion
 {
     NSString *shortVersionString = [self objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     if (shortVersionString)
@@ -158,7 +160,7 @@
     return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey];
 }
 
-- (id)objectForInfoDictionaryKey:(NSString *)key
+- (nullable id)objectForInfoDictionaryKey:(NSString *)key
 {
     if (self.isMainBundle) {
         // Common fast path - if we're updating the main bundle, that means our updater and host bundle's lifetime is the same
@@ -182,7 +184,7 @@
     return [(NSNumber *)[self objectForInfoDictionaryKey:key] boolValue];
 }
 
-- (id)objectForUserDefaultsKey:(NSString *)defaultName
+- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName
 {
     if (!defaultName || !self.defaultsDomain) {
         return nil;
@@ -200,7 +202,7 @@
 }
 
 // Note this handles nil being passed for defaultName, in which case the user default will be removed
-- (void)setObject:(id)value forUserDefaultsKey:(NSString *)defaultName
+- (void)setObject:(nullable id)value forUserDefaultsKey:(NSString *)defaultName
 {
 	if (self.usesStandardUserDefaults)
 	{
@@ -245,7 +247,7 @@
     }
 }
 
-- (id)objectForKey:(NSString *)key {
+- (nullable id)objectForKey:(NSString *)key {
     return [self objectForUserDefaultsKey:key] ? [self objectForUserDefaultsKey:key] : [self objectForInfoDictionaryKey:key];
 }
 
@@ -254,3 +256,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -105,6 +105,18 @@ NS_ASSUME_NONNULL_BEGIN
         return [self version]; // Fall back on the normal version string.
 }
 
+- (nullable NSString *)updaterCustomIconPath
+{
+    NSString *configurationPath = [self.bundle objectForInfoDictionaryKey:SUUpdaterCustomIconKey];
+    NSString *iconPath = [self.bundle pathForResource:configurationPath ofType:@"icns"];
+
+    if (!iconPath) {
+        iconPath = [self.bundle pathForResource:configurationPath ofType:nil];
+    }
+    
+    return iconPath;
+}
+
 - (BOOL)isRunningOnReadOnlyVolume
 {
     struct statfs statfs_info;


### PR DESCRIPTION
Hi again,

This pull request contains an option to set a custom icon for the Autoupdate app within Sparkle. We use this option internally to set different icons for different projects. Because the Autoupdate icon can appear in the dock during installation, we've found it has been helpful to users to associate the icon with our app, but not to use the exact same icon as our app, which can cause confusion.

Although we could modify the Autoupdate app target to use a different icon, this change change brings two benefits. First, because we use different Autoupdate icons for different projects, we would need to keep separate Sparkle branches for each project if we modified the Autoupdate target. Second, we would need to make sure to re-apply the custom icons every time we updated from upstream.

I'm wary of asking Sparkle Project to accept too many changes with optional feature flags, but solving these problems otherwise requires us to maintain multiple internal Forks of Sparkle, and we are trying to avoid using an internal fork at all. I also believe this could be useful to other users who are in a similar position.

Additionally, because this change required me to modify SUHost, I added more complete nullability annotations to that file. I would be happy to split these changes into separate pull requests if that makes things easier for you, or remove one of the commits if you do not wish to take it.

Thanks again!