### PR TITLE
Sparkle 2.x: Delay startup of updater

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -80,11 +80,15 @@ static NSMutableDictionary *sharedUpdaters = nil;
         _userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:bundle delegate:self];
         _updater = [[SPUUpdater alloc] initWithHostBundle:bundle applicationBundle:bundle userDriver:_userDriver delegate:self];
 
-        NSError *updaterError = nil;
-        if (![_updater startUpdater:&updaterError]) {
-            SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
-            abort();
-        }
+        // Delay starting the updater, so that the host has a chance to configure the updater
+        // either in applicationWillFinishLaunching: or by setting properties right after initialisation
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSError *updaterError = nil;
+            if (![_updater startUpdater:&updaterError]) {
+                SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
+                abort();
+            }
+        });
     }
     return self;
 }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -84,7 +84,7 @@ static NSMutableDictionary *sharedUpdaters = nil;
         // either in applicationWillFinishLaunching: or by setting properties right after initialisation
         dispatch_async(dispatch_get_main_queue(), ^{
             NSError *updaterError = nil;
-            if (![_updater startUpdater:&updaterError]) {
+            if (![self.updater startUpdater:&updaterError]) {
                 SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
                 abort();
             }


### PR DESCRIPTION
This PR tries to address the problem reported in #1505

It delays the startup of the updater when using the SUUpdater compatibility class, so that the host has a chance to configure the updater before it is started (eg. in willFinishLaunching:)

I've not made any attempts to fix the `abort()` calls, those are a separate issue.