### PR TITLE
Remove most production-reachable instances of abort().

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -69,14 +69,12 @@
 {
     // Nothing really to do here.. this shouldn't be called.
     SULog(SULogLevelError, @"Error: resumeInstallingUpdateWithCompletion: called on SPUAutomaticUpdateDriver");
-    abort();
 }
 
 - (void)resumeUpdate:(id<SPUResumableUpdate>)__unused resumableUpdate completion:(SPUUpdateDriverCompletion)__unused completionBlock __attribute__((noreturn))
 {
     // Nothing really to do here.. this shouldn't be called.
     SULog(SULogLevelError, @"Error: resumeDownloadedUpdate:completion: called on SPUAutomaticUpdateDriver");
-    abort();
 }
 
 - (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -73,7 +73,15 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     NSError *updaterError = nil;
     if (![self.updater startUpdater:&updaterError]) {
         SULog(SULogLevelError, @"Fatal updater error (%ld): %@", updaterError.code, updaterError.localizedDescription);
-        abort();
+        
+        // Delay the alert four seconds so it doesn't show RIGHT as the app launches, but also doesn't interrupt the user once they really get to work.
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            NSAlert *alert = [[NSAlert alloc] init];
+            alert.messageText = @"Unable to Check For Updates";
+            alert.informativeText = @"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version.";
+            [alert addButtonWithTitle:@"OK"];
+            [alert runModal];
+        });
     }
 }
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -134,9 +134,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
  If the updater's delegate implements -[SPUUpdaterDelegate feedURLStringForUpdater:], this will return that feed URL.
  Otherwise if the feed URL has been set before, the feed URL returned will be retrieved from the host bundle's user defaults.
  Otherwise the feed URL in the host bundle's Info.plist will be returned.
- If no feed URL can be retrieved, this will raise an exception.
+ If no feed URL can be retrieved, returns nil.
  
- This property must be called on the main thread.
+ This property must be called on the main thread; calls from background threads will return nil.
  */
 @property (nonatomic, readonly) NSURL *feedURL;
 
@@ -149,7 +149,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  Passing nil will remove any feed URL that has been set in the host bundle's user defaults.
  
- This method must be called on the main thread.
+ This method must be called on the main thread; calls from background threads will have no effect.
  */
 - (void)setFeedURL:(NSURL * _Nullable)feedURL;
 

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -56,7 +56,10 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUDowngradeError = 4006,
     SUInstallationCanceledError = 4007,
     SUInstallationAuthorizeLaterError = 4008,
-    SUNotAllowedInteractionError = 4009
+    SUNotAllowedInteractionError = 4009,
+    
+    // API misuse errors.
+    SUIncorrectAPIUsageError = 5000
 };
 
 #endif

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -105,7 +105,8 @@
     NSString *version = [self _version];
     if (version == nil) {
         SULog(SULogLevelError, @"This host (%@) has no %@! This attribute is required.", [self bundlePath], (__bridge NSString *)kCFBundleVersionKey);
-        abort();
+        // Instead of abort()-ing, return an empty string to satisfy the _Nonnull contract.
+        return @"";
     }
     return version;
 }

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -86,7 +86,6 @@ static NSMutableDictionary *sharedUpdaters = nil;
             NSError *updaterError = nil;
             if (![self.updater startUpdater:&updaterError]) {
                 SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
-                abort();
             }
         });
     }

--- a/TestApplication/SUUpdateSettingsWindowController.m
+++ b/TestApplication/SUUpdateSettingsWindowController.m
@@ -56,7 +56,12 @@
     NSError *updaterError = nil;
     if (![self.updater startUpdater:&updaterError]) {
         NSLog(@"Failed to start updater with error: %@", updaterError);
-        abort();
+        
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"Updater Error";
+        alert.informativeText = @"The Updater failed to start. For detailed error information, check the Console.app log."
+        [alert addButtonWithTitle:@"OK"];
+        [alert runModal];
     }
 }
 


### PR DESCRIPTION
A first stab at resolving issue #1510. 

I'm sure there will be things to tweak and if this approach seems sensible, the user-facing strings in the `NSAlert` windows will need to be localized. 

I used `NSException` for the programmatic errors that should immediately crash with extreme prejudice. In some spots I just removed the `abort()` and in others I relaxed the crash to a no-op with suitable console logging. 