### PR TITLE
ui-separation-and-xpc branch fixes

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -492,6 +492,13 @@
 			remoteGlobalIDString = 5D06E8CF0FD68C7C005AE3F6;
 			remoteInfo = BinaryDelta;
 		};
+		37DC0CE52340667000501A67 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EA1E280E22B64522004AA304;
+			remoteInfo = bsdiff;
+		};
 		61B5F91B09C4CF7200B25A18 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2457,6 +2464,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				37DC0CE62340667000501A67 /* PBXTargetDependency */,
 			);
 			name = Autoupdate;
 			productName = Autoupdate;
@@ -3357,6 +3365,11 @@
 			isa = PBXTargetDependency;
 			target = 5D06E8CF0FD68C7C005AE3F6 /* BinaryDelta */;
 			targetProxy = 14950069195FB8A600BC5B5B /* PBXContainerItemProxy */;
+		};
+		37DC0CE62340667000501A67 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EA1E280E22B64522004AA304 /* bsdiff */;
+			targetProxy = 37DC0CE52340667000501A67 /* PBXContainerItemProxy */;
 		};
 		61B5F91C09C4CF7200B25A18 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Sparkle/SPUURLRequest.m
+++ b/Sparkle/SPUURLRequest.m
@@ -61,9 +61,9 @@ static NSString *SPUURLRequestNetworkServiceTypeKey = @"SPUURLRequestNetworkServ
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeObject:self.url forKey:SPUURLRequestURLKey];
-    [coder encodeInteger:self.cachePolicy forKey:SPUURLRequestCachePolicyKey];
+    [coder encodeInteger:(NSInteger)self.cachePolicy forKey:SPUURLRequestCachePolicyKey];
     [coder encodeDouble:self.timeoutInterval forKey:SPUURLRequestTimeoutIntervalKey];
-    [coder encodeInteger:self.networkServiceType forKey:SPUURLRequestNetworkServiceTypeKey];
+    [coder encodeInteger:(NSInteger)self.networkServiceType forKey:SPUURLRequestNetworkServiceTypeKey];
     
     if (self.httpHeaderFields != nil) {
         [coder encodeObject:self.httpHeaderFields forKey:SPUURLRequestHttpHeaderFieldsKey];


### PR DESCRIPTION
- bsdiff wasn't an explicit dependency for the Autoupdater target
- Added explicit casts to silence Xcode 11 warnings