### PR TITLE
Remove max size from update alert.

### DIFF
--- a/Sparkle/ar.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ar.lproj/SUUpdateAlert.xib
@@ -206,7 +206,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ar.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ar.lproj/SUUpdateAlert.xib
@@ -30,7 +30,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -207,6 +206,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/cs.lproj/SUUpdateAlert.xib
+++ b/Sparkle/cs.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/cs.lproj/SUUpdateAlert.xib
+++ b/Sparkle/cs.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/da.lproj/SUUpdateAlert.xib
+++ b/Sparkle/da.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/da.lproj/SUUpdateAlert.xib
+++ b/Sparkle/da.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/de.lproj/SUUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/de.lproj/SUUpdateAlert.xib
+++ b/Sparkle/de.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/el.lproj/SUUpdateAlert.xib
+++ b/Sparkle/el.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/el.lproj/SUUpdateAlert.xib
+++ b/Sparkle/el.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="660" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="660" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/en.lproj/SUUpdateAlert.xib
+++ b/Sparkle/en.lproj/SUUpdateAlert.xib
@@ -206,7 +206,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/en.lproj/SUUpdateAlert.xib
+++ b/Sparkle/en.lproj/SUUpdateAlert.xib
@@ -30,7 +30,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -207,6 +206,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/es.lproj/SUUpdateAlert.xib
+++ b/Sparkle/es.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/es.lproj/SUUpdateAlert.xib
+++ b/Sparkle/es.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/fi.lproj/SUUpdateAlert.xib
+++ b/Sparkle/fi.lproj/SUUpdateAlert.xib
@@ -206,7 +206,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/fi.lproj/SUUpdateAlert.xib
+++ b/Sparkle/fi.lproj/SUUpdateAlert.xib
@@ -30,7 +30,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -207,6 +206,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/fr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/fr.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/fr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/fr.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/hr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/hr.lproj/SUUpdateAlert.xib
@@ -30,7 +30,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -207,6 +206,7 @@ Gw
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/hr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/hr.lproj/SUUpdateAlert.xib
@@ -206,7 +206,6 @@ Gw
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/hu.lproj/SUUpdateAlert.xib
+++ b/Sparkle/hu.lproj/SUUpdateAlert.xib
@@ -203,7 +203,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/hu.lproj/SUUpdateAlert.xib
+++ b/Sparkle/hu.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -204,6 +203,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/is.lproj/SUUpdateAlert.xib
+++ b/Sparkle/is.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/is.lproj/SUUpdateAlert.xib
+++ b/Sparkle/is.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/it.lproj/SUUpdateAlert.xib
+++ b/Sparkle/it.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/it.lproj/SUUpdateAlert.xib
+++ b/Sparkle/it.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ja.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ja.lproj/SUUpdateAlert.xib
@@ -206,7 +206,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ja.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ja.lproj/SUUpdateAlert.xib
@@ -30,7 +30,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -207,6 +206,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ko.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ko.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ko.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ko.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/nb.lproj/SUUpdateAlert.xib
+++ b/Sparkle/nb.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/nb.lproj/SUUpdateAlert.xib
+++ b/Sparkle/nb.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/nl.lproj/SUUpdateAlert.xib
+++ b/Sparkle/nl.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/nl.lproj/SUUpdateAlert.xib
+++ b/Sparkle/nl.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/pl.lproj/SUUpdateAlert.xib
+++ b/Sparkle/pl.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/pl.lproj/SUUpdateAlert.xib
+++ b/Sparkle/pl.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/pt_BR.lproj/SUUpdateAlert.xib
+++ b/Sparkle/pt_BR.lproj/SUUpdateAlert.xib
@@ -203,7 +203,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/pt_BR.lproj/SUUpdateAlert.xib
+++ b/Sparkle/pt_BR.lproj/SUUpdateAlert.xib
@@ -27,7 +27,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -204,6 +203,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/pt_PT.lproj/SUUpdateAlert.xib
+++ b/Sparkle/pt_PT.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/pt_PT.lproj/SUUpdateAlert.xib
+++ b/Sparkle/pt_PT.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ro.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ro.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ro.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ro.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ru.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ru.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/ru.lproj/SUUpdateAlert.xib
+++ b/Sparkle/ru.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="660" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="660" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/sk.lproj/SUUpdateAlert.xib
+++ b/Sparkle/sk.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/sk.lproj/SUUpdateAlert.xib
+++ b/Sparkle/sk.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/sl.lproj/SUUpdateAlert.xib
+++ b/Sparkle/sl.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/sl.lproj/SUUpdateAlert.xib
+++ b/Sparkle/sl.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/sv.lproj/SUUpdateAlert.xib
+++ b/Sparkle/sv.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="644" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="644" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/sv.lproj/SUUpdateAlert.xib
+++ b/Sparkle/sv.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/th.lproj/SUUpdateAlert.xib
+++ b/Sparkle/th.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/th.lproj/SUUpdateAlert.xib
+++ b/Sparkle/th.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/tr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/tr.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/tr.lproj/SUUpdateAlert.xib
+++ b/Sparkle/tr.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/uk.lproj/SUUpdateAlert.xib
+++ b/Sparkle/uk.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/uk.lproj/SUUpdateAlert.xib
+++ b/Sparkle/uk.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="636" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="636" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/zh_CN.lproj/SUUpdateAlert.xib
+++ b/Sparkle/zh_CN.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/zh_CN.lproj/SUUpdateAlert.xib
+++ b/Sparkle/zh_CN.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/zh_TW.lproj/SUUpdateAlert.xib
+++ b/Sparkle/zh_TW.lproj/SUUpdateAlert.xib
@@ -205,7 +205,6 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>

--- a/Sparkle/zh_TW.lproj/SUUpdateAlert.xib
+++ b/Sparkle/zh_TW.lproj/SUUpdateAlert.xib
@@ -29,7 +29,6 @@
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <value key="minSize" type="size" width="550" height="150"/>
-            <value key="maxSize" type="size" width="700" height="600"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -206,6 +205,7 @@ DQ
                     </button>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="width" constant="700" id="VNp-am-qKn"/>
                     <constraint firstItem="10" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="22" id="2ef-4I-Il3"/>
                     <constraint firstAttribute="trailing" secondItem="fKC-QA-GZa" secondAttribute="trailing" constant="20" id="406-Cn-C5d"/>
                     <constraint firstItem="101" firstAttribute="leading" secondItem="10" secondAttribute="leading" id="7XS-9C-U6N"/>


### PR DESCRIPTION
Some users would prefer to resize the update alert window to make release notes easier to read.

It's not clear to me what the benefit of limiting the max window size is, especially in height. Forcing the width to 700 pts is useful because it makes the presentation more predictable.

This PR relaxes only the max-height restriction.

### Risks

I have tested this change on macOS 10.15. Unfortunately I don't have installs of older OS versions to test with. The only risk I see is that interface builder won't let you add a width constraint to the root view. Considering that is commonly done programmatically, I believe this is a bug/limitation of IB and not a real restriction imposed by AppKit.