### PR TITLE
Improve error messages developers run into

### DIFF
--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -121,7 +121,7 @@
                  code:SUInstallationError
                  userInfo:@{
                             NSLocalizedDescriptionKey: SULocalizedString(@"An error occurred while running the updater. Please try again later.", nil),
-                            NSLocalizedFailureReasonErrorKey:@"The remote port connection was invalidated from the updater"
+                            NSLocalizedFailureReasonErrorKey:@"The remote port connection was invalidated from the updater. Please check Console logs for "@SPARKLE_RELAUNCH_TOOL_NAME
                             }
                  ];
                 [strongSelf.delegate installerIsRequestingAbortInstallWithError:remoteError];

--- a/Sparkle/SPUProbeInstallStatus.m
+++ b/Sparkle/SPUProbeInstallStatus.m
@@ -27,7 +27,8 @@
 + (void)probeInstallerInProgressForHostBundleIdentifier:(NSString *)hostBundleIdentifier completion:(void (^)(BOOL))completionHandler
 {
     id<SUInstallerStatusProtocol> installerStatus = nil;
-    if (!SPUXPCServiceExists(@INSTALLER_STATUS_BUNDLE_ID)) {
+    BOOL usesXPC = SPUXPCServiceExists(@INSTALLER_STATUS_BUNDLE_ID);
+    if (!usesXPC) {
         installerStatus = [[SUInstallerStatus alloc] init];
     } else {
         installerStatus = [[SUXPCInstallerStatus alloc] init];
@@ -59,7 +60,11 @@
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(PROBE_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!handledCompletion) {
-            SULog(SULogLevelError, @"Timed out while probing installer progress");
+            if (usesXPC) {
+                SULog(SULogLevelError, @"Timed out while probing installer progress. Please see https://sparkle-project.org/documentation/sandboxing/#testing for potential cause.");
+            } else {
+                SULog(SULogLevelError, @"Timed out while probing installer progress");
+            }
             completionHandler(NO);
             handledCompletion = YES;
         }
@@ -70,7 +75,8 @@
 + (void)probeInstallerUpdateItemForHostBundleIdentifier:(NSString *)hostBundleIdentifier completion:(void (^)(SPUInstallationInfo  * _Nullable))completionHandler
 {
     id<SUInstallerStatusProtocol> installerStatus = nil;
-    if (!SPUXPCServiceExists(@INSTALLER_STATUS_BUNDLE_ID)) {
+    BOOL usesXPC = SPUXPCServiceExists(@INSTALLER_STATUS_BUNDLE_ID);
+    if (!usesXPC) {
         installerStatus = [[SUInstallerStatus alloc] init];
     } else {
         installerStatus = [[SUXPCInstallerStatus alloc] init];
@@ -108,7 +114,11 @@
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(PROBE_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!handledCompletion) {
-            SULog(SULogLevelDefault, @"Timed out while probing installer info data");
+            if (usesXPC) {
+                SULog(SULogLevelDefault, @"Timed out while probing installer info data. Please see https://sparkle-project.org/documentation/sandboxing/#testing for potential cause.");
+            } else {
+                SULog(SULogLevelDefault, @"Timed out while probing installer info data");
+            }
             completionHandler(nil);
             handledCompletion = YES;
         }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -91,7 +91,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 {
     // We're using NSLog instead of SULog here because we don't want to start Sparkle's logger here,
     // and because this is not really an error, just a warning notice
-    NSLog(@"WARNING: This is running a Debug build of Sparkle; don't use this in production!");
+    NSLog(@"WARNING: This is running a Debug build of Sparkle 2; don't use this in production!");
 }
 #endif
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -168,9 +168,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (BOOL)checkIfConfiguredProperly:(NSError * __autoreleasing *)error
 {
+    NSString *hostName = self.host.name;
+    
     if (self.sparkleBundle == nil) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidUpdaterError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@ can't find Sparkle.framework it belongs to.", NSStringFromClass([self class])] }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidUpdaterError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@ can't find Sparkle.framework it belongs to in %@.", NSStringFromClass([self class]), hostName] }];
         }
         return NO;
     }
@@ -182,14 +184,14 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if ([[self hostBundle] bundleIdentifier] == nil) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidHostBundleIdentifierError userInfo:@{ NSLocalizedDescriptionKey: @"Sparkle cannot target a bundle that does not have a valid bundle identifier." }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidHostBundleIdentifierError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Sparkle cannot target a bundle that does not have a valid bundle identifier for %@.", hostName] }];
         }
         return NO;
     }
     
     if (!self.host.validVersion) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidHostVersionError userInfo:@{ NSLocalizedDescriptionKey: @"Sparkle cannot target a bundle that does not have a valid version." }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidHostVersionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Sparkle cannot target a bundle that does not have a valid version for %@.", hostName] }];
         }
         return NO;
     }
@@ -228,7 +230,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         NSString *publicDSAKeyFileKey = [self.host publicDSAKeyFileKey];
         if (publicDSAKeyFileKey != nil) {
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The DSA public key '%@' could not be found.", publicDSAKeyFileKey] }];
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The DSA public key '%@' could not be found for %@.", publicDSAKeyFileKey, hostName] }];
             }
             return NO;
         }
@@ -237,7 +239,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     if (!hasPublicKey) {
         if (!servingOverHttps || ![SUCodeSigningVerifier bundleAtURLIsCodeSigned:[[self hostBundle] bundleURL]]) {
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: @"For security reasons, updates need to be signed with an EdDSA key. See Sparkle's documentation for more information." }];
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"For security reasons, updates need to be signed with an EdDSA key for %@. See Sparkle's documentation for more information.", hostName] }];
             }
             return NO;
         } else {
@@ -652,10 +654,12 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (BOOL)retrieveFeedURL:(NSURL * __autoreleasing *)feedURL error:(NSError * __autoreleasing *)error
 {
+    NSString *hostName = self.host.name;
+    
     if (![NSThread isMainThread]) {
         SULog(SULogLevelError, @"Error: SPUUpdater -retrieveFeedURL:error: must be called on the main thread.");
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUIncorrectAPIUsageError userInfo:@{ NSLocalizedDescriptionKey: @"SUUpdater -retriveFeedURL:error: must be called on the main thread."}];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUIncorrectAPIUsageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"SUUpdater -retriveFeedURL:error: must be called on the main thread for %@", hostName]}];
         }
         return NO;
     }
@@ -671,7 +675,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (!appcastString) { // Can't find an appcast string!
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidFeedURLError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"You must specify the URL of the appcast as the %@ key in either the Info.plist or the user defaults!", SUFeedURLKey] }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidFeedURLError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"You must specify the URL of the appcast as the %@ key in either the Info.plist or the user defaults of %@!", SUFeedURLKey, hostName] }];
         }
         return NO;
     }

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -34,7 +34,7 @@
  
  Note: This class is now deprecated and acts as a thin wrapper around SPUUpdater and SPUStandardUserDriver
  */
-__deprecated_msg("Use SPUStandardUpdaterController or SPUUpdater instead")
+__deprecated_msg("Deprecated in Sparkle 2. Use SPUStandardUpdaterController or SPUUpdater instead")
 SU_EXPORT @interface SUUpdater : NSObject
 
 @property (unsafe_unretained, nonatomic) IBOutlet id<SUUpdaterDelegate> delegate;

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -44,7 +44,7 @@ SU_EXPORT extern NSString *const SUUpdaterAppcastNotificationKey;
 /*!
  Provides methods to control the behavior of an SUUpdater object.
  */
-__deprecated_msg("See SPUUpdaterDelegate instead")
+__deprecated_msg("Deprecated in Sparkle 2. See SPUUpdaterDelegate instead")
 @protocol SUUpdaterDelegate <NSObject>
 @optional
 


### PR DESCRIPTION
Improve error messages developers run into and add better clarification.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

I tested the error messages in a custom app and test app.

macOS version tested: 11.2 (20D64)
