### PR TITLE
Adding support for detecting App Translocation and showing an error

### DIFF
--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -69,6 +69,8 @@
     if ([self.host isRunningOnReadOnlyVolume])
     {
         [self.delegate basicDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.", nil), [self.host name]] }]];
+    } else if ([self.host isRunningTranslocated]) {
+        [self.delegate basicDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningTranslocated userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can’t be updated if it’s running from the location it was downloaded to.", nil), [self.host name]] }]];
     } else {
         [self.appcastDriver loadAppcastFromURL:appcastURL userAgent:userAgent httpHeaders:httpHeaders inBackground:background includesSkippedUpdates:includesSkippedUpdates];
     }

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -37,6 +37,7 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUAppcastError = 1002,
     SURunningFromDiskImageError = 1003,
     SUResumeAppcastError = 1004,
+    SURunningTranslocated = 1005,
 
     // Download phase errors.
     SUTemporaryDirectoryError = 2000,

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -19,6 +19,7 @@
 @property (readonly, nonatomic) BOOL validVersion;
 @property (readonly, copy) NSString *displayVersion;
 @property (getter=isRunningOnReadOnlyVolume, readonly) BOOL runningOnReadOnlyVolume;
+@property (getter=isRunningTranslocated, readonly) BOOL runningTranslocated;
 @property (readonly, copy) NSString *publicDSAKey;
 @property (readonly, nonatomic, copy) NSString *publicDSAKeyFileKey;
 

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -127,6 +127,12 @@
     return (statfs_info.f_flags & MNT_RDONLY) != 0;
 }
 
+- (BOOL)isRunningTranslocated
+{
+    NSString *path = [self.bundle bundlePath];
+    return [path rangeOfString:@"/AppTranslocation/"].location != NSNotFound;
+}
+
 - (NSString *_Nullable)publicDSAKey
 {
     // Maybe the key is just a string in the Info.plist.
@@ -155,7 +161,7 @@
 
 - (NSString * _Nullable)publicDSAKeyFileKey
 {
-    return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey];;
+    return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey];
 }
 
 - (id)objectForInfoDictionaryKey:(NSString *)key

--- a/Sparkle/cs.lproj/Sparkle.strings
+++ b/Sparkle/cs.lproj/Sparkle.strings
@@ -2,6 +2,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Aplikace %1$@ nemůže být aktualizována, protože je spuštěna z média na které nelze zapisovat. Může to být CD/DVD-ROM, obraz disku nebo jen nemáte právo zápisu na disk. Přesuňte aplikaci %1$@ do vaší složky Aplikace, spusťte ji z tohoto umístěni znovu.";
 
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "Aplikace %1$@ nemůže být aktualizována pokud je spuštěna z umístění, ve kterém je stažena.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ je nejnovější dostupná verze";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer DMG Datei oder Laufwerk ohne Schreibzugriff gestartet wurde. Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
 
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "„%1$@“ kann nicht aktualisiert werden, wenn das Programm von dem Ort ausgeführt wird, an den es heruntergeladen wurde.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.";
 
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "%1$@ can’t be updated if it’s running from the location it was downloaded to.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ is currently the newest version available.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ ne peut pas être mis à jour quand il fonctionne à partir d’un volume en lecture seule, comme une image disque ou un lecteur optique. Déplacez %1$@ dans votre dossier Applications, relancez-le à partir de là et réessayez.";
 
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "%1$@ ne peut pas être mis à jour s'il est exécuté depuis le dossier dans lequel il a été téléchargé.";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ est la version la plus récente disponible.";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -4,6 +4,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@は読み出し専用またはテンポラリな場所で開かれているためアップデートできません。%1$@をアプリケーションフォルダに移動し、そこから再起動したあとやり直してください。";
 
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "この場所ではダウンロードされたアップデータを %1$@ に適用できません。";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@は現在入手できる最新バージョンです。";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */

--- a/Sparkle/zh_CN.lproj/Sparkle.strings
+++ b/Sparkle/zh_CN.lproj/Sparkle.strings
@@ -2,6 +2,8 @@
 
 "%1$@ can't be updated, because it was opened from a read-only or a temporary location. Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "无法更新 %1$@，因为它运行于一个只读宗卷如磁盘映像或光盘。移动 %1$@ 到应用程序文件夹并再试一次。";
 
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "如果在下载位置运行此程序，则无法对 %1$@ 进行更新。";
+
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 是当前的最新版本。";
 
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ 可供下载，您现在的版本是 %3$@。要现在下载吗？";


### PR DESCRIPTION
This MR copies over the code accepted in pull request #1392, which added support for detecting App Translocation to the 1.x / `master` branch. This work doesn't appear to have been merged into the `2.x` branch, so here we are. 😄 

The MR contains these additions:

- A method on `SUHost` for detecting app translocation
- A new error code
- Localized strings for several languages (admittedly, only the six languages in which Panic localizes our apps)
- A case in SPUBasicUpdateDriver to detect and handle app translocation

If there's anything missing or mishandled, please let me know, and thank you for consideration of this!