### PR TITLE
Update README for Sparkle 2.x

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,6 +13,8 @@ Sparkle 2.x is currently in beta. Some people already use it in production, but 
 2. Changes from the master branch need to be merged
 3. Bugs and issues have to be fixed
 
+The current status of Sparkle 2.x is tracked in issue #1523.
+
 If you can help with any of the above, please submit pull requests!
 
 New issues that are found should be [reported here](https://github.com/sparkle-project/Sparkle/issues). Internal design documents can be found in [Documentation](Documentation/). Discussion of this fork can be found in [this issue](https://github.com/sparkle-project/Sparkle/issues/363).

--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,19 @@
 # Sparkle 2.x (Beta)
 
-A major fork to the popular Sparkle update framework that supports sandboxing, custom user interfaces, updating other bundles, and a modern secure architecture.
+Secure and reliable software update framework for Cocoa developers.
 
 <img src="Resources/Screenshot.png" width="732" alt="Sparkle shows familiar update window with release notes">
 
-This fork's current status is beta. I am no longer looking into adding or rewriting major functionality, and would like to finalize and have it be battle tested.
+This is the upcoming new version of Sparkle, based on the `ui-separation-and-xpc` branch.
+Major new features are support for sandboxing, custom user interfaces, updating other bundles, and a modern secure architecture.
+
+Sparkle 2.x is currently in beta. Some people already use it in production, but some work is still required before it can be released:
+
+1. Documentation for the website needs to be written (see [https://github.com/sparkle-project/sparkle-project.github.io](sparkle-project.github.io))
+2. Changes from the master branch need to be merged
+3. Bugs and issues have to be fixed
+
+If you can help with any of the above, please submit pull requests!
 
 New issues that are found should be [reported here](https://github.com/sparkle-project/Sparkle/issues). Internal design documents can be found in [Documentation](Documentation/). Discussion of this fork can be found in [this issue](https://github.com/sparkle-project/Sparkle/issues/363).
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# Sparkle-XPC-UI
+# Sparkle 2.x (Beta)
 
 A major fork to the popular Sparkle update framework that supports sandboxing, custom user interfaces, updating other bundles, and a modern secure architecture.
 

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ Sparkle 2.x is currently in beta. Some people already use it in production, but 
 2. Changes from the master branch need to be merged
 3. Bugs and issues have to be fixed
 
-The current status of Sparkle 2.x is tracked in issue #1523.
+The current status of Sparkle 2.x is tracked in issue [#1523](https://github.com/sparkle-project/Sparkle/issues/1523).
 
 If you can help with any of the above, please submit pull requests!
 

--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ A major fork to the popular Sparkle update framework that supports sandboxing, c
 
 This fork's current status is beta. I am no longer looking into adding or rewriting major functionality, and would like to finalize and have it be battle tested.
 
-New issues that are found should be [reported here](https://github.com/sparkle-project/issues), with an indication in the title that they pertain to the `ui-separation-and-xpc` branch. Internal design documents can be found in [Documentation](Documentation/). Discussion of this fork can be found in [this issue](https://github.com/sparkle-project/Sparkle/issues/363).
+New issues that are found should be [reported here](https://github.com/sparkle-project/Sparkle/issues). Internal design documents can be found in [Documentation](Documentation/). Discussion of this fork can be found in [this issue](https://github.com/sparkle-project/Sparkle/issues/363).
 
 # Features
 


### PR DESCRIPTION
This PR updates the README to reflect the current status and fixes a broken link.

It also outlines the steps necessary before Sparkle 2.x can be released, as discussed in https://github.com/sparkle-project/Sparkle/issues/363#issuecomment-565509531. 