### PR TITLE
Replaced deprecated method

### DIFF
--- a/Sparkle/SUSignatures.m
+++ b/Sparkle/SUSignatures.m
@@ -22,7 +22,7 @@ static NSData *decode(NSString *str) {
     }
 
     NSString *stripped = [str stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
-    return [[NSData alloc] initWithBase64Encoding:stripped];
+    return [[NSData alloc] initWithBase64EncodedString:stripped options:0];
 }
 
 - (instancetype)initWithDsa:(NSString * _Nullable)maybeDsa ed:(NSString * _Nullable)maybeEd25519

--- a/sign_update/main.swift
+++ b/sign_update/main.swift
@@ -54,7 +54,7 @@ func edSignature(data: Data, publicEdKey: Data, privateEdKey: Data) -> String {
 
 let args = CommandLine.arguments
 if args.count != 2 {
-    print("Usage: \(args[0]) <archive to sign>\nPrivavte EdDSA (ed25519) key is automatically read from the Keychain.\n")
+    print("Usage: \(args[0]) <archive to sign>\nPrivate EdDSA (ed25519) key is automatically read from the Keychain.\n")
     exit(1)
 }
 


### PR DESCRIPTION
-initWithBase64Encoding has been deprecated since OS X 10.9, and that
is our deployment target.