### PR TITLE
Fix issue #1411

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -17,6 +17,8 @@
 @interface SUBasicUpdateDriver : SUUpdateDriver <SPUDownloaderDelegate>
 
 @property (strong, readonly) SUAppcastItem *updateItem;
+@property (strong, readonly) SUAppcastItem *latestAppcastItem;
+@property (assign, readonly) NSComparisonResult latestAppcastItemComparisonResult;
 @property (strong, readonly) SPUDownloader *download;
 @property (copy, readonly) NSString *downloadPath;
 

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -33,6 +33,8 @@
 @interface SUBasicUpdateDriver ()
 
 @property (strong) SUAppcastItem *updateItem;
+@property (strong) SUAppcastItem *latestAppcastItem;
+@property (assign) NSComparisonResult latestAppcastItemComparisonResult;
 @property (strong) SPUDownloader *download;
 @property (copy) NSString *downloadPath;
 
@@ -47,6 +49,8 @@
 @implementation SUBasicUpdateDriver
 
 @synthesize updateItem;
+@synthesize latestAppcastItem;
+@synthesize latestAppcastItemComparisonResult;
 @synthesize download;
 @synthesize downloadPath;
 
@@ -207,6 +211,10 @@
             item = deltaUpdateItem;
         }
     }
+
+    self.latestAppcastItem = item;
+    self.latestAppcastItemComparisonResult = [[self versionComparator] compareVersion:[self.host version] toVersion:[item versionString]];
+
 
     if ([self itemContainsValidUpdate:item]) {
         self.updateItem = item;

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -120,9 +120,25 @@
 
     if (!self.automaticallyInstallUpdates) {
         NSAlert *alert = [[NSAlert alloc] init];
-        alert.messageText = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
-        alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
-        [alert addButtonWithTitle:SULocalizedString(@"OK", nil)];
+        
+        if (self.latestAppcastItem) // if the appcast was successfully loaded
+        {
+            alert.messageText = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+
+            if (self.latestAppcastItemComparisonResult == NSOrderedDescending ) { // this means the user is a 'newer than latest' version. give a slight hint to the user instead of wrongly claiming this version is identical to the latest feed version.
+                alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.\n(You are currently running version %@.)", nil), [self.host name], self.latestAppcastItem.versionString, [self.host displayVersion]];
+            }
+            else {
+                alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
+            }
+            [alert addButtonWithTitle:SULocalizedString(@"OK", nil)];
+        }
+        else {
+            alert.messageText = SULocalizedString(@"Update Error!", nil);
+            alert.informativeText = SULocalizedString(@"No valid update information could be loaded.", nil);
+            [alert addButtonWithTitle:SULocalizedString(@"Cancel Update", nil)];
+        }
+	    
         [self showAlert:alert];
     }
     

--- a/Sparkle/ar.lproj/Sparkle.strings
+++ b/Sparkle/ar.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "الإصدار %2$@ هو أحدث إصدار متوفر حاليًا لتطبيق %1$@";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "الإصدار %2$@ هو أحدث إصدار متوفر حاليًا لتطبيق %1$@\n(You are currently running version %@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "لديك الإصدار %3$@ من تطبيق %1$@، هل ترغب بتزيل الإصدار %2$@ الآن";
 

--- a/Sparkle/ca.lproj/Sparkle.strings
+++ b/Sparkle/ca.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%@ %@ és la versió disponible més actual.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%@ %@ és la versió disponible més actual.\n(You are currently running version %@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%@ %@ està disponible (ara teniu %@). Voleu actualitzar?";
 

--- a/Sparkle/cs.lproj/Sparkle.strings
+++ b/Sparkle/cs.lproj/Sparkle.strings
@@ -8,6 +8,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je nejnovější dostupná verze";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ je nejnovější dostupná verze.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "Je k dispozici %1$@ %2$@ - nainstalována je %3$@. Přejete si nyní stáhnout aktualizaci?";
 

--- a/Sparkle/da.lproj/Sparkle.strings
+++ b/Sparkle/da.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ er den aktuelle version.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ er den aktuelle version.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ er tilgængelig! Du har %3$@. Skal den hentes nu?";
 

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -8,6 +8,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.\n(Die derzeit installierte Version ist %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du die neue Version jetzt laden?";
 

--- a/Sparkle/el.lproj/Sparkle.strings
+++ b/Sparkle/el.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "Το %1$@ %2$@ είναι η τελευταία διαθέσιμη έκδοση.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "Το %1$@ %2$@ είναι η τελευταία διαθέσιμη έκδοση.\n(Die derzeit installierte Version ist %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "Το %1$@ %2$@ είναι πλέον διαθέσιμο--έχετε το %3$@. Θέλετε να το κατεβάσετε τώρα;";
 

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -8,6 +8,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ is currently the newest version available.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ is now available—you have %3$@. Would you like to download it now?";
 

--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ es la versión más nueva disponible.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ es la versión más nueva disponible.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ ya está disponible (tienes la %3$@). ¿Quisieras descargarla ahora?";
 

--- a/Sparkle/fi.lproj/Sparkle.strings
+++ b/Sparkle/fi.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ on uusin saatavilla oleva versio.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ on uusin saatavilla oleva versio.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ on nyt saatavilla (sinulla on %3$@). Haluatko ladata sen nyt?";
 

--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -8,6 +8,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ est la version la plus récente disponible.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ est la version la plus récente disponible.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ est disponible ; vous utilisez la version %3$@. Voulez-vous le télécharger maintenant ?";
 

--- a/Sparkle/he.lproj/Sparkle.strings
+++ b/Sparkle/he.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ היא הגרסה האחונה הזמינה.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ היא הגרסה האחונה הזמינה.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ זמין כעת (לך יש %3$@). ברצונך להוריד כעת?";
 

--- a/Sparkle/hr.lproj/Sparkle.strings
+++ b/Sparkle/hr.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je trenutačno najnovija dostupna inačica.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ je trenutačno najnovija dostupna inačica.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ je sada dostupna. Ti koristiš inačicu %3$@. Želiš li je sada preuzeti?";
 

--- a/Sparkle/hu.lproj/Sparkle.strings
+++ b/Sparkle/hu.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "A %1$@ %2$@ a jelenleg elérhető legfrissebb verzió.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "A %1$@ %2$@ a jelenleg elérhető legfrissebb verzió.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "A %1$@ %2$@ verziója már elérhető — az Ön jelenlegi verziója a %3$@. Szeretné most letölteni?";
 

--- a/Sparkle/is.lproj/Sparkle.strings
+++ b/Sparkle/is.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%@ %@ er nýjasta útgáfan sem er fáanleg þessa stundina.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%@ %@ er nýjasta útgáfan sem er fáanleg þessa stundina.\n(You are currently running version %@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "Útgafa %2$@ af %1$@ er nú fáanlegt en þú ert með %3$@. Viltu sækja hana núna?";
 

--- a/Sparkle/it.lproj/Sparkle.strings
+++ b/Sparkle/it.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ è la versione più recente attualmente disponibile.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ è la versione più recente attualmente disponibile.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ è disponbile; disponi della versione %3$@. Desideri eseguire l’aggiornamento ora?";
 

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -8,6 +8,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@は現在入手できる最新バージョンです。";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@は現在入手できる最新バージョンです。\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@が入手できます（使用中のバージョンは%3$@です）。今すぐダウンロードしますか?";
 

--- a/Sparkle/ko.lproj/Sparkle.strings
+++ b/Sparkle/ko.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@이(가) 현재 최신 버전입니다.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@이(가) 현재 최신 버전입니다.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@이(가) 업데이트 되었습니다. (현재 버전 : %3$@) 다운로드 하시겠습니까?";
 

--- a/Sparkle/nb.lproj/Sparkle.strings
+++ b/Sparkle/nb.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ er nyeste versjon.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ er nyeste versjon.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ er nå tilgjengelig—du har %3$@. Ønsker du å laste ned og installere nå?";
 

--- a/Sparkle/nl.lproj/Sparkle.strings
+++ b/Sparkle/nl.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is momenteel de nieuwste versie.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ is momenteel de nieuwste versie.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Wil je de update nu downloaden?";
 

--- a/Sparkle/pl.lproj/Sparkle.strings
+++ b/Sparkle/pl.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ jest najnowszą dostępną wersją.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ jest najnowszą dostępną wersją.\n(You are currently running version %3$@.)";
+
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ jest już dostępny (aktualnie posiadasz %3$@). Czy chcesz go teraz pobrać?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */

--- a/Sparkle/pt_BR.lproj/Sparkle.strings
+++ b/Sparkle/pt_BR.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ é a versão mais recente disponível.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ é a versão mais recente disponível.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ está disponível – sua versão é %3$@. Deseja transferi-lo agora?";
 

--- a/Sparkle/pt_PT.lproj/Sparkle.strings
+++ b/Sparkle/pt_PT.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "O %1$@ %2$@ é neste momento a versão mais recente disponível.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "O %1$@ %2$@ é neste momento a versão mais recente disponível.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "O %1$@ %2$@ está agora disponível e tem a versão %3$@. Gostaria de o transferir agora?";
 

--- a/Sparkle/ro.lproj/Sparkle.strings
+++ b/Sparkle/ro.lproj/Sparkle.strings
@@ -8,6 +8,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ este cea ultima versiune disponibilă.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ este cea ultima versiune disponibilă.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ este disponibilă—tu ai %3$@. Dorești să o descărcarci acum?";
 

--- a/Sparkle/ru.lproj/Sparkle.strings
+++ b/Sparkle/ru.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "В настоящий момент %1$@ %2$@ является новейшей версией.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "В настоящий момент %1$@ %2$@ является новейшей версией.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ теперь доступен – вы имеете %3$@. Хотите загрузить его сейчас?";
 

--- a/Sparkle/sk.lproj/Sparkle.strings
+++ b/Sparkle/sk.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@\nje najnovšia dostupná verzia.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@\nje najnovšia dostupná verzia.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "Je dostupná aplikácia %1$@ %2$@ — máte %3$@. Chcete ju prevziať teraz?";
 

--- a/Sparkle/sl.lproj/Sparkle.strings
+++ b/Sparkle/sl.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je najnovejša verzija programa.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ je najnovejša verzija programa.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "Na voljo je %1$@ %2$@ — vi imate %3$@. Ga želite prenesti s spleta sedaj?";
 

--- a/Sparkle/sv.lproj/Sparkle.strings
+++ b/Sparkle/sv.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ är för närvarande den senaste tillgängliga versionen.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ är för närvarande den senaste tillgängliga versionen.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ finns nu tillgänglig—du har %3$@. Vill hämta uppdateringen nu?";
 

--- a/Sparkle/th.lproj/Sparkle.strings
+++ b/Sparkle/th.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ เป็นเวอร์ชั่นใหม่ล่าสุดแล้ว";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ เป็นเวอร์ชั่นใหม่ล่าสุดแล้ว\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ พร้อมให้ดาวน์โหลดแล้ว (คุณมีเวอร์ชั่น %3$@) ต้องการดาวน์โหลดเลยหรือไม่";
 

--- a/Sparkle/tr.lproj/Sparkle.strings
+++ b/Sparkle/tr.lproj/Sparkle.strings
@@ -10,6 +10,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ mevcut en yeni sürümdür.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ mevcut en yeni sürümdür.\n(You are currently running version %3$@.)";
+
 /* de_DE v0.1 - No comment provided by engineer. */
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/uk.lproj/Sparkle.strings
+++ b/Sparkle/uk.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "У данний момент %1$@ %2$@ є останньою версією.";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%У данний момент %1$@ %2$@ є останньою версією.\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ доступна – ви маєте %3$@. Бажаєте завантажити її зараз?";
 

--- a/Sparkle/zh_CN.lproj/Sparkle.strings
+++ b/Sparkle/zh_CN.lproj/Sparkle.strings
@@ -6,6 +6,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 是当前的最新版本。";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ 是当前的最新版本。\n(You are currently running version %3$@.)";
+
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ 可供下载，您现在的版本是 %3$@。要现在下载吗？";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */

--- a/Sparkle/zh_TW.lproj/Sparkle.strings
+++ b/Sparkle/zh_TW.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 已是目前最新的版本。";
 
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ 已是目前最新的版本。\n(You are currently running version %3$@.)";
+
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ 現在已可取得，您的版本則是 %3$@。您要現在下載嗎？";
 


### PR DESCRIPTION
As discussed in bug #1411 this pull request changes two things:

• if the user is not running the latest, but a 'newer-than-latest' version, a slight hint of this fact is given instead of miscommunication that claims his version is identical to the newest version

• if Sparkle was unable to load the appcast, an error message is given instead of wrongly claiming that the copy is up-to-date. it is weird that Sparkle given error messages under some error conditions (no network) but just blindly claims that you're up-to-date under other conditions (unable to load appcast URL, empty appcast, etc). 

as mentioned in #1411 i believe both behaviours fixed in this PR have been causing much harm to date, both to developers as well as to users.