### PR TITLE
Don't initialize the webview if we don't show release notes

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -96,38 +96,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         SPUUpdaterSettings *updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:host.bundle];
         _allowsAutomaticUpdates = updaterSettings.allowsAutomaticUpdates && !item.isInformationOnlyUpdate;
         [self setShouldCascadeWindows:NO];
-        
-        if ([self showsReleaseNotes]) {
-        
-            NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
-            
-            // "-apple-system-font" is a reference to the system UI font. "-apple-system" is the new recommended token, but for backward compatibility we can't use it.
-            NSString *defaultFontFamily = @"-apple-system-font";
-            int defaultFontSize = (int)[NSFont systemFontSize];
-            
-            BOOL javaScriptEnabled = [host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
-            
-            BOOL useWKWebView;
-            if (@available(macOS 10.11, *)) {
-                // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
-                // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
-                // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
-                // In this case, fall back to legacy WebKit view.
-                // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
-                useWKWebView = !SPUXPCServiceExists(@DOWNLOADER_BUNDLE_ID);
-            } else {
-                // Never use WKWebView prior to macOS 10.11. Details are in SUWKWebView.m
-                useWKWebView = NO;
-            }
-            
-            if (useWKWebView) {
-                _webView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
-            } else {
-                _webView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
-            }
-            
-        }
-        
     }
     return self;
 }
@@ -365,12 +333,40 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 {
     BOOL showReleaseNotes = [self showsReleaseNotes];
     
-    NSView *boxContentView = self.releaseNotesBoxView.contentView;
-    [boxContentView addSubview:self.webView.view];
-    
-    self.webView.view.frame = boxContentView.bounds;
-    self.webView.view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-    self.webView.view.hidden = !showReleaseNotes;
+    if (showReleaseNotes) {
+        NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
+        
+        // "-apple-system-font" is a reference to the system UI font. "-apple-system" is the new recommended token, but for backward compatibility we can't use it.
+        NSString *defaultFontFamily = @"-apple-system-font";
+        int defaultFontSize = (int)[NSFont systemFontSize];
+        
+        BOOL javaScriptEnabled = [self.host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
+        
+        BOOL useWKWebView;
+        if (@available(macOS 10.11, *)) {
+            // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
+            // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
+            // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
+            // In this case, fall back to legacy WebKit view.
+            // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
+            useWKWebView = !SPUXPCServiceExists(@DOWNLOADER_BUNDLE_ID);
+        } else {
+            // Never use WKWebView prior to macOS 10.11. Details are in SUWKWebView.m
+            useWKWebView = NO;
+        }
+        
+        if (useWKWebView) {
+            self.webView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+        } else {
+            self.webView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+        }
+        
+        NSView *boxContentView = self.releaseNotesBoxView.contentView;
+        [boxContentView addSubview:self.webView.view];
+        
+        self.webView.view.frame = boxContentView.bounds;
+        self.webView.view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    }
 
     [self.window setFrameAutosaveName: showReleaseNotes ? @"SUUpdateAlert" : @"SUUpdateAlertSmall" ];
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -97,32 +97,37 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         _allowsAutomaticUpdates = updaterSettings.allowsAutomaticUpdates && !item.isInformationOnlyUpdate;
         [self setShouldCascadeWindows:NO];
         
-        NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
+        if ([self showsReleaseNotes]) {
         
-        // "-apple-system-font" is a reference to the system UI font. "-apple-system" is the new recommended token, but for backward compatibility we can't use it.
-        NSString *defaultFontFamily = @"-apple-system-font";
-        int defaultFontSize = (int)[NSFont systemFontSize];
-        
-        BOOL javaScriptEnabled = [host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
-        
-        BOOL useWKWebView;
-        if (@available(macOS 10.11, *)) {
-            // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
-            // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
-            // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
-            // In this case, fall back to legacy WebKit view.
-            // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
-            useWKWebView = !SPUXPCServiceExists(@DOWNLOADER_BUNDLE_ID);
-        } else {
-            // Never use WKWebView prior to macOS 10.11. Details are in SUWKWebView.m
-            useWKWebView = NO;
+            NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
+            
+            // "-apple-system-font" is a reference to the system UI font. "-apple-system" is the new recommended token, but for backward compatibility we can't use it.
+            NSString *defaultFontFamily = @"-apple-system-font";
+            int defaultFontSize = (int)[NSFont systemFontSize];
+            
+            BOOL javaScriptEnabled = [host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
+            
+            BOOL useWKWebView;
+            if (@available(macOS 10.11, *)) {
+                // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
+                // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
+                // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
+                // In this case, fall back to legacy WebKit view.
+                // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
+                useWKWebView = !SPUXPCServiceExists(@DOWNLOADER_BUNDLE_ID);
+            } else {
+                // Never use WKWebView prior to macOS 10.11. Details are in SUWKWebView.m
+                useWKWebView = NO;
+            }
+            
+            if (useWKWebView) {
+                _webView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+            } else {
+                _webView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+            }
+            
         }
         
-        if (useWKWebView) {
-            _webView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
-        } else {
-            _webView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
-        }
     }
     return self;
 }


### PR DESCRIPTION
This change enables Catalyst apps to embed Sparkle in a Plugin as long as they have `SUShowReleaseNotes` set to `false`.