### PR TITLE
Add —release-notes-url-prefix to generate_appcast

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -48,6 +48,7 @@ class ArchiveItem: CustomStringConvertible {
     var dsaSignature: String?
     var edSignature: String?
     var downloadUrlPrefix: URL?
+    var releaseNotesURLPrefix: URL?
 
     init(version: String, shortVersion: String?, feedURL: URL?, minimumSystemVersion: String?, publicEdKey: String?, supportsDSA: Bool, appPath: URL, archivePath: URL) throws {
         self.version = version
@@ -188,7 +189,11 @@ class ArchiveItem: CustomStringConvertible {
         guard let escapedFilename = path.lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
             return nil
         }
-        if let relative = self.feedURL {
+        
+        if let releaseNotesURLPrefix = self.releaseNotesURLPrefix {
+            // If a URL prefix for release notes was passed on the command-line, use it
+            return URL(string: escapedFilename, relativeTo: releaseNotesURLPrefix)
+        } else if let relative = self.feedURL {
             return URL(string: escapedFilename, relativeTo: relative)
         }
         return URL(string: escapedFilename)


### PR DESCRIPTION
This is a PR for #1642 

Added a `—release-notes-url-prefix` argument to `generate_appcast` so that users can provide a prefix that will be used to construct the URL for the location of release notes.

(This commit is modeled after the fix for #1571, which introduced `--download-url-prefix`.)