### PR TITLE
Bump unarchiving tests timeout from 7 seconds to 30 seconds

### DIFF
--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -30,7 +30,7 @@ class SUUnarchiverTest: XCTestCase
         self.unarchiveTestAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, tempArchiveURL: tempArchiveURL, archiveResourceURL: archiveResourceURL, password: password, expectingSuccess: expectingSuccess, testExpectation: unarchivedSuccessExpectation)
         self.unarchiveNonExistentFileTestFailureAppWithExtension(archiveExtension, tempDirectoryURL: tempDirectoryURL, password: password, testExpectation: unarchivedFailureExpectation)
 
-        super.waitForExpectations(timeout: 7.0, handler: nil)
+        super.waitForExpectations(timeout: 30.0, handler: nil)
 
         if !archiveExtension.hasSuffix("pkg") {
             XCTAssertTrue(fileManager.fileExists(atPath: extractedAppURL.path))


### PR DESCRIPTION
testUnarchivingDmg() sometimes exceeds 7 second timeout in CI. Try bumping this to 30 seconds.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Testing in CI.
