### PR TITLE
Support generating appcast with localizations

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		34074BA81FEAC417001CB3A5 /* SPUDownloaderDeprecated.m in Sources */ = {isa = PBXBuildFile; fileRef = 34074BA61FEAC417001CB3A5 /* SPUDownloaderDeprecated.m */; };
 		342731481FF58E5B00285FBD /* SPUDownloaderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342731461FF58E4F00285FBD /* SPUDownloaderTest.swift */; };
 		3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3772FEA813DE0B6B00F79537 /* SUVersionDisplayProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4444E790237B057900CBB3CF /* testlocalizedreleasenotesappcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = 4444E78E237B047B00CBB3CF /* testlocalizedreleasenotesappcast.xml */; };
 		55C14BD4136EEFCE00649790 /* Autoupdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14BD3136EEFCE00649790 /* Autoupdate.m */; };
 		55C14BD9136EF00C00649790 /* SUStatus.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BD8136EF00C00649790 /* SUStatus.xib */; };
 		55C14BEE136EF20D00649790 /* SUAutomaticUpdateAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BDA136EF20D00649790 /* SUAutomaticUpdateAlert.xib */; };
@@ -648,6 +649,7 @@
 		34074BA61FEAC417001CB3A5 /* SPUDownloaderDeprecated.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPUDownloaderDeprecated.m; sourceTree = "<group>"; };
 		342731461FF58E4F00285FBD /* SPUDownloaderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPUDownloaderTest.swift; sourceTree = "<group>"; };
 		3772FEA813DE0B6B00F79537 /* SUVersionDisplayProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUVersionDisplayProtocol.h; sourceTree = "<group>"; };
+		4444E78E237B047B00CBB3CF /* testlocalizedreleasenotesappcast.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = testlocalizedreleasenotesappcast.xml; sourceTree = "<group>"; };
 		4607BEA21948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		4607BEA31948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = nb; path = nb.lproj/SUAutomaticUpdateAlert.xib; sourceTree = "<group>"; };
 		4607BEA41948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = nb; path = nb.lproj/SUUpdateAlert.xib; sourceTree = "<group>"; };
@@ -1275,6 +1277,7 @@
 				5AF6C74E1AEA46D10014A3AB /* test.pkg */,
 				5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */,
 				5F1510A11C96E591006E1629 /* testnamespaces.xml */,
+				4444E78E237B047B00CBB3CF /* testlocalizedreleasenotesappcast.xml */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2110,6 +2113,7 @@
 				14958C6E19AEBC950061B14F /* signed-test-file.txt in Resources */,
 				72AC6B2E1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg in Resources */,
 				C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */,
+				4444E790237B057900CBB3CF /* testlocalizedreleasenotesappcast.xml in Resources */,
 				72AC6B281B9AAD6700F62325 /* SparkleTestCodeSignApp.tar in Resources */,
 				72AC6B2A1B9AAF3A00F62325 /* SparkleTestCodeSignApp.tar.bz2 in Resources */,
 				72AC6B261B9AAC8800F62325 /* SparkleTestCodeSignApp.tar.gz in Resources */,

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -89,4 +89,6 @@ extern NSString *const SURSSElementLink;
 extern NSString *const SURSSElementPubDate;
 extern NSString *const SURSSElementTitle;
 
+extern NSString *const SUXMLLanguage;
+
 #endif

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -78,3 +78,5 @@ NSString *const SURSSElementEnclosure = @"enclosure";
 NSString *const SURSSElementLink = @"link";
 NSString *const SURSSElementPubDate = @"pubDate";
 NSString *const SURSSElementTitle = @"title";
+
+NSString *const SUXMLLanguage = @"xml:lang";

--- a/Tests/Resources/testlocalizedreleasenotesappcast.xml
+++ b/Tests/Resources/testlocalizedreleasenotesappcast.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <!-- A release testing localized release notes -->
+    <item>
+        <title>Version 6.0</title>
+        <pubDate>Sat, 26 Jul 2019 15:20:13 +0000</pubDate>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="6.0" />
+        <sparkle:releaseNotesLink>https://sparkle-project.org/#works</sparkle:releaseNotesLink>
+        <sparkle:releaseNotesLink xml:lang='en'>
+            https://sparkle-project.org/#localized_notes_link_works
+        </sparkle:releaseNotesLink>
+        <sparkle:minimumSystemVersion>2.0.0</sparkle:minimumSystemVersion>
+    </item>
+  </channel>
+</rss>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -68,6 +68,22 @@ class SUAppcastTest: XCTestCase {
         }
     }
 
+    func testParseAppcastWithLocalizedReleaseNotes() {
+        let appcast = SUAppcast()
+        let testFile = Bundle(for: SUAppcastTest.self).path(forResource: "testlocalizedreleasenotesappcast",
+                                                            ofType: "xml")!
+        let testFileUrl = URL(fileURLWithPath: testFile)
+        XCTAssertNotNil(testFileUrl)
+
+        do {
+            let items = try appcast.parseAppcastItems(fromXMLFile: testFileUrl) as! [SUAppcastItem];
+            XCTAssertEqual("https://sparkle-project.org/#localized_notes_link_works", items[0].releaseNotesURL.absoluteString)
+        } catch let err as NSError {
+            NSLog("%@", err)
+            XCTFail(err.localizedDescription)
+        }
+    }
+
     func testNamespaces() {
         let appcast = SUAppcast();
         let testFile = Bundle(for: SUAppcastTest.self).path(forResource: "testnamespaces", ofType: "xml")!;

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -189,5 +189,23 @@ class ArchiveItem: CustomStringConvertible {
         return URL(string: escapedFilename)
     }
 
+    func localizedReleaseNotes() -> [(String, URL)] {
+        let fileManager = FileManager.default
+        var basename = archivePath.deletingPathExtension()
+        if basename.pathExtension == "tar" {
+            basename = basename.deletingPathExtension()
+        }
+        var localizedReleaseNotes = [(String, URL)]()
+        for languageCode in Locale.isoLanguageCodes {
+            let localizedReleaseNoteURL = basename
+                .appendingPathExtension(languageCode)
+                .appendingPathExtension("html")
+            if fileManager.fileExists(atPath: localizedReleaseNoteURL.path) {
+                localizedReleaseNotes.append((languageCode, localizedReleaseNoteURL))
+            }
+        }
+        return localizedReleaseNotes
+    }
+
     let mimeType = "application/octet-stream";
 }

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -109,13 +109,34 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         }
         minVer?.setChildren([text(update.minimumSystemVersion)]);
 
-        let relElement = findElement(name: SUAppcastElementReleaseNotesLink, parent: item);
+        let releaseNotesXpath = "\(SUAppcastElementReleaseNotesLink)"
+        let results = ((try? item.nodes(forXPath: releaseNotesXpath)) as? [XMLElement])?
+            .filter { !($0.attributes ?? [])
+            .contains(where: { $0.name == SUXMLLanguage }) }
+        let relElement = results?.first
         if let url = update.releaseNotesURL {
             if nil == relElement {
                 item.addChild(XMLElement.element(withName: SUAppcastElementReleaseNotesLink, stringValue: url.absoluteString) as! XMLElement);
             }
         } else if let childIndex = relElement?.index {
             item.removeChild(at: childIndex);
+        }
+
+        let languageNotesNodes = ((try? item.nodes(forXPath: releaseNotesXpath)) as? [XMLElement])?
+            .map { ($0, $0.attribute(forName: SUXMLLanguage)?.stringValue )}
+            .filter { $0.1 != nil } ?? []
+        for (node, language) in languageNotesNodes.reversed()
+            where !update.localizedReleaseNotes().contains(where: { $0.0 == language }) {
+            item.removeChild(at: node.index)
+        }
+        for (language, url) in update.localizedReleaseNotes() {
+            if !languageNotesNodes.contains(where: { $0.1 == language }) {
+                let localizedNode = XMLNode.element(withName: SUAppcastElementReleaseNotesLink,
+                                                    children: [XMLNode.text(withStringValue: url.lastPathComponent) as! XMLNode],
+                                                    attributes: [XMLNode.attribute(withName: SUXMLLanguage,
+                                                                                   stringValue: language) as! XMLNode])
+                item.addChild(localizedNode as! XMLNode)
+            }
         }
 
         var enclosure = findElement(name: "enclosure", parent: item);


### PR DESCRIPTION
Previously you would need to use you own solution to add the localized release notes into the appcast but not today.
Fixes #1205