### PR TITLE
cast to NSInteger to get rid of warning on Xcode 11

### DIFF
--- a/Sparkle/SPUURLRequest.m
+++ b/Sparkle/SPUURLRequest.m
@@ -62,9 +62,9 @@ static NSString *SPUURLRequestNetworkServiceTypeKey = @"SPUURLRequestNetworkServ
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeObject:self.url forKey:SPUURLRequestURLKey];
-    [coder encodeInteger:self.cachePolicy forKey:SPUURLRequestCachePolicyKey];
+    [coder encodeInteger:(NSInteger)self.cachePolicy forKey:SPUURLRequestCachePolicyKey];
     [coder encodeDouble:self.timeoutInterval forKey:SPUURLRequestTimeoutIntervalKey];
-    [coder encodeInteger:self.networkServiceType forKey:SPUURLRequestNetworkServiceTypeKey];
+    [coder encodeInteger:(NSInteger)self.networkServiceType forKey:SPUURLRequestNetworkServiceTypeKey];
     
     if (self.httpHeaderFields != nil) {
         [coder encodeObject:self.httpHeaderFields forKey:SPUURLRequestHttpHeaderFieldsKey];


### PR DESCRIPTION
Added cast (twice) to no longer have this warning:
```
Implicit conversion changes signedness: 'NSURLRequestCachePolicy' (aka 'enum NSURLRequestCachePolicy') to 'NSInteger' (aka 'long')
```