### PR TITLE
Use wall time for our updater scheduled check timer

### DIFF
--- a/Sparkle/SPUUpdaterTimer.m
+++ b/Sparkle/SPUUpdaterTimer.m
@@ -7,6 +7,7 @@
 //
 
 #import "SPUUpdaterTimer.h"
+#import "SUConstants.h"
 
 
 #include "AppKitPrevention.h"
@@ -14,14 +15,14 @@
 @interface SPUUpdaterTimer ()
 
 @property (nonatomic, readonly, weak) id<SPUUpdaterTimerDelegate> delegate;
-@property (nonatomic, nullable) NSTimer *timer;
+@property (nonatomic) dispatch_source_t source;
 
 @end
 
 @implementation SPUUpdaterTimer
 
 @synthesize delegate = _delegate;
-@synthesize timer = _timer;
+@synthesize source = _source;
 
 - (instancetype)initWithDelegate:(id<SPUUpdaterTimerDelegate>)delegate
 {
@@ -34,20 +35,27 @@
 
 - (void)startAndFireAfterDelay:(NSTimeInterval)delay
 {
-    assert(self.timer == nil);
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:delay target:self selector:@selector(fire:) userInfo:nil repeats:NO];
-}
-
-- (void)fire:(NSTimer *)__unused timer
-{
-    [self.delegate updaterTimerDidFire];
-    self.timer = nil;
+    self.source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+    
+    // We use the wall time instead of cpu time for our dispatch timer
+    // So eg if the computer sleeps we want to include that time spent in our timer
+    dispatch_time_t timeToFire = dispatch_walltime(NULL, (int64_t)(delay * NSEC_PER_SEC));
+    dispatch_source_set_timer(self.source, timeToFire, DISPATCH_TIME_FOREVER, SULeewayUpdateCheckInterval * NSEC_PER_SEC);
+    
+    __weak __typeof__(self) weakSelf = self;
+    dispatch_source_set_event_handler(self.source, ^{
+        [weakSelf.delegate updaterTimerDidFire];
+    });
+    
+    dispatch_resume(self.source);
 }
 
 - (void)invalidate
 {
-    [self.timer invalidate];
-    self.timer = nil;
+    if (self.source != nil) {
+        dispatch_source_cancel(self.source);
+        self.source = nil;
+    }
 }
 
 @end

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -19,6 +19,7 @@
 extern const NSTimeInterval SUDefaultUpdatePermissionPromptInterval;
 extern const NSTimeInterval SUMinimumUpdateCheckInterval;
 extern const NSTimeInterval SUDefaultUpdateCheckInterval;
+extern const uint64_t SULeewayUpdateCheckInterval;
 extern const NSTimeInterval SUImpatientUpdateCheckInterval;
 
 extern NSString *const SUBundleIdentifier;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -18,6 +18,8 @@
 // Define some minimum intervals to avoid DoS-like checking attacks
 const NSTimeInterval SUMinimumUpdateCheckInterval = DEBUG ? 60 : (60 * 60);
 const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);
+// The amount of time the system can defer our update check (for improved performance)
+const uint64_t SULeewayUpdateCheckInterval = DEBUG ? 1 : 15;
 
 // If the update has already been automatically downloaded, we normally don't want to bug the user about the update
 // However if the user has gone a very long time without quitting an application, we will bug them


### PR DESCRIPTION
We have some code in 1.x that registers for sleep/wake notifications and re-schedules the NSTimer / update check (#1437) so that if a computer is slept for a long time, that time will still be considered. Instead of porting over that solution directly, a simpler approach is to use dispatch API that takes wall time in account, which frees us from registering such notifications.

I introduced a new leeway constant which I set to 15 seconds that the system can defer firing the timer under heavy load (but it's debatable / subjective what a good value should be).

cc @core-code 

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

In the test app I tested that the timer still fires in 60 seconds and that the timer counts the elapsed time when the system is asleep.

macOS version tested: 11.2 (20D64)
