### PR TITLE
Fix Package.swift being updated after tag

### DIFF
--- a/Configurations/release-move-tag.sh
+++ b/Configurations/release-move-tag.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 set -e
 
-# Finishing up - force re-tag
+# Convenience script to automatically commit Package.swift after updating the checksum and move the latest tag
 latest_git_tag=$(git describe --abbrev=0) # gets the latest tag name
-read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for Swift Package Manager release) " -n 1 -r
-echo    # (optional) move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-    long_message=$(git tag -n99 -l $latest_git_tag) # gets corresponding message
-    long_message=${long_message/$latest_git_tag} # trims tag name
-    long_message="$(echo -e "${long_message}" | sed -e 's/^[[:space:]]*//')" # trim leading whitespace
-    git add Package.swift
-    git commit -m "Update Package.swift"
-    git tag -fa $latest_git_tag -m "${long_message}"
+commits_since_tag=$(git rev-list ${latest_git_tag}.. --count)
+if [ "$commits_since_tag" -ge 1 ]; then
+    # If there has been more than one commits since the latest tag, it's highly likely that we did not intend to do a full release
+    echo "WARNING: More than one commit ($commits_since_tag) since tag '$latest_git_tag'. Did you tag a new version?"
+    echo "Package.swift has not been commited and tag has not been moved."
+else
+    # TODO: add sanity check to see if version is actually being updated or not?
+    read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for Swift Package Manager release) " -n 1 -r
+    echo    # (optional) move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        long_message=$(git tag -n99 -l $latest_git_tag) # gets corresponding message
+        long_message=${long_message/$latest_git_tag} # trims tag name
+        long_message="$(echo -e "${long_message}" | sed -e 's/^[[:space:]]*//')" # trim leading whitespace
+        git add Package.swift
+        git commit -m "Update Package.swift"
+        git tag -fa $latest_git_tag -m "${long_message}"
+    fi
 fi

--- a/Configurations/release-move-tag.sh
+++ b/Configurations/release-move-tag.sh
@@ -4,10 +4,10 @@ set -e
 # Convenience script to automatically commit Package.swift after updating the checksum and move the latest tag
 latest_git_tag=$(git describe --abbrev=0) # gets the latest tag name
 commits_since_tag=$(git rev-list ${latest_git_tag}.. --count)
-if [ "$commits_since_tag" -ge 1 ]; then
-    # If there has been more than one commits since the latest tag, it's highly likely that we did not intend to do a full release
-    echo "WARNING: More than one commit ($commits_since_tag) since tag '$latest_git_tag'. Did you tag a new version?"
-    echo "Package.swift has not been commited and tag has not been moved."
+if [ "$commits_since_tag" -gt 0 ]; then
+    # If there have been commits since the latest tag, it's highly likely that we did not intend to do a full release
+    echo "WARNING: $commits_since_tag commit(s) since tag '$latest_git_tag'. Did you tag a new version?"
+    echo "Package.swift has not been committed and tag has not been moved."
 else
     # TODO: add sanity check to see if version is actually being updated or not?
     read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for Swift Package Manager release) " -n 1 -r
@@ -19,5 +19,8 @@ else
         git add Package.swift
         git commit -m "Update Package.swift"
         git tag -fa $latest_git_tag -m "${long_message}"
+        echo "Package.swift committed and tag '$latest_git_tag' moved."
+    else
+        echo "Package.swift has not been committed and tag has not been moved."
     fi
 fi

--- a/Configurations/release-move-tag.sh
+++ b/Configurations/release-move-tag.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Finishing up - force re-tag
+latest_git_tag=$(git describe --abbrev=0) # gets the latest tag name
+read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for Swift Package Manager release) " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    long_message=$(git tag -n99 -l $latest_git_tag) # gets corresponding message
+    long_message=${long_message/$latest_git_tag} # trims tag name
+    long_message="$(echo -e "${long_message}" | sed -e 's/^[[:space:]]*//')" # trim leading whitespace
+    git add Package.swift
+    git commit -m "Update Package.swift"
+    git tag -fa $latest_git_tag -m "${long_message}"
+fi

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ release:
 	open "$(BUILDDIR)/Build/Products/Release/"
 	cat Sparkle.podspec
 	@echo "Don't forget to update CocoaPods! pod trunk push"
-	@echo "Don't forget to commit the updated Package manifest before releasing!"
+	@echo "Don't forget to upload Sparkle-for-Swift-Package-Manager.zip!"
 
 build:
 	xcodebuild clean build

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ localizable-strings:
 
 release:
 	xcodebuild -scheme Distribution -configuration Release -derivedDataPath "$(BUILDDIR)" build
-	git tag -fa <tagname>
+	./Configurations/release-move-tag.sh
 	open "$(BUILDDIR)/Build/Products/Release/"
 	cat Sparkle.podspec
 	@echo "Don't forget to update CocoaPods! pod trunk push"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ localizable-strings:
 
 release:
 	xcodebuild -scheme Distribution -configuration Release -derivedDataPath "$(BUILDDIR)" build
+	git tag -fa <tagname>
 	open "$(BUILDDIR)/Build/Products/Release/"
 	cat Sparkle.podspec
 	@echo "Don't forget to update CocoaPods! pod trunk push"


### PR DESCRIPTION
TL/DR; This PR should fix #1674.

### What it does

Adds a simple script called `release-move-tag.sh` under `Configurations`. It runs as a separate step in `make release`.

I chose to have it as a separate script to improve readability and to allow Xcode to build the Distribution target without invoking anything tag-related.

The script checks that there have been no commits since latest tag to prevent accidentally moving an old tag. Indeed, the script expects to be run after tagging the release just before `make release`, so there should be no commits in-between.

### Tests

I've tested the following successfully:

- Bump version in ConfigCommon.xcconfig and Sparkle.podspec
- Commit and tag
- `make release` and approve moving the tag

It all seemed ok to me. All that would be left is pushing to remote and uploading the corresponding artifacts (including the ZIP for SPM).

### Up for review

I thought about adding some version checks but it seems a little overkill as it seems already safe enough. The script actually asks for user approval before moving the tag. Accordingly, `make release` requires one interaction if we are really releasing (and asks so **before** opening the directory with the assets to be uploaded). We could also remove the interaction entirely and just commit Package.swift and move the tag whenever there have been no commits since latest tag.

I've added comments that are up for review. Naturally, once the changes are approved, I'll do the same on the 2.x branch (**EDIT**: now available #1711).