### PR TITLE
check if SUBundleName is set before normalizing

### DIFF
--- a/Sparkle/SUInstaller.m
+++ b/Sparkle/SUInstaller.m
@@ -152,8 +152,14 @@
 {
     NSBundle *bundle = host.bundle;
     assert(bundle != nil);
-    
-    NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", [host objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey], [[bundle bundlePath] pathExtension]]];
+   
+   NSString * baseBundleName = [host objectForInfoDictionaryKey:@"SUBundleName"];
+   
+   if (baseBundleName == nil) {
+      baseBundleName = [host objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
+   }
+   
+    NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", baseBundleName, [[bundle bundlePath] pathExtension]]];
 
     // Roundtrip string through fileSystemRepresentation to ensure it uses filesystem's Unicode normalization
     // rather than arbitrary Unicode form from Info.plist - #1017


### PR DESCRIPTION
Inspired by https://github.com/sparkle-project/Sparkle/issues/1442

When changing the name of an app, there's a couple things to do in order
to ensure auto-updates still work:

1. set SUBundle Name. This basically tells Sparkle "ey, expect an app
of {SUBundleName}.(app|pkg) instead of the normal name."
2. set `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME` in
commonConfig.xccconfig to reset the name of the app.

in (2), we always used the host's bundle name, instead of checking to
see if SUBundleName was set, which means normalization doesn't work as
expected during app name changes.

A problem that arises is that we will ALWAYS normalize the installed `.app` path to `SUBundleName`--even if the thing you're updating to has a _different_ bundle name from `SUBundleName`. 

I think that's expected behavior, if you specify `SUBundleName` and `Normalize`, but it does seem odd.

## Testing I've done

made `Some App Name.app` update to `Different App Name.app`
- set `SUBundleName` to `Different App Name`
- compiled with `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME = 1`
- saw `Some App Name.app` become `Different App Name.app` when installing the update

made `Some App Name.app` update to a later build of `Some App Name.app`
- set `SUBundleName` to `Different App Name`
- compiled with `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME = 1`
- saw `Some App Name.app` become `Different App Name.app` when installing the update, even though it's really installing `Some App Name`

## Other To-Dos?
- Do docs need to be updated, since this is a behavior change?
  - I think `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME` should be mentioned a bit more prominently--I had to do some digging to find out it was an option for the behavior I want
- Soliciting other users' feedback
  - it's possible (probably) that this behavior change will have an effect on others that are using it.
