### PR TITLE
Prioritize UserDefaults over [NSBundle mainBundle] when fetching value for SUEnableAutomaticChecks

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -275,7 +275,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 }
 
 - (BOOL)automaticChecksEnabled {
-    NSNumber *automaticChecksEnabled = [self.host objectForInfoDictionaryKey:SUEnableAutomaticChecksKey];
+    NSNumber *automaticChecksEnabled = [self.host objectForKey:SUEnableAutomaticChecksKey];
     if (automaticChecksEnabled == nil)
     {
         return false;


### PR DESCRIPTION
Users of the framework may override the value for this parameter in runtime, as opposed to using a static value written into Info.plist.

With the current implementation (#1480 )users that set this parameter dynamically don't see the 'Remind me later' button anymore, unless a value is provided in Info.plist.

Sparkle users that set this parameter in runtime should not be forced to set the parameter in Info.plist as a workaround to have the 'Remind me later' button visible. Instead, Sparkle should honor its documentation and make the value dynamically set via [SUUpdater setAutomaticChecksEnabled] take precedence over the default set in Info.plist.