### PR TITLE
Feature 1646 generate appcast output filename

### DIFF
--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -89,7 +89,7 @@ func loadPrivateKeys(_ privateDSAKey: SecKey?, _ privateEdString: String?) -> Pr
 }
 
 /**
- * Parses all possible command line options and returns a dictionary that contains them
+ * Parses all possible command line options and returns a struct that contains them
  */
 func parseCommandLineOptions() -> CommandLineArguments {
     var arguments = CommandLine.arguments


### PR DESCRIPTION
This is a PR for #1646 

Added a `-o /path/to/file.xml` command line option that directs `generate_appcast` to save a single appcast to the given location.

If this option isn't specified, then `generate_appcast` falls back to its current behavior: the appcast(s) are written to the archive folder. Furthermore, as discussed in the issue, `generate_appcast` will error out if `-o` is specified and multiple appcasts would have been generated.

In addition, this PR contains a commit that adds a CommandLineArgs struct. This should make it slightly cleaner to add new args in the future – at least until `generate_appcast` gets a new arg parser.