### PR TITLE
Allow UpdateAlert and UpdatePermissionPrompt to present on top of fullscreen window

### DIFF
--- a/Sparkle/en.lproj/SUUpdateAlert.xib
+++ b/Sparkle/en.lproj/SUUpdateAlert.xib
@@ -25,6 +25,7 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window identifier="SUUpdateAlert" title="Software Update" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>

--- a/Sparkle/en.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/en.lproj/SUUpdatePermissionPrompt.xib
@@ -20,6 +20,7 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Profile Info">
             <windowStyleMask key="styleMask" titled="YES"/>
+            <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="83" y="492" width="438" height="168"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>


### PR DESCRIPTION
Sets UpdateAlert and UpdatePermissionPrompt window's fullscreen collectionBehavior to NSWindowCollectionBehaviorFullScreenAuxiliary to allow them to present on top of the Main App's window if it's fullscreen.

Fixes undesired behavior mentioned in this issue: https://github.com/sparkle-project/Sparkle/issues/1590