### PR TITLE
Remove hiding skip button and retitling later button

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -325,12 +325,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
             self.automaticallyInstallUpdatesButton.enabled = NO;
         }
     }
-    
-    // A developer wishing for automatic updates shouldn't want users to skip updates
-    // Except maybe when there's a minimum auto update version for auto-downloading specified
-    if (automaticDownloadsEnabledByDeveloper && self.updateItem.minimumAutoupdateVersion.length == 0) {
-        self.skipButton.hidden = YES;
-    }
 
     if ([self.updateItem isCriticalUpdate]) {
         self.skipButton.hidden = YES;
@@ -340,16 +334,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     // Reminding user later doesn't make sense when automatic update checks are off
     if (![self.host boolForKey:SUEnableAutomaticChecksKey]) {
         self.laterButton.hidden = YES;
-    }
-    
-    // If the developer makes use of minimumAutoupdateVersion, just stick to Remind Me Later on the safe side
-    // (Install Later would be harmfully incorrect if this update cannot be automatically installed)
-    // And this is really not the place to do comparison/version checks.
-    // Also make sure to check that the system and developer allows us to automatically update.
-    // This logic is not very sound and gets worse in 2.x where apps can be sandboxed. We may need to revisit this
-    // and also decide if we really need this button in the first place.
-    if ([self.host boolForKey:SUAutomaticallyUpdateKey] && allowsAutomaticUpdates && self.updateItem.minimumAutoupdateVersion.length == 0) {
-        [self.laterButton setTitle:SULocalizedString(@"Install Later", @"Alternate title for 'Remind Me Later' button when automatic updates are enabled")];
     }
 
     [self.window center];


### PR DESCRIPTION
Same reason as #1741

If we can handle all cases properly (minimumAutoupdateVersion, user opting out of automatic downloads, and absence of allowsAutomaticUpdates which is removed in 2.x to both handle sandboxing and resuming automatic downloads) we can possibly accept a contribution to disable skipping / remind me later buttons, without introducing another localization string too.

But right now this is edge case-y and not compatible to 2.x going forward.

The logic to hide the automatic downloads checkbox is still okay. If the user is able to opt out of automatic downloads presumably they have an option somewhere other than this window.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 11.1 (20C69)
