### PR TITLE
Remove hiding skip button on automatic updates logic

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -411,12 +411,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         }
     }
     
-    // A developer wishing for automatic updates shouldn't want users to skip updates
-    // Except maybe when there's a minimum auto update version for auto-downloading specified
-    if (automaticDownloadsEnabledByDeveloper && self.updateItem.minimumAutoupdateVersion.length == 0) {
-        self.skipButton.hidden = YES;
-    }
-    
     BOOL startedInstalling = (self.resumableCompletionBlock != nil);
     if (startedInstalling) {
         // An already downloaded & resumable update can't be skipped


### PR DESCRIPTION
If user opts-out of automatic downloads (eg via app pref), they should be able to skip.

This logic for detecting minimumAutoupdateVersion present isn't sufficient and consistent enough, chooses to have skip visible in cases updates aren't prevented.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 11.1 (20C69)

It is reverting code added recently.
