### PR TITLE
Add dependencies to "Set Git Version Info" Run Script phase

### DIFF
--- a/Configurations/set-git-version-info.sh
+++ b/Configurations/set-git-version-info.sh
@@ -38,3 +38,6 @@ if [ "$version" != "$oldversion" ] ; then
     PlistBuddy -c "Set :CFBundleShortVersionString '$version'" \
         "$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH"
 fi
+
+mkdir -p "$DERIVED_FILE_DIR"
+touch "$DERIVED_FILE_DIR/set-git-version-info-stamp"

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -3082,9 +3082,13 @@
 			files = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/.git/logs/HEAD",
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			name = "Run Script: Set Git Version Info";
 			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+				"$(DERIVED_FILE_DIR)/set-git-version-info-stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
This keeps it from running when nothing's changed, which keeps Xcode from re-signing the framework when nothing's changed, which keeps downstream clients from re-copying the framework when nothing's changed.