### PR TITLE
System profiler privacy and transparency

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -211,7 +211,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
 /*!
  The system profile information that is sent when checking for updates
  */
-@property (nonatomic, readonly, copy) NSArray<NSDictionary<NSString *, id> *> *systemProfileArray;
+@property (nonatomic, readonly, copy) NSArray<NSDictionary<NSString *, NSString *> *> *systemProfileArray;
 
 @end
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -207,6 +207,12 @@ SU_EXPORT @interface SPUUpdater : NSObject
  */
 - (void)resetUpdateCycle;
 
+
+/*!
+ The system profile information that is sent when checking for updates
+ */
+@property (nonatomic, readonly, copy) NSArray<NSDictionary<NSString *, id> *> *systemProfileArray;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -281,7 +281,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     }
 
     if (shouldPrompt) {
-        NSArray<NSDictionary<NSString *, NSString *> *> *profileInfo = [SUSystemProfiler systemProfileArrayForHost:self.host];
+        NSArray<NSDictionary<NSString *, id> *> *profileInfo = self.systemProfileArray;
         // Always say we're sending the system profile here so that the delegate displays the parameters it would send.
         if ([self.delegate respondsToSelector:@selector((feedParametersForUpdater:sendingSystemProfile:))]) {
             NSArray *feedParameters = [self.delegate feedParametersForUpdater:self sendingSystemProfile:YES];

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -756,7 +756,7 @@ static NSString *escapeURLComponent(NSString *str) {
     // Build up the parameterized URL.
     NSMutableArray *parameterStrings = [NSMutableArray array];
     for (NSDictionary<NSString *, NSString *> *currentProfileInfo in parameters) {
-        [parameterStrings addObject:[NSString stringWithFormat:@"%@=%@", escapeURLComponent([[currentProfileInfo objectForKey:@"key"] description]), escapeURLComponent([[currentProfileInfo objectForKey:@"value"] description])]];
+        [parameterStrings addObject:[NSString stringWithFormat:@"%@=%@", escapeURLComponent([currentProfileInfo objectForKey:@"key"]), escapeURLComponent([currentProfileInfo objectForKey:@"value"])]];
     }
 
     NSString *separatorCharacter = @"?";

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -773,6 +773,10 @@ static NSString *escapeURLComponent(NSString *str) {
     return parameterizedFeedURL;
 }
 
+- (NSArray<NSDictionary<NSString *, id> *> *)systemProfileArray {
+    return [SUSystemProfiler systemProfileArrayForHost:self.host];
+}
+
 - (void)setUpdateCheckInterval:(NSTimeInterval)updateCheckInterval
 {
     [self.host setObject:@(updateCheckInterval) forUserDefaultsKey:SUScheduledCheckIntervalKey];

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -281,7 +281,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     }
 
     if (shouldPrompt) {
-        NSArray<NSDictionary<NSString *, id> *> *profileInfo = self.systemProfileArray;
+        NSArray<NSDictionary<NSString *, NSString *> *> *profileInfo = self.systemProfileArray;
         // Always say we're sending the system profile here so that the delegate displays the parameters it would send.
         if ([self.delegate respondsToSelector:@selector((feedParametersForUpdater:sendingSystemProfile:))]) {
             NSArray *feedParameters = [self.delegate feedParametersForUpdater:self sendingSystemProfile:YES];
@@ -739,7 +739,7 @@ static NSString *escapeURLComponent(NSString *str) {
     const NSTimeInterval oneWeek = 60 * 60 * 24 * 7;
     sendingSystemProfile &= (-[lastSubmitDate timeIntervalSinceNow] >= oneWeek);
 
-    NSArray<NSDictionary<NSString *, id> *> *parameters = @[];
+    NSArray<NSDictionary<NSString *, NSString *> *> *parameters = @[];
     if ([self.delegate respondsToSelector:@selector((feedParametersForUpdater:sendingSystemProfile:))]) {
         NSArray *feedParameters = [self.delegate feedParametersForUpdater:self sendingSystemProfile:sendingSystemProfile];
         if (feedParameters != nil) {
@@ -773,7 +773,7 @@ static NSString *escapeURLComponent(NSString *str) {
     return parameterizedFeedURL;
 }
 
-- (NSArray<NSDictionary<NSString *, id> *> *)systemProfileArray {
+- (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArray {
     NSArray *systemProfile = [SUSystemProfiler systemProfileArrayForHost:self.host];
     if ([self.delegate respondsToSelector:@selector(allowedSystemProfileKeysForUpdater:)]) {
         NSArray * allowedKeys = [self.delegate allowedSystemProfileKeysForUpdater:self];

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -38,6 +38,22 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastItemNotificationKey;
 SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 
 // -----------------------------------------------------------------------------
+//    System Profile Keys
+// -----------------------------------------------------------------------------
+
+SU_EXPORT extern NSString *const SUSystemProfilerApplicationNameKey;
+SU_EXPORT extern NSString *const SUSystemProfilerApplicationVersionKey;
+SU_EXPORT extern NSString *const SUSystemProfilerCPU64bitKey;
+SU_EXPORT extern NSString *const SUSystemProfilerCPUCountKey;
+SU_EXPORT extern NSString *const SUSystemProfilerCPUFrequencyKey;
+SU_EXPORT extern NSString *const SUSystemProfilerCPUTypeKey;
+SU_EXPORT extern NSString *const SUSystemProfilerCPUSubtypeKey;
+SU_EXPORT extern NSString *const SUSystemProfilerHardwareModelKey;
+SU_EXPORT extern NSString *const SUSystemProfilerMemoryKey;
+SU_EXPORT extern NSString *const SUSystemProfilerOperatingSystemVersionKey;
+SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
+
+// -----------------------------------------------------------------------------
 //	SPUUpdater Delegate:
 // -----------------------------------------------------------------------------
 
@@ -97,6 +113,21 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
 #else
 - (NSArray *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
+#endif
+
+/*!
+ Returns a list of system profile keys to be appended to the appcast URL's query string.
+
+ If this is unimplemented then all keys will be included.
+
+ \param updater The updater instance.
+
+ \return An array of system profile keys to include in the appcast URL's query string. Elements must be one of the SUSystemProfiler*Key constants
+ */
+#if __has_feature(objc_generics)
+- (NSArray<NSString *> *)allowedSystemProfileKeysForUpdater:(SPUUpdater *)updater;
+#else
+- (NSArray *)allowedSystemProfileKeysForUpdater:(SPUUpdater *)updater;
 #endif
 
 /*!

--- a/Sparkle/SUSystemProfiler.h
+++ b/Sparkle/SUSystemProfiler.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUHost;
 @interface SUSystemProfiler : NSObject
 
-+ (NSArray<NSDictionary<NSString *, id> *> *)systemProfileArrayForHost:(SUHost *)host;
++ (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host;
 
 @end
 

--- a/Sparkle/SUSystemProfiler.h
+++ b/Sparkle/SUSystemProfiler.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUHost;
 @interface SUSystemProfiler : NSObject
 
-+ (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host;
++ (NSArray<NSDictionary<NSString *, id> *> *)systemProfileArrayForHost:(SUHost *)host;
 
 @end
 

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -36,7 +36,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     return [[NSDictionary alloc] initWithContentsOfFile:path];
 }
 
-+ (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host
++ (NSArray<NSDictionary<NSString *, id> *> *)systemProfileArrayForHost:(SUHost *)host
 {
     NSDictionary<NSString *, NSString *> *modelTranslation = [self modelTranslationTable];
 

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -37,7 +37,7 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     return [[NSDictionary alloc] initWithContentsOfFile:path];
 }
 
-+ (NSArray<NSDictionary<NSString *, id> *> *)systemProfileArrayForHost:(SUHost *)host
++ (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host
 {
     NSDictionary<NSString *, NSString *> *modelTranslation = [self modelTranslationTable];
 
@@ -58,7 +58,7 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     error = sysctlbyname("hw.cputype", &value, &length, NULL, 0);
     int cpuType = -1;
     if (error == 0) {
-        //hw.cputype is a bitmask that can contain multiple bits of info. We only want the last 2 bytes to get the architecture
+        //hw.cputype is a bitmask that can contain multiple bits of info. We only want the last byte to get the architecture
         value = (value & 0x000000ff);
         cpuType = value;
         NSString *visibleCPUType;
@@ -68,7 +68,7 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
 			case CPU_TYPE_POWERPC:	visibleCPUType = @"PowerPC";	break;
 			default:				visibleCPUType = @"Unknown";	break;
         }
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUTypeKey, @"CPU Type", @(value), visibleCPUType] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUTypeKey, @"CPU Type", [NSString stringWithFormat:@"%d", value], visibleCPUType] forKeys:profileDictKeys]];
     }
     error = sysctlbyname("hw.cpu64bit_capable", &value, &length, NULL, 0);
     if (error != 0) {
@@ -82,7 +82,7 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
 
     if (error == 0) {
         is64bit = value == 1;
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPU64bitKey, @"CPU is 64-Bit?", @(is64bit), is64bit ? @"Yes" : @"No"] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPU64bitKey, @"CPU is 64-Bit?", [NSString stringWithFormat:@"%d", is64bit], is64bit ? @"Yes" : @"No"] forKeys:profileDictKeys]];
     }
     error = sysctlbyname("hw.cpusubtype", &value, &length, NULL, 0);
     if (error == 0) {
@@ -102,7 +102,7 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
         } else {
             visibleCPUSubType = @"Other";
         }
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUSubtypeKey, @"CPU Subtype", @(value), visibleCPUSubType] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUSubtypeKey, @"CPU Subtype", [NSString stringWithFormat:@"%d", value], visibleCPUSubType] forKeys:profileDictKeys]];
     }
     error = sysctlbyname("hw.model", NULL, &length, NULL, 0);
     if (error == 0) {
@@ -124,7 +124,8 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     // Number of CPUs
     error = sysctlbyname("hw.ncpu", &value, &length, NULL, 0);
     if (error == 0) {
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUCountKey, @"Number of CPUs", @(value), @(value)] forKeys:profileDictKeys]];
+        NSString *stringValue = [NSString stringWithFormat:@"%d", value];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUCountKey, @"Number of CPUs", stringValue, stringValue] forKeys:profileDictKeys]];
     }
 
     // User preferred language
@@ -151,7 +152,8 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     size_t hz_size = sizeof(unsigned long);
     if (sysctlbyname("hw.cpufrequency", &hz, &hz_size, NULL, 0) == 0) {
         unsigned long mhz = hz / 1000000;
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUFrequencyKey, @"CPU Speed (MHz)", @(mhz), @(mhz / 1000.)] forKeys:profileDictKeys]];
+        NSString *stringValue = [NSString stringWithFormat:@"%lu", mhz];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUFrequencyKey, @"CPU Speed (MHz)", stringValue, stringValue] forKeys:profileDictKeys]];
     }
 
     // amount of RAM
@@ -159,7 +161,8 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     size_t bytes_size = sizeof(unsigned long);
     if (sysctlbyname("hw.memsize", &bytes, &bytes_size, NULL, 0) == 0) {
         double megabytes = bytes / (1024. * 1024.);
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerMemoryKey, @"Memory (MB)", @(megabytes), @(megabytes)] forKeys:profileDictKeys]];
+        NSString *stringValue = [NSString stringWithFormat:@"%lu", (unsigned long)megabytes];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerMemoryKey, @"Memory (MB)", stringValue, stringValue] forKeys:profileDictKeys]];
     }
 
     return [profileArray copy];

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -58,6 +58,8 @@ NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     error = sysctlbyname("hw.cputype", &value, &length, NULL, 0);
     int cpuType = -1;
     if (error == 0) {
+        //hw.cputype is a bitmask that can contain multiple bits of info. We only want the last 2 bytes to get the architecture
+        value = (value & 0x000000ff);
         cpuType = value;
         NSString *visibleCPUType;
         switch (value) {

--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -11,21 +11,22 @@
 #import "SUHost.h"
 #import "SUOperatingSystem.h"
 #include <sys/sysctl.h>
+#import "SPUUpdaterDelegate.h"
 
 
 #include "AppKitPrevention.h"
 
-static NSString *const SUSystemProfilerApplicationNameKey = @"appName";
-static NSString *const SUSystemProfilerApplicationVersionKey = @"appVersion";
-static NSString *const SUSystemProfilerCPU64bitKey = @"cpu64bit";
-static NSString *const SUSystemProfilerCPUCountKey = @"ncpu";
-static NSString *const SUSystemProfilerCPUFrequencyKey = @"cpuFreqMHz";
-static NSString *const SUSystemProfilerCPUTypeKey = @"cputype";
-static NSString *const SUSystemProfilerCPUSubtypeKey = @"cpusubtype";
-static NSString *const SUSystemProfilerHardwareModelKey = @"model";
-static NSString *const SUSystemProfilerMemoryKey = @"ramMB";
-static NSString *const SUSystemProfilerOperatingSystemVersionKey = @"osVersion";
-static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
+NSString *const SUSystemProfilerApplicationNameKey = @"appName";
+NSString *const SUSystemProfilerApplicationVersionKey = @"appVersion";
+NSString *const SUSystemProfilerCPU64bitKey = @"cpu64bit";
+NSString *const SUSystemProfilerCPUCountKey = @"ncpu";
+NSString *const SUSystemProfilerCPUFrequencyKey = @"cpuFreqMHz";
+NSString *const SUSystemProfilerCPUTypeKey = @"cputype";
+NSString *const SUSystemProfilerCPUSubtypeKey = @"cpusubtype";
+NSString *const SUSystemProfilerHardwareModelKey = @"model";
+NSString *const SUSystemProfilerMemoryKey = @"ramMB";
+NSString *const SUSystemProfilerOperatingSystemVersionKey = @"osVersion";
+NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
 
 @implementation SUSystemProfiler
 


### PR DESCRIPTION
This PR adds some fixes and enhancements to system profiling. Specifically it adds 2 things:
- Add `SPUUpdater.systemProfileArray` property. This allows developers to access this information to display to users
- Add filtering of system profile array (via `-[SPUUpdaterDelegate allowedSystemProfileKeysForUpdater:]`). This helps developers improve privacy by choosing which profile items to collect and send with update requests. This filtering happens before any additional feed parameters are added.

It also fixes 2 issues with the system profile code:
- Fix an issue with the CPU type property that caused the incorrect value to be returned for ARM/Apple Silicon
- Update a few types in code that incorrectly assumed the profile array had the type `NSArray<NSString *, NSString *>` (some values are NSNumbers)

This is partly related to https://github.com/sparkle-project/Sparkle/issues/1616 and has been implemented on the 2.x branch

This image provides an example of what these changes enable https://coppiceapp.com/images/blog/designing_for_privacy/privacy-sheet.png