### PR TITLE
Hide skip and later buttons in appropriate scenarios

### DIFF
--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -174,11 +174,6 @@ DQ
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
                         <connections>
-                            <binding destination="-2" name="hidden" keyPath="allowsAutomaticUpdates" id="141">
-                                <dictionary key="options">
-                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                </dictionary>
-                            </binding>
                             <binding destination="93" name="value" keyPath="values.SUAutomaticallyUpdate" id="135"/>
                         </connections>
                     </button>

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -391,7 +391,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     
     // When we show release notes, it looks ugly if the install buttons are not closer to the release notes view
     // However when we don't show release notes, it looks ugly if the install buttons are too close to the description field. Shrugs.
-    if (showReleaseNotes && ![self allowsAutomaticUpdates]) {
+    BOOL automaticDownloadsEnabledByDeveloper = [self.host boolForInfoDictionaryKey:SUAutomaticallyUpdateKey];
+    if (showReleaseNotes && (!self.allowsAutomaticUpdates || automaticDownloadsEnabledByDeveloper)) {
         NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
         
         [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
@@ -399,22 +400,31 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         [self.automaticallyInstallUpdatesButton removeFromSuperview];
     }
     
+    if (automaticDownloadsEnabledByDeveloper && !showReleaseNotes) {
+        // Disable automatic install updates option if the developer wishes for it in Info.plist
+        // If we are showing release notes, this button will be hidden instead
+        self.automaticallyInstallUpdatesButton.enabled = NO;
+    }
+    
     BOOL startedInstalling = (self.resumableCompletionBlock != nil);
     if (startedInstalling) {
-        // Should we hide the button or disable the button if the update has already started installing?
-        // Personally I think it looks better when the button is visible on the window...
-        // Anyway an already downloaded update can't be skipped
-        self.skipButton.enabled = NO;
+        // An already downloaded & resumable update can't be skipped
+        self.skipButton.hidden = YES;
         
         // We're going to be relaunching pretty instantaneously
         self.installButton.title = SULocalizedString(@"Install & Relaunch", nil);
         
         // We should be explicit that the update will be installed on quit
-        self.laterButton.title = SULocalizedString(@"Install on Quit", nil);
+        self.laterButton.title = SULocalizedString(@"Install Later", @"Alternate title for 'Remind me later' button when downloaded updates can be resumed");
     }
 
     if ([self.updateItem isCriticalUpdate]) {
-        self.skipButton.enabled = NO;
+        self.skipButton.hidden = YES;
+        self.laterButton.hidden = YES;
+    }
+    
+    if (![self.host boolForKey:SUEnableAutomaticChecksKey]) {
+        self.laterButton.hidden = YES;
     }
 
     [self.window center];

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -425,7 +425,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.installButton.title = SULocalizedString(@"Install and Relaunch", nil);
         
         // We should be explicit that the update will be installed on quit
-        self.laterButton.title = SULocalizedString(@"Install Later", @"Alternate title for 'Remind Me Later' button when downloaded updates can be resumed");
+        self.laterButton.title = SULocalizedString(@"Install On Quit", @"Alternate title for 'Remind Me Later' button when downloaded updates can be resumed");
     }
 
     if ([self.updateItem isCriticalUpdate]) {

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -425,7 +425,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.installButton.title = SULocalizedString(@"Install and Relaunch", nil);
         
         // We should be explicit that the update will be installed on quit
-        self.laterButton.title = SULocalizedString(@"Install On Quit", @"Alternate title for 'Remind Me Later' button when downloaded updates can be resumed");
+        self.laterButton.title = SULocalizedString(@"Install on Quit", @"Alternate title for 'Remind Me Later' button when downloaded updates can be resumed");
     }
 
     if ([self.updateItem isCriticalUpdate]) {

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -389,10 +389,15 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         [self.releaseNotesContainerView removeFromSuperview];
     }
     
+    // NOTE: The code below for deciding what buttons to hide is complex! Due to array of feature configurations :)
+    
     // When we show release notes, it looks ugly if the install buttons are not closer to the release notes view
     // However when we don't show release notes, it looks ugly if the install buttons are too close to the description field. Shrugs.
+    // Automatic downloads is enabled by developer if they set SUAutomaticallyUpdateKey in Info.plist,
+    // rather than the user toggling the setting
     BOOL automaticDownloadsEnabledByDeveloper = [self.host boolForInfoDictionaryKey:SUAutomaticallyUpdateKey];
     if (showReleaseNotes && (!self.allowsAutomaticUpdates || automaticDownloadsEnabledByDeveloper)) {
+        // Fix constraints so that buttons aren't far away from web view when we hide the automatic updates check box
         NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
         
         [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
@@ -407,6 +412,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
             self.automaticallyInstallUpdatesButton.enabled = NO;
         }
         
+        // A developer wishing for automatic updates shouldn't want users to skip updates
         self.skipButton.hidden = YES;
     }
     
@@ -416,10 +422,10 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.skipButton.hidden = YES;
         
         // We're going to be relaunching pretty instantaneously
-        self.installButton.title = SULocalizedString(@"Install & Relaunch", nil);
+        self.installButton.title = SULocalizedString(@"Install and Relaunch", nil);
         
         // We should be explicit that the update will be installed on quit
-        self.laterButton.title = SULocalizedString(@"Install Later", @"Alternate title for 'Remind me later' button when downloaded updates can be resumed");
+        self.laterButton.title = SULocalizedString(@"Install Later", @"Alternate title for 'Remind Me Later' button when downloaded updates can be resumed");
     }
 
     if ([self.updateItem isCriticalUpdate]) {

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -411,8 +411,9 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         }
     }
     
-    if (automaticDownloadsEnabledByDeveloper) {
-        // A developer wishing for automatic updates shouldn't want users to skip updates
+    // A developer wishing for automatic updates shouldn't want users to skip updates
+    // Except maybe when there's a minimum auto update version for auto-downloading specified
+    if (automaticDownloadsEnabledByDeveloper && self.updateItem.minimumAutoupdateVersion.length == 0) {
         self.skipButton.hidden = YES;
     }
     

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -400,10 +400,14 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         [self.automaticallyInstallUpdatesButton removeFromSuperview];
     }
     
-    if (automaticDownloadsEnabledByDeveloper && !showReleaseNotes) {
-        // Disable automatic install updates option if the developer wishes for it in Info.plist
-        // If we are showing release notes, this button will be hidden instead
-        self.automaticallyInstallUpdatesButton.enabled = NO;
+    if (automaticDownloadsEnabledByDeveloper) {
+        if (!showReleaseNotes) {
+            // Disable automatic install updates option if the developer wishes for it in Info.plist
+            // If we are showing release notes, this button will be hidden instead
+            self.automaticallyInstallUpdatesButton.enabled = NO;
+        }
+        
+        self.skipButton.hidden = YES;
     }
     
     BOOL startedInstalling = (self.resumableCompletionBlock != nil);

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -396,22 +396,22 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     // Automatic downloads is enabled by developer if they set SUAutomaticallyUpdateKey in Info.plist,
     // rather than the user toggling the setting
     BOOL automaticDownloadsEnabledByDeveloper = [self.host boolForInfoDictionaryKey:SUAutomaticallyUpdateKey];
-    if (showReleaseNotes && (!self.allowsAutomaticUpdates || automaticDownloadsEnabledByDeveloper)) {
-        // Fix constraints so that buttons aren't far away from web view when we hide the automatic updates check box
-        NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
-        
-        [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
-        
-        [self.automaticallyInstallUpdatesButton removeFromSuperview];
-    }
-    
-    if (automaticDownloadsEnabledByDeveloper) {
-        if (!showReleaseNotes) {
+    if (!self.allowsAutomaticUpdates || automaticDownloadsEnabledByDeveloper) {
+        if (showReleaseNotes) {
+            // Fix constraints so that buttons aren't far away from web view when we hide the automatic updates check box
+            NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
+            
+            [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
+            
+            [self.automaticallyInstallUpdatesButton removeFromSuperview];
+        } else {
             // Disable automatic install updates option if the developer wishes for it in Info.plist
             // If we are showing release notes, this button will be hidden instead
             self.automaticallyInstallUpdatesButton.enabled = NO;
         }
-        
+    }
+    
+    if (automaticDownloadsEnabledByDeveloper) {
         // A developer wishing for automatic updates shouldn't want users to skip updates
         self.skipButton.hidden = YES;
     }
@@ -433,6 +433,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.laterButton.hidden = YES;
     }
     
+    // Reminding user later doesn't make sense when automatic update checks are off
     if (![self.host boolForKey:SUEnableAutomaticChecksKey]) {
         self.laterButton.hidden = YES;
     }


### PR DESCRIPTION
(Take a look at #1734 first)

This is appropriately syncing UI hidden-state changes from 1.x.

* Don't show/enable `automaticallyInstallUpdatesButton` checkbox if developer enables automatic downloading of updates. Leverages off of already-existing logic for checking if `SUAllowsAutomaticUpdatesKey` is NO where window constraints are updated too with checkbox hidden. If release notes are not shown, then button is disabled instead of hidden due to UI conformance (see 'ugly' comments in code).
* Skip button is hidden if developer opts into automatic downloads (now I'm not sure this is a good idea, see discussion in #1734)
* 2.x specific: change Install on Quit to Install Later and hide instead of disable skip button. In this case 2.x guarantees a resumable installation will occur when process is terminated (already reasoning past authorization).

More discussion in #1734 about doing the right things..

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported -- **I need to make some fixes / accommodations for 1.x branch**.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: macOS 11.1 (20C69)
