### PR TITLE
Add support for updating/installing from flat non-archived packages

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -186,7 +186,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     [self.communicator handleMessageWithIdentifier:SPUExtractionStarted data:[NSData data]];
     
     NSString *archivePath = [self.updateDirectoryPath stringByAppendingPathComponent:self.downloadName];
-    id<SUUnarchiverProtocol> unarchiver = [SUUnarchiver unarchiverForPath:archivePath updatingHostBundlePath:self.host.bundlePath decryptionPassword:self.decryptionPassword];
+    id<SUUnarchiverProtocol> unarchiver = [SUUnarchiver unarchiverForPath:archivePath updatingHostBundlePath:self.host.bundlePath decryptionPassword:self.decryptionPassword expectingInstallationType:self.installationType];
     
     BOOL success = NO;
     if (!unarchiver) {
@@ -213,6 +213,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         [unarchiver
          unarchiveWithCompletionBlock:^(NSError * _Nullable error) {
              if (error != nil) {
+                 SULog(SULogLevelError, @"Failed to unarchive %@ with error: %@", archivePath, error);
                  [self unarchiverDidFail];
              } else {
                  [self.communicator handleMessageWithIdentifier:SPUValidationStarted data:[NSData data]];

--- a/Autoupdate/SUFlatPackageUnarchiver.h
+++ b/Autoupdate/SUFlatPackageUnarchiver.h
@@ -1,0 +1,21 @@
+//
+//  SUFlatPackageUnarchiver.h
+//  Autoupdate
+//
+//  Created by Mayur Pawashe on 1/30/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SUUnarchiverProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// An unarchiver for flat packages that doesn't really do any unarchiving
+@interface SUFlatPackageUnarchiver : NSObject <SUUnarchiverProtocol>
+
+- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath expectingInstallationType:(NSString *)installationType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Autoupdate/SUFlatPackageUnarchiver.m
+++ b/Autoupdate/SUFlatPackageUnarchiver.m
@@ -1,0 +1,67 @@
+//
+//  SUFlatPackageUnarchiver.m
+//  Autoupdate
+//
+//  Created by Mayur Pawashe on 1/30/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import "SUFlatPackageUnarchiver.h"
+#import "SUUnarchiverNotifier.h"
+#import "SPUInstallationType.h"
+#import "SUErrors.h"
+
+
+#include "AppKitPrevention.h"
+
+@interface SUFlatPackageUnarchiver ()
+
+@property (nonatomic, readonly) NSString *flatPackagePath;
+@property (nonatomic, readonly) NSString *expectedInstallationType;
+
+@end
+
+@implementation SUFlatPackageUnarchiver
+
+@synthesize flatPackagePath = _flatPackagePath;
+@synthesize expectedInstallationType = _expectedInstallationType;
+
++ (BOOL)canUnarchivePath:(NSString *)path
+{
+    return [path.pathExtension isEqualToString:@"pkg"];
+}
+
++ (BOOL)mustValidateBeforeExtraction
+{
+    return YES;
+}
+
+- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath expectingInstallationType:(NSString *)installationType
+{
+    self = [super init];
+    if (self != nil) {
+        _flatPackagePath = [flatPackagePath copy];
+        _expectedInstallationType = [installationType copy];
+    }
+    return self;
+}
+
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock
+{
+    SUUnarchiverNotifier *notifier = [[SUUnarchiverNotifier alloc] initWithCompletionBlock:completionBlock progressBlock:progressBlock];
+    
+    // Flat packages must use guided package installs, not interactive
+    BOOL isDirectory = NO;
+    if (![self.expectedInstallationType isEqualToString:SPUInstallationTypeGuidedPackage]) {
+        [notifier notifyFailureWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Flat package does not have guided installation type but %@ instead", self.expectedInstallationType]}]];
+    } else if (![[NSFileManager defaultManager] fileExistsAtPath:self.flatPackagePath isDirectory:&isDirectory] || isDirectory) {
+        [notifier notifyFailureWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Flat package does not exist at %@", self.flatPackagePath]}]];
+    } else {
+        [notifier notifyProgress:1.0];
+        [notifier notifySuccess];
+    }
+}
+
+- (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], self.flatPackagePath]; }
+
+@end

--- a/Autoupdate/SUUnarchiver.h
+++ b/Autoupdate/SUUnarchiver.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUUnarchiver : NSObject
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword;
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType;
 
 @end
 

--- a/Autoupdate/SUUnarchiver.m
+++ b/Autoupdate/SUUnarchiver.m
@@ -11,13 +11,14 @@
 #import "SUPipedUnarchiver.h"
 #import "SUDiskImageUnarchiver.h"
 #import "SUBinaryDeltaUnarchiver.h"
+#import "SUFlatPackageUnarchiver.h"
 
 
 #include "AppKitPrevention.h"
 
 @implementation SUUnarchiver
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType
 {
     if ([SUPipedUnarchiver canUnarchivePath:path]) {
         return [[SUPipedUnarchiver alloc] initWithArchivePath:path];
@@ -29,6 +30,9 @@
         assert(hostPath != nil);
         NSString *nonNullHostPath = hostPath;
         return [[SUBinaryDeltaUnarchiver alloc] initWithArchivePath:path updateHostBundlePath:nonNullHostPath];
+    } else if ([SUFlatPackageUnarchiver canUnarchivePath:path]) {
+        // Flat packages are only supported for guided packaage installs
+        return [[SUFlatPackageUnarchiver alloc] initWithFlatPackagePath:path expectingInstallationType:installationType];
     }
     return nil;
 }

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		721D588E25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 721D588B25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.h */; };
 		721D588F25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D588C25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m */; };
 		721D589025BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D588C25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m */; };
+		721D5A8525C65D3F00D23BEA /* SUFlatPackageUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */; };
+		721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */; };
 		721D8A611D48413B0032E472 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		721D8A721D4950B80032E472 /* Autoupdate in Copy Tools */ = {isa = PBXBuildFile; fileRef = 72B398D21D3D879300EE297F /* Autoupdate */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		721D8A7B1D4963190032E472 /* SPULocalCacheDirectory.m in Sources */ = {isa = PBXBuildFile; fileRef = 721BC20D1D1CDE55002BC71E /* SPULocalCacheDirectory.m */; };
@@ -1034,6 +1036,8 @@
 		721C24581CB7567D005440CB /* InstallerProgress-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "InstallerProgress-Info.plist"; path = "Sparkle/InstallerProgress/InstallerProgress-Info.plist"; sourceTree = SOURCE_ROOT; };
 		721D588B25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUPhasedUpdateGroupInfo.h; sourceTree = "<group>"; };
 		721D588C25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUPhasedUpdateGroupInfo.m; sourceTree = "<group>"; };
+		721D5A8325C65D3F00D23BEA /* SUFlatPackageUnarchiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SUFlatPackageUnarchiver.h; path = Autoupdate/SUFlatPackageUnarchiver.h; sourceTree = SOURCE_ROOT; };
+		721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SUFlatPackageUnarchiver.m; path = Autoupdate/SUFlatPackageUnarchiver.m; sourceTree = SOURCE_ROOT; };
 		721D8A831D498F1D0032E472 /* set-agent-signing.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "set-agent-signing.sh"; sourceTree = "<group>"; };
 		721D8A881D4D272E0032E472 /* Installation.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Installation.md; sourceTree = "<group>"; };
 		722194511D3BF987004C34FF /* SPUInstallerAgentProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUInstallerAgentProtocol.h; path = Sparkle/InstallerProgress/SPUInstallerAgentProtocol.h; sourceTree = SOURCE_ROOT; };
@@ -1823,6 +1827,8 @@
 				7267E5811D3D89B300D1BF90 /* SUDiskImageUnarchiver.m */,
 				7267E5821D3D89B300D1BF90 /* SUPipedUnarchiver.h */,
 				7267E5831D3D89B300D1BF90 /* SUPipedUnarchiver.m */,
+				721D5A8325C65D3F00D23BEA /* SUFlatPackageUnarchiver.h */,
+				721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */,
 				7267E5841D3D89B300D1BF90 /* SUUnarchiver.h */,
 				7267E5851D3D89B300D1BF90 /* SUUnarchiver.m */,
 				72316BD11E0DA8430039EFD9 /* SUUnarchiverNotifier.h */,
@@ -3304,6 +3310,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				725F97771C8A62F500265BE4 /* SUAdHocCodeSigning.m in Sources */,
 				5A4094481C74EA5200983BE0 /* SUAppcastTest.swift in Sources */,
 				7267E5EE1D3D915900D1BF90 /* SUBinaryDeltaApply.m in Sources */,
@@ -3555,6 +3562,7 @@
 				7267E5D71D3D8D3F00D1BF90 /* SUHost.m in Sources */,
 				7267E5C31D3D8B2700D1BF90 /* SUInstaller.m in Sources */,
 				5A6DD17123FE1FFC000AEF33 /* SUSignatures.m in Sources */,
+				721D5A8525C65D3F00D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				7267E5CE1D3D8C7500D1BF90 /* SULog.m in Sources */,
 				7267E5C41D3D8B2700D1BF90 /* SUPackageInstaller.m in Sources */,
 				7267E5871D3D89B300D1BF90 /* SUPipedUnarchiver.m in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		721D589025BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D588C25BE59F900D23BEA /* SUPhasedUpdateGroupInfo.m */; };
 		721D5A8525C65D3F00D23BEA /* SUFlatPackageUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */; };
 		721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */; };
+		721D5B1B25C692BB00D23BEA /* SUFlatPackageUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 721D5A8425C65D3F00D23BEA /* SUFlatPackageUnarchiver.m */; };
 		721D8A611D48413B0032E472 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		721D8A721D4950B80032E472 /* Autoupdate in Copy Tools */ = {isa = PBXBuildFile; fileRef = 72B398D21D3D879300EE297F /* Autoupdate */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		721D8A7B1D4963190032E472 /* SPULocalCacheDirectory.m in Sources */ = {isa = PBXBuildFile; fileRef = 721BC20D1D1CDE55002BC71E /* SPULocalCacheDirectory.m */; };
@@ -3359,6 +3360,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				721D5B1B25C692BB00D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				72464F7C1E2097F600FB341C /* SUOperatingSystem.m in Sources */,
 				7205C44C1E1304CE00E370AE /* Appcast.swift in Sources */,
 				7205C44D1E1304CE00E370AE /* ArchiveItem.swift in Sources */,

--- a/Sparkle/SPUInstallationType.h
+++ b/Sparkle/SPUInstallationType.h
@@ -13,7 +13,6 @@
 #define SPUInstallationTypeGuidedPackage @"package" // the preferred installation type for package installations
 #define SPUInstallationTypeInteractivePackage @"interactive-package" // the deprecated installation type; use guided package instead
 
-#define SPUInstallationTypeDefault SPUInstallationTypeApplication
 #define SPUInstallationTypesArray (@[SPUInstallationTypeApplication, SPUInstallationTypeGuidedPackage, SPUInstallationTypeInteractivePackage])
 #define SPUValidInstallationType(x) ((x != nil) && [SPUInstallationTypesArray containsObject:x])
 

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -313,7 +313,14 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
         
         _installationType = [enclosure objectForKey:SUAppcastAttributeInstallationType];
         if (_installationType == nil) {
-            _installationType = SPUInstallationTypeDefault;
+            // If we have a flat package, assume installation type is guided
+            // (flat / non-archived interactive packages are not supported)
+            // Otherwise assume we have a normal application inside an archive
+            if ([_fileURL.pathExtension isEqualToString:@"pkg"]) {
+                _installationType = SPUInstallationTypeGuidedPackage;
+            } else {
+                _installationType = SPUInstallationTypeApplication;
+            }
         } else if (!SPUValidInstallationType(_installationType)) {
             if (error != NULL) {
                 *error = [NSString stringWithFormat:@"Feed item's enclosure lacks valid %@ (found %@)", SUAppcastAttributeInstallationType, _installationType];

--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -10,8 +10,8 @@ import XCTest
 
 class SUUnarchiverTest: XCTestCase
 {
-    func unarchiveTestAppWithExtension(_ archiveExtension: String, password: String? = nil) {
-        let appName = "SparkleTestCodeSignApp"
+    func unarchiveTestAppWithExtension(_ archiveExtension: String, password: String? = nil, resourceName: String = "SparkleTestCodeSignApp", expectingInstallationType installationType: String = SPUInstallationTypeApplication, expectingSuccess: Bool = true) {
+        let appName = resourceName
         let archiveResourceURL = Bundle(for: type(of: self)).url(forResource: appName, withExtension: archiveExtension)!
 
         let fileManager = FileManager.default
@@ -27,19 +27,20 @@ class SUUnarchiverTest: XCTestCase
         let tempArchiveURL = tempDirectoryURL.appendingPathComponent(archiveResourceURL.lastPathComponent)
         let extractedAppURL = tempDirectoryURL.appendingPathComponent(appName).appendingPathExtension("app")
 
-        self.unarchiveTestSuccessAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, tempArchiveURL: tempArchiveURL, archiveResourceURL: archiveResourceURL, password: password, testExpectation: unarchivedSuccessExpectation)
-        self.unarchiveTestFailureAppWithExtension(archiveExtension, tempDirectoryURL: tempDirectoryURL, password: password, testExpectation: unarchivedFailureExpectation)
+        self.unarchiveTestAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, tempArchiveURL: tempArchiveURL, archiveResourceURL: archiveResourceURL, password: password, expectingInstallationType: installationType, expectingSuccess: expectingSuccess, testExpectation: unarchivedSuccessExpectation)
+        self.unarchiveNonExistentFileTestFailureAppWithExtension(archiveExtension, tempDirectoryURL: tempDirectoryURL, password: password, expectingInstallationType: installationType, testExpectation: unarchivedFailureExpectation)
 
         super.waitForExpectations(timeout: 7.0, handler: nil)
 
-        XCTAssertTrue(fileManager.fileExists(atPath: extractedAppURL.path))
-
-        XCTAssertEqual("6a60ab31430cfca8fb499a884f4a29f73e59b472", hashOfTree(extractedAppURL.path))
+        if !archiveExtension.hasSuffix("pkg") {
+            XCTAssertTrue(fileManager.fileExists(atPath: extractedAppURL.path))
+            XCTAssertEqual("6a60ab31430cfca8fb499a884f4a29f73e59b472", hashOfTree(extractedAppURL.path))
+        }
     }
 
-    func unarchiveTestFailureAppWithExtension(_ archiveExtension: String, tempDirectoryURL: URL, password: String?, testExpectation: XCTestExpectation) {
+    func unarchiveNonExistentFileTestFailureAppWithExtension(_ archiveExtension: String, tempDirectoryURL: URL, password: String?, expectingInstallationType installationType: String, testExpectation: XCTestExpectation) {
         let tempArchiveURL = tempDirectoryURL.appendingPathComponent("error-invalid").appendingPathExtension(archiveExtension)
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password)!
+        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             XCTAssertNotNil(error)
@@ -48,16 +49,20 @@ class SUUnarchiverTest: XCTestCase
     }
 
     // swiftlint:disable function_parameter_count
-    func unarchiveTestSuccessAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, tempArchiveURL: URL, archiveResourceURL: URL, password: String?, testExpectation: XCTestExpectation) {
+    func unarchiveTestAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, tempArchiveURL: URL, archiveResourceURL: URL, password: String?, expectingInstallationType installationType: String, expectingSuccess: Bool, testExpectation: XCTestExpectation) {
 
         let fileManager = FileManager.default
 
         try! fileManager.copyItem(at: archiveResourceURL, to: tempArchiveURL)
 
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password)!
+        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
-            XCTAssertNil(error)
+            if expectingSuccess {
+                XCTAssertNil(error)
+            } else {
+                XCTAssertNotNil(error)
+            }
             testExpectation.fulfill()
         }, progressBlock: nil)
     }
@@ -95,5 +100,14 @@ class SUUnarchiverTest: XCTestCase
     func testUnarchivingEncryptedDmg()
     {
         self.unarchiveTestAppWithExtension("enc.dmg", password: "testpass")
+    }
+    
+    func testUnarchivingFlatPackage()
+    {
+        self.unarchiveTestAppWithExtension("pkg", resourceName: "test", expectingInstallationType: SPUInstallationTypeGuidedPackage)
+        
+        self.unarchiveTestAppWithExtension("pkg", resourceName: "test", expectingInstallationType: SPUInstallationTypeInteractivePackage, expectingSuccess: false)
+        
+        self.unarchiveTestAppWithExtension("pkg", resourceName: "test", expectingInstallationType: SPUInstallationTypeApplication, expectingSuccess: false)
     }
 }

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -17,6 +17,7 @@
 #import "SUUpdateValidator.h"
 #import "SUHost.h"
 #import "SUSignatures.h"
+#import "SPUInstallationType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/generate_appcast/Bridging-Header.h
+++ b/generate_appcast/Bridging-Header.h
@@ -7,4 +7,5 @@
 #import "SUBinaryDeltaUnarchiver.h"
 #import "SUBinaryDeltaCreate.h"
 #import "SUSignatures.h"
+#import "SPUInstallationType.h"
 #import "ed25519.h" // Run `git submodule update --init` if you get an error here

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -18,7 +18,7 @@ func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) 
         } catch {
             try fileManager.copyItem(at: itemPath, to: itemCopy)
         }
-        if let unarchiver = SUUnarchiver.unarchiver(forPath: itemCopy.path, updatingHostBundlePath: nil, decryptionPassword: nil) {
+        if let unarchiver = SUUnarchiver.unarchiver(forPath: itemCopy.path, updatingHostBundlePath: nil, decryptionPassword: nil, expectingInstallationType: SPUInstallationTypeApplication) {
             unarchiver.unarchive(completionBlock: { (error: Error?) in
                 if error != nil {
                     callback(error)


### PR DESCRIPTION
With these changes, modern pkg's should no longer need to be archived.

Only guided package installations are supported for flat packages. Specifying an interactive package installation type will result in a rejection. If the file URL has a ".pkg" suffix it is by default assumed to be a guided pkg installation now, which relieves the burden of needing to previously specify sparkle:installationType in the app cast item enclosure, in this case (for 2.x). Moreover, this relieves the burden of developers needing to archive their pkg for Sparkle.

Fixes #54

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported. -- **Ideally, yes. I'll need to take a look**
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update -- **I'll get to this**

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested a regular app install via sparkle test app, a flat pkg install in a mockup app I made (with good signature, bad signature, wrong installation type), archived pkg install, updated unit tests.

macOS version tested: 11.1 (20C69)
