### PR TITLE
Revert exposing systemProfileInformationArray until implemented a better way

### DIFF
--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -170,11 +170,6 @@ SU_EXPORT @interface SUUpdater : NSObject
 @property BOOL sendsSystemProfile;
 
 /*!
- The user's system profile information that will be sent when checking for updates if sendsSystemProfile is true.
- */
-@property (copy, nullable) NSArray<NSDictionary<NSString *, NSString *> *> *systemProfileInformationArray;
-
-/*!
  A property indicating the decryption password used for extracting updates shipped as Apple Disk Images (dmg)
  */
 @property (nonatomic, copy) NSString *decryptionPassword;

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -64,7 +64,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize shouldRescheduleOnWake;
 @synthesize userAgentString = customUserAgentString;
 @synthesize httpHeaders;
-@synthesize systemProfileInformationArray;
 @synthesize driver;
 @synthesize host;
 @synthesize sparkleBundle;
@@ -133,15 +132,6 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         }
         [sharedUpdaters setObject:self forKey:[NSValue valueWithNonretainedObject:bundle]];
         host = [[SUHost alloc] initWithBundle:bundle];
-
-        if (self) {
-            NSArray<NSDictionary<NSString *, NSString *> *> *profileInfo = [SUSystemProfiler systemProfileArrayForHost:self.host];
-            BOOL sendingSystemProfile = [self sendsSystemProfile];
-            if ([self.delegate respondsToSelector:@selector(feedParametersForUpdater:sendingSystemProfile:)]) {
-                profileInfo = [profileInfo arrayByAddingObjectsFromArray:[self.delegate feedParametersForUpdater:self sendingSystemProfile:sendingSystemProfile]];
-            }
-            self.systemProfileInformationArray = profileInfo;
-        }
 
         // This runs the permission prompt if needed, but never before the app has finished launching because the runloop won't run before that
         [self performSelector:@selector(startUpdateCycle) withObject:nil afterDelay:0];
@@ -241,7 +231,6 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         if ([self.delegate respondsToSelector:@selector(feedParametersForUpdater:sendingSystemProfile:)]) {
             profileInfo = [profileInfo arrayByAddingObjectsFromArray:[self.delegate feedParametersForUpdater:self sendingSystemProfile:YES]];
         }
-        self.systemProfileInformationArray = profileInfo;
         [SUUpdatePermissionPrompt promptWithHost:self.host systemProfile:profileInfo reply:^(SUUpdatePermissionResponse *response) {
             [self updatePermissionRequestFinishedWithResponse:response];
             // Schedule checks, but make sure we ignore the delayed call from KVO
@@ -577,7 +566,6 @@ static NSString *escapeURLComponent(NSString *str) {
         parameters = [parameters arrayByAddingObjectsFromArray:[SUSystemProfiler systemProfileArrayForHost:self.host]];
         [self.host setObject:[NSDate date] forUserDefaultsKey:SULastProfileSubmitDateKey];
     }
-    self.systemProfileInformationArray = parameters;
     if ([parameters count] == 0) { return baseFeedURL; }
 
     // Build up the parameterized URL.


### PR DESCRIPTION
cc @pierswalter 

* We cannot make it look like applications are collecting system profile information all the time. (see -[SUUpdater initForBundle:])
* The method collects non-system profile information too (feed parameters from delegate). Presumably users only cares about system profile information. Otherwise the name is incorrect.
* Adding a mutable property to SUUpdater does not sound the best way to go about this; perhaps an API to ask and compute for the systemProfileArray is better idea. Or a delegate API when system profile array will computed & sent.
* This change introduced nullability warnings in SUUpdater.h due to other things not being null annotated there.

A way to implement this in a more suitable way without side-effects mentioned above is welcome. Until then, this is a revert.

## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first. - **NA**
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 11.1 (20C69)
