### PR TITLE
Test SUSignatureVerifier with Ed25519 keys, and make sure invalid keys/signatures fail

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -217,7 +217,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         }
     }
     
-    BOOL hasPublicKey = self.host.publicKeys.dsaPubKey != nil || self.host.publicKeys.ed25519PubKey != nil;
+    BOOL hasPublicKey = self.host.publicKeys.hasAnyKeys;
     if (!hasPublicKey) {
         // If we failed to retrieve a DSA key but the bundle specifies a path to one, we should consider this a configuration failure
         NSString *publicDSAKeyFileKey = [self.host publicDSAKeyFileKey];

--- a/Sparkle/SUSignatures.h
+++ b/Sparkle/SUSignatures.h
@@ -16,12 +16,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(uint8_t, SUSigningInputStatus) {
+    /// An input was not provided at all.
+    SUSigningInputStatusAbsent = 0,
+
+    /// An input was provided, but did not have the correct format.
+    SUSigningInputStatusInvalid,
+
+    /// An input was provided and can be used for verifying signing information.
+    SUSigningInputStatusPresent,
+    SUSigningInputStatusLastValidCase = SUSigningInputStatusPresent
+};
+
 @interface SUSignatures : NSObject <NSSecureCoding> {
     unsigned char ed25519_signature[64];
-    bool has_ed25519_signature;
 }
 @property (strong, readonly, nullable) NSData *dsaSignature;
+@property (readonly) SUSigningInputStatus dsaSignatureStatus;
+
 @property (readonly, nullable, nonatomic) const unsigned char *ed25519Signature;
+@property (readonly) SUSigningInputStatus ed25519SignatureStatus;
 
 - (instancetype)initWithDsa:(NSString * _Nullable)dsa ed:(NSString * _Nullable)ed;
 @end
@@ -29,10 +43,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUPublicKeys : NSObject {
     unsigned char ed25519_public_key[32];
-    bool has_ed25519_public_key;
 }
 @property (strong, readonly, nullable) NSString *dsaPubKey;
+@property (readonly) SUSigningInputStatus dsaPubKeyStatus;
+
 @property (readonly, nullable, nonatomic) const unsigned char *ed25519PubKey;
+@property (readonly) SUSigningInputStatus ed25519PubKeyStatus;
+
+/// Returns YES if either key is present (though they may be invalid).
+@property (readonly) BOOL hasAnyKeys;
 
 - (instancetype)initWithDsa:(NSString * _Nullable)dsa ed:(NSString * _Nullable)ed;
 

--- a/Sparkle/SUSignatures.h
+++ b/Sparkle/SUSignatures.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUSignatures : NSObject <NSSecureCoding> {
     unsigned char ed25519_signature[64];
+    bool has_ed25519_signature;
 }
 @property (strong, readonly, nullable) NSData *dsaSignature;
 @property (readonly, nullable, nonatomic) const unsigned char *ed25519Signature;
@@ -28,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUPublicKeys : NSObject {
     unsigned char ed25519_public_key[32];
+    bool has_ed25519_public_key;
 }
 @property (strong, readonly, nullable) NSString *dsaPubKey;
 @property (readonly, nullable, nonatomic) const unsigned char *ed25519PubKey;

--- a/Sparkle/SUSignatures.m
+++ b/Sparkle/SUSignatures.m
@@ -22,7 +22,11 @@ static NSData *decode(NSString *str) {
     }
 
     NSString *stripped = [str stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
-    return [[NSData alloc] initWithBase64EncodedString:stripped options:0];
+    NSData *result = [[NSData alloc] initWithBase64EncodedString:stripped options:0];
+    if (!result) {
+        return [NSData data]; // Distinguish an absent string from a present-but-invalid one.
+    }
+    return result;
 }
 
 - (instancetype)initWithDsa:(NSString * _Nullable)maybeDsa ed:(NSString * _Nullable)maybeEd25519
@@ -33,9 +37,15 @@ static NSData *decode(NSString *str) {
             _dsaSignature = decode(maybeDsa);
         }
         if (maybeEd25519 != nil) {
+            self->has_ed25519_signature = true;
             NSData *data = decode(maybeEd25519);
             assert(64 == sizeof(self->ed25519_signature));
-            [data getBytes:self->ed25519_signature length:sizeof(self->ed25519_signature)];
+            if ([data length] == sizeof(self->ed25519_signature)) {
+                [data getBytes:self->ed25519_signature length:sizeof(self->ed25519_signature)];
+            } else {
+                // A valid Ed25519 signature never has the top bits set in the final byte.
+                memset(self->ed25519_signature, -1, sizeof(self->ed25519_signature));
+            }
         }
     }
     return self;
@@ -45,10 +55,8 @@ static NSData *decode(NSString *str) {
 // Xcode may enable this in pedantic mode
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    for(size_t i=0; i < sizeof(self->ed25519_signature); i++) {
-        if (self->ed25519_signature[i] != 0) {
-            return self->ed25519_signature;
-        }
+    if (self->has_ed25519_signature) {
+        return self->ed25519_signature;
     }
     return NULL;
 #pragma clang diagnostic pop
@@ -69,6 +77,7 @@ static NSData *decode(NSString *str) {
                 return nil;
             }
             [edSignature getBytes:self->ed25519_signature];
+            self->has_ed25519_signature = true;
         }
     }
     return self;
@@ -104,9 +113,17 @@ static NSData *decode(NSString *str) {
     if (self) {
         _dsaPubKey = maybeDsa;
         if (maybeEd25519 != nil) {
+            self->has_ed25519_public_key = true;
             NSData *ed = decode(maybeEd25519);
             assert(32 == sizeof(self->ed25519_public_key));
-            [ed getBytes:self->ed25519_public_key length:sizeof(self->ed25519_public_key)];
+            if ([ed length] == sizeof(self->ed25519_public_key)) {
+                [ed getBytes:self->ed25519_public_key length:sizeof(self->ed25519_public_key)];
+            } else {
+                // The stored value will be all zeros.
+                // If that /is/ someone's public key, validation will succeed even though they put in an invalid value.
+                // This is not a security vulnerability since the public key is embedded in the app,
+                // rather than being controlled by a remote attacker.
+            }
         }
     }
     return self;
@@ -117,10 +134,8 @@ static NSData *decode(NSString *str) {
 // Xcode may enable this in pedantic mode
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    for(size_t i=0; i < sizeof(self->ed25519_public_key); i++) {
-        if (self->ed25519_public_key[i] != 0) {
-            return self->ed25519_public_key;
-        }
+    if (self->has_ed25519_public_key) {
+        return self->ed25519_public_key;
     }
     return NULL;
 #pragma clang diagnostic pop

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -47,7 +47,7 @@
     SUPublicKeys *publicKeys = self.host.publicKeys;
     SUSignatures *signatures = self.signatures;
 
-    if (publicKeys.dsaPubKey == nil && publicKeys.ed25519PubKey == nil) {
+    if (!publicKeys.hasAnyKeys) {
         SULog(SULogLevelError, @"Failed to validate update before unarchiving because no (Ed)DSA public key was found in the old app");
     } else {
         if ([SUSignatureVerifier validatePath:self.downloadPath withSignatures:signatures withPublicKeys:publicKeys]) {
@@ -128,11 +128,11 @@
 
     SUHost *newHost = [[SUHost alloc] initWithBundle:newBundle];
     SUPublicKeys *newPublicKeys = newHost.publicKeys;
-    BOOL oldHasLegacyDSAKey = publicKeys.dsaPubKey != nil;
-    BOOL oldHasEdDSAKey = publicKeys.ed25519PubKey != nil;
+    BOOL oldHasLegacyDSAKey = publicKeys.dsaPubKeyStatus != SUSigningInputStatusAbsent;
+    BOOL oldHasEdDSAKey = publicKeys.ed25519PubKeyStatus != SUSigningInputStatusAbsent;
     BOOL oldHasAnyDSAKey = oldHasLegacyDSAKey || oldHasEdDSAKey;
-    BOOL newHasLegacyDSAKey = newPublicKeys.dsaPubKey != nil;
-    BOOL newHasEdDSAKey = newPublicKeys.ed25519PubKey != nil;
+    BOOL newHasLegacyDSAKey = newPublicKeys.dsaPubKeyStatus != SUSigningInputStatusAbsent;
+    BOOL newHasEdDSAKey = newPublicKeys.ed25519PubKeyStatus != SUSigningInputStatusAbsent;
     BOOL newHasAnyDSAKey = newHasLegacyDSAKey || newHasEdDSAKey;
     BOOL migratesDSAKeys = oldHasLegacyDSAKey && !oldHasEdDSAKey && newHasEdDSAKey && !newHasLegacyDSAKey;
     BOOL updateIsCodeSigned = [SUCodeSigningVerifier bundleAtURLIsCodeSigned:newHost.bundle.bundleURL];

--- a/Tests/SUSignatureVerifierTest.m
+++ b/Tests/SUSignatureVerifierTest.m
@@ -137,7 +137,7 @@
 
     XCTAssertTrue([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
-                   @"Allow just a DSA signature if that's all that's available");
+                  @"Allow just a DSA signature if that's all that's available");
     XCTAssertFalse([v verifyFileAtPath:self.testFile
                             signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
                    @"Require the DSA signature to match because there's a DSA public key");
@@ -149,9 +149,16 @@
                             signatures:[[SUSignatures alloc] initWithDsa:wrongDSASig ed:edSig]],
                    @"Fail on a bad DSA signature if provided");
 
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:@"lol"]],
+                   @"Fail if the Ed25519 signature is invalid.");
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                           signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:edSig]],
+                   @"Fail if the DSA signature is invalid.");
+
     XCTAssertTrue([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:edSig]],
-                   @"Pass if both are valid");
+                  @"Pass if both are valid");
 }
 
 - (void)testVerifyFileWithWrongKey

--- a/Tests/SUSignatureVerifierTest.m
+++ b/Tests/SUSignatureVerifierTest.m
@@ -1,5 +1,5 @@
 //
-//  SUDSAVerifierTest.m
+//  SUSignatureVerifierTest.m
 //  Sparkle
 //
 //  Created by Kornel on 25/07/2014.
@@ -11,11 +11,11 @@
 #import "SUSignatureVerifier.h"
 #import "SUSignatures.h"
 
-@interface SUDSAVerifierTest : XCTestCase
+@interface SUSignatureVerifierTest : XCTestCase
 @property NSString *testFile, *pubDSAKeyFile, *pubEdKey;
 @end
 
-@implementation SUDSAVerifierTest
+@implementation SUSignatureVerifierTest
 @synthesize testFile, pubDSAKeyFile, pubEdKey;
 
 - (void)setUp

--- a/Tests/SUSignatureVerifierTest.m
+++ b/Tests/SUSignatureVerifierTest.m
@@ -12,59 +12,90 @@
 #import "SUSignatures.h"
 
 @interface SUDSAVerifierTest : XCTestCase
-@property NSString *testFile, *pubKeyFile;
+@property NSString *testFile, *pubDSAKeyFile, *pubEdKey;
 @end
 
 @implementation SUDSAVerifierTest
-@synthesize testFile, pubKeyFile;
+@synthesize testFile, pubDSAKeyFile, pubEdKey;
 
 - (void)setUp
 {
     [super setUp];
 
     self.testFile = [[NSBundle bundleForClass:[self class]] pathForResource:@"signed-test-file" ofType:@"txt"];
-    self.pubKeyFile = [[NSBundle bundleForClass:[self class]] pathForResource:@"test-pubkey" ofType:@"pem"];
+    self.pubDSAKeyFile = [[NSBundle bundleForClass:[self class]] pathForResource:@"test-pubkey" ofType:@"pem"];
+    self.pubEdKey = @"rhHib+w769W2/6/t+oM1ZxgjBB93BfBKMLO0Qo1etQs=";
 }
 
-- (void)testVerifyFileAtPath
+- (void)testVerifyFileAtPathUsingDSA
 {
-    NSString *pubKey = [NSString stringWithContentsOfFile:self.pubKeyFile encoding:NSASCIIStringEncoding error:nil];
+    NSString *pubKey = [NSString stringWithContentsOfFile:self.pubDSAKeyFile encoding:NSASCIIStringEncoding error:nil];
     XCTAssertNotNil(pubKey, @"Public key must be readable");
 
     NSString *validSig = @"MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
 
     XCTAssertTrue([self checkFile:self.testFile
-                       withPubKey:pubKey
+                       withDSAKey:pubKey
                         signature:validSig],
                   @"Expected valid signature");
 
     XCTAssertFalse([self checkFile:self.testFile
-                        withPubKey:@"lol"
+                        withDSAKey:@"lol"
                          signature:validSig],
                    @"Invalid pubkey");
 
-    XCTAssertFalse([self checkFile:self.pubKeyFile
-                        withPubKey:pubKey
+    XCTAssertFalse([self checkFile:self.pubDSAKeyFile
+                        withDSAKey:pubKey
                          signature:validSig],
                    @"Wrong file checked");
 
     XCTAssertFalse([self checkFile:self.testFile
-                        withPubKey:pubKey
+                        withDSAKey:pubKey
                          signature:@"MCwCFCIHCiYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="],
                    @"Expected invalid signature");
 
     XCTAssertTrue([self checkFile:self.testFile
-                       withPubKey:pubKey
+                       withDSAKey:pubKey
                         signature:@"MC0CFAsKO7cq2q7L5/FWe6ybVIQkwAwSAhUA2Q8GKsE309eugi/v3Kh1W3w3N8c="],
                   @"Expected valid signature");
 
     XCTAssertFalse([self checkFile:self.testFile
-                        withPubKey:pubKey
+                        withDSAKey:pubKey
                          signature:@"MC0CFAsKO7cq2q7L5/FWe6ybVIQkwAwSAhUA2Q8GKsE309eugi/v3Kh1W3w3N8"],
                    @"Expected invalid signature");
 }
 
-- (BOOL)checkFile:(NSString *)aFile withPubKey:(NSString *)pubKey signature:(NSString *)sigString
+- (void)testVerifyFileAtPathUsingED25519
+{
+    NSString *validSig = @"EIawm2YkDZ2gBfkEMF2+1VuuTeXnCGZOdnMdVgPPvDZioq7bvDayXqKkIIzSjKMmeFdcFJOHdnba5ZV60+gPBw==";
+
+    XCTAssertTrue([self checkFile:self.testFile
+                        withEdKey:self.pubEdKey
+                        signature:validSig],
+                  @"Expected valid signature");
+
+    XCTAssertFalse([self checkFile:self.testFile
+                         withEdKey:@"lol"
+                         signature:validSig],
+                   @"Invalid pubkey");
+
+    XCTAssertFalse([self checkFile:self.pubDSAKeyFile
+                         withEdKey:self.pubEdKey
+                         signature:validSig],
+                   @"Wrong file checked");
+
+    XCTAssertFalse([self checkFile:self.testFile
+                         withEdKey:self.pubEdKey
+                         signature:@"wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="],
+                   @"Expected wrong signature");
+
+    XCTAssertFalse([self checkFile:self.testFile
+                         withEdKey:self.pubEdKey
+                         signature:@"lol"],
+                   @"Invalid signature");
+}
+
+- (BOOL)checkFile:(NSString *)aFile withDSAKey:(NSString *)pubKey signature:(NSString *)sigString
 {
     SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:pubKey ed:nil];
     SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
@@ -74,9 +105,82 @@
     return [v verifyFileAtPath:aFile signatures:sig];
 }
 
+- (BOOL)checkFile:(NSString *)aFile withEdKey:(NSString *)pubKey signature:(NSString *)sigString
+{
+    SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:nil ed:pubKey];
+    SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
+
+    SUSignatures *sig = [[SUSignatures alloc] initWithDsa:nil ed:sigString];
+
+    return [v verifyFileAtPath:aFile signatures:sig];
+}
+
+- (void)testVerifyFileWithBothKeys
+{
+    NSString *dsaKey = [NSString stringWithContentsOfFile:self.pubDSAKeyFile encoding:NSASCIIStringEncoding error:nil];
+    XCTAssertNotNil(dsaKey, @"Public key must be readable");
+
+    SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:dsaKey ed:self.pubEdKey];
+    SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
+
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                            signatures:[[SUSignatures alloc] initWithDsa:nil ed:nil]],
+                   @"Fail if no signatures are provided");
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                            signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:@"lol"]],
+                   @"Fail if both signatures are invalid");
+
+    NSString *dsaSig = @"MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
+    NSString *wrongDSASig = @"MCwCFCIHCiYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
+    NSString *edSig = @"EIawm2YkDZ2gBfkEMF2+1VuuTeXnCGZOdnMdVgPPvDZioq7bvDayXqKkIIzSjKMmeFdcFJOHdnba5ZV60+gPBw==";
+    NSString *wrongEdSig = @"wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ==";
+
+    XCTAssertTrue([v verifyFileAtPath:self.testFile
+                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
+                   @"Allow just a DSA signature if that's all that's available");
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                            signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
+                   @"Require the DSA signature to match because there's a DSA public key");
+
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:wrongEdSig]],
+                   @"Fail on a bad Ed25519 signature regardless");
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
+                            signatures:[[SUSignatures alloc] initWithDsa:wrongDSASig ed:edSig]],
+                   @"Fail on a bad DSA signature if provided");
+
+    XCTAssertTrue([v verifyFileAtPath:self.testFile
+                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:edSig]],
+                   @"Pass if both are valid");
+}
+
+- (void)testVerifyFileWithWrongKey
+{
+    NSString *dsaSig = @"MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
+    NSString *edSig = @"EIawm2YkDZ2gBfkEMF2+1VuuTeXnCGZOdnMdVgPPvDZioq7bvDayXqKkIIzSjKMmeFdcFJOHdnba5ZV60+gPBw==";
+
+    NSString *dsaKey = [NSString stringWithContentsOfFile:self.pubDSAKeyFile encoding:NSASCIIStringEncoding error:nil];
+    XCTAssertNotNil(dsaKey, @"Public key must be readable");
+
+    SUPublicKeys *dsaOnlyKeys = [[SUPublicKeys alloc] initWithDsa:dsaKey ed:nil];
+    SUSignatureVerifier *dsaOnlyVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:dsaOnlyKeys];
+
+    XCTAssertFalse([dsaOnlyVerifier verifyFileAtPath:self.testFile
+                                          signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
+                   @"DSA cannot verify an Ed signature");
+
+    SUPublicKeys *edOnlyKeys = [[SUPublicKeys alloc] initWithDsa:nil ed:self.pubEdKey];
+    SUSignatureVerifier *edOnlyVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:edOnlyKeys];
+
+    XCTAssertFalse([edOnlyVerifier verifyFileAtPath:self.testFile
+                                         signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
+                   @"Ed cannot verify an DSA signature");
+
+}
+
 - (void)testValidatePath
 {
-    NSString *dsaStr = [NSString stringWithContentsOfFile:self.pubKeyFile encoding:NSASCIIStringEncoding error:nil];
+    NSString *dsaStr = [NSString stringWithContentsOfFile:self.pubDSAKeyFile encoding:NSASCIIStringEncoding error:nil];
     XCTAssertNotNil(dsaStr);
     SUPublicKeys *pubkeys = [[SUPublicKeys alloc] initWithDsa:dsaStr ed:nil];
     XCTAssertNotNil(pubkeys);


### PR DESCRIPTION
Adds some tests for Ed25519 signature verification, and tightens up some logic around invalid Ed25519 signatures and keys. (Please double-check that my logic is sound in SUSignatures.m when it comes to the invalid keys and signatures.)

The remaining work to test in #1553 is the logic around upgrades and prevalidation in SUUpdateValidator. It doesn't look like there are any existing unit tests for that, so that might take a bit longer.

(I suppose there should also be tests for generate_appcast, but I'm not the one who worked on that.)