### PR TITLE
feat: properly compare versions with commit SHA

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -119,7 +119,12 @@
     SUAppcastItem *item = nil;
     for(SUAppcastItem *candidate in appcastItems) {
         if ([self hostSupportsItem:candidate]) {
-            if (!item || [comparator compareVersion:item.versionString toVersion:candidate.versionString] == NSOrderedAscending) {
+            if (
+                !item || (
+                    [item.date compare:candidate.date] == NSOrderedAscending &&
+                    [comparator compareVersion:item.versionString toVersion:candidate.versionString] != NSOrderedDescending
+                )
+            ) {
                 item = candidate;
             }
         }

--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -33,12 +33,15 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     kNumberType,
     kStringType,
     kSeparatorType,
+    kDashType,
 };
 
 - (SUCharacterType)typeOfCharacter:(NSString *)character
 {
     if ([character isEqualToString:@"."]) {
         return kSeparatorType;
+    } else if ([character isEqualToString:@"-"]) {
+        return kDashType;
     } else if ([[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
         return kNumberType;
     } else if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
@@ -67,6 +70,9 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     for (i = 1; i <= n; ++i) {
         character = [version substringWithRange:NSMakeRange(i, 1)];
         newType = [self typeOfCharacter:character];
+        if (newType == kDashType) {
+            break;
+        }
         if (oldType != newType || oldType == kSeparatorType) {
             // We've reached a new segment
             NSString *aPart = [[NSString alloc] initWithString:s];

--- a/Tests/SUVersionComparisonTest.m
+++ b/Tests/SUVersionComparisonTest.m
@@ -33,10 +33,18 @@
     SUAssertAscending(comparator, @"0.1", @"0.1.2");
 }
 
-- (void)testPrereleases
+- (void)testCommitSHAs
 {
     SUStandardVersionComparator *comparator = [[SUStandardVersionComparator alloc] init];
     
+    SUAssertAscending(comparator, @"1.5.5-335d3e2", @"1.5.6-b252311");
+    SUAssertEqual(comparator, @"1.5.5-335d3e2", @"1.5.5-a655360");
+}
+
+- (void)testPrereleases
+{
+    SUStandardVersionComparator *comparator = [[SUStandardVersionComparator alloc] init];
+  
     SUAssertAscending(comparator, @"1.5.5", @"1.5.6a1");
     SUAssertAscending(comparator, @"1.1.0b1", @"1.1.0b2");
     SUAssertAscending(comparator, @"1.1.1b2", @"1.1.2b1");


### PR DESCRIPTION
When two versions have the same major/minor/patch numbers (eg: `1.5.5-335d3e2` and `1.5.5-a655360`), the newer version is used (determined by its `date` property).