### PR TITLE
Use the hash of the archive for extraction when generating an appcast

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		767B61AD1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */; };
 		767B61AE1972D488004E0C3C /* SUGuidedPackageInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 767B61AB1972D488004E0C3C /* SUGuidedPackageInstaller.m */; };
 		A5BF4F1D1BC7668B007A052A /* SUTestWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = A5BF4F1C1BC7668B007A052A /* SUTestWebServer.m */; };
+		B2D3F865245CEA24009BA78C /* URL+Hashing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D3F864245CEA24009BA78C /* URL+Hashing.swift */; };
 		C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */ = {isa = PBXBuildFile; fileRef = C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */; };
 		E1545EC51E1D7E0200FAECE8 /* SUTouchBarButtonGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = E1545EC31E1D7E0200FAECE8 /* SUTouchBarButtonGroup.h */; };
 		E1545EC61E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */; };
@@ -948,6 +949,7 @@
 		8DC2EF5B0486A6940098B216 /* Sparkle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sparkle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5BF4F1B1BC7668B007A052A /* SUTestWebServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUTestWebServer.h; sourceTree = "<group>"; };
 		A5BF4F1C1BC7668B007A052A /* SUTestWebServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUTestWebServer.m; sourceTree = "<group>"; };
+		B2D3F864245CEA24009BA78C /* URL+Hashing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Hashing.swift"; sourceTree = "<group>"; };
 		C23E88591BE7AF890050BB73 /* SparkleTestCodeSignApp.enc.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSignApp.enc.dmg; sourceTree = "<group>"; };
 		E1545EC31E1D7E0200FAECE8 /* SUTouchBarButtonGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUTouchBarButtonGroup.h; sourceTree = "<group>"; };
 		E1545EC41E1D7E0200FAECE8 /* SUTouchBarButtonGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUTouchBarButtonGroup.m; sourceTree = "<group>"; };
@@ -1324,6 +1326,7 @@
 				5AA96C571E0AE0DB00CA4346 /* main.swift */,
 				5AE13F771E0C9B12000D2C2C /* Signatures.swift */,
 				5A5AC5351E0C6CA300998119 /* Unarchive.swift */,
+				B2D3F864245CEA24009BA78C /* URL+Hashing.swift */,
 			);
 			path = generate_appcast;
 			sourceTree = "<group>";
@@ -2275,6 +2278,7 @@
 				5A5AC5381E0C6D3000998119 /* FeedXML.swift in Sources */,
 				5AA96C581E0AE0DB00CA4346 /* main.swift in Sources */,
 				5AE13F781E0C9B12000D2C2C /* Signatures.swift in Sources */,
+				B2D3F865245CEA24009BA78C /* URL+Hashing.swift in Sources */,
 				5AE13FBA1E0DA389000D2C2C /* SUBinaryDeltaApply.m in Sources */,
 				5AAD00661E0C2D9B00AF411E /* SUBinaryDeltaCommon.m in Sources */,
 				5AAD00671E0C2D9B00AF411E /* SUBinaryDeltaCreate.m in Sources */,

--- a/generate_appcast/URL+Hashing.swift
+++ b/generate_appcast/URL+Hashing.swift
@@ -1,0 +1,45 @@
+//
+//  URL+Hashing.swift
+//  generate_appcast
+//
+//  Created by Nate Weaver on 2020-05-01.
+//  Copyright © 2020 Sparkle Project. All rights reserved.
+//
+
+import Foundation
+import CommonCrypto
+
+extension FileHandle {
+
+    func sha256String() -> String? {
+        var context = CC_SHA256_CTX()
+        CC_SHA256_Init(&context)
+
+        while true {
+            let data = self.readData(ofLength: 65_536)
+
+            guard data.count > 0 else { break }
+
+            let _ = data.withUnsafeBytes {
+                CC_SHA256_Update(&context, $0.baseAddress, numericCast($0.count))
+            }
+        }
+
+        let hash = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: Int(CC_SHA256_DIGEST_LENGTH))
+
+        CC_SHA256_Final(hash.baseAddress, &context)
+
+        return hash.reduce("") { $0 + String(format: "%02x", $1) }
+    }
+
+}
+
+extension URL {
+
+    func sha256String() -> String? {
+        guard let filehandle = try? FileHandle(forReadingFrom: self) else { return nil }
+
+        return filehandle.sha256String()
+    }
+
+}

--- a/generate_appcast/URL+Hashing.swift
+++ b/generate_appcast/URL+Hashing.swift
@@ -11,7 +11,11 @@ import CommonCrypto
 
 extension FileHandle {
 
-    func sha256String() -> String? {
+    /// Calculate the SHA-256 hash of the file referenced by the file handle.
+    ///
+    /// - Returns: The SHA-256 hash of the file (as a hexadecimal string).
+    func sha256String() -> String {
+        // This uses CommonCrypto instead of CryptoKit so it can work on macOS < 10.15
         var context = CC_SHA256_CTX()
         CC_SHA256_Init(&context)
 
@@ -36,7 +40,12 @@ extension FileHandle {
 
 extension URL {
 
+    /// Calculates the SHA-256 hash of the file referened by the URL.
+    ///
+    /// - Returns: The SHA-256 hash of the file (as a hexadecimal string), or `nil` if
+    ///   the URL doesn't point to a file.
     func sha256String() -> String? {
+        guard self.isFileURL else { return nil }
         guard let filehandle = try? FileHandle(forReadingFrom: self) else { return nil }
 
         return filehandle.sha256String()

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -58,7 +58,13 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, verbose: Boo
     var running = 0;
     for item in dir.filter({ !$0.hasPrefix(".") && !$0.hasSuffix(".delta") && !$0.hasSuffix(".xml") && !$0.hasSuffix(".html") }) {
         let itemPath = archivesSourceDir.appendingPathComponent(item);
-        let archiveDestDir = archivesDestDir.appendingPathComponent(itemPath.lastPathComponent);
+        let archiveDestDir: URL
+
+        if let hash = itemPath.sha256String() {
+            archiveDestDir = archivesDestDir.appendingPathComponent(hash)
+        } else {
+            archiveDestDir = archivesDestDir.appendingPathComponent(itemPath.lastPathComponent)
+        }
 
         var isDir:ObjCBool = false;
         if (fileManager.fileExists(atPath: itemPath.path, isDirectory: &isDir) && isDir.boolValue) {


### PR DESCRIPTION
Fixes #1559.

Notes: I'm not sure if 64 K is a good read buffer size or if larger would be better.