### PR TITLE
Apply custom headers to app download

### DIFF
--- a/Sparkle/SUBasicUpdateDriver.m
+++ b/Sparkle/SUBasicUpdateDriver.m
@@ -352,7 +352,19 @@
         request.networkServiceType = NSURLNetworkServiceTypeBackground;
     }
 
-    [request setValue:[updater userAgentString] forHTTPHeaderField:@"User-Agent"];
+    NSString *userAgentString = [updater userAgentString];
+    if (userAgentString) {
+        [request setValue:userAgentString forHTTPHeaderField:@"User-Agent"];
+    }
+
+    NSDictionary<NSString *, NSString *> *httpHeaders = [updater httpHeaders];
+    if (httpHeaders) {
+        for (NSString *key in httpHeaders) {
+            NSString *value = [httpHeaders objectForKey:key];
+            [request setValue:value forHTTPHeaderField:key];
+        }
+    }
+
     if ([[updater delegate] respondsToSelector:@selector(updater:willDownloadUpdate:withRequest:)]) {
         [[updater delegate] updater:self.updater
                       willDownloadUpdate:self.updateItem

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -149,14 +149,14 @@ SU_EXPORT @interface SUUpdater : NSObject
 @property (strong, readonly) NSBundle *sparkleBundle;
 
 /*!
- The user agent used when checking for updates.
+ The user agent used when checking for and downloading updates.
 
  The default implementation can be overrided.
  */
 @property (nonatomic, copy) NSString *userAgentString;
 
 /*!
- The HTTP headers used when checking for updates.
+ The HTTP headers used when checking for and downloading updates.
 
  The keys of this dictionary are HTTP header fields (NSString) and values are corresponding values (NSString)
  */


### PR DESCRIPTION
The custom headers added in #489 only applied to the appcast download.
This makes them apply to the app download as well for the case when both are hosted behind authentication.


## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [ ] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

macOS version tested: 11.1