### PR TITLE
Fix issues with phased group updates found in #1736

### DIFF
--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -191,7 +191,7 @@
             self.displayVersionString = self.versionString;
         }
 
-        NSString* enclosureRolloutIntervalString = [enclosure objectForKey:SUAppcastAttributePhasedRolloutInterval];
+        NSString* enclosureRolloutIntervalString = [dict objectForKey:SUAppcastElementPhasedRolloutInterval];
         if(enclosureRolloutIntervalString) {
             self.phasedRolloutInterval = @(enclosureRolloutIntervalString.integerValue);
         }

--- a/Sparkle/SUAutomaticUpdateDriver.m
+++ b/Sparkle/SUAutomaticUpdateDriver.m
@@ -234,4 +234,9 @@ static const NSTimeInterval SUAutomaticUpdatePromptImpatienceTimer = 60 * 60 * 2
     }
 }
 
+- (BOOL)usesPhasedRollout
+{
+    return YES;
+}
+
 @end

--- a/Sparkle/SUBasicUpdateDriver.h
+++ b/Sparkle/SUBasicUpdateDriver.h
@@ -27,6 +27,7 @@
 - (BOOL)isItemNewer:(SUAppcastItem *)ui;
 - (BOOL)itemPreventsAutoupdate:(SUAppcastItem *)ui;
 - (BOOL)hostSupportsItem:(SUAppcastItem *)ui;
+- (BOOL)usesPhasedRollout;
 - (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui;
 - (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui;
 - (void)appcastDidFinishLoading:(SUAppcast *)ac;

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -71,7 +71,6 @@ extern NSString *const SUAppcastAttributeEDSignature;
 extern NSString *const SUAppcastAttributeShortVersionString;
 extern NSString *const SUAppcastAttributeVersion;
 extern NSString *const SUAppcastAttributeOsType;
-extern NSString *const SUAppcastAttributePhasedRolloutInterval;
 
 extern NSString *const SUAppcastElementCriticalUpdate;
 extern NSString *const SUAppcastElementDeltas;
@@ -80,6 +79,7 @@ extern NSString *const SUAppcastElementMinimumSystemVersion;
 extern NSString *const SUAppcastElementMaximumSystemVersion;
 extern NSString *const SUAppcastElementReleaseNotesLink;
 extern NSString *const SUAppcastElementTags;
+extern NSString *const SUAppcastElementPhasedRolloutInterval;
 
 extern NSString *const SURSSAttributeURL;
 extern NSString *const SURSSAttributeLength;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -61,7 +61,6 @@ NSString *const SUAppcastAttributeEDSignature = @"sparkle:edSignature";
 NSString *const SUAppcastAttributeShortVersionString = @"sparkle:shortVersionString";
 NSString *const SUAppcastAttributeVersion = @"sparkle:version";
 NSString *const SUAppcastAttributeOsType = @"sparkle:os";
-NSString *const SUAppcastAttributePhasedRolloutInterval = @"sparkle:phasedRolloutInterval";
 
 NSString *const SUAppcastElementCriticalUpdate = @"sparkle:criticalUpdate";
 NSString *const SUAppcastElementDeltas = @"sparkle:deltas";
@@ -70,6 +69,7 @@ NSString *const SUAppcastElementMinimumSystemVersion = @"sparkle:minimumSystemVe
 NSString *const SUAppcastElementMaximumSystemVersion = @"sparkle:maximumSystemVersion";
 NSString *const SUAppcastElementReleaseNotesLink = @"sparkle:releaseNotesLink";
 NSString *const SUAppcastElementTags = @"sparkle:tags";
+NSString *const SUAppcastElementPhasedRolloutInterval = @"sparkle:phasedRolloutInterval";
 
 NSString *const SURSSAttributeURL = @"url";
 NSString *const SURSSAttributeLength = @"length";

--- a/Sparkle/SUScheduledUpdateDriver.m
+++ b/Sparkle/SUScheduledUpdateDriver.m
@@ -10,12 +10,7 @@
 #import "SUUpdaterPrivate.h"
 #import "SUUpdaterDelegate.h"
 
-#import "SUSystemUpdateInfo.h"
 #import "SUAppcastItem.h"
-
-@interface SUScheduledUpdateDriver ()
-- (BOOL)isItemReadyForPhasedRollout:(SUAppcastItem *)ui;
-@end
 
 @implementation SUScheduledUpdateDriver
 
@@ -27,26 +22,9 @@
     return self;
 }
 
-- (BOOL)hostSupportsItem:(SUAppcastItem *)ui {
-    return [super hostSupportsItem:ui] && [self isItemReadyForPhasedRollout:ui];
-}
-
-- (BOOL)isItemReadyForPhasedRollout:(SUAppcastItem *)ui {
-    if([ui isCriticalUpdate] || ![ui phasedRolloutInterval]) {
-        return YES;
-    }
-
-    NSDate* itemReleaseDate = ui.date;
-    if(!itemReleaseDate) {
-        return YES;
-    }
-
-    NSTimeInterval timeSinceRelease = [[NSDate date] timeIntervalSinceDate:itemReleaseDate];
-
-    NSTimeInterval phasedRolloutInterval = [[ui phasedRolloutInterval] doubleValue];
-    NSTimeInterval timeToWaitForGroup = phasedRolloutInterval * [SUSystemUpdateInfo updateGroupForHost:self.host];
-
-    return timeSinceRelease >= timeToWaitForGroup;
+- (BOOL)usesPhasedRollout
+{
+    return YES;
 }
 
 - (void)didFindValidUpdate
@@ -81,11 +59,6 @@
     }
 
     return [super shouldShowUpdateAlertForItem:item];
-}
-
-- (void)downloaderDidFinishWithTemporaryDownloadData:(SPUDownloadData * _Nullable) downloadData {
-    [SUSystemUpdateInfo setNewUpdateGroupIdentifierForHost:self.host]; // use new update group next time
-    [super downloaderDidFinishWithTemporaryDownloadData:downloadData];
 }
 
 @end

--- a/Sparkle/SUSystemUpdateInfo.m
+++ b/Sparkle/SUSystemUpdateInfo.m
@@ -65,7 +65,7 @@
 }
 
 + (NSNumber*)updateGroupIdentifierForHost:(SUHost*)host {
-    NSNumber* updateGroupIdentifier = [host objectForInfoDictionaryKey:SUUpdateGroupIdentifierKey];
+    NSNumber* updateGroupIdentifier = [host objectForUserDefaultsKey:SUUpdateGroupIdentifierKey];
     if(updateGroupIdentifier == nil) {
         updateGroupIdentifier = [self setNewUpdateGroupIdentifierForHost:host];
     }

--- a/Tests/Resources/testappcast.xml
+++ b/Tests/Resources/testappcast.xml
@@ -12,7 +12,8 @@
     <!-- The best chosen release -->
     <item>
         <title>Version 3.0</title>
-        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="3.0" sparkle:phasedRolloutInterval="86400" />
+        <sparkle:phasedRolloutInterval>86400</sparkle:phasedRolloutInterval>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="3.0" />
         <sparkle:deltas>
             <enclosure url="http://localhost:1337/3.0_from_2.0.patch"
             sparkle:version="3.0"


### PR DESCRIPTION
Brings over phased group update fixes from #1736 to 1.x cc @fjaeger

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) - **it fixes the update group that is saved from never being read, thus each schedule check always unintentionally resulted in different update group**
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - **because it moves app cast enclosure attribute -> item element. this feature seems complex enough combined with no documentation and significant existing defects that, I'm not very worried about existing clients**
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 11.1 (20C69)

Testing done in #1736, ran unit tests here.