### PR TITLE
Merge generate_appcast updates from 1.x branch to 2.x branch

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -479,7 +479,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 {
     NSURL *requestURL = request.URL;
     NSString *scheme = requestURL.scheme;
-    BOOL whitelistedSafe = [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"] || [requestURL.absoluteString isEqualToString:@"about:blank"];
+    BOOL isAboutBlank = [requestURL.absoluteString isEqualToString:@"about:blank"];
+    BOOL whitelistedSafe = isAboutBlank || [@[@"http", @"https", @"macappstore", @"macappstores", @"itms-apps", @"itms-appss"] containsObject:scheme];
 
     // Do not allow redirects to dangerous protocols such as file://
     if (!whitelistedSafe) {

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -74,7 +74,8 @@ class SUAppcastTest: XCTestCase {
         XCTAssertNotNil(testFileUrl)
 
          do {
-            let items = try appcast.parseAppcastItems(fromXMLFile: testFileUrl) as! [SUAppcastItem];
+            let testFileData = try Data(contentsOf: testFileUrl)
+            let items = try appcast.parseAppcastItems(fromXMLData: testFileData, relativeTo: testFileUrl) as! [SUAppcastItem];
             XCTAssertEqual("https://sparkle-project.org/#localized_notes_link_works", items[0].releaseNotesURL.absoluteString)
         } catch let err as NSError {
             NSLog("%@", err)

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -48,6 +48,7 @@ class ArchiveItem: CustomStringConvertible {
     var dsaSignature: String?
     var edSignature: String?
     var downloadUrlPrefix: URL?
+    var releaseNotesURLPrefix: URL?
 
     init(version: String, shortVersion: String?, feedURL: URL?, minimumSystemVersion: String?, publicEdKey: String?, supportsDSA: Bool, appPath: URL, archivePath: URL) throws {
         self.version = version
@@ -188,7 +189,11 @@ class ArchiveItem: CustomStringConvertible {
         guard let escapedFilename = path.lastPathComponent.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
             return nil
         }
-        if let relative = self.feedURL {
+        
+        if let releaseNotesURLPrefix = self.releaseNotesURLPrefix {
+            // If a URL prefix for release notes was passed on the command-line, use it
+            return URL(string: escapedFilename, relativeTo: releaseNotesURLPrefix)
+        } else if let relative = self.feedURL {
             return URL(string: escapedFilename, relativeTo: relative)
         }
         return URL(string: escapedFilename)

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -63,7 +63,8 @@ class ArchiveItem: CustomStringConvertible {
         } else {
             self.publicEdKey = nil
         }
-        self.archiveFileAttributes = try FileManager.default.attributesOfItem(atPath: self.archivePath.path)
+        let path = (self.archivePath.path as NSString).resolvingSymlinksInPath
+        self.archiveFileAttributes = try FileManager.default.attributesOfItem(atPath: path)
         self.deltas = []
     }
 

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -108,16 +108,24 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         }
         minVer?.setChildren([text(update.minimumSystemVersion)])
 
+        // Look for an existing release notes element
         let releaseNotesXpath = "\(SUAppcastElementReleaseNotesLink)"
         let results = ((try? item.nodes(forXPath: releaseNotesXpath)) as? [XMLElement])?
             .filter { !($0.attributes ?? [])
             .contains(where: { $0.name == SUXMLLanguage }) }
         let relElement = results?.first
+        
         if let url = update.releaseNotesURL {
-            if nil == relElement {
+            // The update includes a valid release notes URL
+            if let existingReleaseNotesElement = relElement {
+                // The existing item includes a release notes element. Update it.
+                existingReleaseNotesElement.stringValue = url.absoluteString
+            } else {
+                // The existing item doesn't have a release notes element. Add one.
                 item.addChild(XMLElement.element(withName: SUAppcastElementReleaseNotesLink, stringValue: url.absoluteString) as! XMLElement)
             }
         } else if let childIndex = relElement?.index {
+            // The update doesn't include a release notes URL. Remove it.
             item.removeChild(at: childIndex)
         }
 

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -10,33 +10,45 @@ import Foundation
 
 var verbose = false
 
-func printUsage() {
-    let command = URL(fileURLWithPath: CommandLine.arguments.first!).lastPathComponent
-    print("Generate appcast from a directory of Sparkle update archives\n",
-          "Usage:\n",
-          "      \(command) <directory with update files>\n",
-        " e.g. \(command) ./my-app-release-zipfiles/\n",
-        "\nOR for old apps that have a DSA keys (deprecated):\n",
-        "      \(command) <private DSA key path> <directory with update files>\n",
-        " e.g. \(command) dsa_priv.pem archives/\n",
-        "\n",
-        "Appcast files and deltas will be written to the archives directory.\n",
-        "Note that pkg-based updates are not supported.\n"
-    )
+// Enum that contains keys for command-line arguments
+struct CommandLineArguments {
+    var privateDSAKey : SecKey?
+    var privateEdString : String?
+    var downloadURLPrefix : URL?
+    var releaseNotesURLPrefix: URL?
+    var outputPathURL: URL?
+    var archivesSourceDir: URL?
 }
 
-func printHelp() {
+func printUsage() {
     let command = URL(fileURLWithPath: CommandLine.arguments.first!).lastPathComponent
-    print(
-        "Usage: \(command) [OPTIONS] [ARCHIVES_FOLDER]\n",
-        "Options:\n",
-        "\t-f: provide the path to the private DSA key\n",
-        "\t-n: provide the name of the private DSA key. This option has to be used together with `-k`\n",
-        "\t-k: provide the name of the keychain. This option has to be used together with `-n`\n",
-        "\t-s: provide the path to the private EdDSA key\n",
-        "\t--download-url-prefix: provide a prefix used to construct URLs for update downloads\n",
-        "\t--release-notes-url-prefix: provide a prefix used to construct URLs for release notes\n"
-    )
+    let usage = """
+
+Generate appcast from a directory of Sparkle update archives
+
+Usage: \(command) [OPTIONS] [ARCHIVES_FOLDER]
+    -h: prints this message
+    -f: provide the path to the private DSA key
+    -n: provide the name of the private DSA key. This option must be used with `-k`
+    -k: provide the name of the keychain. This option must be used with `-n`
+    -s: provide the path to the private EdDSA key
+    -o: provide a filename for the generated appcast (allowed when only one will be created)
+    
+    --download-url-prefix: provide a prefix used to construct URLs for update downloads
+    --release-notes-url-prefix: provide a prefix used to construct URLs for release notes
+    
+Examples:
+    \(command) ./my-app-release-zipfiles/
+    \(command) -o appcast-name.xml ./my-app-release-zipfiles/
+    
+    \(command) dsa_priv.pem ./my-app-release-zipfiles/ [DEPRECATED]
+
+Appcast files and deltas will be written to the archives directory.
+Note that pkg-based updates are not supported.
+
+"""
+    
+    print(usage)
 }
 
 func loadPrivateKeys(_ privateDSAKey: SecKey?, _ privateEdString: String?) -> PrivateKeys {
@@ -77,26 +89,24 @@ func loadPrivateKeys(_ privateDSAKey: SecKey?, _ privateEdString: String?) -> Pr
 }
 
 /**
- * Parses all possible command line options and returns the values in a tuple.
+ * Parses all possible command line options and returns a struct that contains them
  */
-func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?, privateEdString: String?, downloadUrlPrefix: URL?, releaseNotesURLPrefix: URL?, archivesSourceDir: URL) {
-    // if the option `-h` is in the argument list print the help dialog
-    if argumentList.contains("-h") {
-        printHelp()
+func parseCommandLineOptions() -> CommandLineArguments {
+    var arguments = CommandLine.arguments
+    
+    // If there are fewer than two arguments (the name of the application +
+    // the required archive directory), or if `-h` is in the argument list,
+    // then show the usage message
+    if arguments.count < 2  || arguments.contains("-h") {
+        printUsage()
         exit(1)
     }
-
-    // make a mutable copy of the argument list
-    var arguments = argumentList
-    // remove the first element since this is the path to executable which we don't need
+    
+    // Remove the first element since this is the path to executable which we don't need
     arguments.removeFirst()
 
-    // define the variables for the possible argument values
-    var privateDSAKey: SecKey?
-    var privateEdString: String?
-    var downloadUrlPrefix: URL?
-    var releaseNotesURLPrefix: URL?
-    var archivesSourceDir: URL
+    // Create the struct that will hold the parsed args
+    var commandLineArguments = CommandLineArguments()
 
     // check if the private dsa key option is present
     if let privateDSAKeyOptionIndex = arguments.firstIndex(of: "-f") {
@@ -109,7 +119,7 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
         // get the private DSA key
         let privateKeyUrl = URL(fileURLWithPath: arguments[privateDSAKeyOptionIndex + 1])
         do {
-            privateDSAKey = try loadPrivateDSAKey(at: privateKeyUrl)
+            commandLineArguments.privateDSAKey = try loadPrivateDSAKey(at: privateKeyUrl)
         } catch {
             print("Unable to load DSA private key from", privateKeyUrl.path, "\n", error)
             exit(1)
@@ -132,7 +142,7 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
         let keyName: String = arguments[keyNameOptionIndex + 1]
         let keychainUrl: URL = URL(fileURLWithPath: arguments[keychainNameOptionIndex + 1])
         do {
-            privateDSAKey = try loadPrivateDSAKey(named: keyName, fromKeychainAt: keychainUrl)
+            commandLineArguments.privateDSAKey = try loadPrivateDSAKey(named: keyName, fromKeychainAt: keychainUrl)
         } catch {
             print("Unable to load DSA private key '\(keyName)' from keychain at", keychainUrl.path, "\n", error)
             exit(1)
@@ -154,7 +164,7 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
         }
 
         // get the private EdDSA key string
-        privateEdString = arguments[privateEdDSAKeyOptionIndex + 1]
+        commandLineArguments.privateEdString = arguments[privateEdDSAKeyOptionIndex + 1]
 
         // remove the already parsed argument
         arguments.remove(at: privateEdDSAKeyOptionIndex + 1)
@@ -170,7 +180,7 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
         }
 
         // get the download url prefix
-        downloadUrlPrefix = URL(string: arguments[downloadUrlPrefixOptionIndex + 1])
+        commandLineArguments.downloadURLPrefix = URL(string: arguments[downloadUrlPrefixOptionIndex + 1])
 
         // remove the parsed argument
         arguments.remove(at: downloadUrlPrefixOptionIndex + 1)
@@ -180,16 +190,32 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
     // Check if a URL prefix was specified for the release notes
     if let releaseNotesURLPrefixOptionIndex = arguments.firstIndex(of: "--release-notes-url-prefix") {
         if releaseNotesURLPrefixOptionIndex + 1 >= arguments.count {
-            print("Foo few arguments were given")
+            print("Too few arguments were given")
             exit(1)
         }
         
         // Get the URL prefix for the release notes
-        releaseNotesURLPrefix = URL(string: arguments[releaseNotesURLPrefixOptionIndex + 1])
+        commandLineArguments.releaseNotesURLPrefix = URL(string: arguments[releaseNotesURLPrefixOptionIndex + 1])
         
         // Remove the parsed argument
         arguments.remove(at: releaseNotesURLPrefixOptionIndex + 1)
         arguments.remove(at: releaseNotesURLPrefixOptionIndex)
+    }
+    
+    // Check if an output filename was specified
+    if let outputFilenameOptionIndex = arguments.firstIndex(of: "-o") {
+        // check that when accessing the value of the option we don't get out of bounds
+        if outputFilenameOptionIndex + 1 >= arguments.count {
+            print("Too few arguments were given")
+            exit(1)
+        }
+        
+        // Get the URL prefix for the release notes
+        commandLineArguments.outputPathURL = URL(fileURLWithPath: arguments[outputFilenameOptionIndex + 1])
+        
+        // Remove the parsed argument
+        arguments.remove(at: outputFilenameOptionIndex + 1)
+        arguments.remove(at: outputFilenameOptionIndex)
     }
 
     // now that all command line options have been removed from the arguments array
@@ -197,11 +223,11 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
     if arguments.count == 2 {
         // if there are two arguments left they are the private DSA key and the path to the archives directory (in this order)
         // first get the private DSA key
-        let privateKeyUrl = URL(fileURLWithPath: arguments[0])
+        let privateKeyURL = URL(fileURLWithPath: arguments[0])
         do {
-            privateDSAKey = try loadPrivateDSAKey(at: privateKeyUrl)
+            commandLineArguments.privateDSAKey = try loadPrivateDSAKey(at: privateKeyURL)
         } catch {
-            print("Unable to load DSA private key from", privateKeyUrl.path, "\n", error)
+            print("Unable to load DSA private key from", privateKeyURL.path, "\n", error)
             exit(1)
         }
 
@@ -210,49 +236,64 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
     }
 
     // now only the archives source dir is left
-    archivesSourceDir = URL(fileURLWithPath: arguments[0], isDirectory: true)
+    if let archivesSourceDir = arguments.first {
+        commandLineArguments.archivesSourceDir = URL(fileURLWithPath: archivesSourceDir, isDirectory: true)
+    } else {
+        print("Archive folder must be specified")
+        exit(1);
+    }
 
-    return (privateDSAKey, privateEdString, downloadUrlPrefix, releaseNotesURLPrefix, archivesSourceDir)
+    return commandLineArguments
 }
 
 func main() {
-    let args = CommandLine.arguments
-    if args.count < 2 {
-        printUsage()
-        exit(1)
-    }
-
-    var privateDSAKey: SecKey?
-    var privateEdString: String?
-    var downloadUrlPrefix: URL?
-    var releaseNotesURLPrefix: URL?
-    var archivesSourceDir: URL
-
-    (privateDSAKey, privateEdString, downloadUrlPrefix, releaseNotesURLPrefix, archivesSourceDir) = parseCommandLineOptions(argumentList: args)
-
-    let keys = loadPrivateKeys(privateDSAKey, privateEdString)
-
+    // Parse the command line arguments
+    let args = parseCommandLineOptions()
+    
+    // If parsing the command line options was successful, then
+    // the archivesSourceDir must exist
+    let archivesSourceDir = args.archivesSourceDir!
+    
+    // Extract the keys
+    let keys = loadPrivateKeys(args.privateDSAKey, args.privateEdString)
+    
     do {
         let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, keys: keys, verbose: verbose)
 
         // If a URL prefix was provided, set on the archive items
-        if downloadUrlPrefix != nil || releaseNotesURLPrefix != nil {
+        if args.downloadURLPrefix != nil || args.releaseNotesURLPrefix != nil {
             for (_, archiveItems) in allUpdates {
                 for archiveItem in archiveItems {
-                    if downloadUrlPrefix != nil {
-                        archiveItem.downloadUrlPrefix = downloadUrlPrefix
+                    if let downloadURLPrefix = args.downloadURLPrefix {
+                        archiveItem.downloadUrlPrefix = downloadURLPrefix
                     }
-                    if releaseNotesURLPrefix != nil {
+                    if let releaseNotesURLPrefix = args.releaseNotesURLPrefix {
                         archiveItem.releaseNotesURLPrefix = releaseNotesURLPrefix
                     }
                 }
             }
         }
 
+        // If a (single) output filename was specified on the command-line, but more than one
+        // appcast file was found in the archives, then it's an error.
+        if let outputPathURL = args.outputPathURL,
+            allUpdates.count > 1 {
+            print("Cannot write to \(outputPathURL.path): multiple appcasts found")
+            exit(1);
+        }
+        
         for (appcastFile, updates) in allUpdates {
-            let appcastDestPath = URL(fileURLWithPath: appcastFile, relativeTo: archivesSourceDir)
+            // If an output filename was specified, use it.
+            // Otherwise, use the name of the appcast file found in the archive.
+            let appcastDestPath = args.outputPathURL ?? URL(fileURLWithPath: appcastFile,
+                                                            relativeTo: archivesSourceDir)
+            
+            // Write the appcast
             try writeAppcast(appcastDestPath: appcastDestPath, updates: updates)
-            print("Written", appcastDestPath.path, "based on", updates.count, "updates")
+            
+            // Inform the user, pluralizing "update" if necessary
+            let updateString = (updates.count == 1) ? "update" : "updates"
+            print("Wrote \(updates.count) \(updateString) to: \(appcastDestPath.path)")
         }
     } catch {
         print("Error generating appcast from directory", archivesSourceDir.path, "\n", error)

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -34,7 +34,8 @@ func printHelp() {
         "\t-n: provide the name of the private DSA key. This option has to be used together with `-k`\n",
         "\t-k: provide the name of the keychain. This option has to be used together with `-n`\n",
         "\t-s: provide the path to the private EdDSA key\n",
-        "\t--download-url-prefix: provide a static url that will be used as prefix for the url from where updates will be downloaded\n"
+        "\t--download-url-prefix: provide a prefix used to construct URLs for update downloads\n",
+        "\t--release-notes-url-prefix: provide a prefix used to construct URLs for release notes\n"
     )
 }
 
@@ -75,7 +76,10 @@ func loadPrivateKeys(_ privateDSAKey: SecKey?, _ privateEdString: String?) -> Pr
     return PrivateKeys(privateDSAKey: privateDSAKey, privateEdKey: privateEdKey, publicEdKey: publicEdKey)
 }
 
-func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?, privateEdString: String?, downloadUrlPrefix: URL?, archivesSourceDir: URL) {
+/**
+ * Parses all possible command line options and returns the values in a tuple.
+ */
+func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?, privateEdString: String?, downloadUrlPrefix: URL?, releaseNotesURLPrefix: URL?, archivesSourceDir: URL) {
     // if the option `-h` is in the argument list print the help dialog
     if argumentList.contains("-h") {
         printHelp()
@@ -91,6 +95,7 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
     var privateDSAKey: SecKey?
     var privateEdString: String?
     var downloadUrlPrefix: URL?
+    var releaseNotesURLPrefix: URL?
     var archivesSourceDir: URL
 
     // check if the private dsa key option is present
@@ -171,6 +176,21 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
         arguments.remove(at: downloadUrlPrefixOptionIndex + 1)
         arguments.remove(at: downloadUrlPrefixOptionIndex)
     }
+    
+    // Check if a URL prefix was specified for the release notes
+    if let releaseNotesURLPrefixOptionIndex = arguments.firstIndex(of: "--release-notes-url-prefix") {
+        if releaseNotesURLPrefixOptionIndex + 1 >= arguments.count {
+            print("Foo few arguments were given")
+            exit(1)
+        }
+        
+        // Get the URL prefix for the release notes
+        releaseNotesURLPrefix = URL(string: arguments[releaseNotesURLPrefixOptionIndex + 1])
+        
+        // Remove the parsed argument
+        arguments.remove(at: releaseNotesURLPrefixOptionIndex + 1)
+        arguments.remove(at: releaseNotesURLPrefixOptionIndex)
+    }
 
     // now that all command line options have been removed from the arguments array
     // there should only be the path to the private DSA key (if provided) path to the archives dir left
@@ -192,7 +212,7 @@ func parseCommandLineOptions(argumentList: [String]) -> (privateDSAKey: SecKey?,
     // now only the archives source dir is left
     archivesSourceDir = URL(fileURLWithPath: arguments[0], isDirectory: true)
 
-    return (privateDSAKey, privateEdString, downloadUrlPrefix, archivesSourceDir)
+    return (privateDSAKey, privateEdString, downloadUrlPrefix, releaseNotesURLPrefix, archivesSourceDir)
 }
 
 func main() {
@@ -205,20 +225,26 @@ func main() {
     var privateDSAKey: SecKey?
     var privateEdString: String?
     var downloadUrlPrefix: URL?
+    var releaseNotesURLPrefix: URL?
     var archivesSourceDir: URL
 
-    (privateDSAKey, privateEdString, downloadUrlPrefix, archivesSourceDir) = parseCommandLineOptions(argumentList: args)
+    (privateDSAKey, privateEdString, downloadUrlPrefix, releaseNotesURLPrefix, archivesSourceDir) = parseCommandLineOptions(argumentList: args)
 
     let keys = loadPrivateKeys(privateDSAKey, privateEdString)
 
     do {
         let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, keys: keys, verbose: verbose)
 
-        // if a download url prefix was provided set it for each archive item
-        if downloadUrlPrefix != nil {
+        // If a URL prefix was provided, set on the archive items
+        if downloadUrlPrefix != nil || releaseNotesURLPrefix != nil {
             for (_, archiveItems) in allUpdates {
                 for archiveItem in archiveItems {
-                    archiveItem.downloadUrlPrefix = downloadUrlPrefix
+                    if downloadUrlPrefix != nil {
+                        archiveItem.downloadUrlPrefix = downloadUrlPrefix
+                    }
+                    if releaseNotesURLPrefix != nil {
+                        archiveItem.releaseNotesURLPrefix = releaseNotesURLPrefix
+                    }
                 }
             }
         }


### PR DESCRIPTION
The following changes have been brought forward from `master`:

- Adds `--release-notes-url-prefix`
- Adds `-o` flag (plus improved usage info)
- Webview for release notes accepts `macappstore`, `macappstores`, `itms-apps`, and `itms-appss` URL schemes
- `generate_appcast` follows symlinks