### PR TITLE
Alert adjustments 1x

### DIFF
--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -174,11 +174,6 @@ DQ
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
                         <connections>
-                            <binding destination="-2" name="hidden" keyPath="allowsAutomaticUpdates" id="141">
-                                <dictionary key="options">
-                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                </dictionary>
-                            </binding>
                             <binding destination="93" name="value" keyPath="values.SUAutomaticallyUpdate" id="135"/>
                         </connections>
                     </button>

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -326,8 +326,9 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         }
     }
     
-    if (automaticDownloadsEnabledByDeveloper) {
-        // A developer wishing for automatic updates shouldn't want users to skip updates
+    // A developer wishing for automatic updates shouldn't want users to skip updates
+    // Except maybe when there's a minimum auto update version for auto-downloading specified
+    if (automaticDownloadsEnabledByDeveloper && self.updateItem.minimumAutoupdateVersion.length == 0) {
         self.skipButton.hidden = YES;
     }
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -347,6 +347,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     // (Install Later would be harmfully incorrect if this update cannot be automatically installed)
     // And this is really not the place to do comparison/version checks.
     // Also make sure to check that the system and developer allows us to automatically update.
+    // This logic is not very sound and gets worse in 2.x where apps can be sandboxed. We may need to revisit this
+    // and also decide if we really need this button in the first place.
     if ([self.host boolForKey:SUAutomaticallyUpdateKey] && allowsAutomaticUpdates && self.updateItem.minimumAutoupdateVersion.length == 0) {
         [self.laterButton setTitle:SULocalizedString(@"Install Later", @"Alternate title for 'Remind Me Later' button when automatic updates are enabled")];
     }

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -345,8 +345,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     
     // If the developer makes use of minimumAutoupdateVersion, just stick to Remind Me Later on the safe side
     // (Install Later would be harmfully incorrect if this update cannot be automatically installed)
-    // And SUUpdateAlert is really not the place to do comparison/version checks.
-    // Also make sure to check that the system allows us to automatically update.
+    // And this is really not the place to do comparison/version checks.
+    // Also make sure to check that the system and developer allows us to automatically update.
     if ([self.host boolForKey:SUAutomaticallyUpdateKey] && allowsAutomaticUpdates && self.updateItem.minimumAutoupdateVersion.length == 0) {
         [self.laterButton setTitle:SULocalizedString(@"Install Later", @"Alternate title for 'Remind Me Later' button when automatic updates are enabled")];
     }

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -313,22 +313,20 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     // Automatic downloads is enabled by developer if they set SUAutomaticallyUpdateKey in Info.plist,
     // rather than the user toggling the setting
     BOOL automaticDownloadsEnabledByDeveloper = [self.host boolForInfoDictionaryKey:SUAutomaticallyUpdateKey];
-    if (showReleaseNotes && (!allowsAutomaticUpdates || automaticDownloadsEnabledByDeveloper)) {
-        // Fix constraints so that buttons aren't far away from web view when we hide the automatic updates check box
-        NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
-        
-        [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
-        
-        [self.automaticallyInstallUpdatesButton removeFromSuperview];
+    if (!allowsAutomaticUpdates || automaticDownloadsEnabledByDeveloper) {
+        if (showReleaseNotes) {
+            // Fix constraints so that buttons aren't far away from web view when we hide the automatic updates check box
+            NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
+            
+            [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
+            
+            [self.automaticallyInstallUpdatesButton removeFromSuperview];
+        } else {
+            self.automaticallyInstallUpdatesButton.enabled = NO;
+        }
     }
     
     if (automaticDownloadsEnabledByDeveloper) {
-        if (!showReleaseNotes) {
-            // Disable automatic install updates option if the developer wishes for it in Info.plist
-            // If we are showing release notes, this button will be hidden instead
-            self.automaticallyInstallUpdatesButton.enabled = NO;
-        }
-        
         // A developer wishing for automatic updates shouldn't want users to skip updates
         self.skipButton.hidden = YES;
     }


### PR DESCRIPTION
Fix fallout issues from #1696 for `master`: 
* Constraints not being updated when automatic checkbox is hidden
* Setting being read from user defaults rather than Info.plist which broke the user toggling the automatic checkbox setting in other cases
* Showing Install Later for cases where app cast prevents automatic installing of updates
* Capitalization title fixes

Some simplification / sync with 2.x too (#1733)

I'm not a huge fan with the growing complexity here of additional features and the "Install Later" change which I may not preserve for 2.x.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App (with testing lots of different boolean flags in Info.plist)
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: macOS 11.1 (20C69)
