### PR TITLE
fix: read SUAutomaticallyUpdate from Info.plist

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -482,7 +482,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     }
 
     // Otherwise, automatically downloading updates is allowed. Does the user want it?
-    return [self.host boolForUserDefaultsKey:SUAutomaticallyUpdateKey];
+    return [self.host boolForKey:SUAutomaticallyUpdateKey];
 }
 
 - (void)setFeedURL:(NSURL *)feedURL


### PR DESCRIPTION
`SUAutomaticallyUpdate` will now be read from `Info.plist` if it has not been set in `NSUserDefaults`. This brings the behavior into line with the documentation.