### PR TITLE
Support mpkg for updating/installing flat non-archived packages

### DIFF
--- a/Autoupdate/SUFlatPackageUnarchiver.m
+++ b/Autoupdate/SUFlatPackageUnarchiver.m
@@ -28,7 +28,7 @@
 
 + (BOOL)canUnarchivePath:(NSString *)path
 {
-    return [path.pathExtension isEqualToString:@"pkg"];
+    return [path.pathExtension isEqualToString:@"pkg"] || [path.pathExtension isEqualToString:@"mpkg"];
 }
 
 + (BOOL)mustValidateBeforeExtraction

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -316,7 +316,7 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
             // If we have a flat package, assume installation type is guided
             // (flat / non-archived interactive packages are not supported)
             // Otherwise assume we have a normal application inside an archive
-            if ([_fileURL.pathExtension isEqualToString:@"pkg"]) {
+            if ([_fileURL.pathExtension isEqualToString:@"pkg"] || [_fileURL.pathExtension isEqualToString:@"mpkg"]) {
                 _installationType = SPUInstallationTypeGuidedPackage;
             } else {
                 _installationType = SPUInstallationTypeApplication;


### PR DESCRIPTION
Add mpkg to list of flat-style pkg formats that are supported without needing to archive them.

Confirmed that mpkg packages can be flat.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

I tested that a pkg file I renamed to mpkg passed through properly in the downloader and unarchiver (only that `installer` didn't succeed because it wasn't a real mpkg file; I don't know how to create a real one, but should be sufficient enough test for validating this).

macOS version tested: 11.2 (20D64)
