### PR TITLE
Fixes `make release` for 2.x

### DIFF
--- a/Sparkle.podspec
+++ b/Sparkle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "Sparkle"
-  s.version     = "1.20.0"
+  s.version     = "2.0.0"
   s.summary     = "A software update framework for macOS"
   s.description = "Sparkle is an easy-to-use software update framework for Cocoa developers."
   s.homepage    = "http://sparkle-project.org"


### PR DESCRIPTION
Looks like d2ac8bc61eff51461a6bc43ce146e35d53d163c9 broke the `make release` command

It failed with error message from `make-release-package.sh`:
```
podspec version '1.20.0' does not match the current project version '2.0.0'
```