### PR TITLE
Corrected hyphenation for 'already current' status message (Fixes #1466)

### DIFF
--- a/Sparkle/en.lproj/Sparkle.strings
+++ b/Sparkle/en.lproj/Sparkle.strings
@@ -94,4 +94,4 @@
 "You already have the newest version of %@." = "You already have the newest version of %@.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You're up-to-date!" = "You’re up-to-date!";
+"You're up-to-date!" = "You’re up to date!";


### PR DESCRIPTION
(Coincidentally, exactly a year to the day since @ryanfrancesconi opened #1466)
<hr>

Ryan is correct here.

'Up-to-date' (hyphenated) is an attributive compound adjective:
> _"Experts recommend using up-to-date software."_

Whereas 'up to date' (unhyphenated) is a predicative compound adjective:
> _"Experts recommend keeping software up to date."_

We should be using the latter in this instance:
> _"You're up to date!"_