### PR TITLE
Alter update not found error message

### DIFF
--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -156,7 +156,7 @@
     }
 }
 
-- (void)didNotFindUpdate
+- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult
 {
     if (!self.aborted) {
         if ([self.updaterDelegate respondsToSelector:@selector((updaterDidNotFindUpdate:))]) {
@@ -164,13 +164,34 @@
         }
         [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterDidNotFindUpdateNotification object:self.updater];
         
+        NSString *localizedDescription;
+        NSString *recoverySuggestion;
+        NSString *recoveryOption;
+        
+        if (latestAppcastItem != nil) { // if the appcast was successfully loaded
+            localizedDescription = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+            
+            if (hostToLatestAppcastItemComparisonResult == NSOrderedDescending) { // this means the user is a 'newer than latest' version. give a slight hint to the user instead of wrongly claiming this version is identical to the latest feed version.
+                recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.\n(You are currently running version %@.)", nil), [self.host name], latestAppcastItem.displayVersionString, [self.host displayVersion]];
+            } else {
+                recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
+            }
+            
+            recoveryOption = @"OK";
+        } else {
+            localizedDescription = SULocalizedString(@"Update Error!", nil);
+            recoverySuggestion = SULocalizedString(@"No valid update information could be loaded.", nil);
+            recoveryOption = @"Cancel Update";
+        }
+        
         NSError *notFoundError =
         [NSError
          errorWithDomain:SUSparkleErrorDomain
          code:SUNoUpdateError
          userInfo:@{
-                    NSLocalizedDescriptionKey: SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates."),
-                    NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]]
+                    NSLocalizedDescriptionKey: localizedDescription,
+                    NSLocalizedRecoverySuggestionErrorKey: recoverySuggestion,
+                    NSLocalizedRecoveryOptionsErrorKey: @[recoveryOption]
                     }
          ];
         [self.delegate basicDriverIsRequestingAbortUpdateWithError:notFoundError];

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -169,7 +169,8 @@
          errorWithDomain:SUSparkleErrorDomain
          code:SUNoUpdateError
          userInfo:@{
-                    NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"You already have the newest version of %@.", "'Error' message when the user checks for updates but is already current or the feed doesn't contain any updates. (not necessarily shown in UI)"), self.host.name]
+                    NSLocalizedDescriptionKey: SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates."),
+                    NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]]
                     }
          ];
         [self.delegate basicDriverIsRequestingAbortUpdateWithError:notFoundError];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -272,16 +272,15 @@
     [self.coreComponent acceptAcknowledgement];
 }
 
-- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
+//- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
+- (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
     assert(NSThread.isMainThread);
     
     [self.coreComponent registerAcknowledgement:acknowledgement];
     
-    NSAlert *alert = [[NSAlert alloc] init];
-    alert.messageText = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
-    alert.informativeText = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
-    [alert addButtonWithTitle:SULocalizedString(@"OK", nil)];
+    NSAlert *alert = [NSAlert alertWithError:error];
+    alert.alertStyle = NSAlertStyleInformational;
     [self showAlert:alert];
     
     [self.coreComponent acceptAcknowledgement];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -272,7 +272,6 @@
     [self.coreComponent acceptAcknowledgement];
 }
 
-//- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
 - (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
     assert(NSThread.isMainThread);

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -274,7 +274,7 @@
         NSError *nonNullError = error;
         
         if (error.code == SUNoUpdateError) {
-            [self.userDriver showUpdateNotFoundWithAcknowledgement:^{
+            [self.userDriver showUpdateNotFoundWithError:(NSError * _Nonnull)error acknowledgement:^{
                 dispatch_async(dispatch_get_main_queue(), ^{
                     abortUpdate();
                 });

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -274,11 +274,23 @@
         NSError *nonNullError = error;
         
         if (error.code == SUNoUpdateError) {
-            [self.userDriver showUpdateNotFoundWithError:(NSError * _Nonnull)error acknowledgement:^{
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    abortUpdate();
-                });
-            }];
+            if ([self.userDriver respondsToSelector:@selector(showUpdateNotFoundWithError:acknowledgement:)]) {
+                [self.userDriver showUpdateNotFoundWithError:(NSError * _Nonnull)error acknowledgement:^{
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        abortUpdate();
+                    });
+                }];
+            } else if ([self.userDriver respondsToSelector:@selector(showUpdateNotFoundWithAcknowledgement:)]) {
+                // Eventually we should remove this fallback once clients adopt -showUpdateNotFoundWithError:acknowledgement:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                [self.userDriver showUpdateNotFoundWithAcknowledgement:^{
+#pragma clang diagnostic pop
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        abortUpdate();
+                    });
+                }];
+            }
         } else if (error.code == SUInstallationCanceledError || error.code == SUInstallationAuthorizeLaterError) {
             abortUpdate();
         } else {

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -289,6 +289,10 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  */
 - (void)dismissUpdateInstallation;
 
+@optional
+
+- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement __deprecated_msg("Implement -showUpdateNotFoundWithError:acknowledgement: instead");
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -171,9 +171,10 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  *
  * Let the user know a new update was not found after they tried initiating an update check.
  *
- * @param acknowledgement Acknowledge to the updater that no update found was shown.
+ * @param error The error associated with why a new update was not found.
+ * @param acknowledgement Acknowledge to the updater that no update found error was shown.
  */
-- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement;
+- (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement;
 
 /*!
  * Show the user an update error occurred
@@ -181,6 +182,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * Let the user know that the updater failed with an error. This will not be invoked without the user having been
  * aware that an update was in progress.
  *
+ * @param error The error associated with what update error occurred..
  * @param acknowledgement Acknowledge to the updater that the error was shown.
  */
 - (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement;

--- a/Sparkle/SUAppcastDriver.h
+++ b/Sparkle/SUAppcastDriver.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didFailToFetchAppcastWithError:(NSError *)error;
 - (void)didFinishLoadingAppcast:(SUAppcast *)appcast;
 - (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)appcastItem preventsAutoupdate:(BOOL)preventsAutoupdate;
-- (void)didNotFindUpdate;
+- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult;
 
 @end
 

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -110,7 +110,8 @@
         self.nonDeltaUpdateItem = nonDeltaUpdateItem;
         [self.delegate didFindValidUpdateWithAppcastItem:item preventsAutoupdate:[self itemPreventsAutoupdate:item]];
     } else {
-        [self.delegate didNotFindUpdate];
+        NSComparisonResult hostToLatestAppcastItemComparisonResult = (item != nil) ? [[self versionComparator] compareVersion:[self.host version] toVersion:[item versionString]] : 0;
+        [self.delegate didNotFindUpdateWithLatestAppcastItem:item hostToLatestAppcastItemComparisonResult:hostToLatestAppcastItemComparisonResult];
     }
 }
 

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -232,7 +232,7 @@
     [self acceptAcknowledgementAfterDelay];
 }
 
-- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement
+- (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
     [self.coreComponent registerAcknowledgement:acknowledgement];
     

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -173,7 +173,7 @@
     }
 }
 
-- (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))__unused acknowledgement __attribute__((noreturn))
+- (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))__unused acknowledgement __attribute__((noreturn))
 {
     if (self.verbose) {
         fprintf(stderr, "No new update available!\n");


### PR DESCRIPTION
Alter update not found message in two special out-of-ordinary cases: if user is running version greater than latest appcast version or if no appcast items were found.

Ports #1427 over to 2.x (cc @core-code @DivineDominion)

I changed the UI driver method to create an alert from the NSError object so Sparkle can control what sort of error to provide, if the user driver wishes to use it.

I'll do a localization sync at some later point.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported. **NA**
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App (modified)
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

I tested case where host was running version > latest appcast feed, case where no appcast items were present, case where latest version in appcast feed was the same as host version.

macOS version tested: 11.2 (20D64)
