### PR TITLE
Correct generate_appcast -s command line argument usage help

### DIFF
--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -31,7 +31,7 @@ Usage: \(command) [OPTIONS] [ARCHIVES_FOLDER]
     -f: provide the path to the private DSA key
     -n: provide the name of the private DSA key. This option must be used with `-k`
     -k: provide the name of the keychain. This option must be used with `-n`
-    -s: provide the path to the private EdDSA key
+    -s: provide the private EdDSA key (128 characters)
     -o: provide a filename for the generated appcast (allowed when only one will be created)
     
     --download-url-prefix: provide a prefix used to construct URLs for update downloads


### PR DESCRIPTION
Fixes sparkle-project/Sparkle#1766

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Cosmetic change, did not test.