### PR TITLE
Add `—release-notes-url-prefix` support to localized release notes

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -212,7 +212,13 @@ class ArchiveItem: CustomStringConvertible {
                 .appendingPathExtension(languageCode)
                 .appendingPathExtension("html")
             if fileManager.fileExists(atPath: localizedReleaseNoteURL.path) {
-                localizedReleaseNotes.append((languageCode, localizedReleaseNoteURL))
+                if let releaseNotesURLPrefix = self.releaseNotesURLPrefix {
+                    localizedReleaseNotes.append((languageCode, URL(string: localizedReleaseNoteURL.lastPathComponent, relativeTo: releaseNotesURLPrefix)!))
+                }
+                else {
+                    localizedReleaseNotes.append((languageCode, URL(string: localizedReleaseNoteURL.lastPathComponent)!))
+                }
+                
             }
         }
         return localizedReleaseNotes

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -139,7 +139,7 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem]) throws {
         for (language, url) in update.localizedReleaseNotes() {
             if !languageNotesNodes.contains(where: { $0.1 == language }) {
                 let localizedNode = XMLNode.element(withName: SUAppcastElementReleaseNotesLink,
-                                                    children: [XMLNode.text(withStringValue: url.lastPathComponent) as! XMLNode],
+                                                    children: [XMLNode.text(withStringValue: url.absoluteString) as! XMLNode],
                                                     attributes: [XMLNode.attribute(withName: SUXMLLanguage,
                                                                                    stringValue: language) as! XMLNode, ])
                 item.addChild(localizedNode as! XMLNode)


### PR DESCRIPTION
This PR aims to add the recently added feature `—release-notes-url-prefix` https://github.com/sparkle-project/Sparkle/pull/1644 for localized release notes.