### PR TITLE
Allow relative URLs in appcasts

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -208,7 +208,17 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
         if (data != nil) {
             NSURLResponse *response = self.download.response;
             assert(response != nil);
-            downloadData = [[SPUDownloadData alloc] initWithData:data textEncodingName:response.textEncodingName MIMEType:response.MIMEType];
+
+            NSURL *responseURL = response.URL;
+            if (responseURL == nil) {
+                responseURL = self.download.currentRequest.URL;
+            }
+            if (responseURL == nil) {
+                responseURL = self.download.originalRequest.URL;
+            }
+            assert(responseURL != nil);
+
+            downloadData = [[SPUDownloadData alloc] initWithData:data URL:responseURL textEncodingName:response.textEncodingName MIMEType:response.MIMEType];
         }
     }
     

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		5A5DD401249585E70045EB3E /* SUUpdateValidatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5DD400249585E70045EB3E /* SUUpdateValidatorTest.swift */; };
 		5A5DD402249586840045EB3E /* SUUpdateValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 729924931DF4A45000DBCDF5 /* SUUpdateValidator.m */; };
 		5A5DD40424958B000045EB3E /* SUUpdateValidatorTest in Resources */ = {isa = PBXBuildFile; fileRef = 5A5DD40324958AFF0045EB3E /* SUUpdateValidatorTest */; };
+		5A5DD41D249F116E0045EB3E /* test-relative-urls.xml in Resources */ = {isa = PBXBuildFile; fileRef = 5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */; };
 		5A6DD17123FE1FFC000AEF33 /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E286D22B665E8004AA304 /* SUSignatures.m */; };
 		5AA89BA523FE27660094DAB8 /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E286D22B665E8004AA304 /* SUSignatures.m */; };
 		5AA89BA623FE276A0094DAB8 /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E286D22B665E8004AA304 /* SUSignatures.m */; };
@@ -966,6 +967,7 @@
 		55E6F33219EC9F6C00005E76 /* SUErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUErrors.h; sourceTree = "<group>"; };
 		5A5DD400249585E70045EB3E /* SUUpdateValidatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SUUpdateValidatorTest.swift; sourceTree = "<group>"; };
 		5A5DD40324958AFF0045EB3E /* SUUpdateValidatorTest */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SUUpdateValidatorTest; sourceTree = "<group>"; };
+		5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "test-relative-urls.xml"; sourceTree = "<group>"; };
 		5AA4DCD01C73E5510078F128 /* SUAppcastTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUAppcastTest.swift; sourceTree = "<group>"; };
 		5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast.xml; sourceTree = "<group>"; };
 		5AEF45D9189D1CC90030D7DC /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Sparkle.strings; sourceTree = "<group>"; };
@@ -1714,6 +1716,7 @@
 				5AF6C74E1AEA46D10014A3AB /* test.pkg */,
 				5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */,
 				5F1510A11C96E591006E1629 /* testnamespaces.xml */,
+				5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */,
 				5A5DD40324958AFF0045EB3E /* SUUpdateValidatorTest */,
 			);
 			path = Resources;
@@ -2976,6 +2979,7 @@
 				72AC6B2A1B9AAF3A00F62325 /* SparkleTestCodeSignApp.tar.bz2 in Resources */,
 				72AC6B261B9AAC8800F62325 /* SparkleTestCodeSignApp.tar.gz in Resources */,
 				72AC6B2C1B9AB0EE00F62325 /* SparkleTestCodeSignApp.tar.xz in Resources */,
+				5A5DD41D249F116E0045EB3E /* test-relative-urls.xml in Resources */,
 				F8761EB31ADC50EB000C9034 /* SparkleTestCodeSignApp.zip in Resources */,
 				5A5DD40424958B000045EB3E /* SUUpdateValidatorTest in Resources */,
 				14958C6F19AEBC980061B14F /* test-pubkey.pem in Resources */,

--- a/Sparkle/SPUDownloadData.h
+++ b/Sparkle/SPUDownloadData.h
@@ -16,12 +16,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 SU_EXPORT @interface SPUDownloadData : NSObject <NSSecureCoding>
 
-- (instancetype)initWithData:(NSData *)data textEncodingName:(NSString * _Nullable)textEncodingName MIMEType:(NSString * _Nullable)MIMEType;
+- (instancetype)initWithData:(NSData *)data URL:(NSURL *)URL textEncodingName:(NSString * _Nullable)textEncodingName MIMEType:(NSString * _Nullable)MIMEType;
 
 /*!
  * The raw data that was downloaded.
  */
 @property (nonatomic, readonly) NSData *data;
+
+/*!
+ * The URL that was fetched from.
+ *
+ * This may be different from the URL in the request if there were redirects involved.
+ */
+@property (nonatomic, readonly, copy) NSURL *URL;
 
 /*!
  * The IANA charset encoding name if available. Eg: "utf-8"

--- a/Sparkle/SPUDownloadData.m
+++ b/Sparkle/SPUDownloadData.m
@@ -12,12 +12,14 @@
 #include "AppKitPrevention.h"
 
 static NSString *SPUDownloadDataKey = @"SPUDownloadData";
+static NSString *SPUDownloadURLKey = @"SPUDownloadURL";
 static NSString *SPUDownloadTextEncodingKey = @"SPUDownloadTextEncoding";
 static NSString *SPUDownloadMIMETypeKey = @"SPUDownloadMIMEType";
 
 @implementation SPUDownloadData
 
 @synthesize data = _data;
+@synthesize URL = _URL;
 @synthesize textEncodingName = _textEncodingName;
 @synthesize MIMEType = _MIMEType;
 
@@ -26,11 +28,12 @@ static NSString *SPUDownloadMIMETypeKey = @"SPUDownloadMIMEType";
     return YES;
 }
 
-- (instancetype)initWithData:(NSData *)data textEncodingName:(NSString * _Nullable)textEncodingName MIMEType:(NSString *)MIMEType
+- (instancetype)initWithData:(NSData *)data URL:(NSURL *)URL textEncodingName:(NSString * _Nullable)textEncodingName MIMEType:(NSString *)MIMEType
 {
     self = [super init];
     if (self != nil) {
         _data = data;
+        _URL = URL;
         _textEncodingName = textEncodingName;
         _MIMEType = MIMEType;
     }
@@ -40,7 +43,8 @@ static NSString *SPUDownloadMIMETypeKey = @"SPUDownloadMIMEType";
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeObject:self.data forKey:SPUDownloadDataKey];
-    
+    [coder encodeObject:self.URL forKey:SPUDownloadURLKey];
+
     if (self.textEncodingName != nil) {
         [coder encodeObject:self.textEncodingName forKey:SPUDownloadTextEncodingKey];
     }
@@ -56,12 +60,17 @@ static NSString *SPUDownloadMIMETypeKey = @"SPUDownloadMIMEType";
     if (data == nil) {
         return nil;
     }
-    
+
+    NSURL *URL = [decoder decodeObjectOfClass:[NSURL class] forKey:SPUDownloadURLKey];
+    if (URL == nil) {
+        return nil;
+    }
+
     NSString *textEncodingName = [decoder decodeObjectOfClass:[NSString class] forKey:SPUDownloadTextEncodingKey];
     
     NSString *MIMEType = [decoder decodeObjectOfClass:[NSString class] forKey:SPUDownloadMIMETypeKey];
     
-    return [self initWithData:data textEncodingName:textEncodingName MIMEType:MIMEType];
+    return [self initWithData:data URL:URL textEncodingName:textEncodingName MIMEType:MIMEType];
 }
 
 @end

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -85,7 +85,7 @@
     SPUDownloadURLWithRequest(request, ^(SPUDownloadData * _Nullable downloadData, NSError * _Nullable error) {
         if (downloadData != nil) {
             NSError *parseError = nil;
-            NSArray *appcastItems = [self parseAppcastItemsFromXMLData:downloadData.data error:&parseError];
+            NSArray *appcastItems = [self parseAppcastItemsFromXMLData:downloadData.data relativeToURL:downloadData.URL error:&parseError];
             
             if (appcastItems != nil) {
                 self.items = appcastItems;
@@ -151,7 +151,7 @@
     }
 }
 
--(NSArray *)parseAppcastItemsFromXMLData:(NSData *)appcastData error:(NSError *__autoreleasing*)errorp {
+-(NSArray *)parseAppcastItemsFromXMLData:(NSData *)appcastData relativeToURL:(NSURL *)appcastURL error:(NSError *__autoreleasing*)errorp {
     if (errorp) {
         *errorp = nil;
     }
@@ -243,7 +243,7 @@
         }
 
         NSString *errString;
-        SUAppcastItem *anItem = [[SUAppcastItem alloc] initWithDictionary:dict failureReason:&errString];
+        SUAppcastItem *anItem = [[SUAppcastItem alloc] initWithDictionary:dict relativeToURL:appcastURL failureReason:&errString];
         if (anItem) {
             [appcastItems addObject:anItem];
 		}

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -33,6 +33,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 // Initializes with data from a dictionary provided by the RSS class.
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString **)error;
+- (instancetype)initWithDictionary:(NSDictionary *)dict relativeToURL:(NSURL *)appcastURL failureReason:(NSString **)error;
 
 @property (getter=isDeltaUpdate, readonly) BOOL deltaUpdate;
 @property (getter=isCriticalUpdate, readonly) BOOL criticalUpdate;

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -165,10 +165,15 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict
 {
-    return [self initWithDictionary:dict failureReason:nil];
+    return [self initWithDictionary:dict relativeToURL:nil failureReason:nil];
 }
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString *__autoreleasing *)error
+{
+    return [self initWithDictionary:dict relativeToURL:nil failureReason:error];
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)dict relativeToURL:(NSURL *)appcastURL failureReason:(NSString *__autoreleasing *)error
 {
     self = [super init];
     if (self) {
@@ -215,7 +220,7 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
             if (![theInfoURL isKindOfClass:[NSString class]]) {
                 SULog(SULogLevelError, @"%@ -%@ Info URL is not of valid type.", NSStringFromClass([self class]), NSStringFromSelector(_cmd));
             } else {
-                _infoURL = [NSURL URLWithString:theInfoURL];
+                _infoURL = [NSURL URLWithString:theInfoURL relativeToURL:appcastURL];
             }
         }
 
@@ -248,7 +253,7 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
         if (enclosureURLString) {
             // Sparkle used to always URL-encode, so for backwards compatibility spaces in URLs must be forgiven.
             NSString *fileURLString = [enclosureURLString stringByReplacingOccurrencesOfString:@" " withString:@"%20"];
-            _fileURL = [NSURL URLWithString:fileURLString];
+            _fileURL = [NSURL URLWithString:fileURLString relativeToURL:appcastURL];
         }
         if (enclosure) {
             _signatures = [[SUSignatures alloc] initWithDsa:[enclosure objectForKey:SUAppcastAttributeDSASignature] ed:[enclosure objectForKey:SUAppcastAttributeEDSignature]];
@@ -284,7 +289,7 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
         // Find the appropriate release notes URL.
         NSString *releaseNotesString = [dict objectForKey:SUAppcastElementReleaseNotesLink];
         if (releaseNotesString) {
-            NSURL *url = [NSURL URLWithString:releaseNotesString];
+            NSURL *url = [NSURL URLWithString:releaseNotesString relativeToURL:appcastURL];
             if ([url isFileURL]) {
                 SULog(SULogLevelError, @"Release notes with file:// URLs are not supported");
             } else {

--- a/Tests/Resources/test-relative-urls.xml
+++ b/Tests/Resources/test-relative-urls.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 3.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <sparkle:releaseNotesLink>notes/relnote-3.0.txt</sparkle:releaseNotesLink>
+        <enclosure url="release-3.0.zip" sparkle:version="3.0" length="1346234" />
+    </item>
+    <item>
+        <title>Version 2.0</title>
+        <description>desc</description>
+        <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+        <sparkle:version>2.0</sparkle:version>
+        <link>/info/info-2.0.txt</link>
+    </item>
+  </channel>
+</rss>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -17,7 +17,7 @@ class SUAppcastTest: XCTestCase {
         let testData = NSData(contentsOfFile: testFile)!
 
         do {
-            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data) as! [SUAppcastItem]
+            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data, relativeTo: nil) as! [SUAppcastItem]
 
             XCTAssertEqual(4, items.count)
 
@@ -72,7 +72,7 @@ class SUAppcastTest: XCTestCase {
         let testData = NSData(contentsOfFile: testFile)!
 
         do {
-            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data) as! [SUAppcastItem]
+            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data, relativeTo: nil) as! [SUAppcastItem]
 
             XCTAssertEqual(2, items.count)
 
@@ -80,6 +80,28 @@ class SUAppcastTest: XCTestCase {
             XCTAssertEqual("desc", items[1].itemDescription)
             XCTAssertNotNil(items[0].releaseNotesURL)
             XCTAssertEqual("https://sparkle-project.org/#works", items[0].releaseNotesURL!.absoluteString)
+        } catch let err as NSError {
+            NSLog("%@", err)
+            XCTFail(err.localizedDescription)
+        }
+    }
+
+    func testRelativeURLs() {
+        let appcast = SUAppcast()
+        let testFile = Bundle(for: SUAppcastTest.self).path(forResource: "test-relative-urls", ofType: "xml")!
+        let testData = NSData(contentsOfFile: testFile)!
+
+        do {
+            let baseURL = URL(string: "https://fake.sparkle-project.org/updates/index.xml")!
+            let items = try appcast.parseAppcastItems(fromXMLData: testData as Data, relativeTo: baseURL) as! [SUAppcastItem]
+
+            XCTAssertEqual(2, items.count)
+
+            XCTAssertEqual("https://fake.sparkle-project.org/updates/release-3.0.zip", items[0].fileURL?.absoluteString)
+            XCTAssertEqual("https://fake.sparkle-project.org/updates/notes/relnote-3.0.txt", items[0].releaseNotesURL?.absoluteString)
+
+            XCTAssertEqual("https://fake.sparkle-project.org/info/info-2.0.txt", items[1].infoURL?.absoluteString)
+
         } catch let err as NSError {
             NSLog("%@", err)
             XCTFail(err.localizedDescription)

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -41,7 +41,7 @@ static const char *SUAppleQuarantineIdentifier = "com.apple.quarantine";
 
 @interface SUAppcast (Private)
 
--(NSArray * _Nullable)parseAppcastItemsFromXMLData:(NSData *)appcastData error:(NSError *__autoreleasing*)errorp;
+-(nullable NSArray *)parseAppcastItemsFromXMLData:(NSData *)appcastData relativeToURL:(nullable NSURL *)appcastURL error:(NSError *__autoreleasing*)errorp;
 
 @end
 


### PR DESCRIPTION
The base URL is taken from the server response rather than from the original requested URL to account for redirects.