### PR TITLE
Don't swallow errors for scheduled driver after update is shown

### DIFF
--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -18,24 +18,20 @@
 @interface SPUScheduledUpdateDriver() <SPUUIBasedUpdateDriverDelegate>
 
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
-@property (nonatomic, readonly) id updater;
-@property (nonatomic, readonly) id <SPUUpdaterDelegate> updaterDelegate;
+@property (nonatomic) BOOL showedUpdate;
 
 @end
 
 @implementation SPUScheduledUpdateDriver
 
 @synthesize uiDriver = _uiDriver;
-@synthesize updater = _updater;
-@synthesize updaterDelegate = _updaterDelegate;
+@synthesize showedUpdate = _showedUpdate;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle sparkleBundle:(NSBundle *)sparkleBundle updater:(id)updater userDriver:(id <SPUUserDriver>)userDriver updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate
 {
     self = [super init];
     if (self != nil) {
         _uiDriver = [[SPUUIBasedUpdateDriver alloc] initWithHost:host applicationBundle:applicationBundle sparkleBundle:sparkleBundle updater:updater userDriver:userDriver userInitiated:NO updaterDelegate:updaterDelegate delegate:self];
-        _updater = updater;
-        _updaterDelegate = updaterDelegate;
     }
     return self;
 }
@@ -64,30 +60,23 @@
     [self.uiDriver resumeUpdate:resumableUpdate completion:completionBlock];
 }
 
+- (void)uiDriverDidShowUpdate
+{
+    self.showedUpdate = YES;
+}
+
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error
 {
-    // Don't tell the user that no update was found or some appcast fetch error occurred for scheduled update checks
-    [self abortUpdateWithError:nil];
-    
-    [self notifyDelegateAboutError:error];
+    // Don't tell the user that no update was found or some appcast fetch error occurred for scheduled update checks if we haven't shown the update
+    [self abortUpdateWithError:self.showedUpdate ? error : nil];
 }
 
 - (void)coreDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error
 {
-    // Don't tell the user that a non-UI update error occurred for scheduled update checks
-    [self abortUpdateWithError:nil];
-    
-    [self notifyDelegateAboutError:error];
+    // Don't tell the user that an update error occurred for scheduled update checks if we haven't shown the update
+    [self abortUpdateWithError:self.showedUpdate ? error : nil];
 }
 
-- (void)notifyDelegateAboutError:(nullable NSError *)error
-{
-    if (error == nil) { return; }
-    if ([self.updaterDelegate respondsToSelector:@selector(updater:scheduledUpdateCheckDidAbortWithError:)]) {
-        [self.updaterDelegate updater:self.updater scheduledUpdateCheckDidAbortWithError:(NSError * _Nonnull)error];
-    }
-}
-    
 - (void)uiDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error
 {
     [self abortUpdateWithError:error];

--- a/Sparkle/SPUUIBasedUpdateDriver.h
+++ b/Sparkle/SPUUIBasedUpdateDriver.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 - (void)basicDriverDidFinishLoadingAppcast;
+- (void)uiDriverDidShowUpdate;
 
 @end
 

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -167,6 +167,10 @@
         }];
     }
     
+    if ([self.delegate respondsToSelector:@selector(uiDriverDidShowUpdate)]) {
+        [self.delegate uiDriverDidShowUpdate];
+    }
+    
     id <SPUUpdaterDelegate> updaterDelegate = self.updaterDelegate;
     if (updateItem.releaseNotesURL != nil && (![updaterDelegate respondsToSelector:@selector(updaterShouldDownloadReleaseNotes:)] || [updaterDelegate updaterShouldDownloadReleaseNotes:self.updater])) {
         NSURLRequest *request = [NSURLRequest requestWithURL:updateItem.releaseNotesURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30];

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -333,14 +333,6 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  */
 - (void)updater:(SPUUpdater *)updater didAbortWithError:(NSError *)error;
 
-/*!
- Called after an update is aborted due to an error during an scheduled update check.
-  
- \param updater The updater instance.
- \param error The error that caused the abort
- */
-- (void)updater:(SPUUpdater *)updater scheduledUpdateCheckDidAbortWithError:(NSError *)error;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Don't swallow errors for scheduled driver after update is shown

Improved fix for #1494. We don't need a delegate method to work around this; we should just only swallow errors before we show the user an update for automatically scheduled update checks. (cc @martinjankoehler)

Bug: previously for scheduled update checks, if an error occurred after an update was shown to the user (eg invalid signature, extraction failure, etc), user would not be shown that an error occurred.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported. **NA**
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested that a bad appcast xml feed and no new updates did not trigger unexpected user alert.
Tested that bad appcast signature and missing `sparkle:installationType` for archived pkg's triggered expected user alert.

macOS version tested: 11.1 (20C69)
