### PR TITLE
Minor fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "ed25519"]
-	path = ed25519
+[submodule "Vendor/ed25519"]
+	path = Vendor/ed25519
 	url = https://github.com/orlp/ed25519

--- a/Configurations/bsdiff-Debug.xcconfig
+++ b/Configurations/bsdiff-Debug.xcconfig
@@ -1,0 +1,3 @@
+//  Copyright © 2019 Sparkle Project. All rights reserved.
+
+#include "bsdiff-Shared.xcconfig"

--- a/Configurations/bsdiff-Release.xcconfig
+++ b/Configurations/bsdiff-Release.xcconfig
@@ -1,0 +1,3 @@
+//  Copyright © 2019 Sparkle Project. All rights reserved.
+
+#include "bsdiff-Shared.xcconfig"

--- a/Configurations/bsdiff-Shared.xcconfig
+++ b/Configurations/bsdiff-Shared.xcconfig
@@ -1,0 +1,14 @@
+//  Copyright © 2019 Sparkle Project. All rights reserved.
+
+// Deployment
+SKIP_INSTALL = YES
+
+// Packaging
+EXECUTABLE_PREFIX = lib
+PRODUCT_NAME = $(TARGET_NAME)
+
+// Search Paths
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Disable Warnings - this is a third-party project, and we'll trust that the maintainers know what they're doing.
+WARNING_CFLAGS = $(inherited) -Wno-comma

--- a/Configurations/ed25519-Debug.xcconfig
+++ b/Configurations/ed25519-Debug.xcconfig
@@ -1,0 +1,3 @@
+//  Copyright © 2019 Sparkle Project. All rights reserved.
+
+#include "ed25519-Shared.xcconfig"

--- a/Configurations/ed25519-Release.xcconfig
+++ b/Configurations/ed25519-Release.xcconfig
@@ -1,0 +1,3 @@
+//  Copyright © 2019 Sparkle Project. All rights reserved.
+
+#include "ed25519-Shared.xcconfig"

--- a/Configurations/ed25519-Shared.xcconfig
+++ b/Configurations/ed25519-Shared.xcconfig
@@ -1,0 +1,14 @@
+//  Copyright © 2019 Sparkle Project. All rights reserved.
+
+// Deployment
+SKIP_INSTALL = YES
+
+// Packaging
+EXECUTABLE_PREFIX = lib
+PRODUCT_NAME = $(TARGET_NAME)
+
+// Search Paths
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Disable Warnings - this is a third-party project, and we'll trust that the maintainers know what they're doing.
+WARNING_CFLAGS = $(inherited) -Wno-cast-qual -Wno-conversion -Wno-sign-conversion

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		142E0E0919A83AAC00E4312B /* SUBinaryDeltaTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 142E0E0819A83AAC00E4312B /* SUBinaryDeltaTest.m */; };
 		14652F7C19A9725300959E44 /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E20FD68CC7005AE3F6 /* SUBinaryDeltaCommon.m */; };
 		14652F7D19A9726700959E44 /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E00FD68CC7005AE3F6 /* SUBinaryDeltaApply.m */; };
-		14652F7E19A9728A00959E44 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
 		14652F8019A9740F00959E44 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		14652F8219A9746000959E44 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		14652F8419A978C200959E44 /* SUExport.h in Headers */ = {isa = PBXBuildFile; fileRef = 14652F8319A9759F00959E44 /* SUExport.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -97,9 +96,6 @@
 		5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AAD00511E0BE6BE00AF411E /* ArchiveItem.swift */; };
 		5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E20FD68CC7005AE3F6 /* SUBinaryDeltaCommon.m */; };
 		5AAD00671E0C2D9B00AF411E /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
-		5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
-		5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
-		5AAD006A1E0C2DB500AF411E /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AAD006B1E0C2DBF00AF411E /* libxar.tbd */; };
 		5AB8F169214D4AE300A1187F /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF04876214D2E5F00B5789F /* SUSignatures.m */; };
 		5AB8F181214D564C00A1187F /* sha512.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F170214D564A00A1187F /* sha512.h */; };
@@ -124,7 +120,6 @@
 		5AE13FB81E0D9F8E000D2C2C /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		5AE13FB91E0DA384000D2C2C /* SUBinaryDeltaUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E9380FD69271005AE3F6 /* SUBinaryDeltaUnarchiver.m */; };
 		5AE13FBA1E0DA389000D2C2C /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E00FD68CC7005AE3F6 /* SUBinaryDeltaApply.m */; };
-		5AE13FBB1E0DA391000D2C2C /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
 		5AE13FBD1E0DA39B000D2C2C /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE13FBC1E0DA39B000D2C2C /* libbz2.tbd */; };
 		5AE459001C34118500E3BB47 /* SUUpdaterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 14950074195FDF5900BC5B5B /* SUUpdaterTest.m */; };
 		5AE459021C34118500E3BB47 /* SUVersionComparisonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 61227A150DB548B800AB99EA /* SUVersionComparisonTest.m */; };
@@ -134,9 +129,7 @@
 		5AF6C74F1AEA46D10014A3AB /* test.pkg in Resources */ = {isa = PBXBuildFile; fileRef = 5AF6C74E1AEA46D10014A3AB /* test.pkg */; };
 		5AF6C7541AEA49840014A3AB /* SUInstallerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6C74C1AEA40760014A3AB /* SUInstallerTest.m */; };
 		5AF9DC3C1981DBEE001EA135 /* SUDSAVerifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF9DC3B1981DBEE001EA135 /* SUDSAVerifierTest.m */; };
-		5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
 		5D06E8EA0FD68CDB005AE3F6 /* SUBinaryDeltaTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E30FD68CC7005AE3F6 /* SUBinaryDeltaTool.m */; };
-		5D06E8EB0FD68CE4005AE3F6 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
 		5D06E8EC0FD68CE4005AE3F6 /* SUBinaryDeltaApply.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E00FD68CC7005AE3F6 /* SUBinaryDeltaApply.m */; };
 		5D06E8ED0FD68CE4005AE3F6 /* SUBinaryDeltaCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8E20FD68CC7005AE3F6 /* SUBinaryDeltaCommon.m */; };
 		5D06E8FD0FD68D6B005AE3F6 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */; };
@@ -222,12 +215,8 @@
 		720B16451C66433D006985FB /* SUTestApplicationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720B16431C66433D006985FB /* SUTestApplicationTest.swift */; };
 		7210C7681B9A9A1500EB90AC /* SUUnarchiverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */; };
 		721BC2111D1DFF05002BC71E /* SUFileOperationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 722954C31D04E66F00ECF9CA /* SUFileOperationConstants.m */; };
-		721CF1A71AD7643600D9AC09 /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
-		721CF1A81AD7644100D9AC09 /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
-		721CF1A91AD7644C00D9AC09 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		721CF1AA1AD7647000D9AC09 /* libxar.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1AF5890FD7678C0065DB48 /* libxar.1.dylib */; };
 		721CF1AB1AD764EB00D9AC09 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D06E8FB0FD68D61005AE3F6 /* libbz2.dylib */; };
-		7223E7631AD1AEFF008E3161 /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		722589D71E0AD86B005EA0B9 /* SUUnarchiverProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 722589D61E0AD86B005EA0B9 /* SUUnarchiverProtocol.h */; };
 		722589DA1E0B19F4005EA0B9 /* SUUnarchiverNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 722589D81E0B19F4005EA0B9 /* SUUnarchiverNotifier.h */; };
 		722589DB1E0B19F4005EA0B9 /* SUUnarchiverNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 722589D91E0B19F4005EA0B9 /* SUUnarchiverNotifier.m */; };
@@ -254,9 +243,6 @@
 		72316BE41E0E1C7F0039EFD9 /* SUSystemUpdateInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 72316BE21E0E1C7F0039EFD9 /* SUSystemUpdateInfo.m */; };
 		72316BE61E1087060039EFD9 /* SUUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 72316BE51E1087060039EFD9 /* SUUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		723A920E1D722438004A9DED /* SUSpotlightImporterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A920D1D722438004A9DED /* SUSpotlightImporterTest.swift */; };
-		723B252D1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
-		723B252E1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
-		723B252F1CEAB3A600909873 /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
 		723B25301CEAB3A600909873 /* bscommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 723B252C1CEAB3A600909873 /* bscommon.h */; };
 		72464F7D1E213ED400FB341C /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		72544FFC1D0991A4000CFB2C /* SUFileOperationConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 722954C31D04E66F00ECF9CA /* SUFileOperationConstants.m */; };
@@ -323,6 +309,20 @@
 		EA4311E3229D641400A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
 		EA4311E4229D643300A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
 		EA4311E5229D644700A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
+		EA4311EF229D651F00A5503D /* bscommon.c in Sources */ = {isa = PBXBuildFile; fileRef = 723B252B1CEAB3A600909873 /* bscommon.c */; };
+		EA4311F0229D651F00A5503D /* bscommon.h in Sources */ = {isa = PBXBuildFile; fileRef = 723B252C1CEAB3A600909873 /* bscommon.h */; };
+		EA4311F1229D651F00A5503D /* bsdiff.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DB0FD68CB9005AE3F6 /* bsdiff.c */; };
+		EA4311F2229D651F00A5503D /* bspatch.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D06E8DC0FD68CB9005AE3F6 /* bspatch.c */; };
+		EA4311F3229D651F00A5503D /* bspatch.h in Sources */ = {isa = PBXBuildFile; fileRef = 611142E810FB1BE5009810AA /* bspatch.h */; };
+		EA4311F4229D651F00A5503D /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
+		EA4311F5229D651F00A5503D /* sais.h in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7621AD1AEFF008E3161 /* sais.h */; };
+		EA4311F6229D652700A5503D /* bscommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 723B252C1CEAB3A600909873 /* bscommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311F7229D652700A5503D /* bspatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 611142E810FB1BE5009810AA /* bspatch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311F8229D652700A5503D /* sais.h in Headers */ = {isa = PBXBuildFile; fileRef = 7223E7621AD1AEFF008E3161 /* sais.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311FC229D65E400A5503D /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311EA229D651300A5503D /* libbsdiff.a */; };
+		EA4311FD229D65FC00A5503D /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311EA229D651300A5503D /* libbsdiff.a */; };
+		EA4311FE229D660B00A5503D /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311EA229D651300A5503D /* libbsdiff.a */; };
+		EA4311FF229D662600A5503D /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311EA229D651300A5503D /* libbsdiff.a */; };
 		F8761EB11ADC5068000C9034 /* SUCodeSigningVerifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F8761EB01ADC5068000C9034 /* SUCodeSigningVerifierTest.m */; };
 		F8761EB31ADC50EB000C9034 /* SparkleTestCodeSignApp.zip in Resources */ = {isa = PBXBuildFile; fileRef = F8761EB21ADC50EB000C9034 /* SparkleTestCodeSignApp.zip */; };
 		F8761EB61ADC5E7A000C9034 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B078CD15A5FB6100600039 /* SUCodeSigningVerifier.m */; };
@@ -935,6 +935,10 @@
 		EA4311C7229D612A00A5503D /* ed25519-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ed25519-Shared.xcconfig"; sourceTree = "<group>"; };
 		EA4311C8229D613B00A5503D /* ed25519-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ed25519-Release.xcconfig"; sourceTree = "<group>"; };
 		EA4311C9229D614300A5503D /* ed25519-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ed25519-Debug.xcconfig"; sourceTree = "<group>"; };
+		EA4311EA229D651300A5503D /* libbsdiff.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libbsdiff.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA4311F9229D655E00A5503D /* bsdiff-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "bsdiff-Shared.xcconfig"; sourceTree = "<group>"; };
+		EA4311FA229D656700A5503D /* bsdiff-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "bsdiff-Debug.xcconfig"; sourceTree = "<group>"; };
+		EA4311FB229D657A00A5503D /* bsdiff-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "bsdiff-Release.xcconfig"; sourceTree = "<group>"; };
 		F8761EB01ADC5068000C9034 /* SUCodeSigningVerifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUCodeSigningVerifierTest.m; sourceTree = "<group>"; };
 		F8761EB21ADC50EB000C9034 /* SparkleTestCodeSignApp.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = SparkleTestCodeSignApp.zip; sourceTree = "<group>"; };
 		FA1941CA0D94A70100DD942E /* ConfigFrameworkDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ConfigFrameworkDebug.xcconfig; sourceTree = "<group>"; };
@@ -979,6 +983,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311FC229D65E400A5503D /* libbsdiff.a in Frameworks */,
 				EA4311BD229D5FF000A5503D /* libed25519.a in Frameworks */,
 				5AE13FBD1E0DA39B000D2C2C /* libbz2.tbd in Frameworks */,
 				5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */,
@@ -997,6 +1002,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311FD229D65FC00A5503D /* libbsdiff.a in Frameworks */,
 				5D06E9050FD68D7D005AE3F6 /* Foundation.framework in Frameworks */,
 				5D06E8FF0FD68D6D005AE3F6 /* libbz2.dylib in Frameworks */,
 				5D1AF58B0FD7678C0065DB48 /* libxar.1.dylib in Frameworks */,
@@ -1009,6 +1015,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311FE229D660B00A5503D /* libbsdiff.a in Frameworks */,
 				14732BD119610A1200593899 /* AppKit.framework in Frameworks */,
 				14732BD019610A0D00593899 /* Foundation.framework in Frameworks */,
 				721CF1AB1AD764EB00D9AC09 /* libbz2.dylib in Frameworks */,
@@ -1051,6 +1058,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311FF229D662600A5503D /* libbsdiff.a in Frameworks */,
 				EA4311E4229D643300A5503D /* libed25519.a in Frameworks */,
 				1495006E195FCE1100BC5B5B /* AppKit.framework in Frameworks */,
 				1495006F195FCE1800BC5B5B /* Foundation.framework in Frameworks */,
@@ -1065,6 +1073,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		EA43119E229D5FBC00A5503D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA4311E8229D651300A5503D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1088,6 +1103,7 @@
 				8DC2EF5B0486A6940098B216 /* Sparkle.framework */,
 				726B2B5D1C645FC900388755 /* UI Tests.xctest */,
 				EA4311A0229D5FBC00A5503D /* libed25519.a */,
+				EA4311EA229D651300A5503D /* libbsdiff.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1559,6 +1575,9 @@
 			isa = PBXGroup;
 			children = (
 				14732BB1195FF6B700593899 /* .clang-format */,
+				EA4311FA229D656700A5503D /* bsdiff-Debug.xcconfig */,
+				EA4311FB229D657A00A5503D /* bsdiff-Release.xcconfig */,
+				EA4311F9229D655E00A5503D /* bsdiff-Shared.xcconfig */,
 				5D06E8F10FD68D21005AE3F6 /* ConfigBinaryDelta.xcconfig */,
 				5D06E8F20FD68D21005AE3F6 /* ConfigBinaryDeltaDebug.xcconfig */,
 				5D06E8F30FD68D21005AE3F6 /* ConfigBinaryDeltaRelease.xcconfig */,
@@ -1690,6 +1709,16 @@
 				EA4311BA229D5FD600A5503D /* precomp_data.h in Headers */,
 				EA4311BB229D5FD600A5503D /* sc.h in Headers */,
 				EA4311BC229D5FD600A5503D /* sha512.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA4311E6229D651300A5503D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA4311F6229D652700A5503D /* bscommon.h in Headers */,
+				EA4311F7229D652700A5503D /* bspatch.h in Headers */,
+				EA4311F8229D652700A5503D /* sais.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1932,6 +1961,23 @@
 			productReference = EA4311A0229D5FBC00A5503D /* libed25519.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		EA4311E9229D651300A5503D /* bsdiff */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA4311EB229D651300A5503D /* Build configuration list for PBXNativeTarget "bsdiff" */;
+			buildPhases = (
+				EA4311E6229D651300A5503D /* Headers */,
+				EA4311E7229D651300A5503D /* Sources */,
+				EA4311E8229D651300A5503D /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = bsdiff;
+			productName = bsdiff;
+			productReference = EA4311EA229D651300A5503D /* libbsdiff.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1971,6 +2017,9 @@
 						LastSwiftMigration = 0920;
 					};
 					EA43119F229D5FBC00A5503D = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
+					EA4311E9229D651300A5503D = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
 				};
@@ -2046,6 +2095,7 @@
 				5AA96C541E0AE0DB00CA4346 /* generate_appcast */,
 				5AB8F19E214DA72000A1187F /* generate_keys */,
 				5A5ADED6214EDE4900DF0099 /* sign_update */,
+				EA4311E9229D651300A5503D /* bsdiff */,
 				EA43119F229D5FBC00A5503D /* ed25519 */,
 			);
 		};
@@ -2228,12 +2278,8 @@
 			files = (
 				5AE13FA01E0D4F65000D2C2C /* Appcast.swift in Sources */,
 				5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */,
-				5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */,
-				5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */,
-				5AE13FBB1E0DA391000D2C2C /* bspatch.c in Sources */,
 				5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */,
 				5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */,
-				5AAD006A1E0C2DB500AF411E /* sais.c in Sources */,
 				5AE13F781E0C9B12000D2C2C /* Signatures.swift in Sources */,
 				5AE13FBA1E0DA389000D2C2C /* SUBinaryDeltaApply.m in Sources */,
 				5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */,
@@ -2265,10 +2311,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				723B252F1CEAB3A600909873 /* bscommon.c in Sources */,
-				5D06E8E90FD68CDB005AE3F6 /* bsdiff.c in Sources */,
-				14652F7E19A9728A00959E44 /* bspatch.c in Sources */,
-				7223E7631AD1AEFF008E3161 /* sais.c in Sources */,
 				14652F7D19A9726700959E44 /* SUBinaryDeltaApply.m in Sources */,
 				14652F7C19A9725300959E44 /* SUBinaryDeltaCommon.m in Sources */,
 				7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */,
@@ -2284,10 +2326,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				723B252E1CEAB3A600909873 /* bscommon.c in Sources */,
-				721CF1A71AD7643600D9AC09 /* bsdiff.c in Sources */,
-				721CF1A81AD7644100D9AC09 /* bspatch.c in Sources */,
-				721CF1A91AD7644C00D9AC09 /* sais.c in Sources */,
 				342731481FF58E5B00285FBD /* SPUDownloaderTest.swift in Sources */,
 				5A4094481C74EA5200983BE0 /* SUAppcastTest.swift in Sources */,
 				72D4DAA11AD7632900B211E2 /* SUBinaryDeltaCreate.m in Sources */,
@@ -2343,8 +2381,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				723B252D1CEAB3A600909873 /* bscommon.c in Sources */,
-				5D06E8EB0FD68CE4005AE3F6 /* bspatch.c in Sources */,
 				34074B9E1FEABD5A001CB3A5 /* SPUDownloadData.m in Sources */,
 				34074B901FEABD08001CB3A5 /* SPUDownloader.m in Sources */,
 				34074BA81FEAC417001CB3A5 /* SPUDownloaderDeprecated.m in Sources */,
@@ -2417,6 +2453,20 @@
 				EA4311B3229D5FC600A5503D /* sha512.h in Sources */,
 				EA4311B4229D5FC600A5503D /* sign.c in Sources */,
 				EA4311B5229D5FC600A5503D /* verify.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA4311E7229D651300A5503D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA4311EF229D651F00A5503D /* bscommon.c in Sources */,
+				EA4311F0229D651F00A5503D /* bscommon.h in Sources */,
+				EA4311F1229D651F00A5503D /* bsdiff.c in Sources */,
+				EA4311F2229D651F00A5503D /* bspatch.c in Sources */,
+				EA4311F3229D651F00A5503D /* bspatch.h in Sources */,
+				EA4311F4229D651F00A5503D /* sais.c in Sources */,
+				EA4311F5229D651F00A5503D /* sais.h in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3087,6 +3137,27 @@
 			};
 			name = Release;
 		};
+		EA4311EC229D651300A5503D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA4311FA229D656700A5503D /* bsdiff-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		EA4311ED229D651300A5503D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA4311FA229D656700A5503D /* bsdiff-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Coverage;
+		};
+		EA4311EE229D651300A5503D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA4311FB229D657A00A5503D /* bsdiff-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3236,6 +3307,16 @@
 				EA4311A2229D5FBC00A5503D /* Debug */,
 				EA4311A3229D5FBC00A5503D /* Coverage */,
 				EA4311A4229D5FBC00A5503D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EA4311EB229D651300A5503D /* Build configuration list for PBXNativeTarget "bsdiff" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA4311EC229D651300A5503D /* Debug */,
+				EA4311ED229D651300A5503D /* Coverage */,
+				EA4311EE229D651300A5503D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -1116,7 +1116,7 @@
 				14732BB81960EEB600593899 /* Resources */,
 				61227A100DB5484000AB99EA /* Tests */,
 				61B5F91D09C4CF7F00B25A18 /* Test Application */,
-				14732BB51960ECBA00593899 /* Third Party */,
+				14732BB51960ECBA00593899 /* Vendor */,
 				1420DE391962322200203BB0 /* Documentation */,
 				FA1941C40D94A6EA00DD942E /* Configurations */,
 				726B2B5E1C645FC900388755 /* UITests */,
@@ -1173,13 +1173,12 @@
 			path = Documentation;
 			sourceTree = "<group>";
 		};
-		14732BB51960ECBA00593899 /* Third Party */ = {
+		14732BB51960ECBA00593899 /* Vendor */ = {
 			isa = PBXGroup;
 			children = (
 				14732BB61960ECE800593899 /* bsdiff */,
 				5AB8F16E214D560700A1187F /* ed25519 */,
 			);
-			name = "Third Party";
 			path = Vendor;
 			sourceTree = "<group>";
 		};

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -91,16 +91,6 @@
 		5A5AC5361E0C6CA300998119 /* Unarchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5AC5351E0C6CA300998119 /* Unarchive.swift */; };
 		5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5AC5371E0C6D3000998119 /* FeedXML.swift */; };
 		5A5ADEDA214EDE4900DF0099 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5ADED9214EDE4900DF0099 /* main.swift */; };
-		5A5ADEDF214EDF6300DF0099 /* add_scalar.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F171214D564A00A1187F /* add_scalar.c */; };
-		5A5ADEE0214EDF6300DF0099 /* fe.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17C214D564B00A1187F /* fe.c */; };
-		5A5ADEE1214EDF6300DF0099 /* ge.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F175214D564B00A1187F /* ge.c */; };
-		5A5ADEE2214EDF6300DF0099 /* key_exchange.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F178214D564B00A1187F /* key_exchange.c */; };
-		5A5ADEE3214EDF6300DF0099 /* keypair.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17F214D564C00A1187F /* keypair.c */; };
-		5A5ADEE4214EDF6300DF0099 /* sc.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F16F214D564A00A1187F /* sc.c */; };
-		5A5ADEE5214EDF6300DF0099 /* seed.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17B214D564B00A1187F /* seed.c */; };
-		5A5ADEE6214EDF6300DF0099 /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F172214D564B00A1187F /* sha512.c */; };
-		5A5ADEE7214EDF6300DF0099 /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17D214D564B00A1187F /* sign.c */; };
-		5A5ADEE8214EDF6300DF0099 /* verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F177214D564B00A1187F /* verify.c */; };
 		5A6D31EE1BF53245009C5157 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7275F9C01B5F1F2900B1D19E /* SUFileManager.m */; };
 		5A6D31EF1BF5325F009C5157 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA96C571E0AE0DB00CA4346 /* main.swift */; };
@@ -112,44 +102,14 @@
 		5AAD006A1E0C2DB500AF411E /* sais.c in Sources */ = {isa = PBXBuildFile; fileRef = 7223E7611AD1AEFF008E3161 /* sais.c */; };
 		5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AAD006B1E0C2DBF00AF411E /* libxar.tbd */; };
 		5AB8F169214D4AE300A1187F /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF04876214D2E5F00B5789F /* SUSignatures.m */; };
-		5AB8F180214D564C00A1187F /* sc.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F16F214D564A00A1187F /* sc.c */; };
 		5AB8F181214D564C00A1187F /* sha512.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F170214D564A00A1187F /* sha512.h */; };
-		5AB8F182214D564C00A1187F /* add_scalar.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F171214D564A00A1187F /* add_scalar.c */; };
-		5AB8F183214D564C00A1187F /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F172214D564B00A1187F /* sha512.c */; };
 		5AB8F184214D564C00A1187F /* fe.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F173214D564B00A1187F /* fe.h */; };
 		5AB8F185214D564C00A1187F /* ed25519.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F174214D564B00A1187F /* ed25519.h */; };
-		5AB8F186214D564C00A1187F /* ge.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F175214D564B00A1187F /* ge.c */; };
 		5AB8F187214D564C00A1187F /* precomp_data.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F176214D564B00A1187F /* precomp_data.h */; };
-		5AB8F188214D564C00A1187F /* verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F177214D564B00A1187F /* verify.c */; };
-		5AB8F189214D564C00A1187F /* key_exchange.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F178214D564B00A1187F /* key_exchange.c */; };
 		5AB8F18A214D564C00A1187F /* fixedint.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F179214D564B00A1187F /* fixedint.h */; };
 		5AB8F18B214D564C00A1187F /* ge.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F17A214D564B00A1187F /* ge.h */; };
-		5AB8F18C214D564C00A1187F /* seed.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17B214D564B00A1187F /* seed.c */; };
-		5AB8F18D214D564C00A1187F /* fe.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17C214D564B00A1187F /* fe.c */; };
-		5AB8F18E214D564C00A1187F /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17D214D564B00A1187F /* sign.c */; };
 		5AB8F18F214D564C00A1187F /* sc.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F17E214D564B00A1187F /* sc.h */; };
-		5AB8F190214D564C00A1187F /* keypair.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17F214D564C00A1187F /* keypair.c */; };
-		5AB8F191214DA5FD00A1187F /* add_scalar.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F171214D564A00A1187F /* add_scalar.c */; };
-		5AB8F192214DA5FD00A1187F /* fe.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17C214D564B00A1187F /* fe.c */; };
-		5AB8F193214DA5FD00A1187F /* ge.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F175214D564B00A1187F /* ge.c */; };
-		5AB8F194214DA5FD00A1187F /* key_exchange.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F178214D564B00A1187F /* key_exchange.c */; };
-		5AB8F195214DA5FD00A1187F /* keypair.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17F214D564C00A1187F /* keypair.c */; };
-		5AB8F196214DA5FD00A1187F /* sc.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F16F214D564A00A1187F /* sc.c */; };
-		5AB8F197214DA5FD00A1187F /* seed.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17B214D564B00A1187F /* seed.c */; };
-		5AB8F198214DA5FD00A1187F /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F172214D564B00A1187F /* sha512.c */; };
-		5AB8F199214DA5FD00A1187F /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17D214D564B00A1187F /* sign.c */; };
-		5AB8F19A214DA5FD00A1187F /* verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F177214D564B00A1187F /* verify.c */; };
 		5AB8F1A2214DA72000A1187F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F1A1214DA72000A1187F /* main.swift */; };
-		5AB8F1AC214DAB9D00A1187F /* add_scalar.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F171214D564A00A1187F /* add_scalar.c */; };
-		5AB8F1AD214DAB9D00A1187F /* fe.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17C214D564B00A1187F /* fe.c */; };
-		5AB8F1AE214DAB9D00A1187F /* ge.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F175214D564B00A1187F /* ge.c */; };
-		5AB8F1AF214DAB9D00A1187F /* key_exchange.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F178214D564B00A1187F /* key_exchange.c */; };
-		5AB8F1B0214DAB9D00A1187F /* keypair.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17F214D564C00A1187F /* keypair.c */; };
-		5AB8F1B1214DAB9D00A1187F /* sc.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F16F214D564A00A1187F /* sc.c */; };
-		5AB8F1B2214DAB9D00A1187F /* seed.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17B214D564B00A1187F /* seed.c */; };
-		5AB8F1B3214DAB9D00A1187F /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F172214D564B00A1187F /* sha512.c */; };
-		5AB8F1B4214DAB9D00A1187F /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17D214D564B00A1187F /* sign.c */; };
-		5AB8F1B5214DAB9D00A1187F /* verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F177214D564B00A1187F /* verify.c */; };
 		5AD0FA7F1C73F2E2004BCEFF /* testappcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */; };
 		5AE13F781E0C9B12000D2C2C /* Signatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE13F771E0C9B12000D2C2C /* Signatures.swift */; };
 		5AE13FA01E0D4F65000D2C2C /* Appcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE13F9F1E0D4F65000D2C2C /* Appcast.swift */; };
@@ -190,16 +150,6 @@
 		5D1AF59A0FD767E50065DB48 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1AF5990FD767E50065DB48 /* libz.dylib */; };
 		5D1AF82B0FD768180065DB48 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D1AF5990FD767E50065DB48 /* libz.dylib */; };
 		5F1510A21C96E591006E1629 /* testnamespaces.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5F1510A11C96E591006E1629 /* testnamespaces.xml */; };
-		5FD37C9D216B3E5A0003A1B6 /* add_scalar.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F171214D564A00A1187F /* add_scalar.c */; };
-		5FD37C9E216B3E5A0003A1B6 /* fe.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17C214D564B00A1187F /* fe.c */; };
-		5FD37C9F216B3E5A0003A1B6 /* ge.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F175214D564B00A1187F /* ge.c */; };
-		5FD37CA0216B3E5A0003A1B6 /* key_exchange.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F178214D564B00A1187F /* key_exchange.c */; };
-		5FD37CA1216B3E5A0003A1B6 /* keypair.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17F214D564C00A1187F /* keypair.c */; };
-		5FD37CA2216B3E5A0003A1B6 /* sc.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F16F214D564A00A1187F /* sc.c */; };
-		5FD37CA3216B3E5A0003A1B6 /* seed.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17B214D564B00A1187F /* seed.c */; };
-		5FD37CA4216B3E5A0003A1B6 /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F172214D564B00A1187F /* sha512.c */; };
-		5FD37CA5216B3E5A0003A1B6 /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17D214D564B00A1187F /* sign.c */; };
-		5FD37CA6216B3E5A0003A1B6 /* verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F177214D564B00A1187F /* verify.c */; };
 		610134730DD250470049ACDF /* SUUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 610134710DD250470049ACDF /* SUUpdateDriver.h */; settings = {ATTRIBUTES = (); }; };
 		610134740DD250470049ACDF /* SUUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 610134720DD250470049ACDF /* SUUpdateDriver.m */; };
 		6101347B0DD2541A0049ACDF /* SUProbingUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 610134790DD2541A0049ACDF /* SUProbingUpdateDriver.h */; settings = {ATTRIBUTES = (); }; };
@@ -344,6 +294,35 @@
 		E1545EC61E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */; };
 		E1D4DDF921C1C5F8003D32E7 /* DarkAqua.css in Resources */ = {isa = PBXBuildFile; fileRef = E1D4DDF821C1C5F8003D32E7 /* DarkAqua.css */; };
 		E1EC2A301E21667000245715 /* SUTouchBarButtonGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */; };
+		EA4311A5229D5FC600A5503D /* add_scalar.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F171214D564A00A1187F /* add_scalar.c */; };
+		EA4311A6229D5FC600A5503D /* ed25519.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F174214D564B00A1187F /* ed25519.h */; };
+		EA4311A7229D5FC600A5503D /* fe.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17C214D564B00A1187F /* fe.c */; };
+		EA4311A8229D5FC600A5503D /* fe.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F173214D564B00A1187F /* fe.h */; };
+		EA4311A9229D5FC600A5503D /* fixedint.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F179214D564B00A1187F /* fixedint.h */; };
+		EA4311AA229D5FC600A5503D /* ge.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F175214D564B00A1187F /* ge.c */; };
+		EA4311AB229D5FC600A5503D /* ge.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17A214D564B00A1187F /* ge.h */; };
+		EA4311AC229D5FC600A5503D /* key_exchange.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F178214D564B00A1187F /* key_exchange.c */; };
+		EA4311AD229D5FC600A5503D /* keypair.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17F214D564C00A1187F /* keypair.c */; };
+		EA4311AE229D5FC600A5503D /* precomp_data.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F176214D564B00A1187F /* precomp_data.h */; };
+		EA4311AF229D5FC600A5503D /* sc.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F16F214D564A00A1187F /* sc.c */; };
+		EA4311B0229D5FC600A5503D /* sc.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17E214D564B00A1187F /* sc.h */; };
+		EA4311B1229D5FC600A5503D /* seed.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17B214D564B00A1187F /* seed.c */; };
+		EA4311B2229D5FC600A5503D /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F172214D564B00A1187F /* sha512.c */; };
+		EA4311B3229D5FC600A5503D /* sha512.h in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F170214D564A00A1187F /* sha512.h */; };
+		EA4311B4229D5FC600A5503D /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F17D214D564B00A1187F /* sign.c */; };
+		EA4311B5229D5FC600A5503D /* verify.c in Sources */ = {isa = PBXBuildFile; fileRef = 5AB8F177214D564B00A1187F /* verify.c */; };
+		EA4311B6229D5FD600A5503D /* ed25519.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F174214D564B00A1187F /* ed25519.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311B7229D5FD600A5503D /* fe.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F173214D564B00A1187F /* fe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311B8229D5FD600A5503D /* fixedint.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F179214D564B00A1187F /* fixedint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311B9229D5FD600A5503D /* ge.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F17A214D564B00A1187F /* ge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311BA229D5FD600A5503D /* precomp_data.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F176214D564B00A1187F /* precomp_data.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311BB229D5FD600A5503D /* sc.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F17E214D564B00A1187F /* sc.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311BC229D5FD600A5503D /* sha512.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB8F170214D564A00A1187F /* sha512.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA4311BD229D5FF000A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
+		EA4311E2229D640400A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
+		EA4311E3229D641400A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
+		EA4311E4229D643300A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
+		EA4311E5229D644700A5503D /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA4311A0229D5FBC00A5503D /* libed25519.a */; };
 		F8761EB11ADC5068000C9034 /* SUCodeSigningVerifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F8761EB01ADC5068000C9034 /* SUCodeSigningVerifierTest.m */; };
 		F8761EB31ADC50EB000C9034 /* SparkleTestCodeSignApp.zip in Resources */ = {isa = PBXBuildFile; fileRef = F8761EB21ADC50EB000C9034 /* SparkleTestCodeSignApp.zip */; };
 		F8761EB61ADC5E7A000C9034 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B078CD15A5FB6100600039 /* SUCodeSigningVerifier.m */; };
@@ -722,23 +701,23 @@
 		5AA96C5D1E0AE0F900CA4346 /* Appcast-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Appcast-Bridging-Header.h"; sourceTree = "<group>"; };
 		5AAD00511E0BE6BE00AF411E /* ArchiveItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchiveItem.swift; sourceTree = "<group>"; };
 		5AAD006B1E0C2DBF00AF411E /* libxar.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxar.tbd; path = usr/lib/libxar.tbd; sourceTree = SDKROOT; };
-		5AB8F16F214D564A00A1187F /* sc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sc.c; path = ed25519/src/sc.c; sourceTree = SOURCE_ROOT; };
-		5AB8F170214D564A00A1187F /* sha512.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha512.h; path = ed25519/src/sha512.h; sourceTree = SOURCE_ROOT; };
-		5AB8F171214D564A00A1187F /* add_scalar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = add_scalar.c; path = ed25519/src/add_scalar.c; sourceTree = SOURCE_ROOT; };
-		5AB8F172214D564B00A1187F /* sha512.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sha512.c; path = ed25519/src/sha512.c; sourceTree = SOURCE_ROOT; };
-		5AB8F173214D564B00A1187F /* fe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe.h; path = ed25519/src/fe.h; sourceTree = SOURCE_ROOT; };
-		5AB8F174214D564B00A1187F /* ed25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed25519.h; path = ed25519/src/ed25519.h; sourceTree = SOURCE_ROOT; };
-		5AB8F175214D564B00A1187F /* ge.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge.c; path = ed25519/src/ge.c; sourceTree = SOURCE_ROOT; };
-		5AB8F176214D564B00A1187F /* precomp_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = precomp_data.h; path = ed25519/src/precomp_data.h; sourceTree = SOURCE_ROOT; };
-		5AB8F177214D564B00A1187F /* verify.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = verify.c; path = ed25519/src/verify.c; sourceTree = SOURCE_ROOT; };
-		5AB8F178214D564B00A1187F /* key_exchange.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = key_exchange.c; path = ed25519/src/key_exchange.c; sourceTree = SOURCE_ROOT; };
-		5AB8F179214D564B00A1187F /* fixedint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fixedint.h; path = ed25519/src/fixedint.h; sourceTree = SOURCE_ROOT; };
-		5AB8F17A214D564B00A1187F /* ge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge.h; path = ed25519/src/ge.h; sourceTree = SOURCE_ROOT; };
-		5AB8F17B214D564B00A1187F /* seed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = seed.c; path = ed25519/src/seed.c; sourceTree = SOURCE_ROOT; };
-		5AB8F17C214D564B00A1187F /* fe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe.c; path = ed25519/src/fe.c; sourceTree = SOURCE_ROOT; };
-		5AB8F17D214D564B00A1187F /* sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sign.c; path = ed25519/src/sign.c; sourceTree = SOURCE_ROOT; };
-		5AB8F17E214D564B00A1187F /* sc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sc.h; path = ed25519/src/sc.h; sourceTree = SOURCE_ROOT; };
-		5AB8F17F214D564C00A1187F /* keypair.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = keypair.c; path = ed25519/src/keypair.c; sourceTree = SOURCE_ROOT; };
+		5AB8F16F214D564A00A1187F /* sc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sc.c; path = Vendor/ed25519/src/sc.c; sourceTree = SOURCE_ROOT; };
+		5AB8F170214D564A00A1187F /* sha512.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sha512.h; path = Vendor/ed25519/src/sha512.h; sourceTree = SOURCE_ROOT; };
+		5AB8F171214D564A00A1187F /* add_scalar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = add_scalar.c; path = Vendor/ed25519/src/add_scalar.c; sourceTree = SOURCE_ROOT; };
+		5AB8F172214D564B00A1187F /* sha512.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sha512.c; path = Vendor/ed25519/src/sha512.c; sourceTree = SOURCE_ROOT; };
+		5AB8F173214D564B00A1187F /* fe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fe.h; path = Vendor/ed25519/src/fe.h; sourceTree = SOURCE_ROOT; };
+		5AB8F174214D564B00A1187F /* ed25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ed25519.h; path = Vendor/ed25519/src/ed25519.h; sourceTree = SOURCE_ROOT; };
+		5AB8F175214D564B00A1187F /* ge.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge.c; path = Vendor/ed25519/src/ge.c; sourceTree = SOURCE_ROOT; };
+		5AB8F176214D564B00A1187F /* precomp_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = precomp_data.h; path = Vendor/ed25519/src/precomp_data.h; sourceTree = SOURCE_ROOT; };
+		5AB8F177214D564B00A1187F /* verify.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = verify.c; path = Vendor/ed25519/src/verify.c; sourceTree = SOURCE_ROOT; };
+		5AB8F178214D564B00A1187F /* key_exchange.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = key_exchange.c; path = Vendor/ed25519/src/key_exchange.c; sourceTree = SOURCE_ROOT; };
+		5AB8F179214D564B00A1187F /* fixedint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fixedint.h; path = Vendor/ed25519/src/fixedint.h; sourceTree = SOURCE_ROOT; };
+		5AB8F17A214D564B00A1187F /* ge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ge.h; path = Vendor/ed25519/src/ge.h; sourceTree = SOURCE_ROOT; };
+		5AB8F17B214D564B00A1187F /* seed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = seed.c; path = Vendor/ed25519/src/seed.c; sourceTree = SOURCE_ROOT; };
+		5AB8F17C214D564B00A1187F /* fe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe.c; path = Vendor/ed25519/src/fe.c; sourceTree = SOURCE_ROOT; };
+		5AB8F17D214D564B00A1187F /* sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sign.c; path = Vendor/ed25519/src/sign.c; sourceTree = SOURCE_ROOT; };
+		5AB8F17E214D564B00A1187F /* sc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sc.h; path = Vendor/ed25519/src/sc.h; sourceTree = SOURCE_ROOT; };
+		5AB8F17F214D564C00A1187F /* keypair.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = keypair.c; path = Vendor/ed25519/src/keypair.c; sourceTree = SOURCE_ROOT; };
 		5AB8F19F214DA72000A1187F /* generate_keys */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = generate_keys; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AB8F1A1214DA72000A1187F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		5AB8F1A8214DA85900A1187F /* ConfigGenerateKeys.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ConfigGenerateKeys.xcconfig; sourceTree = "<group>"; };
@@ -952,6 +931,10 @@
 		E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUTouchBarButtonGroup.m; sourceTree = "<group>"; };
 		E19CA4901E2E7E4D009D4D18 /* SUTouchBarForwardDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUTouchBarForwardDeclarations.h; sourceTree = "<group>"; };
 		E1D4DDF821C1C5F8003D32E7 /* DarkAqua.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = DarkAqua.css; sourceTree = "<group>"; };
+		EA4311A0229D5FBC00A5503D /* libed25519.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libed25519.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA4311C7229D612A00A5503D /* ed25519-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ed25519-Shared.xcconfig"; sourceTree = "<group>"; };
+		EA4311C8229D613B00A5503D /* ed25519-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ed25519-Release.xcconfig"; sourceTree = "<group>"; };
+		EA4311C9229D614300A5503D /* ed25519-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ed25519-Debug.xcconfig"; sourceTree = "<group>"; };
 		F8761EB01ADC5068000C9034 /* SUCodeSigningVerifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUCodeSigningVerifierTest.m; sourceTree = "<group>"; };
 		F8761EB21ADC50EB000C9034 /* SparkleTestCodeSignApp.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = SparkleTestCodeSignApp.zip; sourceTree = "<group>"; };
 		FA1941CA0D94A70100DD942E /* ConfigFrameworkDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ConfigFrameworkDebug.xcconfig; sourceTree = "<group>"; };
@@ -988,6 +971,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311E3229D641400A5503D /* libed25519.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -995,6 +979,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311BD229D5FF000A5503D /* libed25519.a in Frameworks */,
 				5AE13FBD1E0DA39B000D2C2C /* libbz2.tbd in Frameworks */,
 				5AAD006C1E0C2DBF00AF411E /* libxar.tbd in Frameworks */,
 			);
@@ -1004,6 +989,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311E2229D640400A5503D /* libed25519.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1037,6 +1023,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311E5229D644700A5503D /* libed25519.a in Frameworks */,
 				14950073195FCE4E00BC5B5B /* AppKit.framework in Frameworks */,
 				14950072195FCE4B00BC5B5B /* Foundation.framework in Frameworks */,
 				61B5F90F09C4CF3A00B25A18 /* Sparkle.framework in Frameworks */,
@@ -1064,6 +1051,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA4311E4229D643300A5503D /* libed25519.a in Frameworks */,
 				1495006E195FCE1100BC5B5B /* AppKit.framework in Frameworks */,
 				1495006F195FCE1800BC5B5B /* Foundation.framework in Frameworks */,
 				61177A1F0D1112E900749C97 /* IOKit.framework in Frameworks */,
@@ -1073,6 +1061,13 @@
 				61B5F8F709C4CEB300B25A18 /* Security.framework in Frameworks */,
 				55C14F32136EFC2400649790 /* SystemConfiguration.framework in Frameworks */,
 				61B5FC4C09C4FD5E00B25A18 /* WebKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA43119E229D5FBC00A5503D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1092,6 +1087,7 @@
 				612279D90DB5470200AB99EA /* Sparkle Unit Tests.xctest */,
 				8DC2EF5B0486A6940098B216 /* Sparkle.framework */,
 				726B2B5D1C645FC900388755 /* UI Tests.xctest */,
+				EA4311A0229D5FBC00A5503D /* libed25519.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1107,7 +1103,7 @@
 				14732BB51960ECBA00593899 /* Third Party */,
 				1420DE391962322200203BB0 /* Documentation */,
 				FA1941C40D94A6EA00DD942E /* Configurations */,
-				726B2B5E1C645FC900388755 /* UI Tests */,
+				726B2B5E1C645FC900388755 /* UITests */,
 				5AB8F1A0214DA72000A1187F /* generate_keys */,
 				5A5ADED8214EDE4900DF0099 /* sign_update */,
 				0867D69AFE84028FC02AAC07 /* Frameworks */,
@@ -1165,6 +1161,7 @@
 			isa = PBXGroup;
 			children = (
 				14732BB61960ECE800593899 /* bsdiff */,
+				5AB8F16E214D560700A1187F /* ed25519 */,
 			);
 			name = "Third Party";
 			path = Vendor;
@@ -1315,7 +1312,7 @@
 				5AB8F177214D564B00A1187F /* verify.c */,
 			);
 			name = ed25519;
-			path = ../ed25519;
+			path = ed25519/src;
 			sourceTree = "<group>";
 		};
 		5AB8F1A0214DA72000A1187F /* generate_keys */ = {
@@ -1330,7 +1327,6 @@
 		5AF04874214D2E2800B5789F /* Signatures */ = {
 			isa = PBXGroup;
 			children = (
-				5AB8F16E214D560700A1187F /* ed25519 */,
 				5AF04875214D2E5F00B5789F /* SUSignatures.h */,
 				5AF04876214D2E5F00B5789F /* SUSignatures.m */,
 			);
@@ -1550,13 +1546,13 @@
 			path = ../../fileop;
 			sourceTree = "<group>";
 		};
-		726B2B5E1C645FC900388755 /* UI Tests */ = {
+		726B2B5E1C645FC900388755 /* UITests */ = {
 			isa = PBXGroup;
 			children = (
 				720B16431C66433D006985FB /* SUTestApplicationTest.swift */,
 				720B16421C66433D006985FB /* UITests-Info.plist */,
 			);
-			path = "UITests";
+			path = UITests;
 			sourceTree = "<group>";
 		};
 		FA1941C40D94A6EA00DD942E /* Configurations */ = {
@@ -1597,6 +1593,9 @@
 				149B78641B7D3A4800D7D62C /* ConfigUnitTestCoverage.xcconfig */,
 				FA3AAF3A1050B273004B3130 /* ConfigUnitTestDebug.xcconfig */,
 				FA3AAF391050B273004B3130 /* ConfigUnitTestRelease.xcconfig */,
+				EA4311C9229D614300A5503D /* ed25519-Debug.xcconfig */,
+				EA4311C8229D613B00A5503D /* ed25519-Release.xcconfig */,
+				EA4311C7229D612A00A5503D /* ed25519-Shared.xcconfig */,
 				14732BC91960F70A00593899 /* make-release-package.sh */,
 				14652F7919A93E5F00959E44 /* set-git-version-info.sh */,
 				146EC84E19A68CF8004A50C5 /* Sparkle.podspec */,
@@ -1677,6 +1676,20 @@
 				61A354550DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.h in Headers */,
 				61A2259E0D1C495D00430CCD /* SUVersionComparisonProtocol.h in Headers */,
 				3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA43119C229D5FBC00A5503D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA4311B6229D5FD600A5503D /* ed25519.h in Headers */,
+				EA4311B7229D5FD600A5503D /* fe.h in Headers */,
+				EA4311B8229D5FD600A5503D /* fixedint.h in Headers */,
+				EA4311B9229D5FD600A5503D /* ge.h in Headers */,
+				EA4311BA229D5FD600A5503D /* precomp_data.h in Headers */,
+				EA4311BB229D5FD600A5503D /* sc.h in Headers */,
+				EA4311BC229D5FD600A5503D /* sha512.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1902,6 +1915,23 @@
 			productReference = 8DC2EF5B0486A6940098B216 /* Sparkle.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		EA43119F229D5FBC00A5503D /* ed25519 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA4311A1229D5FBC00A5503D /* Build configuration list for PBXNativeTarget "ed25519" */;
+			buildPhases = (
+				EA43119C229D5FBC00A5503D /* Headers */,
+				EA43119D229D5FBC00A5503D /* Sources */,
+				EA43119E229D5FBC00A5503D /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ed25519;
+			productName = ed25519;
+			productReference = EA4311A0229D5FBC00A5503D /* libed25519.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1939,6 +1969,9 @@
 					};
 					8DC2EF4F0486A6940098B216 = {
 						LastSwiftMigration = 0920;
+					};
+					EA43119F229D5FBC00A5503D = {
+						CreatedOnToolsVersion = 10.2.1;
 					};
 				};
 			};
@@ -2013,6 +2046,7 @@
 				5AA96C541E0AE0DB00CA4346 /* generate_appcast */,
 				5AB8F19E214DA72000A1187F /* generate_keys */,
 				5A5ADED6214EDE4900DF0099 /* sign_update */,
+				EA43119F229D5FBC00A5503D /* ed25519 */,
 			);
 		};
 /* End PBXProject section */
@@ -2184,17 +2218,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5A5ADEDF214EDF6300DF0099 /* add_scalar.c in Sources */,
-				5A5ADEE0214EDF6300DF0099 /* fe.c in Sources */,
-				5A5ADEE1214EDF6300DF0099 /* ge.c in Sources */,
-				5A5ADEE2214EDF6300DF0099 /* key_exchange.c in Sources */,
-				5A5ADEE3214EDF6300DF0099 /* keypair.c in Sources */,
 				5A5ADEDA214EDE4900DF0099 /* main.swift in Sources */,
-				5A5ADEE4214EDF6300DF0099 /* sc.c in Sources */,
-				5A5ADEE5214EDF6300DF0099 /* seed.c in Sources */,
-				5A5ADEE6214EDF6300DF0099 /* sha512.c in Sources */,
-				5A5ADEE7214EDF6300DF0099 /* sign.c in Sources */,
-				5A5ADEE8214EDF6300DF0099 /* verify.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2202,23 +2226,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5AB8F191214DA5FD00A1187F /* add_scalar.c in Sources */,
 				5AE13FA01E0D4F65000D2C2C /* Appcast.swift in Sources */,
 				5AAD00521E0BE6BE00AF411E /* ArchiveItem.swift in Sources */,
 				5AAD00681E0C2DAB00AF411E /* bscommon.c in Sources */,
 				5AAD00691E0C2DAB00AF411E /* bsdiff.c in Sources */,
 				5AE13FBB1E0DA391000D2C2C /* bspatch.c in Sources */,
-				5AB8F192214DA5FD00A1187F /* fe.c in Sources */,
 				5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */,
-				5AB8F193214DA5FD00A1187F /* ge.c in Sources */,
-				5AB8F194214DA5FD00A1187F /* key_exchange.c in Sources */,
-				5AB8F195214DA5FD00A1187F /* keypair.c in Sources */,
 				5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */,
 				5AAD006A1E0C2DB500AF411E /* sais.c in Sources */,
-				5AB8F196214DA5FD00A1187F /* sc.c in Sources */,
-				5AB8F197214DA5FD00A1187F /* seed.c in Sources */,
-				5AB8F198214DA5FD00A1187F /* sha512.c in Sources */,
-				5AB8F199214DA5FD00A1187F /* sign.c in Sources */,
 				5AE13F781E0C9B12000D2C2C /* Signatures.swift in Sources */,
 				5AE13FBA1E0DA389000D2C2C /* SUBinaryDeltaApply.m in Sources */,
 				5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */,
@@ -2235,7 +2250,6 @@
 				5AE13FA11E0D7168000D2C2C /* SUUnarchiver.m in Sources */,
 				5AE13FB71E0D9F42000D2C2C /* SUUnarchiverNotifier.m in Sources */,
 				5A5AC5361E0C6CA300998119 /* Unarchive.swift in Sources */,
-				5AB8F19A214DA5FD00A1187F /* verify.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2243,17 +2257,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5AB8F1AC214DAB9D00A1187F /* add_scalar.c in Sources */,
-				5AB8F1AD214DAB9D00A1187F /* fe.c in Sources */,
-				5AB8F1AE214DAB9D00A1187F /* ge.c in Sources */,
-				5AB8F1AF214DAB9D00A1187F /* key_exchange.c in Sources */,
-				5AB8F1B0214DAB9D00A1187F /* keypair.c in Sources */,
 				5AB8F1A2214DA72000A1187F /* main.swift in Sources */,
-				5AB8F1B1214DAB9D00A1187F /* sc.c in Sources */,
-				5AB8F1B2214DAB9D00A1187F /* seed.c in Sources */,
-				5AB8F1B3214DAB9D00A1187F /* sha512.c in Sources */,
-				5AB8F1B4214DAB9D00A1187F /* sign.c in Sources */,
-				5AB8F1B5214DAB9D00A1187F /* verify.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2306,21 +2310,11 @@
 			files = (
 				61B5F93009C4CFDC00B25A18 /* main.m in Sources */,
 				726F2CEB1BC9C733001971A4 /* SUConstants.m in Sources */,
-				5FD37CA0216B3E5A0003A1B6 /* key_exchange.c in Sources */,
-				5FD37C9E216B3E5A0003A1B6 /* fe.c in Sources */,
-				5FD37C9F216B3E5A0003A1B6 /* ge.c in Sources */,
 				5A6D31EE1BF53245009C5157 /* SUFileManager.m in Sources */,
 				721BC2111D1DFF05002BC71E /* SUFileOperationConstants.m in Sources */,
-				5FD37CA2216B3E5A0003A1B6 /* sc.c in Sources */,
 				5A6D31EF1BF5325F009C5157 /* SUOperatingSystem.m in Sources */,
 				72E45CF31B640CDD005C701A /* SUTestApplicationDelegate.m in Sources */,
-				5FD37CA6216B3E5A0003A1B6 /* verify.c in Sources */,
-				5FD37CA3216B3E5A0003A1B6 /* seed.c in Sources */,
 				A5BF4F1D1BC7668B007A052A /* SUTestWebServer.m in Sources */,
-				5FD37C9D216B3E5A0003A1B6 /* add_scalar.c in Sources */,
-				5FD37CA4216B3E5A0003A1B6 /* sha512.c in Sources */,
-				5FD37CA5216B3E5A0003A1B6 /* sign.c in Sources */,
-				5FD37CA1216B3E5A0003A1B6 /* keypair.c in Sources */,
 				72E45CF71B640DAE005C701A /* SUUpdateSettingsWindowController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2349,17 +2343,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5AB8F182214D564C00A1187F /* add_scalar.c in Sources */,
 				723B252D1CEAB3A600909873 /* bscommon.c in Sources */,
 				5D06E8EB0FD68CE4005AE3F6 /* bspatch.c in Sources */,
-				5AB8F18D214D564C00A1187F /* fe.c in Sources */,
-				5AB8F186214D564C00A1187F /* ge.c in Sources */,
-				5AB8F189214D564C00A1187F /* key_exchange.c in Sources */,
-				5AB8F190214D564C00A1187F /* keypair.c in Sources */,
-				5AB8F180214D564C00A1187F /* sc.c in Sources */,
-				5AB8F18C214D564C00A1187F /* seed.c in Sources */,
-				5AB8F183214D564C00A1187F /* sha512.c in Sources */,
-				5AB8F18E214D564C00A1187F /* sign.c in Sources */,
 				34074B9E1FEABD5A001CB3A5 /* SPUDownloadData.m in Sources */,
 				34074B901FEABD08001CB3A5 /* SPUDownloader.m in Sources */,
 				34074BA81FEAC417001CB3A5 /* SPUDownloaderDeprecated.m in Sources */,
@@ -2408,7 +2393,30 @@
 				61B5F8EE09C4CE3C00B25A18 /* SUUpdater.m in Sources */,
 				729924741DF3478A00DBCDF5 /* SUUpdateValidator.m in Sources */,
 				61A354560DF113C70076ECB1 /* SUUserInitiatedUpdateDriver.m in Sources */,
-				5AB8F188214D564C00A1187F /* verify.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA43119D229D5FBC00A5503D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA4311A5229D5FC600A5503D /* add_scalar.c in Sources */,
+				EA4311A6229D5FC600A5503D /* ed25519.h in Sources */,
+				EA4311A7229D5FC600A5503D /* fe.c in Sources */,
+				EA4311A8229D5FC600A5503D /* fe.h in Sources */,
+				EA4311A9229D5FC600A5503D /* fixedint.h in Sources */,
+				EA4311AA229D5FC600A5503D /* ge.c in Sources */,
+				EA4311AB229D5FC600A5503D /* ge.h in Sources */,
+				EA4311AC229D5FC600A5503D /* key_exchange.c in Sources */,
+				EA4311AD229D5FC600A5503D /* keypair.c in Sources */,
+				EA4311AE229D5FC600A5503D /* precomp_data.h in Sources */,
+				EA4311AF229D5FC600A5503D /* sc.c in Sources */,
+				EA4311B0229D5FC600A5503D /* sc.h in Sources */,
+				EA4311B1229D5FC600A5503D /* seed.c in Sources */,
+				EA4311B2229D5FC600A5503D /* sha512.c in Sources */,
+				EA4311B3229D5FC600A5503D /* sha512.h in Sources */,
+				EA4311B4229D5FC600A5503D /* sign.c in Sources */,
+				EA4311B5229D5FC600A5503D /* verify.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3058,6 +3066,27 @@
 			};
 			name = Release;
 		};
+		EA4311A2229D5FBC00A5503D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA4311C9229D614300A5503D /* ed25519-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		EA4311A3229D5FBC00A5503D /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA4311C9229D614300A5503D /* ed25519-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Coverage;
+		};
+		EA4311A4229D5FBC00A5503D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EA4311C8229D613B00A5503D /* ed25519-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3197,6 +3226,16 @@
 				726B2B641C645FC900388755 /* Debug */,
 				726B2B651C645FC900388755 /* Coverage */,
 				726B2B661C645FC900388755 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EA4311A1229D5FBC00A5503D /* Build configuration list for PBXNativeTarget "ed25519" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA4311A2229D5FBC00A5503D /* Debug */,
+				EA4311A3229D5FBC00A5503D /* Coverage */,
+				EA4311A4229D5FBC00A5503D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sparkle/SUSignatureVerifier.m
+++ b/Sparkle/SUSignatureVerifier.m
@@ -16,7 +16,7 @@
 #import "SULog.h"
 #import "SUSignatures.h"
 #include <CommonCrypto/CommonDigest.h>
-#import "ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // Run `git submodule update --init` if you get an error here
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SUSignatureVerifier.m
+++ b/Sparkle/SUSignatureVerifier.m
@@ -16,7 +16,7 @@
 #import "SULog.h"
 #import "SUSignatures.h"
 #include <CommonCrypto/CommonDigest.h>
-#import "../ed25519/src/ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // run `git submodule update --init` if you get an erorr here
 
 
 #include "AppKitPrevention.h"

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -10,7 +10,7 @@
 #import "SUUpdateSettingsWindowController.h"
 #import "SUFileManager.h"
 #import "SUTestWebServer.h"
-#import "ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // Run `git submodule update --init` if you get an error here
 
 @interface SUTestApplicationDelegate ()
 

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -10,7 +10,7 @@
 #import "SUUpdateSettingsWindowController.h"
 #import "SUFileManager.h"
 #import "SUTestWebServer.h"
-#import "../ed25519/src/ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // run `git submodule update --init` if you get an erorr here
 
 @interface SUTestApplicationDelegate ()
 

--- a/generate_appcast/Appcast-Bridging-Header.h
+++ b/generate_appcast/Appcast-Bridging-Header.h
@@ -7,4 +7,4 @@
 #import "SUBinaryDeltaUnarchiver.h"
 #import "SUBinaryDeltaCreate.h"
 #import "SUSignatures.h"
-#import "../ed25519/src/ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // run `git submodule update --init` if you get an erorr here

--- a/generate_appcast/Appcast-Bridging-Header.h
+++ b/generate_appcast/Appcast-Bridging-Header.h
@@ -7,4 +7,4 @@
 #import "SUBinaryDeltaUnarchiver.h"
 #import "SUBinaryDeltaCreate.h"
 #import "SUSignatures.h"
-#import "ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // Run `git submodule update --init` if you get an error here

--- a/generate_keys/Bridging-Header.h
+++ b/generate_keys/Bridging-Header.h
@@ -3,4 +3,4 @@
 #import "SUConstants.h"
 #import "SUErrors.h"
 #import "SUSignatures.h"
-#import "ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // Run `git submodule update --init` if you get an error here

--- a/generate_keys/Bridging-Header.h
+++ b/generate_keys/Bridging-Header.h
@@ -3,4 +3,4 @@
 #import "SUConstants.h"
 #import "SUErrors.h"
 #import "SUSignatures.h"
-#import "../ed25519/src/ed25519.h" // run `git submodule update --init` if you get an erorr here
+#import "ed25519.h" // run `git submodule update --init` if you get an erorr here


### PR DESCRIPTION
As discussed in #363, I'll start small and bring over changes a piece at a time. 

This first PR is more of a tidy up: 

The vendor dependencies "bsdiff" and "ed25519" have been converted to static library targets, and the filesystem has been cleaned up to group them both under `$(PROJECT_ROOT)/Vendor`. 

Both were being included in multiple targets as raw source files, which can lead to maintenance issues down the road.