### PR TITLE
fix: undesirable popups when checking for updates

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -352,7 +352,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 {
     NSURL *requestURL = request.URL;
     NSString *scheme = requestURL.scheme;
-    BOOL whitelistedSafe = [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"] || [requestURL.absoluteString isEqualToString:@"about:blank"];
+    BOOL isAboutBlank = [requestURL.absoluteString isEqualToString:@"about:blank"];
+    BOOL whitelistedSafe = [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"] || isAboutBlank;
 
     // Do not allow redirects to dangerous protocols such as file://
     if (!whitelistedSafe) {
@@ -362,7 +363,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     }
 
     if (self.webViewFinishedLoading) {
-        if (requestURL) {
+        if (requestURL && !isAboutBlank) {
             [[NSWorkspace sharedWorkspace] openURL:requestURL];
         }
 


### PR DESCRIPTION
Hi!

I use [this page](https://alt-tab-macos.netlify.app/changelog-bare) for release notes. It contains some JavaScript to load google translate if the user language is not English. This works great in a `WebView`, however it creates 3 popups:

![image](https://user-images.githubusercontent.com/106195/81593450-6b541100-93fa-11ea-82f3-59861fdbffd0.png)


After digging deeper, I found out that the google translate script loads a bunch of iframes. These have no `src` attribute. They triggers the `decidePolicyForNavigationAction` method in Sparkle, which calls `[[NSWorkspace sharedWorkspace] openURL:requestURL];` which result in the popups.

I don't think there is any point in ever opening a about:blank link for the user, thus this PR ignores these URLs.

---

If you decide to not merge this, could you please help me build on my fork? I ran `make release`, then made a zip out of the result, uploaded it to my fork's releases, then made [these changes to the podspec](https://github.com/lwouis/Sparkle/commit/fb1d08ecf51abc0a8da3982517289a0cbd0d6be3). Also note that I had to do [that tweak](https://github.com/lwouis/Sparkle/commit/17cc2cab09adb1a7c0877c752dc9ea1a1517f545) to build on my mac.

After this I updated the Podfile in my project to: `pod 'Sparkle', :git => 'https://github.com/lwouis/Sparkle.git', :branch => 'master'`.

My project doesn't build and complains that the Sparkle framework is missing. I don't quite understand how Sparkle is packaged/delivered.

Thanks a lot!

Louis Pontoise