### PR TITLE
Add download, extract, skip delegate methods from 1.x

### DIFF
--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -211,6 +211,10 @@
         [SUPhasedUpdateGroupInfo setNewUpdateGroupIdentifierForHost:self.host];
     }
     
+    if ([self.updaterDelegate respondsToSelector:@selector(updater:didDownloadUpdate:)]) {
+        [self.updaterDelegate updater:self.updater didDownloadUpdate:self.updateItem];
+    }
+    
     self.resumableUpdate = downloadedUpdate;
     [self extractUpdate:downloadedUpdate];
 }
@@ -233,6 +237,10 @@
 
 - (void)extractUpdate:(SPUDownloadedUpdate *)downloadedUpdate
 {
+    if ([self.updaterDelegate respondsToSelector:@selector(updater:willExtractUpdate:)]) {
+        [self.updaterDelegate updater:self.updater willExtractUpdate:self.updateItem];
+    }
+    
     // Now we have to extract the downloaded archive.
     if ([self.delegate respondsToSelector:@selector(coreDriverDidStartExtractingUpdate)]) {
         [self.delegate coreDriverDidStartExtractingUpdate];
@@ -245,6 +253,10 @@
             // If the installer started properly, we can't use the downloaded update archive anymore
             // Especially if the installer fails later and we try resuming the update with a missing archive file
             [self clearDownloadedUpdate];
+            
+            if ([self.updaterDelegate respondsToSelector:@selector(updater:didExtractUpdate:)]) {
+                [self.updaterDelegate updater:self.updater didExtractUpdate:self.updateItem];
+            }
         }
     }];
 }

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -118,6 +118,10 @@
                 switch (choice) {
                     case SPUSkipThisInformationalVersionChoice:
                         [self.host setObject:[updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
+                        
+                        if ([self.updaterDelegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
+                            [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
+                        }
                         // Fall through
                     case SPUDismissInformationalNoticeChoice:
                         [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -107,6 +107,8 @@
 
 - (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem preventsAutoupdate:(BOOL)preventsAutoupdate
 {
+    id <SPUUpdaterDelegate> updaterDelegate = self.updaterDelegate;
+    
     if (updateItem.isInformationOnlyUpdate) {
         assert(!self.resumingDownloadedUpdate);
         assert(!self.resumingInstallingUpdate);
@@ -134,6 +136,10 @@
                     case SPUSkipThisVersionChoice:
                         [self.coreDriver clearDownloadedUpdate];
                         [self.host setObject:[updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
+                        
+                        if ([self.updaterDelegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
+                            [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
+                        }
                         // Fall through
                     case SPUInstallLaterChoice:
                         [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
@@ -151,6 +157,10 @@
                         break;
                     case SPUSkipThisVersionChoice:
                         [self.host setObject:[updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
+                        
+                        if ([self.updaterDelegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
+                            [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
+                        }
                         // Fall through
                     case SPUInstallLaterChoice:
                         [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
@@ -171,7 +181,6 @@
         [self.delegate uiDriverDidShowUpdate];
     }
     
-    id <SPUUpdaterDelegate> updaterDelegate = self.updaterDelegate;
     if (updateItem.releaseNotesURL != nil && (![updaterDelegate respondsToSelector:@selector(updaterShouldDownloadReleaseNotes:)] || [updaterDelegate updaterShouldDownloadReleaseNotes:self.updater])) {
         NSURLRequest *request = [NSURLRequest requestWithURL:updateItem.releaseNotesURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30];
         

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -217,6 +217,14 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (void)updater:(SPUUpdater *)updater willDownloadUpdate:(SUAppcastItem *)item withRequest:(NSMutableURLRequest *)request;
 
 /*!
+ Called immediately after succesfull download of the specified update.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that has been downloaded.
+ */
+- (void)updater:(SPUUpdater *)updater didDownloadUpdate:(SUAppcastItem *)item;
+
+/*!
  Called after the specified update failed to download.
  
  \param updater The updater instance.
@@ -231,6 +239,22 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  \param updater The updater instance.
  */
 - (void)userDidCancelDownload:(SPUUpdater *)updater;
+
+/*!
+ Called immediately before extracting the specified downloaded update.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that is proposed to be extracted.
+ */
+- (void)updater:(SPUUpdater *)updater willExtractUpdate:(SUAppcastItem *)item;
+
+/*!
+ Called immediately after extracting the specified downloaded update.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that has been extracted.
+ */
+- (void)updater:(SPUUpdater *)updater didExtractUpdate:(SUAppcastItem *)item;
 
 /*!
  Called immediately before installing the specified update.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -189,6 +189,14 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (void)updaterDidNotFindUpdate:(SPUUpdater *)updater;
 
 /*!
+ Called when an update is skipped by the user.
+ 
+ \param updater The updater instance.
+ \param item The appcast item corresponding to the update that the user skipped.
+ */
+- (void)updater:(SPUUpdater *)updater userDidSkipThisVersion:(SUAppcastItem *)item;
+
+/*!
  Returns whether the release notes (if available) should be downloaded after an update is found and shown.
  
  This is specifically for the releaseNotesLink element in the appcast.

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -405,6 +405,9 @@ static NSMutableDictionary *sharedUpdaters = nil;
         self.postponedInstallHandler = installHandler;
 
         shouldPostponeRelaunch = [self.delegate updater:self shouldPostponeRelaunchForUpdate:item untilInvoking:invocation];
+    } else if ([self.delegate respondsToSelector:@selector(updater:shouldPostponeRelaunchForUpdate:)]) {
+        // This API should really take a block, but not fixing a 1.x mishap now
+        shouldPostponeRelaunch = [self.delegate updater:self shouldPostponeRelaunchForUpdate:item];
     }
     
     return shouldPostponeRelaunch;

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -462,7 +462,13 @@ static NSMutableDictionary *sharedUpdaters = nil;
 {
     BOOL installationHandledByDelegate = NO;
     
-    if ([self.delegate respondsToSelector:@selector(updater:willInstallUpdateOnQuit:immediateInstallationInvocation:)]) {
+    if ([self.delegate respondsToSelector:@selector((updater:willInstallUpdateOnQuit:immediateInstallationBlock:))]) {
+        [self.delegate updater:self willInstallUpdateOnQuit:item immediateInstallationBlock:immediateInstallHandler];
+        
+        // We have to assume they will handle the installation since they implement this method
+        // Not ideal, but this is why this delegate callback is deprecated
+        installationHandledByDelegate = YES;
+    } else if ([self.delegate respondsToSelector:@selector(updater:willInstallUpdateOnQuit:immediateInstallationInvocation:)]) {
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[[self class] instanceMethodSignatureForSelector:@selector(finishSilentInstallation)]];
         
         // This invocation will retain self, but this instance is kept alive forever by our singleton pattern anyway

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -326,6 +326,13 @@ static NSMutableDictionary *sharedUpdaters = nil;
     }
 }
 
+- (void)updater:(SPUUpdater *)__unused updater userDidSkipThisVersion:(nonnull SUAppcastItem *)item
+{
+    if ([self.delegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
+        [self.delegate updater:self userDidSkipThisVersion:item];
+    }
+}
+
 - (void)updater:(SPUUpdater *)__unused updater willDownloadUpdate:(SUAppcastItem *)item withRequest:(NSMutableURLRequest *)request
 {
     if ([self.delegate respondsToSelector:@selector(updater:willDownloadUpdate:withRequest:)]) {

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -337,7 +337,14 @@ static NSMutableDictionary *sharedUpdaters = nil;
 {
     if ([self.delegate respondsToSelector:@selector(updater:willDownloadUpdate:withRequest:)]) {
         [self.delegate updater:self willDownloadUpdate:item withRequest:request];
-        }
+    }
+}
+
+- (void)updater:(SPUUpdater *)__unused updater didDownloadUpdate:(SUAppcastItem *)item
+{
+    if ([self.delegate respondsToSelector:@selector(updater:didDownloadUpdate:)]) {
+        [self.delegate updater:self didDownloadUpdate:item];
+    }
 }
 
 - (void)updater:(SPUUpdater *)__unused updater failedToDownloadUpdate:(SUAppcastItem *)item error:(NSError *)error
@@ -351,6 +358,20 @@ static NSMutableDictionary *sharedUpdaters = nil;
 {
     if ([self.delegate respondsToSelector:@selector(userDidCancelDownload:)]) {
         [self.delegate userDidCancelDownload:self];
+    }
+}
+
+- (void)updater:(SPUUpdater *)updater willExtractUpdate:(SUAppcastItem *)item
+{
+    if ([self.delegate respondsToSelector:@selector(updater:willExtractUpdate:)]) {
+        [self.delegate updater:self willExtractUpdate:item];
+    }
+}
+
+- (void)updater:(SPUUpdater *)updater didExtractUpdate:(SUAppcastItem *)item
+{
+    if ([self.delegate respondsToSelector:@selector(updater:didExtractUpdate:)]) {
+        [self.delegate updater:self didExtractUpdate:item];
     }
 }
 

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -161,6 +161,14 @@ __deprecated_msg("See SPUUpdaterDelegate instead")
 - (void)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
 
 /*!
+ Called when an update is skipped by the user.
+ 
+ \param updater The updater instance.
+ \param item The appcast item corresponding to the update that the user skipped.
+ */
+- (void)updater:(SUUpdater *)updater userDidSkipThisVersion:(SUAppcastItem *)item;
+
+/*!
  Returns whether the relaunch should be delayed in order to perform other tasks.
  
  This is not called if the user didn't relaunch on the previous update,

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -137,6 +137,14 @@ __deprecated_msg("See SPUUpdaterDelegate instead")
 - (void)updater:(SUUpdater *)updater willDownloadUpdate:(SUAppcastItem *)item withRequest:(NSMutableURLRequest *)request;
 
 /*!
+ Called immediately after succesfull download of the specified update.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that has been downloaded.
+ */
+- (void)updater:(SUUpdater *)updater didDownloadUpdate:(SUAppcastItem *)item;
+
+/*!
  Called after the specified update failed to download.
  
  \param updater The SUUpdater instance.
@@ -151,6 +159,22 @@ __deprecated_msg("See SPUUpdaterDelegate instead")
  \param updater The SUUpdater instance.
  */
 - (void)userDidCancelDownload:(SUUpdater *)updater;
+
+/*!
+ Called immediately before extracting the specified downloaded update.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that is proposed to be extracted.
+ */
+- (void)updater:(SUUpdater *)updater willExtractUpdate:(SUAppcastItem *)item;
+
+/*!
+ Called immediately after extracting the specified downloaded update.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that has been extracted.
+ */
+- (void)updater:(SUUpdater *)updater didExtractUpdate:(SUAppcastItem *)item;
 
 /*!
  Called immediately before installing the specified update.

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -296,6 +296,17 @@ __deprecated_msg("See SPUUpdaterDelegate instead")
 - (void)updater:(SUUpdater *)updater willInstallUpdateOnQuit:(SUAppcastItem *)item immediateInstallationInvocation:(NSInvocation *)invocation;
 
 /*!
+ Called when an update is scheduled to be silently installed on quit.
+ This is after an update has been automatically downloaded in the background.
+ (i.e. SUUpdater::automaticallyDownloadsUpdates is YES)
+ This method acts as a more modern alternative to SUUpdaterDelegate::updater:willInstallUpdateOnQuit:immediateInstallationInvocation: using a block instead of NSInvocation, which is not available in Swift environments.
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that is proposed to be installed.
+ \param installationBlock Can be used to trigger an immediate silent install and relaunch.
+ */
+- (void)updater:(SUUpdater *)updater willInstallUpdateOnQuit:(SUAppcastItem *)item immediateInstallationBlock:(void (^)(void))installationBlock;
+
+/*!
  Calls after an update that was scheduled to be silently installed on quit has been canceled.
  
  \param updater The SUUpdater instance.

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -209,6 +209,21 @@ __deprecated_msg("See SPUUpdaterDelegate instead")
 - (BOOL)updater:(SUUpdater *)updater shouldPostponeRelaunchForUpdate:(SUAppcastItem *)item untilInvoking:(NSInvocation *)invocation;
 
 /*!
+ Returns whether the relaunch should be delayed in order to perform other tasks.
+ 
+ This is not called if the user didn't relaunch on the previous update,
+ in that case it will immediately restart.
+ 
+ This method acts as a simpler alternative to SUUpdaterDelegate::updater:shouldPostponeRelaunchForUpdate:untilInvoking: avoiding usage of NSInvocation, which is not available in Swift environments.
+ 
+ \param updater The SUUpdater instance.
+ \param item The appcast item corresponding to the update that is proposed to be installed.
+ 
+ \return \c YES to delay the relaunch.
+ */
+- (BOOL)updater:(SUUpdater *)updater shouldPostponeRelaunchForUpdate:(SUAppcastItem *)item;
+
+/*!
  Returns whether the application should be relaunched at all.
  
  Some apps \b cannot be relaunched under certain circumstances.


### PR DESCRIPTION
Add download, extract, skip delegate methods from 1.x and add appropriate stub methods to legacy SUUpdaterDelegate including methods to postpone installation.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

I tested the new skip, did/will extract, did download methods on SPUUpdaterDelegate in a modified version of the test app.

macOS version tested: 11.2 (20D64)
