### PR TITLE
Fix framework header includes by using double quotes and suppressing warnings (2.x)

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -21,7 +21,7 @@
 #import "SUFileManager.h"
 #import "SPUInstallationInfo.h"
 #import "SUAppcastItem.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SUInstallerCommunicationProtocol.h"
 #import "AgentConnection.h"
 #import "SPUInstallerAgentProtocol.h"

--- a/Autoupdate/SUGuidedPackageInstaller.m
+++ b/Autoupdate/SUGuidedPackageInstaller.m
@@ -8,7 +8,7 @@
 
 #import <sys/stat.h>
 #import "SUGuidedPackageInstaller.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"

--- a/Autoupdate/SUInstaller.m
+++ b/Autoupdate/SUInstaller.m
@@ -13,7 +13,7 @@
 #import "SUHost.h"
 #import "SUConstants.h"
 #import "SULog.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SPUInstallationType.h"
 
 

--- a/Autoupdate/SUPackageInstaller.m
+++ b/Autoupdate/SUPackageInstaller.m
@@ -8,7 +8,7 @@
 
 #import "SUPackageInstaller.h"
 #import "SUConstants.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SULog.h"
 
 

--- a/Autoupdate/SUPipedUnarchiver.m
+++ b/Autoupdate/SUPipedUnarchiver.m
@@ -9,7 +9,7 @@
 #import "SUPipedUnarchiver.h"
 #import "SUUnarchiverNotifier.h"
 #import "SULog.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"

--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -11,8 +11,8 @@
 #import "SUConstants.h"
 #import "SUHost.h"
 #import "SULog.h"
-#import <Sparkle/SUErrors.h>
-#import <Sparkle/SUVersionComparisonProtocol.h>
+#import "SUErrors.h"
+#import "SUVersionComparisonProtocol.h"
 #import "SUStandardVersionComparator.h"
 
 

--- a/Autoupdate/SUUnarchiverNotifier.m
+++ b/Autoupdate/SUUnarchiverNotifier.m
@@ -8,7 +8,7 @@
 
 #import "SUUnarchiverNotifier.h"
 #import "SULocalizations.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -62,7 +62,7 @@ CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES
 CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
 CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = YES
 CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES
-CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO
 CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
 CLANG_WARN_UNREACHABLE_CODE = YES
 GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES
@@ -93,4 +93,4 @@ GCC_WARN_UNUSED_VARIABLE = YES
 WARNING_CFLAGS_EXTRA = -Wno-custom-atomic-properties -Wno-implicit-atomic-properties
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-quoted-include-in-framework-header $(WARNING_CFLAGS_EXTRA)
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso $(WARNING_CFLAGS_EXTRA)

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -93,4 +93,4 @@ GCC_WARN_UNUSED_VARIABLE = YES
 WARNING_CFLAGS_EXTRA = -Wno-custom-atomic-properties -Wno-implicit-atomic-properties
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso $(WARNING_CFLAGS_EXTRA)
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-quoted-include-in-framework-header $(WARNING_CFLAGS_EXTRA)

--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -10,8 +10,8 @@
 #import "SPUDownloaderDelegate.h"
 #import "SPULocalCacheDirectory.h"
 #import "SPUURLRequest.h"
-#import <Sparkle/SPUDownloadData.h>
-#import <Sparkle/SUErrors.h>
+#import "SPUDownloadData.h"
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -9,12 +9,12 @@
 #import "SPUAutomaticUpdateDriver.h"
 #import "SPUUpdateDriver.h"
 #import "SUHost.h"
-#import <Sparkle/SPUUpdaterDelegate.h>
+#import "SPUUpdaterDelegate.h"
 #import "SPUCoreBasedUpdateDriver.h"
 #import "SULog.h"
 #import "SUAppcastItem.h"
-#import <Sparkle/SPUUserDriver.h>
-#import <Sparkle/SUErrors.h>
+#import "SPUUserDriver.h"
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -8,8 +8,8 @@
 
 #import "SPUBasicUpdateDriver.h"
 #import "SUAppcastDriver.h"
-#import <Sparkle/SPUUpdaterDelegate.h>
-#import <Sparkle/SUErrors.h>
+#import "SPUUpdaterDelegate.h"
+#import "SUErrors.h"
 #import "SULog.h"
 #import "SULocalizations.h"
 #import "SUHost.h"

--- a/Sparkle/SPUCoreBasedUpdateDriver.h
+++ b/Sparkle/SPUCoreBasedUpdateDriver.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SPUStatusCompletionResults.h>
+#import "SPUStatusCompletionResults.h"
 #import "SPUUpdateDriver.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -13,7 +13,7 @@
 #import "SPUInstallerDriver.h"
 #import "SPUDownloadDriver.h"
 #import "SULog.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SPUResumableUpdate.h"
 #import "SPUDownloadedUpdate.h"
 #import "SPUInformationalUpdate.h"

--- a/Sparkle/SPUDownloadData.h
+++ b/Sparkle/SPUDownloadData.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUDownloadData.m
+++ b/Sparkle/SPUDownloadData.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import <Sparkle/SPUDownloadData.h>
+#import "SPUDownloadData.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -10,15 +10,15 @@
 #import "SPUDownloaderDelegate.h"
 #import "SPUDownloader.h"
 #import "SPUXPCServiceInfo.h"
-#import <Sparkle/SUAppcastItem.h>
+#import "SUAppcastItem.h"
 #import "SUFileManager.h"
 #import "SULocalizations.h"
 #import "SUHost.h"
 #import "SULog.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SPUURLRequest.h"
 #import "SPUDownloadedUpdate.h"
-#import <Sparkle/SPUDownloadData.h>
+#import "SPUDownloadData.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -10,11 +10,11 @@
 #import "SULog.h"
 #import "SPUMessageTypes.h"
 #import "SPUXPCServiceInfo.h"
-#import <Sparkle/SPUUpdaterDelegate.h>
+#import "SPUUpdaterDelegate.h"
 #import "SUAppcastItem.h"
 #import "SULog.h"
 #import "SULocalizations.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SUHost.h"
 #import "SUFileManager.h"
 #import "SPUSecureCoding.h"

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -8,9 +8,9 @@
 
 #import "SPUScheduledUpdateDriver.h"
 #import "SUHost.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SPUUpdaterDelegate.h"
-#import <Sparkle/SPUUserDriver.h>
+#import "SPUUserDriver.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -7,7 +7,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -9,7 +9,7 @@
 #import "SPUStandardUpdaterController.h"
 #import "SPUUpdater.h"
 #import "SUHost.h"
-#import <Sparkle/SPUStandardUserDriver.h>
+#import "SPUStandardUserDriver.h"
 #import "SUConstants.h"
 #import "SULog.h"
 

--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -7,9 +7,9 @@
 //
 
 #import <Cocoa/Cocoa.h>
-#import <Sparkle/SPUUserDriver.h>
-#import <Sparkle/SPUStandardUserDriverProtocol.h>
-#import <Sparkle/SUExport.h>
+#import "SPUUserDriver.h"
+#import "SPUStandardUserDriverProtocol.h"
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -6,11 +6,11 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import <Sparkle/SPUStandardUserDriver.h>
-#import <Sparkle/SPUUserDriverCoreComponent.h>
-#import <Sparkle/SPUStandardUserDriverDelegate.h>
+#import "SPUStandardUserDriver.h"
+#import "SPUUserDriverCoreComponent.h"
+#import "SPUStandardUserDriverDelegate.h"
 #import "SUAppcastItem.h"
-#import <Sparkle/SUVersionDisplayProtocol.h>
+#import "SUVersionDisplayProtocol.h"
 #import "SUHost.h"
 #import "SUUpdatePermissionPrompt.h"
 #import "SUStatusController.h"

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 @protocol SUVersionDisplay;
 

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -8,14 +8,14 @@
 
 #import "SPUUIBasedUpdateDriver.h"
 #import "SPUCoreBasedUpdateDriver.h"
-#import <Sparkle/SPUUserDriver.h>
+#import "SPUUserDriver.h"
 #import "SUHost.h"
 #import "SUConstants.h"
 #import "SPUUpdaterDelegate.h"
 #import "SUAppcastItem.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SPUURLDownload.h"
-#import <Sparkle/SPUDownloadData.h>
+#import "SPUDownloadData.h"
 #import "SPUResumableUpdate.h"
 
 

--- a/Sparkle/SPUURLDownload.m
+++ b/Sparkle/SPUURLDownload.m
@@ -9,11 +9,11 @@
 #import "SPUURLDownload.h"
 #import "SPUXPCServiceInfo.h"
 #import "SPUURLRequest.h"
-#import <Sparkle/SPUDownloadData.h>
+#import "SPUDownloadData.h"
 #import "SPUDownloaderProtocol.h"
 #import "SPUDownloaderDelegate.h"
 #import "SPUDownloader.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUUpdatePermissionRequest.h
+++ b/Sparkle/SPUUpdatePermissionRequest.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUUpdatePermissionRequest.m
+++ b/Sparkle/SPUUpdatePermissionRequest.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import <Sparkle/SPUUpdatePermissionRequest.h>
+#import "SPUUpdatePermissionRequest.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
-#import <Sparkle/SPUUserDriver.h>
+#import "SUExport.h"
+#import "SPUUserDriver.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -6,12 +6,12 @@
 //  Copyright 2006 Andy Matuschak. All rights reserved.
 //
 
-#import <Sparkle/SPUUpdater.h>
+#import "SPUUpdater.h"
 #import "SPUUpdaterDelegate.h"
 #import "SPUUpdaterSettings.h"
 #import "SUHost.h"
-#import <Sparkle/SPUUpdatePermissionRequest.h>
-#import <Sparkle/SUUpdatePermissionResponse.h>
+#import "SPUUpdatePermissionRequest.h"
+#import "SUUpdatePermissionResponse.h"
 #import "SPUUpdateDriver.h"
 #import "SUConstants.h"
 #import "SULog.h"
@@ -24,7 +24,7 @@
 #import "SPUProbeInstallStatus.h"
 #import "SUAppcastItem.h"
 #import "SPUInstallationInfo.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SPUXPCServiceInfo.h"
 #import "SPUUpdaterCycle.h"
 #import "SPUUpdaterTimer.h"

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 @protocol SUVersionComparison;
 @class SPUUpdater, SUAppcast, SUAppcastItem;

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import <Sparkle/SPUUpdaterSettings.h>
+#import "SPUUpdaterSettings.h"
 #import "SUHost.h"
 #import "SUConstants.h"
 

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SPUStatusCompletionResults.h>
-#import <Sparkle/SUExport.h>
+#import "SPUStatusCompletionResults.h"
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SPUUserDriverCoreComponent.h
+++ b/Sparkle/SPUUserDriverCoreComponent.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SPUStatusCompletionResults.h>
-#import <Sparkle/SUExport.h>
+#import "SPUStatusCompletionResults.h"
+#import "SUExport.h"
 
 @protocol SPUStandardUserDriverDelegate;
 

--- a/Sparkle/SPUUserDriverCoreComponent.m
+++ b/Sparkle/SPUUserDriverCoreComponent.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import <Sparkle/SPUUserDriverCoreComponent.h>
+#import "SPUUserDriverCoreComponent.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -8,7 +8,7 @@
 
 #import "SPUUserInitiatedUpdateDriver.h"
 #import "SPUUIBasedUpdateDriver.h"
-#import <Sparkle/SPUUserDriver.h>
+#import "SPUUserDriver.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -10,7 +10,7 @@
 #define SUAPPCAST_H
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -6,17 +6,17 @@
 //  Copyright 2006 Andy Matuschak. All rights reserved.
 //
 
-#import <Sparkle/SUExport.h>
-#import <Sparkle/SUAppcast.h>
-#import <Sparkle/SUAppcastItem.h>
-#import <Sparkle/SUVersionComparisonProtocol.h>
+#import "SUExport.h"
+#import "SUAppcast.h"
+#import "SUAppcastItem.h"
+#import "SUVersionComparisonProtocol.h"
 #import "SUConstants.h"
 #import "SULog.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 #import "SULocalizations.h"
 #import "SPUXPCServiceInfo.h"
 #import "SPUURLDownload.h"
-#import <Sparkle/SPUDownloadData.h>
+#import "SPUDownloadData.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -7,12 +7,12 @@
 //
 
 #import "SUAppcastDriver.h"
-#import <Sparkle/SUAppcast.h>
+#import "SUAppcast.h"
 #import "SUAppcastItem.h"
-#import <Sparkle/SUVersionComparisonProtocol.h>
+#import "SUVersionComparisonProtocol.h"
 #import "SUStandardVersionComparator.h"
 #import "SUOperatingSystem.h"
-#import <Sparkle/SPUUpdaterDelegate.h>
+#import "SPUUpdaterDelegate.h"
 #import "SUHost.h"
 #import "SUConstants.h"
 

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -10,7 +10,7 @@
 #define SUAPPCASTITEM_H
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 @class SUSignatures;
 
 SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -6,8 +6,8 @@
 //  Copyright 2006 Andy Matuschak. All rights reserved.
 //
 
-#import <Sparkle/SUAppcastItem.h>
-#import <Sparkle/SUVersionComparisonProtocol.h>
+#import "SUAppcastItem.h"
+#import "SUVersionComparisonProtocol.h"
 #import "SULog.h"
 #import "SUConstants.h"
 #import "SUSignatures.h"

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -7,7 +7,7 @@
 //
 
 #import "SUConstants.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 
 #ifndef DEBUG
 #define DEBUG 0

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -10,7 +10,7 @@
 #define SUERRORS_H
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 /**
  * Error domain used by Sparkle

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -7,7 +7,7 @@
 //
 
 #import "SUFileManager.h"
-#import <Sparkle/SUErrors.h>
+#import "SUErrors.h"
 
 #include <sys/xattr.h>
 #include <sys/errno.h>

--- a/Sparkle/SUStandardVersionComparator.h
+++ b/Sparkle/SUStandardVersionComparator.h
@@ -10,8 +10,8 @@
 #define SUSTANDARDVERSIONCOMPARATOR_H
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
-#import <Sparkle/SUVersionComparisonProtocol.h>
+#import "SUExport.h"
+#import "SUVersionComparisonProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -6,8 +6,8 @@
 //  Copyright 2007 Andy Matuschak. All rights reserved.
 //
 
-#import <Sparkle/SUVersionComparisonProtocol.h>
-#import <Sparkle/SUStandardVersionComparator.h>
+#import "SUVersionComparisonProtocol.h"
+#import "SUStandardVersionComparator.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -10,8 +10,8 @@
 #define SUUPDATEALERT_H
 
 #import <Cocoa/Cocoa.h>
-#import <Sparkle/SUVersionDisplayProtocol.h>
-#import <Sparkle/SPUStatusCompletionResults.h>
+#import "SUVersionDisplayProtocol.h"
+#import "SPUStatusCompletionResults.h"
 
 @protocol SUUpdateAlertDelegate;
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -18,10 +18,10 @@
 #import "SUConstants.h"
 #import "SULog.h"
 #import "SULocalizations.h"
-#import <Sparkle/SUAppcastItem.h>
-#import <Sparkle/SPUDownloadData.h>
+#import "SUAppcastItem.h"
+#import "SPUDownloadData.h"
 #import "SUApplicationInfo.h"
-#import <Sparkle/SPUUpdaterSettings.h>
+#import "SPUUpdaterSettings.h"
 #import "SUSystemUpdateInfo.h"
 #import "SUTouchBarForwardDeclarations.h"
 #import "SUTouchBarButtonGroup.h"

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -7,8 +7,8 @@
 //
 
 #import "SUUpdatePermissionPrompt.h"
-#import <Sparkle/SPUUpdatePermissionRequest.h>
-#import <Sparkle/SUUpdatePermissionResponse.h>
+#import "SPUUpdatePermissionRequest.h"
+#import "SUUpdatePermissionResponse.h"
 #import "SULocalizations.h"
 
 #import "SUHost.h"

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 /*!
  This class represents a response for permission to check updates.

--- a/Sparkle/SUUpdatePermissionResponse.m
+++ b/Sparkle/SUUpdatePermissionResponse.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Sparkle Project. All rights reserved.
 //
 
-#import <Sparkle/SUUpdatePermissionResponse.h>
+#import "SUUpdatePermissionResponse.h"
 
 
 #include "AppKitPrevention.h"

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -10,10 +10,10 @@
 #define SUUPDATER_H
 
 #import <Cocoa/Cocoa.h>
-#import <Sparkle/SUExport.h>
-#import <Sparkle/SUVersionComparisonProtocol.h>
-#import <Sparkle/SUVersionDisplayProtocol.h>
-#import <Sparkle/SUUpdaterDelegate.h>
+#import "SUExport.h"
+#import "SUVersionComparisonProtocol.h"
+#import "SUVersionDisplayProtocol.h"
+#import "SUUpdaterDelegate.h"
 
 @class SUAppcastItem, SUAppcast, NSMenuItem;
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -6,11 +6,11 @@
 //  Copyright 2006 Andy Matuschak. All rights reserved.
 //
 
-#import <Sparkle/SUUpdater.h>
-#import <Sparkle/SPUUpdater.h>
-#import <Sparkle/SPUStandardUserDriver.h>
-#import <Sparkle/SPUStandardUserDriverDelegate.h>
-#import <Sparkle/SPUUpdaterDelegate.h>
+#import "SUUpdater.h"
+#import "SPUUpdater.h"
+#import "SPUStandardUserDriver.h"
+#import "SPUStandardUserDriverDelegate.h"
+#import "SPUUpdaterDelegate.h"
 #import "SULog.h"
 
 @interface SUUpdater () <SPUUpdaterDelegate, SPUStandardUserDriverDelegate>

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 @protocol SUVersionComparison, SUVersionDisplay;
 @class SUUpdater, SUAppcast, SUAppcastItem;

--- a/Sparkle/SUVersionComparisonProtocol.h
+++ b/Sparkle/SUVersionComparisonProtocol.h
@@ -10,7 +10,7 @@
 #define SUVERSIONCOMPARISONPROTOCOL_H
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUVersionDisplayProtocol.h
+++ b/Sparkle/SUVersionDisplayProtocol.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 
 /*!
     Applies special display formatting to version numbers.

--- a/Sparkle/Sparkle.h
+++ b/Sparkle/Sparkle.h
@@ -12,27 +12,32 @@
 // This list should include the shared headers. It doesn't matter if some of them aren't shared (unless
 // there are name-space collisions) so we can list all of them to start with:
 
-#import <Sparkle/SUExport.h>
-#import <Sparkle/SUAppcast.h>
-#import <Sparkle/SUAppcastItem.h>
-#import <Sparkle/SUStandardVersionComparator.h>
-#import <Sparkle/SPUUpdater.h>
-#import <Sparkle/SPUUpdaterDelegate.h>
-#import <Sparkle/SPUUpdaterSettings.h>
-#import <Sparkle/SPUStandardUpdaterController.h>
-#import <Sparkle/SUVersionComparisonProtocol.h>
-#import <Sparkle/SUVersionDisplayProtocol.h>
-#import <Sparkle/SUErrors.h>
-#import <Sparkle/SPUUpdatePermissionRequest.h>
-#import <Sparkle/SUUpdatePermissionResponse.h>
-#import <Sparkle/SPUUserDriver.h>
-#import <Sparkle/SPUStandardUserDriver.h>
-#import <Sparkle/SPUStandardUserDriverDelegate.h>
-#import <Sparkle/SPUUserDriverCoreComponent.h>
-#import <Sparkle/SPUDownloadData.h>
+#pragma clang diagnostic push
+// Do not use <> style includes since 2.x has two frameworks that need to work: Sparkle and SparkleCore
+#pragma clang diagnostic ignored "-Wquoted-include-in-framework-header"
 
-#import <Sparkle/SUUpdater.h> // deprecated
-#import <Sparkle/SUUpdaterDelegate.h> // deprecated
+#import "SUExport.h"
+#import "SUAppcast.h"
+#import "SUAppcastItem.h"
+#import "SUStandardVersionComparator.h"
+#import "SPUUpdater.h"
+#import "SPUUpdaterDelegate.h"
+#import "SPUUpdaterSettings.h"
+#import "SPUStandardUpdaterController.h"
+#import "SUVersionComparisonProtocol.h"
+#import "SUVersionDisplayProtocol.h"
+#import "SUErrors.h"
+#import "SPUUpdatePermissionRequest.h"
+#import "SUUpdatePermissionResponse.h"
+#import "SPUUserDriver.h"
+#import "SPUStandardUserDriver.h"
+#import "SPUStandardUserDriverDelegate.h"
+#import "SPUUserDriverCoreComponent.h"
+#import "SPUDownloadData.h"
 
+#import "SUUpdater.h" // deprecated
+#import "SUUpdaterDelegate.h" // deprecated
+
+#pragma clang diagnostic pop
 
 #endif

--- a/Sparkle/SparkleCore.h
+++ b/Sparkle/SparkleCore.h
@@ -14,18 +14,24 @@
 // This list should include the shared headers. It doesn't matter if some of them aren't shared (unless
 // there are name-space collisions) so we can list all of them to start with:
 
-#import <Sparkle/SUAppcast.h>
+#pragma clang diagnostic push
+// Do not use <> style includes since 2.x has two frameworks that need to work: Sparkle and SparkleCore
+#pragma clang diagnostic ignored "-Wquoted-include-in-framework-header"
+
+#import "SUAppcast.h"
 #import "SUAppcastItem.h"
 #import "SUStandardVersionComparator.h"
 #import "SPUUpdater.h"
 #import "SPUUpdaterDelegate.h"
 #import "SPUUpdaterSettings.h"
-#import <Sparkle/SUVersionComparisonProtocol.h>
-#import <Sparkle/SUErrors.h>
-#import <Sparkle/SPUUpdatePermissionRequest.h>
-#import <Sparkle/SUUpdatePermissionResponse.h>
-#import <Sparkle/SPUUserDriver.h>
-#import <Sparkle/SPUUserDriverCoreComponent.h>
-#import <Sparkle/SPUDownloadData.h>
+#import "SUVersionComparisonProtocol.h"
+#import "SUErrors.h"
+#import "SPUUpdatePermissionRequest.h"
+#import "SUUpdatePermissionResponse.h"
+#import "SPUUserDriver.h"
+#import "SPUUserDriverCoreComponent.h"
+#import "SPUDownloadData.h"
+
+#pragma clang diagnostic pop
 
 #endif

--- a/Tests/SUUpdaterTest.m
+++ b/Tests/SUUpdaterTest.m
@@ -8,9 +8,9 @@
 
 #import <XCTest/XCTest.h>
 #import "SUConstants.h"
-#import <Sparkle/SPUUpdater.h>
-#import <Sparkle/SPUStandardUserDriver.h>
-#import <Sparkle/SPUUpdaterDelegate.h>
+#import "SPUUpdater.h"
+#import "SPUStandardUserDriver.h"
+#import "SPUUpdaterDelegate.h"
 
 @interface SUUpdaterTest : XCTestCase <SPUUpdaterDelegate>
 @property (strong) SPUUpdater *updater;

--- a/Tests/SUVersionComparisonTest.m
+++ b/Tests/SUVersionComparisonTest.m
@@ -6,7 +6,7 @@
 //  Copyright 2008 Andy Matuschak. All rights reserved.
 //
 
-#import <Sparkle/SUStandardVersionComparator.h>
+#import <Sparkle/Sparkle.h>
 
 #import <XCTest/XCTest.h>
 

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -8,12 +8,12 @@
 #import "SUPipedUnarchiver.h"
 #import "SUBinaryDeltaCommon.h"
 #import "SUFileManager.h"
-#import <Sparkle/SUExport.h>
+#import "SUExport.h"
 #import "SUAppcast.h"
-#import <Sparkle/SUAppcastItem.h>
+#import "SUAppcastItem.h"
 #import "SUAppcastDriver.h"
-#import <Sparkle/SUVersionComparisonProtocol.h>
-#import <Sparkle/SUStandardVersionComparator.h>
+#import "SUVersionComparisonProtocol.h"
+#import "SUStandardVersionComparator.h"
 #import "SUUpdateValidator.h"
 #import "SUHost.h"
 #import "SUSignatures.h"

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -9,7 +9,6 @@
 #import "SPUCommandLineUserDriver.h"
 #import <AppKit/AppKit.h>
 #import <SparkleCore/SparkleCore.h>
-#import <Sparkle/SPUUserDriverCoreComponent.h>
 
 #define SCHEDULED_UPDATE_TIMER_THRESHOLD 2.0 // seconds
 


### PR DESCRIPTION
In order for SparkleCore.framework (Sparkle without standard UI bits) to build / work, headers can be `SparkleCore/*.h` or  or `Sparkle/*.h` thus we should just use `".h"` instead of assuming the framework name (which will break one of these cases). For clients that include Sparkle.h or SparkleCore.h directly, suppress compile warnings that may occur with a pragma. Disable the double quote include warning in CommonConfig. This change also makes header include style consistent (before it was inconsistent in many places).