### PR TITLE
feat: read SUFeedURL from env if not found in the plist

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -95,6 +95,8 @@ class ArchiveItem: CustomStringConvertible {
             var feedURL: URL?
             if let feedURLStr = infoPlist["SUFeedURL"] as? String {
                 feedURL = URL(string: feedURLStr)
+            } else if let envFeedURLStr = ProcessInfo.processInfo.environment["SUFeedURL"] {
+                feedURL = URL(string: envFeedURLStr);
             }
 
             try self.init(version: version,


### PR DESCRIPTION
Small extension to generate_appcast command.

Users can set feed url as env variable SUFeedURL, it will be used when the default SUFeedURL key cannot be found in the app Info.plist.

Motivation - more apps configure feed straight from code without using to the plist entry. On appcast generation 
when feed url cannot be found links in appcast xml are incomplete/broken (contain only a file name).
For such cases, user can specify feed url as env variable and get correct appcast xml on output.