### PR TITLE
Capitalizes french translation of "Vous utilisez actuellement..." ("Y…

### DIFF
--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -12,7 +12,7 @@
 
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ est la version la plus récente disponible.";
 
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ est la version la plus récente disponible.\n(vous utilisez actuellement la version %3$@)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ est la version la plus récente disponible.\n(Vous utilisez actuellement la version %3$@)";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available--you have %@. Would you like to download it now?" = "%1$@ %2$@ est disponible ; vous utilisez la version %3$@. Voulez-vous le télécharger maintenant ?";


### PR DESCRIPTION
…ou are currently running...")

French speaking user of our App recommended this minor adjustment to the capitalization of this translation.