### PR TITLE
Eliminate assumption that user driver calls are invoked in any thread

### DIFF
--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -60,9 +60,7 @@
 
 - (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent showCanCheckForUpdates:canCheckForUpdates];
-    });
+    [self.coreComponent showCanCheckForUpdates:canCheckForUpdates];
 }
 
 - (BOOL)canCheckForUpdates
@@ -74,13 +72,11 @@
 
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // This shows a modal alert dialog which unlike other alerts cannot be closed until the user makes a decision
-        // This means that we can never programatically close the dialog if something goes horribly wrong
-        // But this dialog should only show up once in the application's lifetime so this may be an OK decision
-        
-        [SUUpdatePermissionPrompt promptWithHost:self.host request:request reply:reply];
-    });
+    // This shows a modal alert dialog which unlike other alerts cannot be closed until the user makes a decision
+    // This means that we can never programatically close the dialog if something goes horribly wrong
+    // But this dialog should only show up once in the application's lifetime so this may be an OK decision
+    
+    [SUUpdatePermissionPrompt promptWithHost:self.host request:request reply:reply];
 }
 
 #pragma mark Update Alert Focus
@@ -119,18 +115,16 @@
 
 - (void)showUpdateFoundWithAlertHandler:(SUUpdateAlert *(^)(SPUStandardUserDriver *, SUHost *, id<SUVersionDisplay>))alertHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        id <SUVersionDisplay> versionDisplayer = nil;
-        if ([self.delegate respondsToSelector:@selector(standardUserDriverRequestsVersionDisplayer)]) {
-            versionDisplayer = [self.delegate standardUserDriverRequestsVersionDisplayer];
-        }
-        
-        __weak SPUStandardUserDriver *weakSelf = self;
-        SUHost *host = self.host;
-        self.activeUpdateAlert = alertHandler(weakSelf, host, versionDisplayer);
-        
-        [self setUpFocusForActiveUpdateAlert];
-    });
+    id <SUVersionDisplay> versionDisplayer = nil;
+    if ([self.delegate respondsToSelector:@selector(standardUserDriverRequestsVersionDisplayer)]) {
+        versionDisplayer = [self.delegate standardUserDriverRequestsVersionDisplayer];
+    }
+    
+    __weak SPUStandardUserDriver *weakSelf = self;
+    SUHost *host = self.host;
+    self.activeUpdateAlert = alertHandler(weakSelf, host, versionDisplayer);
+    
+    [self setUpFocusForActiveUpdateAlert];
 }
 
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
@@ -175,35 +169,29 @@
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.activeUpdateAlert showUpdateReleaseNotesWithDownloadData:downloadData];
-    });
+    [self.activeUpdateAlert showUpdateReleaseNotesWithDownloadData:downloadData];
 }
 
 - (void)showUpdateReleaseNotesFailedToDownloadWithError:(NSError *)error
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // I don't want to expose SULog here because it's more of a user driver facing error
-        // For our purposes we just ignore it and continue on..
-        NSLog(@"Failed to download release notes with error: %@", error);
-        [self.activeUpdateAlert showReleaseNotesFailedToDownload];
-    });
+    // I don't want to expose SULog here because it's more of a user driver facing error
+    // For our purposes we just ignore it and continue on..
+    NSLog(@"Failed to download release notes with error: %@", error);
+    [self.activeUpdateAlert showReleaseNotesFailedToDownload];
 }
 
 #pragma mark Install & Relaunch Update
 
 - (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.statusController beginActionWithTitle:SULocalizedString(@"Ready to Install", nil) maxProgressValue:1.0 statusText:nil];
-        [self.statusController setProgressValue:1.0]; // Fill the bar.
-        [self.statusController setButtonEnabled:YES];
-        [self.statusController setButtonTitle:SULocalizedString(@"Install and Relaunch", nil) target:self action:@selector(installAndRestart:) isDefault:YES];
-        [[self.statusController window] makeKeyAndOrderFront:self];
-        [NSApp requestUserAttention:NSInformationalRequest];
-        
-        [self.coreComponent registerInstallUpdateHandler:installUpdateHandler];
-    });
+    [self.statusController beginActionWithTitle:SULocalizedString(@"Ready to Install", nil) maxProgressValue:1.0 statusText:nil];
+    [self.statusController setProgressValue:1.0]; // Fill the bar.
+    [self.statusController setButtonEnabled:YES];
+    [self.statusController setButtonTitle:SULocalizedString(@"Install and Relaunch", nil) target:self action:@selector(installAndRestart:) isDefault:YES];
+    [[self.statusController window] makeKeyAndOrderFront:self];
+    [NSApp requestUserAttention:NSInformationalRequest];
+    
+    [self.coreComponent registerInstallUpdateHandler:installUpdateHandler];
 }
 
 - (void)installAndRestart:(id)__unused sender
@@ -215,22 +203,20 @@
 
 - (void)showUserInitiatedUpdateCheckWithCompletion:(void (^)(SPUUserInitiatedCheckStatus))updateCheckStatusCompletion
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
-        
-        self.checkingController = [[SUStatusController alloc] initWithHost:self.host];
-        [[self.checkingController window] center]; // Force the checking controller to load its window.
-        [self.checkingController beginActionWithTitle:SULocalizedString(@"Checking for updates...", nil) maxProgressValue:0.0 statusText:nil];
-        [self.checkingController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelCheckForUpdates:) isDefault:NO];
-        [self.checkingController showWindow:self];
-        
-        // For background applications, obtain focus.
-        // Useful if the update check is requested from another app like System Preferences.
-        if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]])
-        {
-            [NSApp activateIgnoringOtherApps:YES];
-        }
-    });
+    [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
+    
+    self.checkingController = [[SUStatusController alloc] initWithHost:self.host];
+    [[self.checkingController window] center]; // Force the checking controller to load its window.
+    [self.checkingController beginActionWithTitle:SULocalizedString(@"Checking for updates...", nil) maxProgressValue:0.0 statusText:nil];
+    [self.checkingController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelCheckForUpdates:) isDefault:NO];
+    [self.checkingController showWindow:self];
+    
+    // For background applications, obtain focus.
+    // Useful if the update check is requested from another app like System Preferences.
+    if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]])
+    {
+        [NSApp activateIgnoringOtherApps:YES];
+    }
 }
 
 - (void)closeCheckingWindow
@@ -250,64 +236,56 @@
 
 - (void)dismissUserInitiatedUpdateCheck
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent completeUpdateCheckStatus];
-        [self closeCheckingWindow];
-    });
+    [self.coreComponent completeUpdateCheckStatus];
+    [self closeCheckingWindow];
 }
 
 #pragma mark Update Errors
 
 - (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        
-        NSAlert *alert = [[NSAlert alloc] init];
-        alert.messageText = SULocalizedString(@"Update Error!", nil);
-        alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
-        [alert addButtonWithTitle:SULocalizedString(@"Cancel Update", nil)];
-        [self showAlert:alert];
-        
-        [self.coreComponent acceptAcknowledgement];
-    });
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = SULocalizedString(@"Update Error!", nil);
+    alert.informativeText = [NSString stringWithFormat:@"%@", [error localizedDescription]];
+    [alert addButtonWithTitle:SULocalizedString(@"Cancel Update", nil)];
+    [self showAlert:alert];
+    
+    [self.coreComponent acceptAcknowledgement];
 }
 
 - (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        
-        NSAlert *alert = [[NSAlert alloc] init];
-        alert.messageText = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
-        alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
-        [alert addButtonWithTitle:SULocalizedString(@"OK", nil)];
-        [self showAlert:alert];
-        
-        [self.coreComponent acceptAcknowledgement];
-    });
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.messageText = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+    alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
+    [alert addButtonWithTitle:SULocalizedString(@"OK", nil)];
+    [self showAlert:alert];
+    
+    [self.coreComponent acceptAcknowledgement];
 }
 
 - (void)showAlert:(NSAlert *)alert
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        id <SPUStandardUserDriverDelegate> delegate = self.delegate;
-        
-        if ([delegate respondsToSelector:@selector(standardUserDriverWillShowModalAlert)]) {
-            [delegate standardUserDriverWillShowModalAlert];
-        }
-        
-        // When showing a modal alert we need to ensure that background applications
-        // are focused to inform the user since there is no dock icon to notify them.
-        if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) { [[NSApplication sharedApplication] activateIgnoringOtherApps:YES]; }
-        
-        [alert setIcon:[SUApplicationInfo bestIconForHost:self.host]];
-        [alert runModal];
-        
-        if ([delegate respondsToSelector:@selector(standardUserDriverDidShowModalAlert)]) {
-            [delegate standardUserDriverDidShowModalAlert];
-        }
-    });
+    id <SPUStandardUserDriverDelegate> delegate = self.delegate;
+    
+    if ([delegate respondsToSelector:@selector(standardUserDriverWillShowModalAlert)]) {
+        [delegate standardUserDriverWillShowModalAlert];
+    }
+    
+    // When showing a modal alert we need to ensure that background applications
+    // are focused to inform the user since there is no dock icon to notify them.
+    if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) { [[NSApplication sharedApplication] activateIgnoringOtherApps:YES]; }
+    
+    [alert setIcon:[SUApplicationInfo bestIconForHost:self.host]];
+    [alert runModal];
+    
+    if ([delegate respondsToSelector:@selector(standardUserDriverDidShowModalAlert)]) {
+        [delegate standardUserDriverDidShowModalAlert];
+    }
 }
 
 #pragma mark Download & Install Updates
@@ -322,13 +300,11 @@
 
 - (void)showDownloadInitiatedWithCompletion:(void (^)(SPUDownloadUpdateStatus))downloadUpdateStatusCompletion
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
-        
-        [self showStatusController];
-        [self.statusController beginActionWithTitle:SULocalizedString(@"Downloading update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
-        [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelDownload:) isDefault:NO];
-    });
+    [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
+    
+    [self showStatusController];
+    [self.statusController beginActionWithTitle:SULocalizedString(@"Downloading update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
+    [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelDownload:) isDefault:NO];
 }
 
 - (void)cancelDownload:(id)__unused sender
@@ -338,9 +314,7 @@
 
 - (void)showDownloadDidReceiveExpectedContentLength:(uint64_t)expectedContentLength
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.statusController setMaxProgressValue:expectedContentLength];
-    });
+    [self.statusController setMaxProgressValue:expectedContentLength];
 }
 
 - (NSString *)localizedStringFromByteCount:(long long)value
@@ -375,42 +349,36 @@
 
 - (void)showDownloadDidReceiveDataOfLength:(uint64_t)length
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        double newProgressValue = [self.statusController progressValue] + (double)length;
-        
-        // In case our expected content length was incorrect
-        if (newProgressValue > [self.statusController maxProgressValue]) {
-            [self.statusController setMaxProgressValue:newProgressValue];
-        }
-        
-        [self.statusController setProgressValue:newProgressValue];
-        if ([self.statusController maxProgressValue] > 0.0)
-            [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ of %@", nil), [self localizedStringFromByteCount:(long long)self.statusController.progressValue], [self localizedStringFromByteCount:(long long)self.statusController.maxProgressValue]]];
-        else
-            [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ downloaded", nil), [self localizedStringFromByteCount:(long long)self.statusController.progressValue]]];
-    });
+    double newProgressValue = [self.statusController progressValue] + (double)length;
+    
+    // In case our expected content length was incorrect
+    if (newProgressValue > [self.statusController maxProgressValue]) {
+        [self.statusController setMaxProgressValue:newProgressValue];
+    }
+    
+    [self.statusController setProgressValue:newProgressValue];
+    if ([self.statusController maxProgressValue] > 0.0)
+        [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ of %@", nil), [self localizedStringFromByteCount:(long long)self.statusController.progressValue], [self localizedStringFromByteCount:(long long)self.statusController.maxProgressValue]]];
+    else
+        [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ downloaded", nil), [self localizedStringFromByteCount:(long long)self.statusController.progressValue]]];
 }
 
 - (void)showDownloadDidStartExtractingUpdate
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent completeDownloadStatus];
-        
-        [self showStatusController];
-        [self.statusController beginActionWithTitle:SULocalizedString(@"Extracting update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
-        [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:nil action:nil isDefault:NO];
-        [self.statusController setButtonEnabled:NO];
-    });
+    [self.coreComponent completeDownloadStatus];
+    
+    [self showStatusController];
+    [self.statusController beginActionWithTitle:SULocalizedString(@"Extracting update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
+    [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:nil action:nil isDefault:NO];
+    [self.statusController setButtonEnabled:NO];
 }
 
 - (void)showExtractionReceivedProgress:(double)progress
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if ([self.statusController maxProgressValue] == 0.0) {
-            [self.statusController setMaxProgressValue:1];
-        }
-        [self.statusController setProgressValue:progress];
-    });
+    if ([self.statusController maxProgressValue] == 0.0) {
+        [self.statusController setMaxProgressValue:1];
+    }
+    [self.statusController setProgressValue:progress];
 }
 
 - (void)_showInstallingUpdate
@@ -421,38 +389,29 @@
 
 - (void)showInstallingUpdate
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self _showInstallingUpdate];
-    });
+    [self _showInstallingUpdate];
 }
 
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // Deciding not to show anything here
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        [self.coreComponent acceptAcknowledgement];
-    });
+    // Deciding not to show anything here
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    [self.coreComponent acceptAcknowledgement];
 }
 
 #pragma mark Aborting Everything
 
 - (void)showSendingTerminationSignal
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // The "quit" event can always be canceled or delayed by the application we're updating
-        // So we can't easily predict how long the installation will take or if it won't happen right away
-        // We close our status window because we don't want it persisting for too long and have it obscure other windows
-        [self.statusController close];
-        self.statusController = nil;
-    });
+    // The "quit" event can always be canceled or delayed by the application we're updating
+    // So we can't easily predict how long the installation will take or if it won't happen right away
+    // We close our status window because we don't want it persisting for too long and have it obscure other windows
+    [self.statusController close];
+    self.statusController = nil;
 }
 
-- (void)_dismissUpdateInstallation
+- (void)dismissUpdateInstallation
 {
-    // Make sure everything we call here does not dispatch async to main queue
-    // because we are already on the main queue (and I've been bitten in the past by this before)
-    
     [self.coreComponent dismissUpdateInstallation];
     
     [self closeCheckingWindow];
@@ -466,13 +425,6 @@
         [self.activeUpdateAlert close];
         self.activeUpdateAlert = nil;
     }
-}
-
-- (void)dismissUpdateInstallation
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self _dismissUpdateInstallation];
-    });
 }
 
 @end

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -60,11 +60,15 @@
 
 - (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent showCanCheckForUpdates:canCheckForUpdates];
 }
 
 - (BOOL)canCheckForUpdates
 {
+    assert(NSThread.isMainThread);
+    
     return self.coreComponent.canCheckForUpdates;
 }
 
@@ -72,6 +76,8 @@
 
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply
 {
+    assert(NSThread.isMainThread);
+    
     // This shows a modal alert dialog which unlike other alerts cannot be closed until the user makes a decision
     // This means that we can never programatically close the dialog if something goes horribly wrong
     // But this dialog should only show up once in the application's lifetime so this may be an OK decision
@@ -129,6 +135,8 @@
 
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
+    assert(NSThread.isMainThread);
+    
     [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
         return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem alreadyDownloaded:NO host:host versionDisplayer:versionDisplayer completionBlock:^(SPUUpdateAlertChoice choice) {
             reply(choice);
@@ -139,6 +147,8 @@
 
 - (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
+    assert(NSThread.isMainThread);
+    
     [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
         return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem alreadyDownloaded:YES host:host versionDisplayer:versionDisplayer completionBlock:^(SPUUpdateAlertChoice choice) {
             reply(choice);
@@ -149,6 +159,8 @@
 
 - (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply
 {
+    assert(NSThread.isMainThread);
+    
     [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
         return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem host:host versionDisplayer:versionDisplayer resumableCompletionBlock:^(SPUInstallUpdateStatus choice) {
             reply(choice);
@@ -159,6 +171,8 @@
 
 - (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply
 {
+    assert(NSThread.isMainThread);
+    
     [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
         return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem host:host versionDisplayer:versionDisplayer informationalCompletionBlock:^(SPUInformationalUpdateAlertChoice choice) {
             reply(choice);
@@ -169,11 +183,15 @@
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
 {
+    assert(NSThread.isMainThread);
+    
     [self.activeUpdateAlert showUpdateReleaseNotesWithDownloadData:downloadData];
 }
 
 - (void)showUpdateReleaseNotesFailedToDownloadWithError:(NSError *)error
 {
+    assert(NSThread.isMainThread);
+    
     // I don't want to expose SULog here because it's more of a user driver facing error
     // For our purposes we just ignore it and continue on..
     NSLog(@"Failed to download release notes with error: %@", error);
@@ -184,6 +202,8 @@
 
 - (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
 {
+    assert(NSThread.isMainThread);
+    
     [self.statusController beginActionWithTitle:SULocalizedString(@"Ready to Install", nil) maxProgressValue:1.0 statusText:nil];
     [self.statusController setProgressValue:1.0]; // Fill the bar.
     [self.statusController setButtonEnabled:YES];
@@ -203,6 +223,8 @@
 
 - (void)showUserInitiatedUpdateCheckWithCompletion:(void (^)(SPUUserInitiatedCheckStatus))updateCheckStatusCompletion
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
     
     self.checkingController = [[SUStatusController alloc] initWithHost:self.host];
@@ -236,6 +258,8 @@
 
 - (void)dismissUserInitiatedUpdateCheck
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent completeUpdateCheckStatus];
     [self closeCheckingWindow];
 }
@@ -244,6 +268,8 @@
 
 - (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent registerAcknowledgement:acknowledgement];
     
     NSAlert *alert = [[NSAlert alloc] init];
@@ -257,6 +283,8 @@
 
 - (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent registerAcknowledgement:acknowledgement];
     
     NSAlert *alert = [[NSAlert alloc] init];
@@ -300,6 +328,8 @@
 
 - (void)showDownloadInitiatedWithCompletion:(void (^)(SPUDownloadUpdateStatus))downloadUpdateStatusCompletion
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
     
     [self showStatusController];
@@ -314,6 +344,8 @@
 
 - (void)showDownloadDidReceiveExpectedContentLength:(uint64_t)expectedContentLength
 {
+    assert(NSThread.isMainThread);
+    
     [self.statusController setMaxProgressValue:expectedContentLength];
 }
 
@@ -349,6 +381,8 @@
 
 - (void)showDownloadDidReceiveDataOfLength:(uint64_t)length
 {
+    assert(NSThread.isMainThread);
+    
     double newProgressValue = [self.statusController progressValue] + (double)length;
     
     // In case our expected content length was incorrect
@@ -365,6 +399,8 @@
 
 - (void)showDownloadDidStartExtractingUpdate
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent completeDownloadStatus];
     
     [self showStatusController];
@@ -375,25 +411,26 @@
 
 - (void)showExtractionReceivedProgress:(double)progress
 {
+    assert(NSThread.isMainThread);
+    
     if ([self.statusController maxProgressValue] == 0.0) {
         [self.statusController setMaxProgressValue:1];
     }
     [self.statusController setProgressValue:progress];
 }
 
-- (void)_showInstallingUpdate
+- (void)showInstallingUpdate
 {
+    assert(NSThread.isMainThread);
+    
     [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
     [self.statusController setButtonEnabled:NO];
 }
 
-- (void)showInstallingUpdate
-{
-    [self _showInstallingUpdate];
-}
-
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement
 {
+    assert(NSThread.isMainThread);
+    
     // Deciding not to show anything here
     [self.coreComponent registerAcknowledgement:acknowledgement];
     [self.coreComponent acceptAcknowledgement];
@@ -403,6 +440,8 @@
 
 - (void)showSendingTerminationSignal
 {
+    assert(NSThread.isMainThread);
+    
     // The "quit" event can always be canceled or delayed by the application we're updating
     // So we can't easily predict how long the installation will take or if it won't happen right away
     // We close our status window because we don't want it persisting for too long and have it obscure other windows
@@ -412,6 +451,8 @@
 
 - (void)dismissUpdateInstallation
 {
+    assert(NSThread.isMainThread);
+    
     [self.coreComponent dismissUpdateInstallation];
     
     [self closeCheckingWindow];

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -32,16 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
  a response back from the user driver. Note that every parameter block, or reply, *must* be responded to eventually -
  that is, none can be ignored. Furthermore, they can only be replied to *once* - a reply or completion block should be considered
  invalidated after it's once used. The faster a reply can be made, the more Sparkle may be able to idle, and so the better.
- Lastly, every method in this protocol can be called from any thread. Thus, an implementor may choose to always
- dispatch asynchronously to the main thread. However, an implementor should also avoid unnecessary nested asynchronous dispatches.
+ Every method in this protocol can be assumed to be called from the main thread.
  
- An implementor of this protocol should act defensively. For example, it may be possible for an action that says to
- invalidate or dismiss something to be called multiple times in succession, and the implementor may choose to ignore further requests.
+ It may be possible for an action that says to invalidate or dismiss something to be called multiple times in succession, and the implementor may choose to ignore further requests. (TODO: This should be verified if this actually can happen in practice).
  
- Note: Once upon a time, when first developing the user driver API, I had the user driver exist in a separate process from the rest of the framework.
+ Note: Once upon a time, when first developing the user driver API, I had the user driver exist in a separate process from the rest of the framework (this is no longer supported).
  If you're familiar with how the higher level XPC APIs work, this explains why some of the decisions above were made
  (reply block executed on any thread, reply block replied only once, single reply block, void return types, idleness, no optional methods, ...)
- This is somewhat of an artifact (maybe?) now, but I think most of these set of restrictions still enforces a well designed API.
+ This is somewhat of an artifact now, but I think most of these set of restrictions still enforces a well designed API.
  */
 SU_EXPORT @protocol SPUUserDriver <NSObject>
 

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -118,10 +118,8 @@
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)__unused request reply:(void (^)(SUUpdatePermissionResponse *))reply
 {
     // Just make a decision..
-    dispatch_async(dispatch_get_main_queue(), ^{
-        SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:YES sendSystemProfile:NO];
-        reply(response);
-    });
+    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:YES sendSystemProfile:NO];
+    reply(response);
 }
 
 #pragma mark Update Found
@@ -154,44 +152,36 @@
 
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
-    });
+    [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
 }
 
 - (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
-    });
+    [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
 }
 
 - (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self showUpdateWithAppcastItem:appcastItem skippable:NO reply:^(SPUUpdateAlertChoice choice) {
-            switch (choice) {
-                case SPUInstallUpdateChoice:
-                    reply(SPUInstallAndRelaunchUpdateNow);
-                    break;
-                case SPUInstallLaterChoice:
-                    reply(SPUDismissUpdateInstallation);
-                    break;
-                case SPUSkipThisVersionChoice:
-                    abort();
-            }
-        }];
-    });
+    [self showUpdateWithAppcastItem:appcastItem skippable:NO reply:^(SPUUpdateAlertChoice choice) {
+        switch (choice) {
+            case SPUInstallUpdateChoice:
+                reply(SPUInstallAndRelaunchUpdateNow);
+                break;
+            case SPUInstallLaterChoice:
+                reply(SPUDismissUpdateInstallation);
+                break;
+            case SPUSkipThisVersionChoice:
+                abort();
+        }
+    }];
 }
 
 - (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply
 {
     // Todo: show user interface for this
-    dispatch_async(dispatch_get_main_queue(), ^{
-        NSLog(@"Found info URL: %@", appcastItem.infoURL);
-        
-        reply(SPUDismissInformationalNoticeChoice);
-    });
+    NSLog(@"Found info URL: %@", appcastItem.infoURL);
+    
+    reply(SPUDismissInformationalNoticeChoice);
 }
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
@@ -207,33 +197,27 @@
 
 - (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerInstallUpdateHandler:installUpdateHandler];
-        
-        __weak SUPopUpTitlebarUserDriver *weakSelf = self;
-        [self addUpdateButtonWithTitle:@"Install & Relaunch" action:^(NSButton *__unused button) {
-            [weakSelf.coreComponent installUpdateWithChoice:SPUInstallAndRelaunchUpdateNow];
-        }];
-    });
+    [self.coreComponent registerInstallUpdateHandler:installUpdateHandler];
+    
+    __weak SUPopUpTitlebarUserDriver *weakSelf = self;
+    [self addUpdateButtonWithTitle:@"Install & Relaunch" action:^(NSButton *__unused button) {
+        [weakSelf.coreComponent installUpdateWithChoice:SPUInstallAndRelaunchUpdateNow];
+    }];
 }
 
 #pragma mark Check for Updates
 
 - (void)showUserInitiatedUpdateCheckWithCompletion:(void (^)(SPUUserInitiatedCheckStatus))updateCheckStatusCompletion
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
-        
-        [self addUpdateButtonWithTitle:@"Checking for Updates…"];
-    });
+    [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
+    
+    [self addUpdateButtonWithTitle:@"Checking for Updates…"];
 }
 
 - (void)dismissUserInitiatedUpdateCheck
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent completeUpdateCheckStatus];
-        [self removeUpdateButton];
-    });
+    [self.coreComponent completeUpdateCheckStatus];
+    [self removeUpdateButton];
 }
 
 #pragma mark Update Errors
@@ -248,120 +232,90 @@
 
 - (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        
-        NSLog(@"Error: %@", error);
-        [self addUpdateButtonWithTitle:@"Update Errored!" action:nil];
-        
-        [self acceptAcknowledgementAfterDelay];
-    });
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    
+    NSLog(@"Error: %@", error);
+    [self addUpdateButtonWithTitle:@"Update Errored!" action:nil];
+    
+    [self acceptAcknowledgementAfterDelay];
 }
 
 - (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        
-        [self addUpdateButtonWithTitle:@"No Update Available" action:nil];
-        
-        [self acceptAcknowledgementAfterDelay];
-    });
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    
+    [self addUpdateButtonWithTitle:@"No Update Available" action:nil];
+    
+    [self acceptAcknowledgementAfterDelay];
 }
 
 #pragma mark Download & Install Updates
 
 - (void)showDownloadInitiatedWithCompletion:(void (^)(SPUDownloadUpdateStatus))downloadUpdateStatusCompletion
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
-    });
+    [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
 }
 
 - (void)showDownloadDidReceiveExpectedContentLength:(uint64_t)expectedContentLength
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self addUpdateButtonWithTitle:@"Downloading…"];
-        self.contentLengthDownloaded = 0;
-        self.expectedContentLength = expectedContentLength;
-    });
+    [self addUpdateButtonWithTitle:@"Downloading…"];
+    self.contentLengthDownloaded = 0;
+    self.expectedContentLength = expectedContentLength;
 }
 
 - (void)showDownloadDidReceiveDataOfLength:(uint64_t)length
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.contentLengthDownloaded += length;
-        
-        // In case our expected content length was incorrect
-        if (self.contentLengthDownloaded > self.expectedContentLength) {
-            self.expectedContentLength = self.contentLengthDownloaded;
-        }
-        
-        if (self.expectedContentLength > 0) {
-            double progress = (double)self.contentLengthDownloaded / self.expectedContentLength;
-            [self addUpdateButtonWithTitle:[NSString stringWithFormat:@"Downloading (%0.0f%%)", progress * 100] action:nil];
-        }
-    });
+    self.contentLengthDownloaded += length;
+    
+    // In case our expected content length was incorrect
+    if (self.contentLengthDownloaded > self.expectedContentLength) {
+        self.expectedContentLength = self.contentLengthDownloaded;
+    }
+    
+    if (self.expectedContentLength > 0) {
+        double progress = (double)self.contentLengthDownloaded / self.expectedContentLength;
+        [self addUpdateButtonWithTitle:[NSString stringWithFormat:@"Downloading (%0.0f%%)", progress * 100] action:nil];
+    }
 }
 
 - (void)showDownloadDidStartExtractingUpdate
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent completeDownloadStatus];
-        [self addUpdateButtonWithTitle:@"Extracting…"];
-    });
+    [self.coreComponent completeDownloadStatus];
+    [self addUpdateButtonWithTitle:@"Extracting…"];
 }
 
 - (void)showExtractionReceivedProgress:(double)progress
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self addUpdateButtonWithTitle:[NSString stringWithFormat:@"Extracting (%d%%)…", (int)(progress * 100)]];
-    });
+    [self addUpdateButtonWithTitle:[NSString stringWithFormat:@"Extracting (%d%%)…", (int)(progress * 100)]];
 }
 
 - (void)showInstallingUpdate
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self addUpdateButtonWithTitle:@"Installing…"];
-    });
+    [self addUpdateButtonWithTitle:@"Installing…"];
 }
 
 - (void)showSendingTerminationSignal
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        // In case our termination request fails or is delayed
-        [self removeUpdateButton];
-    });
+    // In case our termination request fails or is delayed
+    [self removeUpdateButton];
 }
 
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        
-        [self addUpdateButtonWithTitle:@"Installation Finished!"];
-        
-        [self acceptAcknowledgementAfterDelay];
-    });
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    
+    [self addUpdateButtonWithTitle:@"Installation Finished!"];
+    
+    [self acceptAcknowledgementAfterDelay];
 }
 
 #pragma mark Aborting Everything
 
-- (void)_dismissUpdateInstallation
+- (void)dismissUpdateInstallation
 {
-    // Make sure everything we call here does not dispatch async to main queue
-    // because we are already on the main queue (and I've been bitten in the past by this before)
-    
     [self.coreComponent dismissUpdateInstallation];
     
     [self removeUpdateButton];
-}
-
-- (void)dismissUpdateInstallation
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self _dismissUpdateInstallation];
-    });
 }
 
 @end

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -113,7 +113,7 @@
 
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
-    self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
+    [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
     reply(SPUInstallUpdateChoice);
 }
 

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -46,42 +46,34 @@
 
 - (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent showCanCheckForUpdates:canCheckForUpdates];
-    });
+    [self.coreComponent showCanCheckForUpdates:canCheckForUpdates];
 }
 
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)__unused request reply:(void (^)(SUUpdatePermissionResponse *))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.updatePermissionResponse == nil) {
-            // We don't want to make this decision on behalf of the user.
-            fprintf(stderr, "Error: Asked to grant update permission. Exiting.\n");
-            exit(EXIT_FAILURE);
-        } else {
-            if (self.verbose) {
-                fprintf(stderr, "Granting permission for automatic update checks with sending system profile %s...\n", self.updatePermissionResponse.sendSystemProfile ? "enabled" : "disabled");
-            }
-            reply(self.updatePermissionResponse);
+    if (self.updatePermissionResponse == nil) {
+        // We don't want to make this decision on behalf of the user.
+        fprintf(stderr, "Error: Asked to grant update permission. Exiting.\n");
+        exit(EXIT_FAILURE);
+    } else {
+        if (self.verbose) {
+            fprintf(stderr, "Granting permission for automatic update checks with sending system profile %s...\n", self.updatePermissionResponse.sendSystemProfile ? "enabled" : "disabled");
         }
-    });
+        reply(self.updatePermissionResponse);
+    }
 }
 
 - (void)showUserInitiatedUpdateCheckWithCompletion:(void (^)(SPUUserInitiatedCheckStatus))updateCheckStatusCompletion
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
-        if (self.verbose) {
-            fprintf(stderr, "Checking for Updates...\n");
-        }
-    });
+    [self.coreComponent registerUpdateCheckStatusHandler:updateCheckStatusCompletion];
+    if (self.verbose) {
+        fprintf(stderr, "Checking for Updates...\n");
+    }
 }
 
 - (void)dismissUserInitiatedUpdateCheck
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent completeUpdateCheckStatus];
-    });
+    [self.coreComponent completeUpdateCheckStatus];
 }
 
 - (void)displayReleaseNotes:(const char * _Nullable)releaseNotes
@@ -121,201 +113,167 @@
 
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
-        reply(SPUInstallUpdateChoice);
-    });
+    self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
+    reply(SPUInstallUpdateChoice);
 }
 
 - (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"downloaded"];
-        reply(SPUInstallUpdateChoice);
-    });
+    [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"downloaded"];
+    reply(SPUInstallUpdateChoice);
 }
 
 - (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerInstallUpdateHandler:reply];
-        [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"resumable"];
-        
-        if (self.deferInstallation) {
-            if (self.verbose) {
-                fprintf(stderr, "Deferring Installation.\n");
-            }
-            [self.coreComponent installUpdateWithChoice:SPUDismissUpdateInstallation];
-        } else {
-            [self.coreComponent installUpdateWithChoice:SPUInstallAndRelaunchUpdateNow];
+    [self.coreComponent registerInstallUpdateHandler:reply];
+    [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"resumable"];
+    
+    if (self.deferInstallation) {
+        if (self.verbose) {
+            fprintf(stderr, "Deferring Installation.\n");
         }
-    });
+        [self.coreComponent installUpdateWithChoice:SPUDismissUpdateInstallation];
+    } else {
+        [self.coreComponent installUpdateWithChoice:SPUInstallAndRelaunchUpdateNow];
+    }
 }
 
 - (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        fprintf(stderr, "Found information for new update: %s\n", appcastItem.infoURL.absoluteString.UTF8String);
-        
-        reply(SPUDismissInformationalNoticeChoice);
-    });
+    fprintf(stderr, "Found information for new update: %s\n", appcastItem.infoURL.absoluteString.UTF8String);
+    
+    reply(SPUDismissInformationalNoticeChoice);
 }
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            if (downloadData.MIMEType != nil && [downloadData.MIMEType isEqualToString:@"text/plain"]) {
-                NSStringEncoding encoding;
-                if (downloadData.textEncodingName == nil) {
-                    encoding = NSUTF8StringEncoding;
-                } else {
-                    CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)downloadData.textEncodingName);
-                    if (cfEncoding != kCFStringEncodingInvalidId) {
-                        encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
-                    } else {
-                        encoding = NSUTF8StringEncoding;
-                    }
-                }
-                [self displayPlainTextReleaseNotes:downloadData.data encoding:encoding];
+    if (self.verbose) {
+        if (downloadData.MIMEType != nil && [downloadData.MIMEType isEqualToString:@"text/plain"]) {
+            NSStringEncoding encoding;
+            if (downloadData.textEncodingName == nil) {
+                encoding = NSUTF8StringEncoding;
             } else {
-                [self displayHTMLReleaseNotes:downloadData.data];
+                CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)downloadData.textEncodingName);
+                if (cfEncoding != kCFStringEncodingInvalidId) {
+                    encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+                } else {
+                    encoding = NSUTF8StringEncoding;
+                }
             }
+            [self displayPlainTextReleaseNotes:downloadData.data encoding:encoding];
+        } else {
+            [self displayHTMLReleaseNotes:downloadData.data];
         }
-    });
+    }
 }
 
 - (void)showUpdateReleaseNotesFailedToDownloadWithError:(NSError *)error
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Error: Unable to download release notes: %s\n", error.localizedDescription.UTF8String);
-        }
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Error: Unable to download release notes: %s\n", error.localizedDescription.UTF8String);
+    }
 }
 
 - (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))__unused acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "No new update available!\n");
-        }
-        exit(EXIT_SUCCESS);
-    });
+    if (self.verbose) {
+        fprintf(stderr, "No new update available!\n");
+    }
+    exit(EXIT_SUCCESS);
 }
 
 - (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))__unused acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        fprintf(stderr, "Error: Update has failed: %s\n", error.localizedDescription.UTF8String);
-        exit(EXIT_FAILURE);
-    });
+    fprintf(stderr, "Error: Update has failed: %s\n", error.localizedDescription.UTF8String);
+    exit(EXIT_FAILURE);
 }
 
 - (void)showDownloadInitiatedWithCompletion:(void (^)(SPUDownloadUpdateStatus))downloadUpdateStatusCompletion
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
-        
-        if (self.verbose) {
-            fprintf(stderr, "Downloading Update...\n");
-        }
-    });
+    [self.coreComponent registerDownloadStatusHandler:downloadUpdateStatusCompletion];
+    
+    if (self.verbose) {
+        fprintf(stderr, "Downloading Update...\n");
+    }
 }
 
 - (void)showDownloadDidReceiveExpectedContentLength:(uint64_t)expectedContentLength
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Downloading %llu bytes...\n", expectedContentLength);
-        }
-        self.bytesDownloaded = 0;
-        self.bytesToDownload = expectedContentLength;
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Downloading %llu bytes...\n", expectedContentLength);
+    }
+    self.bytesDownloaded = 0;
+    self.bytesToDownload = expectedContentLength;
 }
 
 - (void)showDownloadDidReceiveDataOfLength:(uint64_t)length
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.bytesDownloaded += length;
-        
-        // In case our expected content length was incorrect
-        if (self.bytesDownloaded > self.bytesToDownload) {
-            self.bytesToDownload = self.bytesDownloaded;
-        }
-        
-        if (self.bytesToDownload > 0 && self.verbose) {
-            fprintf(stderr, "Downloaded %llu out of %llu bytes (%.0f%%)\n", self.bytesDownloaded, self.bytesToDownload, (self.bytesDownloaded * 100.0 / self.bytesToDownload));
-        }
-    });
+    self.bytesDownloaded += length;
+    
+    // In case our expected content length was incorrect
+    if (self.bytesDownloaded > self.bytesToDownload) {
+        self.bytesToDownload = self.bytesDownloaded;
+    }
+    
+    if (self.bytesToDownload > 0 && self.verbose) {
+        fprintf(stderr, "Downloaded %llu out of %llu bytes (%.0f%%)\n", self.bytesDownloaded, self.bytesToDownload, (self.bytesDownloaded * 100.0 / self.bytesToDownload));
+    }
 }
 
 - (void)showDownloadDidStartExtractingUpdate
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent completeDownloadStatus];
-        
-        if (self.verbose) {
-            fprintf(stderr, "Extracting update...\n");
-        }
-    });
+    [self.coreComponent completeDownloadStatus];
+    
+    if (self.verbose) {
+        fprintf(stderr, "Extracting update...\n");
+    }
 }
 
 - (void)showExtractionReceivedProgress:(double)progress
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Extracting Update (%.0f%%)\n", progress * 100);
-        }
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Extracting Update (%.0f%%)\n", progress * 100);
+    }
 }
 
 - (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerInstallUpdateHandler:installUpdateHandler];
-        
-        if (self.deferInstallation) {
-            if (self.verbose) {
-                fprintf(stderr, "Deferring Installation.\n");
-            }
-            [self.coreComponent installUpdateWithChoice:SPUDismissUpdateInstallation];
-        } else {
-            [self.coreComponent installUpdateWithChoice:SPUInstallAndRelaunchUpdateNow];
+    [self.coreComponent registerInstallUpdateHandler:installUpdateHandler];
+    
+    if (self.deferInstallation) {
+        if (self.verbose) {
+            fprintf(stderr, "Deferring Installation.\n");
         }
-    });
+        [self.coreComponent installUpdateWithChoice:SPUDismissUpdateInstallation];
+    } else {
+        [self.coreComponent installUpdateWithChoice:SPUInstallAndRelaunchUpdateNow];
+    }
 }
 
 - (void)showInstallingUpdate
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Installing Update...\n");
-        }
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Installing Update...\n");
+    }
 }
 
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.coreComponent registerAcknowledgement:acknowledgement];
-        
-        if (self.verbose) {
-           fprintf(stderr, "Installation Finished.\n");
-        }
-        
-        [self.coreComponent acceptAcknowledgement];
-    });
+    [self.coreComponent registerAcknowledgement:acknowledgement];
+    
+    if (self.verbose) {
+       fprintf(stderr, "Installation Finished.\n");
+    }
+    
+    [self.coreComponent acceptAcknowledgement];
 }
 
 - (void)dismissUpdateInstallation
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Exiting.\n");
-        }
-        exit(EXIT_SUCCESS);
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Exiting.\n");
+    }
+    exit(EXIT_SUCCESS);
 }
 
 - (void)showSendingTerminationSignal

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -174,7 +174,7 @@
     }
 }
 
-- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))__unused acknowledgement
+- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))__unused acknowledgement __attribute__((noreturn))
 {
     if (self.verbose) {
         fprintf(stderr, "No new update available!\n");
@@ -182,7 +182,7 @@
     exit(EXIT_SUCCESS);
 }
 
-- (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))__unused acknowledgement
+- (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))__unused acknowledgement __attribute__((noreturn))
 {
     fprintf(stderr, "Error: Update has failed: %s\n", error.localizedDescription.UTF8String);
     exit(EXIT_FAILURE);
@@ -268,7 +268,7 @@
     [self.coreComponent acceptAcknowledgement];
 }
 
-- (void)dismissUpdateInstallation
+- (void)dismissUpdateInstallation __attribute__((noreturn))
 {
     if (self.verbose) {
         fprintf(stderr, "Exiting.\n");


### PR DESCRIPTION
This reduces friction in creating a SPUUserDriver. This assumption that the calls could be made from any thread is a relic of the past of separating the user driver into a different process from the updater/scheduler, which is no longer sane or supported.

This should speed up things very slightly too.