### PR TITLE
Update INSTALL to include submodule init step

### DIFF
--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -5,6 +5,7 @@ If release products have not already been built, they can be built by:
 ```
 cd <path-to>/Sparkle/
 
+git submodule update --init --recursive
 make release
 ```
 


### PR DESCRIPTION
The install description currently fails to notify the user that they should install the git submodule(s) present in the repo.

This causes `make release` to fail.