### PR TITLE
Update SUSystemProfiler.m

### DIFF
--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -102,6 +102,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
             switch (value) {
                 case CPU_SUBTYPE_ARM64E:    visibleCPUSubType=@"ARM64E";  break;
                 default:                    visibleCPUSubType = @"Other"; break;
+            }
         } else {
             visibleCPUSubType = @"Other";
         }


### PR DESCRIPTION
Masked sysctl hw.cputype value when evaluating the CPU type.
Used macros from mach/machine.h instead of magic numbers.
Added support for ARM in evaluation of hw.cpusubtype.
Used "Other" instead of "Unknown" as visibleCPUType for values not covered by the explicit cases.