### PR TITLE
Fix second bold sentence in read-only update alert dialog. (#15…

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -65,13 +65,14 @@
     [super checkForUpdatesAtURL:URL host:aHost];
 	if ([aHost isRunningOnReadOnlyVolume])
 	{
+        NSString *hostName = [aHost name];
         if ([aHost isRunningTranslocated])
         {
-            [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningTranslocated userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to.", nil), [aHost name], [aHost name]] }]];
+            [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningTranslocated userInfo:@{ NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:SULocalizedString(@"Quit %1$@, move it into your Applications folder, relaunch it from there and try again.", nil), hostName], NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can’t be updated if it’s running from the location it was downloaded to.", nil), hostName], }]];
         }
         else
         {
-            [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.", nil), [aHost name]] }]];
+            [self abortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated, because it was opened from a read-only or a temporary location.", nil), hostName], NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:SULocalizedString(@"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.", nil), hostName] }]];
         }
         return;
     }

--- a/Sparkle/ar.lproj/Sparkle.strings
+++ b/Sparkle/ar.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "تم تنزيل %1$@ %2$@ وهو جاهز للاستخدام، هل ترغب بتثبيت التحديث وإعادة تشغيل %1$@ الآن؟";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "لا يمكن تحديث %1$@ إذا شُغّل من وحدة تخزين للقراءة فقط كصورة قرص أو قارئ الأقراص الضوئية. انقل %1$@ إلى مجلد التطبيقات وأعد تشغيله من هناك ثم حاول مجددًا.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "لا يمكن تحديث %1$@ إذا شُغّل من وحدة تخزين للقراءة فقط كصورة قرص أو قارئ الأقراص الضوئية.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "انقل %1$@ إلى مجلد التطبيقات وأعد تشغيله من هناك ثم حاول مجددًا.";
 
 "%@ %@ is currently the newest version available." = "الإصدار %2$@ هو أحدث إصدار متوفر حاليًا لتطبيق %1$@";
 

--- a/Sparkle/ca.lproj/Sparkle.strings
+++ b/Sparkle/ca.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%@ of %@" = "%1$@ de %2$@";
 
-"%1$@ can't be updated when it's running from a disk image. Move %1$@ to your Applications folder, relaunch it, and try again." = "%1$@ no es pot actualitzar quan funciona des d'un disc d'imatge. Moveu %1$@ al vostre directori Aplicacions, reinicieu-lo, i torneu a provar-ho.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ no es pot actualitzar quan funciona des d'un disc d'imatge.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Moveu %1$@ al vostre directori Aplicacions, reinicieu-lo, i torneu a provar-ho.";
 
 "%@ %@ has been installed and will be ready to use next time %@ starts! Would you like to relaunch now?" = "%@ %@ ha estat instal·lat i estarà llest per a ser utilitzat la propera vegada que s'iniciï %@! Voleu reiniciar ara?";
 

--- a/Sparkle/cs.lproj/Sparkle.strings
+++ b/Sparkle/cs.lproj/Sparkle.strings
@@ -2,9 +2,13 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "Aplikace %1$@ %2$@ byla stažean a je připravena k použití po příštím spuštění! Přejete si aplikaci %1$@ nyní nainstalovat a znovu spustit?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Aplikace %1$@ nemůže být aktualizována, protože je spuštěna z dočasného umístění nebo z umístění, na které nelze zapisovat. Přesuňte %1$@ do složky Aplikace a spusťte ji z tohoto umístění znovu.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Aplikace %1$@ nemůže být aktualizována, protože je spuštěna z dočasného umístění nebo z umístění, na které nelze zapisovat.";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Ukončete %1$@, spusťte %1$@ ze složky Aplikace a spusťte aktualizaci znovu. Aplikace %2$@ nemůže být aktualizována pokud je spuštěna z umístění, ve kterém je stažena.";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Přesuňte %1$@ do složky Aplikace a spusťte ji z tohoto umístění znovu.";
+
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Ukončete %1$@, spusťte %1$@ ze složky Aplikace a spusťte aktualizaci znovu.";
+
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "Aplikace %1$@ nemůže být aktualizována pokud je spuštěna z umístění, ve kterém je stažena.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je nejnovější dostupná verze";
 

--- a/Sparkle/da.lproj/Sparkle.strings
+++ b/Sparkle/da.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ er hentet og klar til brug! Vil du installere og genstarte %1$@ nu?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kan ikke opdateres når det køres fra en kun læsbar enhed. Flyt %1$@ til mappen Programmer, genstart derfra og prøv igen.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ kan ikke opdateres når det køres fra en kun læsbar enhed.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Flyt %1$@ til mappen Programmer, genstart derfra og prøv igen.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ er den aktuelle version.";
 

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -2,9 +2,13 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde geladen und steht zur Installation bereit! Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer DMG Datei oder Laufwerk ohne Schreibzugriff gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer DMG Datei oder Laufwerk ohne Schreibzugriff gestartet wurde.";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Beenden Sie „%1$@“, bewegen Sie es in den Ordner „Programme“, starten Sie das Programm von dort erneut und versuchen Sie es noch einmal. „%2$@“ kann nicht aktualisiert werden, wenn das Programm von dem Ort ausgeführt wird, an den es heruntergeladen wurde.";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
+
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Beenden Sie „%1$@“, bewegen Sie es in den Ordner „Programme“, starten Sie das Programm von dort erneut und versuchen Sie es noch einmal.";
+
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "„%1$@“ kann nicht aktualisiert werden, wenn das Programm von dem Ort ausgeführt wird, an den es heruntergeladen wurde.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 

--- a/Sparkle/el.lproj/Sparkle.strings
+++ b/Sparkle/el.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "Το %1$@ %2$@ έχει ληφθεί και είναι έτοιμο προς χρήση! Θα θέλατε να το εγκαταστήσετε και να επανεκκινήσετε το %1$@ τώρα;";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Το %1$@ δεν μπορεί να ενημερωθεί όσο τρέχει από έναν δίσκο ανάγνωσης-μόνο ή έναν οπτικό δίσκο. Μεταφέρετε το %1$@ στον φάκελο εφαρμογών σας, επανεκκινήστε το από εκεί, και ξαναδοκιμάστε.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Το %1$@ δεν μπορεί να ενημερωθεί όσο τρέχει από έναν δίσκο ανάγνωσης-μόνο ή έναν οπτικό δίσκο.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Μεταφέρετε το %1$@ στον φάκελο εφαρμογών σας, επανεκκινήστε το από εκεί, και ξαναδοκιμάστε.";
 
 "%@ %@ is currently the newest version available." = "Το %1$@ %2$@ είναι η τελευταία διαθέσιμη έκδοση.";
 

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -2,9 +2,13 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ can't be updated, because it was opened from a read-only or a temporary location.";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to.";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.";
+
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Quit %1$@, move it into your Applications folder, relaunch it from there and try again.";
+
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "%1$@ can’t be updated if it’s running from the location it was downloaded to.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 

--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -2,7 +2,9 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "¡%1$@ %2$@ se ha descargado y está lista para usarse! ¿Te gustaría instalarla y volver a abrir %1$@ ahora?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ no se puede actualizar porque fue abierta desde una ubicación temporal o de solo lectura. Usa Finder para copiar %1$@ a la carpeta Aplicaciones, vuélvela a abrir desde ahí e inténtalo de nuevo.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ no se puede actualizar porque fue abierta desde una ubicación temporal o de solo lectura.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Usa Finder para copiar %1$@ a la carpeta Aplicaciones, vuélvela a abrir desde ahí e inténtalo de nuevo.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ es la versión más nueva disponible.";
 

--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -2,9 +2,13 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ a été téléchargé. Voulez-vous l’installer et relancer %1$@ maintenant ?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ ne peut pas être mis à jour quand il fonctionne à partir d’un volume en lecture seule, comme une image disque ou un lecteur optique. Déplacez %1$@ dans votre dossier Applications, relancez-le à partir de là et réessayez.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ ne peut pas être mis à jour quand il fonctionne à partir d’un volume en lecture seule, comme une image disque ou un lecteur optique.";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "Quittez %1$@ et déplacez-le dans le dossier Applications, relancez-le à partir de ce dossier et essayez à nouveau. %2$@ ne peut pas être mis à jour s'il est exécuté depuis le dossier dans lequel il a été téléchargé.";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Déplacez %1$@ dans votre dossier Applications, relancez-le à partir de là et réessayez.";
+
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Quittez %1$@ et déplacez-le dans le dossier Applications, relancez-le à partir de ce dossier et essayez à nouveau.";
+
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "%1$@ ne peut pas être mis à jour s'il est exécuté depuis le dossier dans lequel il a été téléchargé.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ est la version la plus récente disponible.";
 

--- a/Sparkle/hr.lproj/Sparkle.strings
+++ b/Sparkle/hr.lproj/Sparkle.strings
@@ -2,7 +2,9 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ je preuzeto i spremno za upotrebu! Želiš li je sada instalirati, te ponovo pokrenuti %1$@?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ nije moguće aktualizirati, jer je pokrenuto s lokacije bez korisničkih prava pisanja, npr. dmg. Kopiraj %1$@ u mapu Aplikacije, pokreni je odande i pokušaj ponovo.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ nije moguće aktualizirati, jer je pokrenuto s lokacije bez korisničkih prava pisanja, npr. dmg.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Kopiraj %1$@ u mapu Aplikacije, pokreni je odande i pokušaj ponovo.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je trenutačno najnovija dostupna inačica.";
 

--- a/Sparkle/hu.lproj/Sparkle.strings
+++ b/Sparkle/hu.lproj/Sparkle.strings
@@ -2,7 +2,9 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "A %1$@ %2$@ verziója letöltődött és készen áll a telepítésre! Szeretné most telepíteni, majd újraindítani a %1$@ alkalmazást?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "A programot nem lehet frissíteni, amikor egy csak olvasható kötetből (pl. lemezképfájl vagy optikai meghajtó) futtatja. Mozgassa a %1$@ alkalmazást az Alkalmazások mappába, indítsa újra onnan, majd próbálja újra a frissítést.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "A programot nem lehet frissíteni, amikor egy csak olvasható kötetből (pl. lemezképfájl vagy optikai meghajtó) futtatja.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Mozgassa a %1$@ alkalmazást az Alkalmazások mappába, indítsa újra onnan, majd próbálja újra a frissítést.";
 
 "%@ %@ is currently the newest version available." = "A %1$@ %2$@ a jelenleg elérhető legfrissebb verzió.";
 

--- a/Sparkle/it.lproj/Sparkle.strings
+++ b/Sparkle/it.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ è stato scaricato ed è pronto per essere utilizzato! Desideri installare e riavviare  %1$@ ora?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Impossibile aggiornare %1$@ quando viene eseguito da un volume di sola lettura come un’immagine disco o un’unità ottica. Spostare %1$@ nella Cartella Applicazioni, riavviarlo e riprovare.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Impossibile aggiornare %1$@ quando viene eseguito da un volume di sola lettura come un’immagine disco o un’unità ottica.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Spostare %1$@ nella Cartella Applicazioni, riavviarlo e riprovare.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ è la versione più recente attualmente disponibile.";
 

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -2,9 +2,13 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@がダウンロードされました! 今すぐ %1$@ をインストールして再起動しますか?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@は読み出し専用またはテンポラリな場所で開かれているためアップデートできません。%1$@をアプリケーションフォルダに移動し、そこから再起動したあとやり直してください。";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@は読み出し専用またはテンポラリな場所で開かれているためアップデートできません。";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "%1$@ を終了させ、アプリケーションフォルダに移動の上再度お試しください。この場所ではダウンロードされたアップデータを %2$@ に適用できません。";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@をアプリケーションフォルダに移動し、そこから再起動したあとやり直してください。";
+
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "%1$@ を終了させ、アプリケーションフォルダに移動の上再度お試しください。";
+
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "この場所ではダウンロードされたアップデータを %1$@ に適用できません。";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@は現在入手できる最新バージョンです。";
 

--- a/Sparkle/ko.lproj/Sparkle.strings
+++ b/Sparkle/ko.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@이(가) 다운로드 되었습니다. 프로그램을 업데이트하고 재실행 하시겠습니까?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@이(가) 디스크 이미지나 CD 드라이브 같은 읽기 전용 볼륨에서 실행되고 있으므로 업데이트 할 수 없습니다. %1$@을(를) 응용프로그램 폴더로 이동하여 다시 실행해 주십시오.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@이(가) 디스크 이미지나 CD 드라이브 같은 읽기 전용 볼륨에서 실행되고 있으므로 업데이트 할 수 없습니다.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@을(를) 응용프로그램 폴더로 이동하여 다시 실행해 주십시오.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@이(가) 현재 최신 버전입니다.";
 

--- a/Sparkle/nb.lproj/Sparkle.strings
+++ b/Sparkle/nb.lproj/Sparkle.strings
@@ -2,7 +2,9 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ er lastet ned og er klar til bruk! Ønsker du å installere og restarte %1$@ nå?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kan ikke oppdateres fra en 'bare lesbar' enhet som f.eks. en cd. Flytt %1$@ til Programmer-katalogen, start på ny og prøv igjen.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ kan ikke oppdateres fra en 'bare lesbar' enhet som f.eks. en cd";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Flytt %1$@ til Programmer-katalogen, start på ny og prøv igjen.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ er nyeste versjon.";
 

--- a/Sparkle/nl.lproj/Sparkle.strings
+++ b/Sparkle/nl.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ is gedownload en klaar om te installeren! Wil je %1$@ nu installeren en herstarten?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kan niet worden geüpdatet, omdat het vanuit een alleen-lezen- of tijdelijke locatie geopend is. Verplaats %1$@ naar de map ’Programma’s’, herstart vandaar en probeer opnieuw.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ kan niet worden geüpdatet, omdat het vanuit een alleen-lezen- of tijdelijke locatie geopend is.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Verplaats %1$@ naar de map ’Programma’s’, herstart vandaar en probeer opnieuw.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is momenteel de nieuwste versie.";
 

--- a/Sparkle/pl.lproj/Sparkle.strings
+++ b/Sparkle/pl.lproj/Sparkle.strings
@@ -1,8 +1,8 @@
-/* "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?"; */
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ został pobrany i jest gotowy do użycia! Czy chcesz teraz zainstalować i ponownie uruchomić %1$@?";
 
-/* "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again."; */
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ nie może zostać uaktualniony, ponieważ został uruchomiony z folderu tymczasowego lub tylko do odczytu. Użyj Findera, aby skopiować %1$@ do folderu Programy, uruchom z nowej lokacji i spróbuj ponownie.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ nie może zostać uaktualniony, ponieważ został uruchomiony z folderu tymczasowego lub tylko do odczytu.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Użyj Findera, aby skopiować %1$@ do folderu Programy, uruchom z nowej lokacji i spróbuj ponownie.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ jest najnowszą dostępną wersją.";
 

--- a/Sparkle/pt_BR.lproj/Sparkle.strings
+++ b/Sparkle/pt_BR.lproj/Sparkle.strings
@@ -2,7 +2,9 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "O app %1$@ %2$@ foi baixado e está pronto para uso! Deseja instalar e reabrir o app %1$@ agora?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "O app %1$@ não pode ser atualizado porque foi aberto de um volume somente leitura ou local temporário. Use o Finder para copiar o app %1$@ para a pasta Downloads, reabra-o e tente novamente.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "O app %1$@ não pode ser atualizado porque foi aberto de um volume somente leitura ou local temporário.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Use o Finder para copiar o app %1$@ para a pasta Aplicações, reabra-o e tente novamente.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ é a versão mais recente disponível.";
 

--- a/Sparkle/pt_PT.lproj/Sparkle.strings
+++ b/Sparkle/pt_PT.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "O %1$@ %2$@ foi transferido e está pronto a instalar! Gostaria de o fazer agora e reiniciar o %1$@ posteriormente?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "O %1$@ não pode ser actualizado quando estiver a ser executado a partir de um volume apenas de leitura como uma imagem de disco ou disco óptico. Mova o %1$@ para a sua pasta Aplicações, reinicie-o aí e tente novamente.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "O %1$@ não pode ser actualizado quando estiver a ser executado a partir de um volume apenas de leitura como uma imagem de disco ou disco óptico.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Use o Finder para copiar o %1$@ para a sua pasta Aplicações, reinicie-o aí e tente novamente.";
 
 "%@ %@ is currently the newest version available." = "O %1$@ %2$@ é neste momento a versão mais recente disponível.";
 

--- a/Sparkle/ro.lproj/Sparkle.strings
+++ b/Sparkle/ro.lproj/Sparkle.strings
@@ -4,7 +4,9 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ a fost descărcată și este gata de utilizare! Dorești să o instalezi și să relansați %1$@ acum?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ nu poate fi actualizată atunci când a fost pornită de pe un volum read-only ca o imagine disc sau o unitate optică. Mută %1$@ în directorul Aplicații, repornește-o de acolo și încearcă din nou.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ nu poate fi actualizată atunci când a fost pornită de pe un volum read-only ca o imagine disc sau o unitate optică.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Mută %1$@ în directorul Aplicații, repornește-o de acolo și încearcă din nou.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ este cea ultima versiune disponibilă.";
 

--- a/Sparkle/ru.lproj/Sparkle.strings
+++ b/Sparkle/ru.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ загружен и готов к использованию! Хотите установить и перезапустить %1$@?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Во время работы %1$@ с тома, предназначенного только для чтения, как например, образа диска или накопителя на оптических дисках, его невозможно обновить. Переместите %1$@ в Папку приложений, перезапустите его оттуда и повторите попытку.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Во время работы %1$@ с тома, предназначенного только для чтения, как например, образа диска или накопителя на оптических дисках, его невозможно обновить.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Переместите %1$@ в Папку приложений, перезапустите его оттуда и повторите попытку.";
 
 "%@ %@ is currently the newest version available." = "В настоящий момент %1$@ %2$@ является новейшей версией.";
 

--- a/Sparkle/sk.lproj/Sparkle.strings
+++ b/Sparkle/sk.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "Aplikácia %1$@ %2$@ bola prevzatá a je pripravená na použitie! Chcete teraz nainštalovať a následne znovu spustiť %1$@?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Aplikáciu %1$@ nemožno aktualizovať, ak je spustená zo zväzku s právami len na čítanie (napríklad z obrazu disku alebo optického disku). Presuňte aplikáciu %1$@ do priečinka Applications, spustite ju odtiaľ a potom znova skúste aktualizáciu.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Aplikáciu %1$@ nemožno aktualizovať, ak je spustená zo zväzku s právami len na čítanie (napríklad z obrazu disku alebo optického disku).";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Presuňte aplikáciu %1$@ do priečinka Applications, spustite ju odtiaľ a potom znova skúste aktualizáciu.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@\nje najnovšia dostupná verzia.";
 

--- a/Sparkle/sl.lproj/Sparkle.strings
+++ b/Sparkle/sl.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ je bil uspešno prenešen s spleta in je pripravljen na namestitev. Ga želite namestiti in ponovno zagnati takoj?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Programa %1$@ ni mogoče posodobiti, ker ga poganjate iz lokacije, kamor pisanje ni dovoljeno (pogosto je to slika diska dmg ali optična enota). Poskusite %1$@ premakniti v direktorij z aplikacijami (Applications), ga ponovno zagnati in šele nato posodobiti.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Programa %1$@ ni mogoče posodobiti, ker ga poganjate iz lokacije, kamor pisanje ni dovoljeno (pogosto je to slika diska dmg ali optična enota).";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Poskusite %1$@ premakniti v direktorij z aplikacijami (Applications), ga ponovno zagnati in šele nato posodobiti.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je najnovejša verzija programa.";
 

--- a/Sparkle/sv.lproj/Sparkle.strings
+++ b/Sparkle/sv.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ har hämtats och är klar att använda! Vill du installera det och starta om %1$@ nu?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kan inte uppdateras när det körs från en skrivskyddad volym som en skivavbild eller en optisk enhet. Flytta %1$@ till mappen Program, starta om det därifrån, och försök igen.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location. " = "%1$@ kan inte uppdateras när det körs från en skrivskyddad volym som en skivavbild eller en optisk enhet.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Flytta %1$@ till mappen Program, starta om det därifrån, och försök igen.";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ är för närvarande den senaste tillgängliga versionen.";
 

--- a/Sparkle/th.lproj/Sparkle.strings
+++ b/Sparkle/th.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ ได้ถูกดาวน์โหลดและพร้อมใช้งานแล้ว คุณต้องการติดตั้งและเริ่ม %1$@ ใหม่เดี๋ยวนี้หรือไม่";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ ไม่สามารถรับการอัพเดทได้เมื่อถูกเรียกจากดิสก์แบบอ่านอย่างเดียวหรือซีดีรอม ย้าย %1$@ ไปยังโฟลเดอร์แอปพลิเคชัน และเรียกใช้งาน จากนั้นลองใหม่อีกครั้ง";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ ไม่สามารถรับการอัพเดทได้เมื่อถูกเรียกจากดิสก์แบบอ่านอย่างเดียวหรือซีดีรอม ย้าย";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ ไปยังโฟลเดอร์แอปพลิเคชัน และเรียกใช้งาน จากนั้นลองใหม่อีกครั้ง";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ เป็นเวอร์ชั่นใหม่ล่าสุดแล้ว";
 

--- a/Sparkle/tr.lproj/Sparkle.strings
+++ b/Sparkle/tr.lproj/Sparkle.strings
@@ -4,7 +4,9 @@
 
 /* de_DE v0.1 - No comment provided by engineer. */
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ uygulaması geçici veya salt okunur bir konumdan açıldığı için güncellenemedi. Lütfen %1$@ uygulamasını Uygulamalar dizinine kopyalayıp yeniden başlatınız.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ uygulaması geçici veya salt okunur bir konumdan açıldığı için güncellenemedi.;
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Lütfen %1$@ uygulamasını Uygulamalar dizinine kopyalayıp yeniden başlatınız.";
 
 /* de_DE v0.1 - No comment provided by engineer. */
 

--- a/Sparkle/uk.lproj/Sparkle.strings
+++ b/Sparkle/uk.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ завантажений і готовий до використання! Бажаєте встановити і перезавантажити %1$@?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Під час роботи з %1$@ з тому, що призначений лише для читання, наприклад, образу диска чи оптичного диску, його неможливо оновити. Перемістіть %1$@ у папку з програмами, перезавантажте його звідти і спробуйте ще раз.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "Під час роботи з %1$@ з тому, що призначений лише для читання, наприклад, образу диска чи оптичного диску, його неможливо оновити.";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Перемістіть %1$@ у папку з програмами, перезавантажте його звідти і спробуйте ще раз.";
 
 "%@ %@ is currently the newest version available." = "У данний момент %1$@ %2$@ є останньою версією.";
 

--- a/Sparkle/zh_CN.lproj/Sparkle.strings
+++ b/Sparkle/zh_CN.lproj/Sparkle.strings
@@ -1,8 +1,12 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ 已下载完毕并可以使用！您想要现在安装 %1$@ 吗？";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "无法更新 %1$@，因为它运行于一个只读宗卷如磁盘映像或光盘。移动 %1$@ 到应用程序文件夹并再试一次。";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "无法更新 %1$@，因为它运行于一个只读宗卷如磁盘映像或光盘。";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again. %2$@ can’t be updated if it’s running from the location it was downloaded to." = "退出 %1$@，将其移至“应用程序”，并在那里重新启动，然后再试。如果在下载位置运行此程序，则无法对 %2$@ 进行更新。";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "移动 %1$@ 到应用程序文件夹并再试一次。";
+
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "退出 %1$@，将其移至“应用程序”，并在那里重新启动，然后再试。";
+
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "如果在下载位置运行此程序，则无法对 %1$@ 进行更新。";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 是当前的最新版本。";
 

--- a/Sparkle/zh_TW.lproj/Sparkle.strings
+++ b/Sparkle/zh_TW.lproj/Sparkle.strings
@@ -1,6 +1,8 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ 已下載且可供使用！您是否要現在安裝並重新啟動%1$@？";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "當 %1$@ 正從唯讀卷宗（如磁碟映像檔或光碟機）執行時，無法進行更新。請將 %1$@ 移至您的“應用程式”檔案夾，從該處重新啟動，然後再試一次。  ";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "當 %1$@ 正從唯讀卷宗（如磁碟映像檔或光碟機）執行時，無法進行更新。";
+
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "請將 %1$@ 移至您的“應用程式”檔案夾，從該處重新啟動，然後再試一次。";
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 已是目前最新的版本。";
 


### PR DESCRIPTION
• Updated error dialog code in SUBasicUpdateDriver, and created a local variable to reuse `[aHost name]`.
• Updated content of Sparkle.strings files, splitting existing affected translations into 2 chunks each.
• Changed "Use Finder to copy" to back to "Copy", since most translations still use that terminology.
• Fixed the Catalan translation, which was using an old string key.
• Removed a few unnecessary comments in the Polish translation.