### PR TITLE
generate_appcast follow symbolic links

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -63,7 +63,8 @@ class ArchiveItem: CustomStringConvertible {
         } else {
             self.publicEdKey = nil
         }
-        self.archiveFileAttributes = try FileManager.default.attributesOfItem(atPath: self.archivePath.path)
+        let path = (self.archivePath.path as NSString).resolvingSymlinksInPath
+        self.archiveFileAttributes = try FileManager.default.attributesOfItem(atPath: path)
         self.deltas = []
     }
 


### PR DESCRIPTION
When archives are stored as symlinks e.g. due to storing binary files in a
git-annex repository, everything works file except file size in the generate
feed xml file. This patch makes generate_appcast correctly determine file size
by following the symlink