### PR TITLE
Separate issue templates for Sparkle 1.x and 2.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/other-issues-1.md
+++ b/.github/ISSUE_TEMPLATE/other-issues-1.md
@@ -2,7 +2,7 @@
 name: Other issues
 about: Found a bug? Want to implement a new feature?
 title: ''
-labels: ''
+labels: '1.x'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other-issues-2.md
+++ b/.github/ISSUE_TEMPLATE/other-issues-2.md
@@ -1,0 +1,10 @@
+---
+name: Other issues related to Sparkle 2.x
+about: Found a bug? Want to implement a new feature?
+title: ''
+labels: '2.x'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-1.md
+++ b/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-1.md
@@ -1,8 +1,8 @@
 ---
-name: Sparkle doesn't work in my app
+name: Sparkle 1.x doesn't work in my app
 about: Problems with integration, unexpected errors
 title: ''
-labels: ''
+labels: '1.x'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-2.md
+++ b/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-2.md
@@ -1,0 +1,34 @@
+---
+name: Sparkle 2.x doesn't work in my app
+about: Problems with using the beta version of Sparkle 2
+title: ''
+labels: '2.x'
+assignees: ''
+
+---
+
+<!-- 
+
+The answer to your issue is probably already in Console.app on your computer.
+Please use Console.app and search for Sparkle.
+
+Please try troubleshooting steps:
+https://github.com/sparkle-project/Sparkle#troubleshooting
+
+-->
+
+### Description of the problem
+
+
+### Do you use Sandboxing in your app?
+
+### Version of `Sparkle.framework` in the latest version of your app
+
+### Version of `Sparkle.framework` in the old version of app that your users have (or N/A)
+
+### Sparkle's output from Console.app
+```
+
+```
+
+### Steps to reproduce the behavior


### PR DESCRIPTION
Create separate issue templates for Sparkle 1.x and 2.x.

The intention is to let users select the version of Sparkle they are using, and to have the `1.x` and `2.x` labels  assigned automatically.