### PR TITLE
Hide automatic update button and skip button, depending on `SUAutomaticallyUpdate` key

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -326,11 +326,28 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.laterButton.enabled = NO;
         self.laterButton.hidden = YES;
     }
+
+    if([self automaticallyUpdateEnabled]) {
+        self.skipButton.hidden = YES;
+        self.automaticallyInstallUpdatesButton.hidden = YES;
+        [self.laterButton setTitle:SULocalizedString(@"Install later", @"Alternate title for 'Remind me later' button when automatic updates are enabled")];
+    }
+
     [self.window center];
 }
 
 - (BOOL)automaticChecksEnabled {
     NSNumber *automaticChecksEnabled = [self.host objectForKey:SUEnableAutomaticChecksKey];
+    if (automaticChecksEnabled == nil)
+    {
+        return false;
+    }
+
+    return [automaticChecksEnabled boolValue];
+}
+
+- (BOOL)automaticallyUpdateEnabled {
+    NSNumber *automaticChecksEnabled = [self.host objectForKey:SUAutomaticallyUpdateKey];
     if (automaticChecksEnabled == nil)
     {
         return false;


### PR DESCRIPTION
This PR adds 3 new keys to be able to let the developer choose what buttons should be shown in the update window. When a key doesn't exist, it will keep the same behavior as of today, showing all the buttons. The keys are the following: 

`SUHideAutomaticallyInstallUpdates` - If set to true it will hide the _Automatically check for updates_ checkbox
`SUHideSkipButton` - If set to true it will hide the _Skip this version_ button
`SUHideLaterButton` - If set to true it will hide the _Remind me later_ button

Signed-off-by: Lorena Rangel <lorena.rangel@docker.com>