### PR TITLE
Fix casting Boolean to BOOL on Apple Silicon

### DIFF
--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
 	}
 	else
 	{
-        value = (BOOL)CFBooleanGetValue((CFBooleanRef)plr);
+        value = CFBooleanGetValue((CFBooleanRef)plr) ? YES : NO;
         CFRelease(plr);
     }
     return value;


### PR DESCRIPTION
This fixes the following error when compiling for Apple Silicon on Xcode 12:

> SUHost.m:231:23: Cast from function call of type 'Boolean' (aka 'unsigned char') to non-matching type 'BOOL' (aka 'bool')