### PR TITLE
Let SPUUpdaterDelegate handle errors currently suppressed

### DIFF
--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -83,8 +83,8 @@
 - (void)notifyDelegateAboutError:(nullable NSError *)error
 {
     if (error == nil) { return; }
-    if ([self.updaterDelegate respondsToSelector:@selector(updater:didAbortWithError:)]) {
-        [self.updaterDelegate updater:self.updater didAbortWithError:(NSError * _Nonnull)error];
+    if ([self.updaterDelegate respondsToSelector:@selector(updater:scheduledUpdateCheckDidAbortWithError:)]) {
+        [self.updaterDelegate updater:self.updater scheduledUpdateCheckDidAbortWithError:(NSError * _Nonnull)error];
     }
 }
     

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -18,18 +18,24 @@
 @interface SPUScheduledUpdateDriver() <SPUUIBasedUpdateDriverDelegate>
 
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
+@property (nonatomic, readonly) id updater;
+@property (nonatomic, readonly) id <SPUUpdaterDelegate> updaterDelegate;
 
 @end
 
 @implementation SPUScheduledUpdateDriver
 
 @synthesize uiDriver = _uiDriver;
+@synthesize updater = _updater;
+@synthesize updaterDelegate = _updaterDelegate;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle sparkleBundle:(NSBundle *)sparkleBundle updater:(id)updater userDriver:(id <SPUUserDriver>)userDriver updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate
 {
     self = [super init];
     if (self != nil) {
         _uiDriver = [[SPUUIBasedUpdateDriver alloc] initWithHost:host applicationBundle:applicationBundle sparkleBundle:sparkleBundle updater:updater userDriver:userDriver userInitiated:NO updaterDelegate:updaterDelegate delegate:self];
+        _updater = updater;
+        _updaterDelegate = updaterDelegate;
     }
     return self;
 }
@@ -58,18 +64,30 @@
     [self.uiDriver resumeUpdate:resumableUpdate completion:completionBlock];
 }
 
-- (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)__unused error
+- (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error
 {
     // Don't tell the user that no update was found or some appcast fetch error occurred for scheduled update checks
     [self abortUpdateWithError:nil];
+    
+    [self notifyDelegateAboutError:error];
 }
 
-- (void)coreDriverIsRequestingAbortUpdateWithError:(nullable NSError *)__unused error
+- (void)coreDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error
 {
     // Don't tell the user that a non-UI update error occurred for scheduled update checks
     [self abortUpdateWithError:nil];
+    
+    [self notifyDelegateAboutError:error];
 }
 
+- (void)notifyDelegateAboutError:(nullable NSError *)error
+{
+    if (error == nil) { return; }
+    if ([self.updaterDelegate respondsToSelector:@selector(updater:didAbortWithError:)]) {
+        [self.updaterDelegate updater:self.updater didAbortWithError:(NSError * _Nonnull)error];
+    }
+}
+    
 - (void)uiDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error
 {
     [self abortUpdateWithError:error];

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -300,6 +300,14 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  */
 - (void)updater:(SPUUpdater *)updater didAbortWithError:(NSError *)error;
 
+/*!
+ Called after an update is aborted due to an error during an scheduled update check.
+  
+ \param updater The updater instance.
+ \param error The error that caused the abort
+ */
+- (void)updater:(SPUUpdater *)updater scheduledUpdateCheckDidAbortWithError:(NSError *)error;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
When using a custom ```SPUUpdaterDelegate```, for example to display updater status information in the preference window, we've noticed that errors are lost which occur during scheduled update checks.

Steps to reproduce:
1.  Use ```Sparkle.framework``` of  ```ui-separation-and-xpc``` 67819be18a4ef48e85ea30dbbf8de582f5ef405c
2. Set ```SUFeedURL``` to ```wrongscheme://...```
3. *ASSERT:* ```-[SPUUpdaterDelegate updater:didAbortWithError:]``` is called

Step 3. currently fails, because ```-[SPUScheduledUpdateDriver basicDriverIsRequestingAbortUpdateWithError:]``` and ```-[SPUScheduledUpdateDriver coreDriverIsRequestingAbortUpdateWithError:]``` are swallowing the ```error``` by passing ```nil``` instead