### PR TITLE
#1449 Fix ongoing download after the update has been cancelled

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -111,6 +111,11 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
     }
 }
 
+- (void)cancelDownload
+{
+    [self cleanup];
+}
+
 - (void)cleanup
 {
     [self enableAutomaticTermination];

--- a/Downloader/SPUDownloaderProtocol.h
+++ b/Downloader/SPUDownloaderProtocol.h
@@ -19,6 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startTemporaryDownloadWithRequest:(SPUURLRequest *)request;
 
+// Cancels any ongoing download
+- (void)cancelDownload;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -131,6 +131,8 @@
         self.connection = nil;
     }
     self.downloadName = nil;
+    
+    [self.downloader cancelDownload];
     self.downloader = nil;
 }
 


### PR DESCRIPTION
This is a PR to the download cancellation bug explained in #1449 .