### PR TITLE
Use angle-bracketed includes for all public framework headers

### DIFF
--- a/Sparkle/SPUDownloadData.h
+++ b/Sparkle/SPUDownloadData.h
@@ -12,7 +12,7 @@
 #import <Foundation/Foundation.h>
 #endif
 
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUDownloader.h
+++ b/Sparkle/SPUDownloader.h
@@ -11,7 +11,7 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SPUDownloaderProtocol.h"
+#import <Sparkle/SPUDownloaderProtocol.h>
 
 @protocol SPUDownloaderDelegate;
 

--- a/Sparkle/SPUDownloaderSession.h
+++ b/Sparkle/SPUDownloaderSession.h
@@ -11,8 +11,8 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SPUDownloader.h"
-#import "SPUDownloaderProtocol.h"
+#import <Sparkle/SPUDownloader.h>
+#import <Sparkle/SPUDownloaderProtocol.h>
 
 NS_CLASS_AVAILABLE(NSURLSESSION_AVAILABLE, 7_0)
 @interface SPUDownloaderSession : SPUDownloader <SPUDownloaderProtocol>

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -14,7 +14,7 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -14,7 +14,7 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 @class SUSignatures;
 
 SU_EXPORT @interface SUAppcastItem : NSObject

--- a/Sparkle/SUCodeSigningVerifier.h
+++ b/Sparkle/SUCodeSigningVerifier.h
@@ -14,7 +14,7 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 
 SU_EXPORT @interface SUCodeSigningVerifier : NSObject
 + (BOOL)codeSignatureAtBundleURL:(NSURL *)oldBundlePath matchesSignatureAtBundleURL:(NSURL *)newBundlePath error:(NSError  **)error;

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -14,7 +14,7 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 
 /**
  * Error domain used by Sparkle

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -7,9 +7,10 @@
 //
 
 #import "SUFileManager.h"
-#import "SUErrors.h"
 #import "SUOperatingSystem.h"
 #import "SUFileOperationConstants.h"
+
+#import <Sparkle/SUErrors.h>
 
 #include <sys/xattr.h>
 #include <sys/errno.h>

--- a/Sparkle/SUStandardVersionComparator.h
+++ b/Sparkle/SUStandardVersionComparator.h
@@ -14,8 +14,8 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SUExport.h"
-#import "SUVersionComparisonProtocol.h"
+#import <Sparkle/SUExport.h>
+#import <Sparkle/SUVersionComparisonProtocol.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -14,9 +14,9 @@
 #else
 #import <Cocoa/Cocoa.h>
 #endif
-#import "SUExport.h"
-#import "SUVersionComparisonProtocol.h"
-#import "SUVersionDisplayProtocol.h"
+#import <Sparkle/SUExport.h>
+#import <Sparkle/SUVersionComparisonProtocol.h>
+#import <Sparkle/SUVersionDisplayProtocol.h>
 
 @class SUAppcastItem, SUAppcast;
 

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -12,7 +12,7 @@
 #import <Foundation/Foundation.h>
 #endif
 
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 
 @protocol SUVersionComparison, SUVersionDisplay;
 @class SUUpdater, SUAppcast, SUAppcastItem;

--- a/Sparkle/SUVersionDisplayProtocol.h
+++ b/Sparkle/SUVersionDisplayProtocol.h
@@ -11,7 +11,7 @@
 #else
 #import <Foundation/Foundation.h>
 #endif
-#import "SUExport.h"
+#import <Sparkle/SUExport.h>
 
 /*!
     Applies special display formatting to version numbers.

--- a/Sparkle/Sparkle.h
+++ b/Sparkle/Sparkle.h
@@ -12,22 +12,22 @@
 // This list should include the shared headers. It doesn't matter if some of them aren't shared (unless
 // there are name-space collisions) so we can list all of them to start with:
 
-#import "SUAppcast.h"
-#import "SUAppcastItem.h"
-#import "SUStandardVersionComparator.h"
-#import "SUUpdater.h"
-#import "SUUpdaterDelegate.h"
-#import "SUVersionComparisonProtocol.h"
-#import "SUVersionDisplayProtocol.h"
-#import "SUErrors.h"
+#import <Sparkle/SUAppcast.h>
+#import <Sparkle/SUAppcastItem.h>
+#import <Sparkle/SUStandardVersionComparator.h>
+#import <Sparkle/SUUpdater.h>
+#import <Sparkle/SUUpdaterDelegate.h>
+#import <Sparkle/SUVersionComparisonProtocol.h>
+#import <Sparkle/SUVersionDisplayProtocol.h>
+#import <Sparkle/SUErrors.h>
 
-#import "SPUDownloader.h"
-#import "SPUDownloaderDelegate.h"
-#import "SPUDownloaderDeprecated.h"
-#import "SPUDownloadData.h"
-#import "SPUDownloaderProtocol.h"
-#import "SPUDownloaderSession.h"
-#import "SPUURLRequest.h"
-#import "SUCodeSigningVerifier.h"
+#import <Sparkle/SPUDownloader.h>
+#import <Sparkle/SPUDownloaderDelegate.h>
+#import <Sparkle/SPUDownloaderDeprecated.h>
+#import <Sparkle/SPUDownloadData.h>
+#import <Sparkle/SPUDownloaderProtocol.h>
+#import <Sparkle/SPUDownloaderSession.h>
+#import <Sparkle/SPUURLRequest.h>
+#import <Sparkle/SUCodeSigningVerifier.h>
 
 #endif


### PR DESCRIPTION
Xcode 12  now suggests turning on [CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER](https://xcodebuildsettings.com/#clang_warn_quoted_include_in_framework_header) which ends up producing warnings in projects which import the Sparkle headers. The Xcode setting corresponds to `-Wquoted-include-in-framework-header`.

This PR fixes all the includes in the public framework headers, so that no such warnings are emitted anymore. Sparkle continues to build without any issues after the change.