### PR TITLE
Fix XQuartz update failing because NSLog caused issues

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		72AC6B2A1B9AAF3A00F62325 /* SparkleTestCodeSignApp.tar.bz2 in Resources */ = {isa = PBXBuildFile; fileRef = 72AC6B291B9AAF3A00F62325 /* SparkleTestCodeSignApp.tar.bz2 */; };
 		72AC6B2C1B9AB0EE00F62325 /* SparkleTestCodeSignApp.tar.xz in Resources */ = {isa = PBXBuildFile; fileRef = 72AC6B2B1B9AB0EE00F62325 /* SparkleTestCodeSignApp.tar.xz */; };
 		72AC6B2E1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg in Resources */ = {isa = PBXBuildFile; fileRef = 72AC6B2D1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg */; };
+		72C4AB7A25E0B4C500D14562 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		72D4DAA11AD7632900B211E2 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
 		72E1D7DD25A3E3AD0001BA6D /* SUWebViewCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 72E1D7D625A3E3AC0001BA6D /* SUWebViewCommon.m */; };
 		72E1D7DE25A3E3AD0001BA6D /* SUWebViewCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 72E1D7D725A3E3AC0001BA6D /* SUWebViewCommon.h */; };
@@ -2469,6 +2470,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72C4AB7A25E0B4C500D14562 /* SULog.m in Sources */,
 				722954B71D04ADAF00ECF9CA /* fileop.m in Sources */,
 				722954BD1D04AE3800ECF9CA /* SUConstants.m in Sources */,
 				722954BC1D04AE1100ECF9CA /* SUFileManager.m in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		72AC6B2C1B9AB0EE00F62325 /* SparkleTestCodeSignApp.tar.xz in Resources */ = {isa = PBXBuildFile; fileRef = 72AC6B2B1B9AB0EE00F62325 /* SparkleTestCodeSignApp.tar.xz */; };
 		72AC6B2E1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg in Resources */ = {isa = PBXBuildFile; fileRef = 72AC6B2D1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg */; };
 		72C4AB7A25E0B4C500D14562 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
+		72C4ABAB25E0BF1900D14562 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		72D4DAA11AD7632900B211E2 /* SUBinaryDeltaCreate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7268AC621AD634C200C3E0C1 /* SUBinaryDeltaCreate.m */; };
 		72E1D7DD25A3E3AD0001BA6D /* SUWebViewCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 72E1D7D625A3E3AC0001BA6D /* SUWebViewCommon.m */; };
 		72E1D7DE25A3E3AD0001BA6D /* SUWebViewCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 72E1D7D725A3E3AC0001BA6D /* SUWebViewCommon.h */; };
@@ -2418,6 +2419,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72C4ABAB25E0BF1900D14562 /* SULog.m in Sources */,
 				14652F7D19A9726700959E44 /* SUBinaryDeltaApply.m in Sources */,
 				14652F7C19A9725300959E44 /* SUBinaryDeltaCommon.m in Sources */,
 				7268AC631AD634C200C3E0C1 /* SUBinaryDeltaCreate.m in Sources */,

--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -136,7 +136,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
         self.statusController = [[SUStatusController alloc] initWithHost:host];
         [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:Nil isDefault:NO];
         [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"")
-                                   maxProgressValue:100 statusText: @""];
+                                   maxProgressValue:0 statusText: @""];
         [self.statusController showWindow:self];
     }
     
@@ -151,10 +151,13 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
             return;
         }
         
-        void(^progressBlock)(double) = ^(double progress){
-            dispatch_async(dispatch_get_main_queue(), ^(){
-                self.statusController.progressValue = progress * 100.0;
-            });
+        void(^progressBlock)(double) = ^(double __unused progress){
+            // Showing determinate progress doesn't work anymore and may be fragile to support, so disabling it and using intermediate progress bar with maxProgressValue as 0
+            // instead of 100 above in beginActionWithTitle:maxProgressValue:statusText: call
+            
+            //dispatch_async(dispatch_get_main_queue(), ^(){
+            //    self.statusController.progressValue = progress * 100.0;
+            //});
         };
 
         NSError *finalInstallationError = nil;

--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -136,7 +136,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
         self.statusController = [[SUStatusController alloc] initWithHost:host];
         [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:Nil isDefault:NO];
         [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"")
-                                   maxProgressValue:100 statusText: @""];
+                                   maxProgressValue:installer.supportsDeterminateProgress ? 100 : 0 statusText: @""];
         [self.statusController showWindow:self];
     }
     
@@ -153,7 +153,9 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
         
         void(^progressBlock)(double) = ^(double progress){
             dispatch_async(dispatch_get_main_queue(), ^(){
-                self.statusController.progressValue = progress * 100.0;
+                if (installer.supportsDeterminateProgress) {
+                    self.statusController.progressValue = progress * 100.0;
+                }
             });
         };
 

--- a/Sparkle/Autoupdate/Autoupdate.m
+++ b/Sparkle/Autoupdate/Autoupdate.m
@@ -136,7 +136,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
         self.statusController = [[SUStatusController alloc] initWithHost:host];
         [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:Nil isDefault:NO];
         [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"")
-                                   maxProgressValue:0 statusText: @""];
+                                   maxProgressValue:100 statusText: @""];
         [self.statusController showWindow:self];
     }
     
@@ -151,13 +151,10 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.5;
             return;
         }
         
-        void(^progressBlock)(double) = ^(double __unused progress){
-            // Showing determinate progress doesn't work anymore and may be fragile to support, so disabling it and using intermediate progress bar with maxProgressValue as 0
-            // instead of 100 above in beginActionWithTitle:maxProgressValue:statusText: call
-            
-            //dispatch_async(dispatch_get_main_queue(), ^(){
-            //    self.statusController.progressValue = progress * 100.0;
-            //});
+        void(^progressBlock)(double) = ^(double progress){
+            dispatch_async(dispatch_get_main_queue(), ^(){
+                self.statusController.progressValue = progress * 100.0;
+            });
         };
 
         NSError *finalInstallationError = nil;

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -10,6 +10,7 @@
 #import "SUOperatingSystem.h"
 #import "SUFileOperationConstants.h"
 
+#import "SULog.h"
 #import "SUErrors.h"
 
 #include <sys/xattr.h>
@@ -320,7 +321,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to remove quarantine %@", rootURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to remove quarantine: %d", rootURL);
 
     NSError *executeError = nil;
     BOOL success = [self _authorizeAndExecuteCommand:SUFileOpRemoveQuarantineCommand sourcePath:path destinationPath:NULL error:&executeError];
@@ -520,7 +521,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to copy %@ to %@", sourceURL, destinationURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to copy %@ to %@", sourceURL, destinationURL);
 
     NSError *executeError = nil;
     if (![self _authorizeAndExecuteCommand:SUFileOpCopyCommand sourcePath:sourcePath destinationPath:destinationPath error:&executeError]) {
@@ -614,7 +615,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to move %@ to %@", sourceURL, destinationURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to move %@ to %@", sourceURL, destinationURL);
 
     char sourcePath[PATH_MAX] = {0};
     if (![sourceURL.path getFileSystemRepresentation:sourcePath maxLength:sizeof(sourcePath)]) {
@@ -785,7 +786,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to change permissions of %@ to match %@", targetURL, matchURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to change permissions of %@ to match %@", targetURL, matchURL);
 
     NSError *executeError = nil;
     BOOL success = [self _authorizeAndExecuteCommand:SUFileOpChangeOwnerAndGroupCommand sourcePath:targetPath destinationPath:matchPath error:&executeError];
@@ -844,7 +845,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to update timestamp of %@", targetURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to update timestamp of %@", targetURL);
 
     NSError *executeError = nil;
     BOOL success = [self _authorizeAndExecuteCommand:SUFileOpUpdateModificationAndAccessTimeCommand sourcePath:path destinationPath:NULL error:&executeError];
@@ -888,7 +889,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to make directory %@", url);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to make directory %@", url);
 
     char path[PATH_MAX] = {0};
     if (![url.path getFileSystemRepresentation:path maxLength:sizeof(path)]) {
@@ -952,7 +953,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to delete %@", url);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to delete %@", url);
 
     char path[PATH_MAX] = {0};
     if (![url.path getFileSystemRepresentation:path maxLength:sizeof(path)]) {
@@ -990,7 +991,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    NSLog(@"Sparkle: Authorization required to run pkg installer %@", packageURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to run pkg installer %@", packageURL);
 
     NSError *executeError = nil;
     BOOL success = [self _authorizeAndExecuteCommand:SUFileOpInstallCommand sourcePath:path destinationPath:NULL lineCallback:^(NSString *line){

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -321,7 +321,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
         return NO;
     }
 
-    SULog(SULogLevelDefault, @"Sparkle: Authorization required to remove quarantine: %d", rootURL);
+    SULog(SULogLevelDefault, @"Sparkle: Authorization required to remove quarantine: %@", rootURL);
 
     NSError *executeError = nil;
     BOOL success = [self _authorizeAndExecuteCommand:SUFileOpRemoveQuarantineCommand sourcePath:path destinationPath:NULL error:&executeError];

--- a/Sparkle/SUGuidedPackageInstaller.m
+++ b/Sparkle/SUGuidedPackageInstaller.m
@@ -54,4 +54,11 @@
     return YES;
 }
 
+// We used to, but it broke due to fragile text processing
+// Maybe one day someone will fix it, but until then.
+- (BOOL)supportsDeterminateProgress
+{
+    return NO;
+}
+
 @end

--- a/Sparkle/SUInstallerProtocol.h
+++ b/Sparkle/SUInstallerProtocol.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 // Should be thread safe
 - (NSString *)installationPath;
 
+- (BOOL)supportsDeterminateProgress;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SUPackageInstaller.m
+++ b/Sparkle/SUPackageInstaller.m
@@ -78,4 +78,9 @@ static NSString *SUOpenUtilityPath = @"/usr/bin/open";
     return NO;
 }
 
+- (BOOL)supportsDeterminateProgress
+{
+    return NO;
+}
+
 @end

--- a/Sparkle/SUPlainInstaller.m
+++ b/Sparkle/SUPlainInstaller.m
@@ -265,4 +265,9 @@
     return YES;
 }
 
+- (BOOL)supportsDeterminateProgress
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
In Sparkle 1.x, Autoupdate is NSTask'ed from the updater with LSBackgroundOnly / LSUIElement set. Somehow when updating XQuartz, any NSLog usage makes Autoupdate get mysteriously killed afterwards.

Literally if I put the two statements right in main():

NSLog(@"foo");
NSLog(@"bar");

Only foo would be logged, bar would not be logged. I even verified this was not just a "logging" issue by writing out files to disk and tried disabling sudden termination redundantly as potential cause but no dice.

So in SUFileManager before we prompt the user an authorization dialog, we logged:
Sparkle: Authorization required to run pkg installer file:///Users/msp/Library/Caches/org.xquartz.X11/org.sparkle-project.Sparkle/PersistentDownloads/YYhaX4Tma/XQuartz%202.8.8/Xquartz.pkg

Which is the last thing seen. Normally if an error occurred we'd log it.

I don't know if there is an OS bug involved but anyway, we should just replace all NSLog usage with SULog (which uses os_log) in Autoupdate. fileop in 1.x which uses SUFileManager should probably never NSLog anyway. Autoupdate tool in 2.x is spawned as a launchd daemon for package installs, so it might not be affected, but I should update SULog usages there anyway to be in sync.

The determinate progress reporting was also broken (#1402), so I'm making it an indeterminate progress bar again rather than trying to debug what has apparently become fragile text parsing.

Fixes #1768

## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first. - **NA - apparently all NSLog usage in the installer was already removed in 2.x so nothing to sync. And I verified even if there were NSLogs, 2.x is not susceptible to this issue.**
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify) - *XQuartz*

I tested this by jamming a debug version of Sparkle into XQuartz. I could not reproduce the issue when I tried attaching the debugger to Autoupdate.

macOS version tested: 11.1 (20C69)
