### PR TITLE
Fix Package.swift

### DIFF
--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -55,6 +55,8 @@ if [ "$ACTION" = "" ] ; then
     # Get latest git tag
     cd "$SRCROOT"
     latest_git_tag=$(git describe --abbrev=0)
+    # Check semantic versioning
+    [[ $latest_git_tag =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]] && echo "Tag $latest_git_tag follows semantic versioning" || echo "WARNING: Tag $latest_git_tag does not follow semantic versioning! SPM will not be able to resolve the repository"
     # Generate new Package manifest
     cd "$CONFIGURATION_BUILD_DIR"
     cp "$SRCROOT/Package.swift" "$CONFIGURATION_BUILD_DIR"

--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -52,6 +52,8 @@ if [ "$ACTION" = "" ] ; then
     cd "$CONFIGURATION_BUILD_DIR/staging-spm"
     #rm -rf "$CONFIGURATION_BUILD_DIR/Sparkle.xcarchive"
     zip -rqyX -9 "../Sparkle-for-Swift-Package-Manager.zip" *
+    # Get latest git tag
+    latest_git_tag=$(git describe --abbrev=0)
     # Generate new Package manifest
     cd "$CONFIGURATION_BUILD_DIR"
     cp "$SRCROOT/Package.swift" "$CONFIGURATION_BUILD_DIR"
@@ -59,10 +61,11 @@ if [ "$ACTION" = "" ] ; then
         # is equivalent to shasum -a 256 FILE
         spm_checksum=$(swift package compute-checksum "Sparkle-for-Swift-Package-Manager.zip")
         rm -rf ".build"
-        sed -E -i '' -e "/let version/ s/[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/$CURRENT_PROJECT_VERSION/" -e "/let checksum/ s/[[:xdigit:]]{64}/$spm_checksum/" "Package.swift"
+        sed -E -i '' -e '/let tag/ s/".+"/"$latest_git_tag"/' -e '/let version/ s/".+"/"$CURRENT_PROJECT_VERSION"/' -e "/let checksum/ s/[[:xdigit:]]{64}/$spm_checksum/" "Package.swift"
         cp "Package.swift" "$SRCROOT"
         echo "Package.swift updated with the following values:"
         echo "Version: $CURRENT_PROJECT_VERSION"
+        echo "Tag: $latest_git_tag"
         echo "Checksum: $spm_checksum"
     else
         echo "warning: Xcode version $XCODE_VERSION_ACTUAL does not support computing checksums for Swift Packages. Please update the Package manifest manually."

--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -53,6 +53,7 @@ if [ "$ACTION" = "" ] ; then
     #rm -rf "$CONFIGURATION_BUILD_DIR/Sparkle.xcarchive"
     zip -rqyX -9 "../Sparkle-for-Swift-Package-Manager.zip" *
     # Get latest git tag
+    cd "$SRCROOT"
     latest_git_tag=$(git describe --abbrev=0)
     # Generate new Package manifest
     cd "$CONFIGURATION_BUILD_DIR"
@@ -61,7 +62,7 @@ if [ "$ACTION" = "" ] ; then
         # is equivalent to shasum -a 256 FILE
         spm_checksum=$(swift package compute-checksum "Sparkle-for-Swift-Package-Manager.zip")
         rm -rf ".build"
-        sed -E -i '' -e '/let tag/ s/".+"/"$latest_git_tag"/' -e '/let version/ s/".+"/"$CURRENT_PROJECT_VERSION"/' -e "/let checksum/ s/[[:xdigit:]]{64}/$spm_checksum/" "Package.swift"
+        sed -E -i '' -e "/let tag/ s/\".+\"/\"$latest_git_tag\"/" -e "/let version/ s/\".+\"/\"$CURRENT_PROJECT_VERSION\"/" -e "/let checksum/ s/[[:xdigit:]]{64}/$spm_checksum/" "Package.swift"
         cp "Package.swift" "$SRCROOT"
         echo "Package.swift updated with the following values:"
         echo "Version: $CURRENT_PROJECT_VERSION"

--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -52,11 +52,18 @@ if [ "$ACTION" = "" ] ; then
     cd "$CONFIGURATION_BUILD_DIR/staging-spm"
     #rm -rf "$CONFIGURATION_BUILD_DIR/Sparkle.xcarchive"
     zip -rqyX -9 "../Sparkle-for-Swift-Package-Manager.zip" *
-    # Get latest git tag
-    cd "$SRCROOT"
-    latest_git_tag=$(git describe --abbrev=0)
-    # Check semantic versioning
-    [[ $latest_git_tag =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]] && echo "Tag $latest_git_tag follows semantic versioning" || echo "WARNING: Tag $latest_git_tag does not follow semantic versioning! SPM will not be able to resolve the repository"
+    
+    # GitHub actions set the CI environment variable to true
+    if [ "$CI" != true ]; then
+        # Get latest git tag
+        cd "$SRCROOT"
+        latest_git_tag=$(git describe --abbrev=0)
+        # Check semantic versioning
+        [[ $latest_git_tag =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]] && echo "Tag $latest_git_tag follows semantic versioning" || echo "WARNING: Tag $latest_git_tag does not follow semantic versioning! SPM will not be able to resolve the repository"
+    else
+        # Dummy placeholder for CI test builds as we don't really need to update Package.swift for building and testing purposes
+        latest_git_tag="CI_BUILD"
+    fi
     # Generate new Package manifest
     cd "$CONFIGURATION_BUILD_DIR"
     cp "$SRCROOT/Package.swift" "$CONFIGURATION_BUILD_DIR"

--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -59,7 +59,12 @@ if [ "$ACTION" = "" ] ; then
         cd "$SRCROOT"
         latest_git_tag=$(git describe --abbrev=0)
         # Check semantic versioning
-        [[ $latest_git_tag =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]] && echo "Tag $latest_git_tag follows semantic versioning" || echo "WARNING: Tag $latest_git_tag does not follow semantic versioning! SPM will not be able to resolve the repository"
+        if [[ $latest_git_tag =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+            echo "Tag $latest_git_tag follows semantic versioning"
+        else
+            echo "ERROR: Tag $latest_git_tag does not follow semantic versioning! SPM will not be able to resolve the repository" >&2
+            exit 1
+        fi
     else
         # Dummy placeholder for CI test builds as we don't really need to update Package.swift for building and testing purposes
         latest_git_tag="CI_BUILD"

--- a/Configurations/release-move-tag.sh
+++ b/Configurations/release-move-tag.sh
@@ -10,7 +10,7 @@ if [ "$commits_since_tag" -gt 0 ]; then
     echo "Package.swift has not been committed and tag has not been moved."
 else
     # TODO: add sanity check to see if version is actually being updated or not?
-    read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for Swift Package Manager release) " -n 1 -r
+    read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for SPM release) [y/N]" -n 1 -r
     echo    # (optional) move to a new line
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         long_message=$(git tag -n99 -l $latest_git_tag) # gets corresponding message

--- a/Configurations/release-move-tag.sh
+++ b/Configurations/release-move-tag.sh
@@ -10,9 +10,11 @@ if [ "$commits_since_tag" -gt 0 ]; then
     echo "Package.swift has not been committed and tag has not been moved."
 else
     # TODO: add sanity check to see if version is actually being updated or not?
-    read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for SPM release) [y/N]" -n 1 -r
+    read -p "Do you want to commit changes to Package.swift and force move tag '$latest_git_tag'? (required for SPM release) [Y/n]" -n 1 -r
     echo    # (optional) move to a new line
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo "Package.swift has not been committed and tag has not been moved."
+    else
         long_message=$(git tag -n99 -l $latest_git_tag) # gets corresponding message
         long_message=${long_message/$latest_git_tag} # trims tag name
         long_message="$(echo -e "${long_message}" | sed -e 's/^[[:space:]]*//')" # trim leading whitespace
@@ -20,7 +22,5 @@ else
         git commit -m "Update Package.swift"
         git tag -fa $latest_git_tag -m "${long_message}"
         echo "Package.swift committed and tag '$latest_git_tag' moved."
-    else
-        echo "Package.swift has not been committed and tag has not been moved."
     fi
 fi

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,12 @@
 // swift-tools-version:5.3
 import PackageDescription
 
+// Version is technically not required here, SPM doesn't check
 let version = "1.24.0"
+// Tag is required to point towards the right asset. SPM requires the tag to follow semantic versioning to be able to resolve it.
+let tag = "1.24.0"
 let checksum = "a9ae129446739a685d2fb60b392606df020ee8e8d132dcc3a5959a8dd0775f35"
-let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(version)/Sparkle-for-Swift-Package-Manager.zip"
+let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/Sparkle-for-Swift-Package-Manager.zip"
 
 let package = Package(
     name: "Sparkle",


### PR DESCRIPTION
I'll do the change for the 2.x branch ASAP, but this fixes the showstopping bug in #1750. Major change is that Package.swift now uses the latest **tag** instead of the version number so it can be used for pre-release versions as well. It still includes the "final" version number even though it is not used in any way anymore.
**IMPORTANT**: it seems that during the release of `1.25.0-rc1` two things were overlooked:
- SPM **needs** the tag to follow semantic versioning to be able to resolve the git repo. `1.25.0rc1` does **not** follow semantic versioning whereas `1.25.0-rc1` does. I've updated make-release-package.sh to check whether the latest tag follows semantic versioning based on a modified version of the "official" RegEx: https://semver.org/. It outputs a warning if the tag does not follow semantic versioning. In that case, you should delete the tag, tag again and run `make release` again.
- The "force tag" stage at the end of `make release` defaults to **no** and seems to have been overlooked. As there are other safeguards in place (only moves the tag when nothing else has been committed), it now defaults to **yes**.

Fixes #1750 

## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other: Ran `make release` with tag `1.25.0-rc2`, successfully moves the tag and uses the correct url in Package.swift

macOS version tested: 11.2
