### PR TITLE
SUFeedUrl generate appcast file extension (let fix)

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -93,9 +93,10 @@ class ArchiveItem: CustomStringConvertible {
 
             var feedURL:URL? = nil;
             if let feedURLStr = infoPlist["SUFeedURL"] as? String {
-                if let feedURL = URL(string: feedURLStr), feedURL.pathExtension == "php" {
-                    feedURL = feedURL.deletingLastPathComponent()
-                    feedURL = feedURL.appendingPathComponent("appcast.xml")
+                feedURL = URL(string: feedURLStr)
+                if feedURL?.pathExtension == "php" {
+                    feedURL = feedURL!.deletingLastPathComponent()
+                    feedURL = feedURL!.appendingPathComponent("appcast.xml")
                 }
             }
 


### PR DESCRIPTION
The previous PR #1454 contains an error.
This fixes that error.

feedURl was a let and therefore not assignable

This branch is tested with several SUFeedURL entries.
