### PR TITLE
Use `XMLNode.Options.nodePrettyPrint` in `generate_appcast` instead of trying to add whitespace manually

### DIFF
--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -23,17 +23,12 @@ func findOrCreateElement(name: String, parent: XMLElement) -> XMLElement {
         return element;
     }
     let element = XMLElement(name: name);
-    linebreak(parent);
     parent.addChild(element);
     return element;
 }
 
 func text(_ text: String) -> XMLNode {
     return XMLNode.text(withStringValue: text) as! XMLNode
-}
-
-func linebreak(_ element: XMLElement) {
-    element.addChild(text("\n"));
 }
 
 
@@ -70,9 +65,7 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         channel = channelNodes[0] as! XMLElement;
     } else {
         channel = XMLElement(name: "channel");
-        linebreak(channel);
         channel.addChild(XMLElement.element(withName: "title", stringValue: appBaseName) as! XMLElement);
-        linebreak(root);
         root.addChild(channel);
     }
 
@@ -90,18 +83,15 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
 
         if createNewItem {
             item = XMLElement.element(withName: "item") as! XMLElement;
-            linebreak(channel);
             channel.addChild(item);
         } else {
             item = existingItems[0] as! XMLElement;
         }
 
         if nil == findElement(name: "title", parent: item) {
-            linebreak(item);
             item.addChild(XMLElement.element(withName: "title", stringValue: update.shortVersion) as! XMLElement);
         }
         if nil == findElement(name: "pubDate", parent: item) {
-            linebreak(item);
             item.addChild(XMLElement.element(withName: "pubDate", stringValue: update.pubDate) as! XMLElement);
         }
 
@@ -115,7 +105,6 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         var minVer = findElement(name: SUAppcastElementMinimumSystemVersion, parent: item);
         if nil == minVer {
             minVer = XMLElement.element(withName: SUAppcastElementMinimumSystemVersion, uri: sparkleNS) as? XMLElement;
-            linebreak(item);
             item.addChild(minVer!);
         }
         minVer?.setChildren([text(update.minimumSystemVersion)]);
@@ -123,17 +112,15 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         let relElement = findElement(name: SUAppcastElementReleaseNotesLink, parent: item);
         if let url = update.releaseNotesURL {
             if nil == relElement {
-                linebreak(item);
                 item.addChild(XMLElement.element(withName: SUAppcastElementReleaseNotesLink, stringValue: url.absoluteString) as! XMLElement);
             }
         } else if let childIndex = relElement?.index {
             item.removeChild(at: childIndex);
         }
-        
+
         var enclosure = findElement(name: "enclosure", parent: item);
         if nil == enclosure {
             enclosure = XMLElement.element(withName: "enclosure") as? XMLElement;
-            linebreak(item);
             item.addChild(enclosure!);
         }
 
@@ -159,7 +146,6 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
             var deltas = findElement(name: SUAppcastElementDeltas, parent: item);
             if nil == deltas {
                 deltas = XMLElement.element(withName: SUAppcastElementDeltas, uri: sparkleNS) as? XMLElement;
-                linebreak(item);
                 item.addChild(deltas!);
             } else {
                 deltas!.setChildren([]);
@@ -179,17 +165,12 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
                 if let sig = delta.dsaSignature {
                     attributes.append(XMLNode.attribute(withName: SUAppcastAttributeDSASignature, uri: sparkleNS, stringValue: sig) as! XMLNode);
                 }
-                linebreak(deltas!);
                 deltas!.addChild(XMLNode.element(withName: "enclosure", children: nil, attributes: attributes) as! XMLElement);
             }
         }
-        if createNewItem {
-            linebreak(item);
-            linebreak(channel);
-        }
     }
 
-    let options = XMLNode.Options.nodeCompactEmptyElement;
+    let options: XMLNode.Options = [.nodeCompactEmptyElement, .nodePrettyPrint];
     let docData = doc.xmlData(options:options);
     let _ = try XMLDocument(data: docData, options:XMLNode.Options()); // Verify that it was generated correctly, which does not always happen!
     try docData.write(to: appcastDestPath);


### PR DESCRIPTION
Before:
```xml
<?xml version="1.0" standalone="yes"?><rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
<channel>
<title>Example</title>
<item>
<title>1.0.0</title>
<pubDate>Sat, 20 Apr 2019 16:55:55 -0700</pubDate>
<sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
<enclosure url="https://example.com/Example.dmg" sparkle:version="1" sparkle:shortVersionString="1.0.0" length="14505373" type="application/octet-stream" sparkle:edSignature="jKWSaYuaZggtf3hynWbaIdtGOHaOeJ3x68j/S2SucdsChqsnMkg0fWe1oXHky9wlrEKwGoT7VudPWjX81AazAQ=="/>
</item>
</channel></rss>
```

After:
```xml
<?xml version="1.0" standalone="yes"?>
<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
    <channel>
        <title>Example</title>
        <item>
            <title>1.0.0</title>
            <pubDate>Sat, 20 Apr 2019 16:55:55 -0700</pubDate>
            <sparkle:minimumSystemVersion>10.14</sparkle:minimumSystemVersion>
            <enclosure url="https://example.com/Example.dmg" sparkle:version="1" sparkle:shortVersionString="1.0.0" length="14505373" type="application/octet-stream" sparkle:edSignature="jKWSaYuaZggtf3hynWbaIdtGOHaOeJ3x68j/S2SucdsChqsnMkg0fWe1oXHky9wlrEKwGoT7VudPWjX81AazAQ=="/>
        </item>
    </channel>
</rss>
```