### PR TITLE
Allow an appcast to prevent the new version from being installed automatically

### DIFF
--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -34,6 +34,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject
 @property (copy, readonly) NSDictionary *deltaUpdates;
 @property (strong, readonly) NSURL *infoURL;
 @property (copy, readonly) NSNumber* phasedRolloutInterval;
+@property (nonatomic, readonly) BOOL doNotAutomaticallyUpdate;
 
 // Initializes with data from a dictionary provided by the RSS class.
 - (instancetype)initWithDictionary:(NSDictionary *)dict;

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -34,7 +34,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject
 @property (copy, readonly) NSDictionary *deltaUpdates;
 @property (strong, readonly) NSURL *infoURL;
 @property (copy, readonly) NSNumber* phasedRolloutInterval;
-@property (nonatomic, readonly) BOOL doNotAutomaticallyUpdate;
+@property (copy, readonly) NSString *minimumAutoupdateVersion;
 
 // Initializes with data from a dictionary provided by the RSS class.
 - (instancetype)initWithDictionary:(NSDictionary *)dict;

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -29,6 +29,7 @@
 @property (strong, readwrite) NSURL *infoURL;
 @property (readwrite, copy) NSDictionary *propertiesDictionary;
 @property (copy, readwrite) NSNumber* phasedRolloutInterval;
+@property (copy, readwrite) NSString *minimumAutoupdateVersion;
 @end
 
 @implementation SUAppcastItem
@@ -48,7 +49,7 @@
 @synthesize osString;
 @synthesize propertiesDictionary;
 @synthesize phasedRolloutInterval;
-@synthesize doNotAutomaticallyUpdate = _doNotAutomaticallyUpdate;
+@synthesize minimumAutoupdateVersion;
 
 - (BOOL)isDeltaUpdate
 {
@@ -155,7 +156,7 @@
             }
             return nil;
         }
-        
+
         if (enclosureURLString) {
             NSString *enclosureLengthString = [enclosure objectForKey:SURSSAttributeLength];
             long long contentLength = 0;
@@ -227,12 +228,7 @@
             self.deltaUpdates = deltas;
         }
 
-        NSString *doNotAutomaticallyUpdateString = [dict objectForKey:SUAppcastAttributeDoNotAutomaticallyUpdate];
-        if (doNotAutomaticallyUpdateString) {
-            _doNotAutomaticallyUpdate = [doNotAutomaticallyUpdateString boolValue];
-        } else {
-            _doNotAutomaticallyUpdate = NO;
-        }
+        self.minimumAutoupdateVersion = [dict objectForKey:SUAppcastElementMinimumAutoupdateVersion];
     }
     return self;
 }

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -48,6 +48,7 @@
 @synthesize osString;
 @synthesize propertiesDictionary;
 @synthesize phasedRolloutInterval;
+@synthesize doNotAutomaticallyUpdate = _doNotAutomaticallyUpdate;
 
 - (BOOL)isDeltaUpdate
 {
@@ -224,6 +225,13 @@
                 [deltas setObject:deltaItem forKey:deltaFrom];
             }
             self.deltaUpdates = deltas;
+        }
+
+        NSString *doNotAutomaticallyUpdateString = [dict objectForKey:SUAppcastAttributeDoNotAutomaticallyUpdate];
+        if (doNotAutomaticallyUpdateString) {
+            _doNotAutomaticallyUpdate = [doNotAutomaticallyUpdateString boolValue];
+        } else {
+            _doNotAutomaticallyUpdate = NO;
         }
     }
     return self;

--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -25,6 +25,7 @@
 - (void)checkForUpdatesAtURL:(NSURL *)URL host:(SUHost *)host;
 
 - (BOOL)isItemNewer:(SUAppcastItem *)ui;
+- (BOOL)itemPreventsAutoupdate:(SUAppcastItem *)ui;
 - (BOOL)hostSupportsItem:(SUAppcastItem *)ui;
 - (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui;
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui;

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -239,6 +239,13 @@
 {
     assert(self.updateItem);
 
+    // Handle the case where the update indicates that it should not be installed automatically (e.g. because it is a paid update)
+    if ([self.updateItem doNotAutomaticallyUpdate]) {
+        [self.updater setAutomaticallyDownloadsUpdates:NO]; // This call will persist this setting (automatic downloads will be permanently deactivated), but that is probably OK after the rare case of a non-automatically updateable update - the user can always reactivate this in the settings or when the update information window appears for the next time.
+        [self.updater checkForUpdatesInBackground]; // Will end up in SUUIBasedUpdateDriver instead of here
+        return;
+    }
+
     id<SUUpdaterPrivate> updater = self.updater;
 
     if ([[updater delegate] respondsToSelector:@selector(updater:didFindValidUpdate:)]) {

--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -174,6 +174,11 @@
     return [[self versionComparator] compareVersion:[self.host version] toVersion:[ui versionString]] == NSOrderedAscending;
 }
 
+- (BOOL)itemPreventsAutoupdate:(SUAppcastItem *)ui
+{
+    return ([ui minimumAutoupdateVersion] && ! [[ui minimumAutoupdateVersion] isEqualToString:@""] && ([[self versionComparator] compareVersion:[self.host version] toVersion:[ui minimumAutoupdateVersion]] == NSOrderedAscending));
+}
+
 - (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui
 {
     NSString *skippedVersion = [self.host objectForUserDefaultsKey:SUSkippedVersionKey];
@@ -239,8 +244,8 @@
 {
     assert(self.updateItem);
 
-    // Handle the case where the update indicates that it should not be installed automatically (e.g. because it is a paid update)
-    if ([self.updateItem doNotAutomaticallyUpdate]) {
+    // Handle the case where the update indicates that an automatic update is only available for specific versions
+    if ([self itemPreventsAutoupdate:self.updateItem]) {
         [self.updater setAutomaticallyDownloadsUpdates:NO]; // This call will persist this setting (automatic downloads will be permanently deactivated), but that is probably OK after the rare case of a non-automatically updateable update - the user can always reactivate this in the settings or when the update information window appears for the next time.
         [self.updater checkForUpdatesInBackground]; // Will end up in SUUIBasedUpdateDriver instead of here
         return;

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -72,6 +72,7 @@ extern NSString *const SUAppcastAttributeShortVersionString;
 extern NSString *const SUAppcastAttributeVersion;
 extern NSString *const SUAppcastAttributeOsType;
 extern NSString *const SUAppcastAttributePhasedRolloutInterval;
+extern NSString *const SUAppcastAttributeDoNotAutomaticallyUpdate;
 
 extern NSString *const SUAppcastElementCriticalUpdate;
 extern NSString *const SUAppcastElementDeltas;

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -72,10 +72,10 @@ extern NSString *const SUAppcastAttributeShortVersionString;
 extern NSString *const SUAppcastAttributeVersion;
 extern NSString *const SUAppcastAttributeOsType;
 extern NSString *const SUAppcastAttributePhasedRolloutInterval;
-extern NSString *const SUAppcastAttributeDoNotAutomaticallyUpdate;
 
 extern NSString *const SUAppcastElementCriticalUpdate;
 extern NSString *const SUAppcastElementDeltas;
+extern NSString *const SUAppcastElementMinimumAutoupdateVersion;
 extern NSString *const SUAppcastElementMinimumSystemVersion;
 extern NSString *const SUAppcastElementMaximumSystemVersion;
 extern NSString *const SUAppcastElementReleaseNotesLink;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -62,10 +62,10 @@ NSString *const SUAppcastAttributeShortVersionString = @"sparkle:shortVersionStr
 NSString *const SUAppcastAttributeVersion = @"sparkle:version";
 NSString *const SUAppcastAttributeOsType = @"sparkle:os";
 NSString *const SUAppcastAttributePhasedRolloutInterval = @"sparkle:phasedRolloutInterval";
-NSString *const SUAppcastAttributeDoNotAutomaticallyUpdate = @"sparkle:doNotAutomaticallyUpdate";
 
 NSString *const SUAppcastElementCriticalUpdate = @"sparkle:criticalUpdate";
 NSString *const SUAppcastElementDeltas = @"sparkle:deltas";
+NSString *const SUAppcastElementMinimumAutoupdateVersion = @"sparkle:minimumAutoupdateVersion";
 NSString *const SUAppcastElementMinimumSystemVersion = @"sparkle:minimumSystemVersion";
 NSString *const SUAppcastElementMaximumSystemVersion = @"sparkle:maximumSystemVersion";
 NSString *const SUAppcastElementReleaseNotesLink = @"sparkle:releaseNotesLink";

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -62,6 +62,7 @@ NSString *const SUAppcastAttributeShortVersionString = @"sparkle:shortVersionStr
 NSString *const SUAppcastAttributeVersion = @"sparkle:version";
 NSString *const SUAppcastAttributeOsType = @"sparkle:os";
 NSString *const SUAppcastAttributePhasedRolloutInterval = @"sparkle:phasedRolloutInterval";
+NSString *const SUAppcastAttributeDoNotAutomaticallyUpdate = @"sparkle:doNotAutomaticallyUpdate";
 
 NSString *const SUAppcastElementCriticalUpdate = @"sparkle:criticalUpdate";
 NSString *const SUAppcastElementDeltas = @"sparkle:deltas";

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -68,8 +68,8 @@
         [[updater delegate] updater:self.updater didFindValidUpdate:updateItem];
     }
 
-    // Handle the case where the update indicates that it should not be installed automatically (e.g. because it is a paid update)
-    if ([updateItem doNotAutomaticallyUpdate]) {
+    // Handle the case where the update indicates that an automatic update is only available for specific versions
+    if ([self itemPreventsAutoupdate:self.updateItem]) {
         self.automaticallyInstallUpdates = NO;
     }
 

--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -63,8 +63,14 @@
 - (void)didFindValidUpdate
 {
     id<SUUpdaterPrivate> updater = self.updater;
+    SUAppcastItem *updateItem = self.updateItem;
     if ([[updater delegate] respondsToSelector:@selector(updater:didFindValidUpdate:)]) {
-        [[updater delegate] updater:self.updater didFindValidUpdate:self.updateItem];
+        [[updater delegate] updater:self.updater didFindValidUpdate:updateItem];
+    }
+
+    // Handle the case where the update indicates that it should not be installed automatically (e.g. because it is a paid update)
+    if ([updateItem doNotAutomaticallyUpdate]) {
+        self.automaticallyInstallUpdates = NO;
     }
 
     if (self.automaticallyInstallUpdates) {
@@ -72,7 +78,6 @@
         return;
     }
 
-    SUAppcastItem *updateItem = self.updateItem;
     if (![self shouldShowUpdateAlertForItem:updateItem]) {
         [self abortUpdate];
         return;


### PR DESCRIPTION
Allow an individual appcast to override the SUAutomaticallyUpdate user defaults setting and prevent the new version from being installed automatically. This is helpful if the version referenced by the appcast is a paid upgrade that should not be applied without an explicit user decision. To use this feature, the new appcast property "sparkle:doNotAutomaticallyUpdate" shall be set to 1 or YES.

Please note that there is a corresponding pull request in the sparkle-project.github.io project.