### PR TITLE
Propagate errors from installer and agent to Sparkle

### DIFF
--- a/Autoupdate/AgentConnection.h
+++ b/Autoupdate/AgentConnection.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) id<SPUInstallerAgentProtocol> agent;
 @property (nonatomic, readonly) BOOL connected;
+@property (nonatomic, nullable) NSError *invalidationError;
 
 @end
 

--- a/Autoupdate/AgentConnection.m
+++ b/Autoupdate/AgentConnection.m
@@ -31,6 +31,7 @@
 @synthesize agent = _agent;
 @synthesize delegate = _delegate;
 @synthesize connected = _connected;
+@synthesize invalidationError = _invalidationError;
 
 - (instancetype)initWithHostBundleIdentifier:(NSString *)bundleIdentifier delegate:(id<AgentConnectionDelegate>)delegate
 {

--- a/Autoupdate/AgentConnection.m
+++ b/Autoupdate/AgentConnection.m
@@ -105,4 +105,11 @@
     acknowledgement();
 }
 
+- (void)connectionWillInvalidateWithError:(NSError *)error
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.invalidationError = error;
+    });
+}
+
 @end

--- a/Autoupdate/AppInstaller.h
+++ b/Autoupdate/AppInstaller.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start;
 
-- (void)cleanupAndExitWithStatus:(int)status error:(NSError * _Nullable)error;
+- (void)cleanupAndExitWithStatus:(int)status error:(NSError * _Nullable)error __attribute__((noreturn));
 
 @end
 

--- a/Autoupdate/AppInstaller.h
+++ b/Autoupdate/AppInstaller.h
@@ -9,12 +9,16 @@
 #import <Foundation/Foundation.h>
 #import "SUUnarchiverProtocol.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface AppInstaller : NSObject
 
 - (instancetype)initWithHostBundleIdentifier:(NSString *)hostBundleIdentifier;
 
 - (void)start;
 
-- (void)cleanupAndExitWithStatus:(int)status __attribute__((noreturn));
+- (void)cleanupAndExitWithStatus:(int)status error:(NSError * _Nullable)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -147,8 +147,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             AppInstaller *strongSelf = weakSelf;
             if (strongSelf != nil) {
                 if (strongSelf.activeConnection != nil && !strongSelf.willCompleteInstallation) {
-                    SULog(SULogLevelError, @"Invalidation on remote port being called, and installation is not close enough to completion!");
-                    [strongSelf cleanupAndExitWithStatus:EXIT_FAILURE];
+                    [strongSelf cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Invalidation on remote port being called, and installation is not close enough to completion!" }]];
                 }
                 strongSelf.communicator = nil;
                 strongSelf.activeConnection = nil;
@@ -170,13 +169,11 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(FIRST_UPDATER_MESSAGE_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!self.receivedInstallationData) {
-            SULog(SULogLevelError, @"Timeout: installation data was never received");
-            [self cleanupAndExitWithStatus:EXIT_FAILURE];
+            [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Timeout: installation data was never received" }]];
         }
         
         if (!self.agentConnection.connected) {
-            SULog(SULogLevelError, @"Timeout: agent connection was never initiated");
-            [self cleanupAndExitWithStatus:EXIT_FAILURE];
+            [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Timeout: agent connection was never initiated" }]];
         }
     });
 }
@@ -188,9 +185,10 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     NSString *archivePath = [self.updateDirectoryPath stringByAppendingPathComponent:self.downloadName];
     id<SUUnarchiverProtocol> unarchiver = [SUUnarchiver unarchiverForPath:archivePath updatingHostBundlePath:self.host.bundlePath decryptionPassword:self.decryptionPassword expectingInstallationType:self.installationType];
     
+    NSError *unarchiverError = nil;
     BOOL success = NO;
     if (!unarchiver) {
-        SULog(SULogLevelError, @"Error: No valid unarchiver for %@", archivePath);
+        unarchiverError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No valid unarchiver was found for %@", archivePath] }];
         
         success = NO;
     } else {
@@ -201,28 +199,27 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         BOOL needsPrevalidation = [[unarchiver class] mustValidateBeforeExtraction] || ![self.installationType isEqualToString:SPUInstallationTypeApplication];
 
         if (needsPrevalidation) {
-            success = [self.updateValidator validateDownloadPath];
+            success = [self.updateValidator validateDownloadPathWithError:&unarchiverError];
         } else {
             success = YES;
         }
     }
     
     if (!success) {
-        [self unarchiverDidFail];
+        [self unarchiverDidFailWithError:unarchiverError];
     } else {
         [unarchiver
          unarchiveWithCompletionBlock:^(NSError * _Nullable error) {
              if (error != nil) {
-                 SULog(SULogLevelError, @"Failed to unarchive %@ with error: %@", archivePath, error);
-                 [self unarchiverDidFail];
+                 [self unarchiverDidFailWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to unarchive %@", archivePath], NSUnderlyingErrorKey: (NSError * _Nonnull)error }]];
              } else {
                  [self.communicator handleMessageWithIdentifier:SPUValidationStarted data:[NSData data]];
                  
-                 BOOL validationSuccess = [self.updateValidator validateWithUpdateDirectory:self.updateDirectoryPath];
+                 NSError *validationError = nil;
+                 BOOL validationSuccess = [self.updateValidator validateWithUpdateDirectory:self.updateDirectoryPath error:&validationError];
                  
                  if (!validationSuccess) {
-                     SULog(SULogLevelError, @"Error: update validation was a failure");
-                     [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                     [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Update validation was a failure", NSUnderlyingErrorKey: validationError }]];
                  } else {
                      [self.communicator handleMessageWithIdentifier:SPUInstallationStartedStage1 data:[NSData data]];
                      
@@ -244,8 +241,15 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     }
 }
 
-- (void)unarchiverDidFail
+- (void)unarchiverDidFailWithError:(NSError *)error
 {
+    SULog(SULogLevelError, @"Failed to unarchive file: %@", error);
+    
+    NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+    if (underlyingError != nil) {
+        SULog(SULogLevelError, @"Error: %@", underlyingError);
+    }
+    
     // No longer need update validator until next possible extraction (eg: if initial delta update fails)
     self.updateValidator = nil;
     
@@ -260,7 +264,8 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     self.relaunchPath = nil;
     self.host = nil;
     
-    [self.communicator handleMessageWithIdentifier:SPUArchiveExtractionFailed data:[NSData data]];
+    NSData *archivedError = SPUArchiveRootObjectSecurely(error);
+    [self.communicator handleMessageWithIdentifier:SPUArchiveExtractionFailed data:archivedError != nil ? archivedError : [NSData data]];
 }
 
 - (void)agentConnectionDidInitiate
@@ -274,8 +279,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
 - (void)agentConnectionDidInvalidate
 {
     if (!self.finishedValidation || !self.agentInitiatedConnection) {
-        SULog(SULogLevelError, @"Error: Agent connection invalidated before installation began");
-        [self cleanupAndExitWithStatus:EXIT_FAILURE];
+        [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Agent connection invalidated before installation began" }]];
     }
 }
 
@@ -294,8 +298,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(RETRIEVE_PROCESS_IDENTIFIER_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (self.terminationListener == nil) {
-            SULog(SULogLevelError, @"Timeout error: failed to retreive process identifier from agent");
-            [self cleanupAndExitWithStatus:EXIT_FAILURE];
+            [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Timeout error: failed to retreive process identifier from agent" }]];
         }
     });
 }
@@ -310,15 +313,13 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             SPUInstallationInputData *installationData = (SPUInstallationInputData *)SPUUnarchiveRootObjectSecurely(data, [SPUInstallationInputData class]);
             if (installationData == nil) {
-                SULog(SULogLevelError, @"Error: Failed to unarchive input installation data");
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to unarchive input installation data" }]];
                 return;
             }
             
             NSString *installationType = installationData.installationType;
             if (!SPUValidInstallationType(installationType)) {
-                SULog(SULogLevelError, @"Error: Received invalid installation type: %@", installationType);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Received invalid installation type: %@", installationType] }]];
                 return;
             }
             
@@ -326,15 +327,13 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSString *bundleIdentifier = hostBundle.bundleIdentifier;
             if (bundleIdentifier == nil || ![bundleIdentifier isEqualToString:self.hostBundleIdentifier]) {
-                SULog(SULogLevelError, @"Error: Failed to match host bundle identifiers %@ and %@", self.hostBundleIdentifier, bundleIdentifier);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Failed to match host bundle identifiers %@ and %@", self.hostBundleIdentifier, bundleIdentifier] }]];
                 return;
             }
             
             // This will be important later
             if (installationData.relaunchPath == nil) {
-                SULog(SULogLevelError, @"Error: Failed to obtain relaunch path from installation data");
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to obtain relaunch path from installation data" }]];
                 return;
             }
             
@@ -345,8 +344,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSString *cacheInstallationPath = [SPULocalCacheDirectory createUniqueDirectoryInDirectory:rootCacheInstallationPath];
             if (cacheInstallationPath == nil) {
-                SULog(SULogLevelError, @"Error: Failed to create installation cache directory in %@", rootCacheInstallationPath);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Failed to create installation cache directory in %@", rootCacheInstallationPath] }]];
                 return;
             }
             
@@ -359,8 +357,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSError *moveError = nil;
             if (![[[SUFileManager alloc] init] moveItemAtURL:downloadURL toURL:downloadDestinationURL error:&moveError]) {
-                SULog(SULogLevelError, @"Error: Failed to move download archive to new location: %@", moveError);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to move download archive to new location", NSUnderlyingErrorKey: moveError }]];
                 return;
             }
             
@@ -368,22 +365,21 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             NSError *attributesError = nil;
             NSString *downloadDestinationPath = downloadDestinationURL.path;
             if (downloadDestinationPath == nil) {
-                SULog(SULogLevelError, @"Error: Failed to retrieve download archive path from %@", downloadDestinationURL);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Failed to retrieve download archive path from %@", downloadDestinationURL] }]];
+                
                 return;
             }
             
             NSDictionary<NSString *, id> *archiveAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:downloadDestinationPath error:&attributesError];
             
             if (archiveAttributes == nil) {
-                SULog(SULogLevelError, @"Error: Failed to retrieve download archive attributes from %@", downloadDestinationPath);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Failed to retrieve download archive attributes from %@", downloadDestinationPath] }]];
+                
                 return;
             }
             
             if (![(NSString *)archiveAttributes[NSFileType] isEqualToString:NSFileTypeRegular]) {
-                SULog(SULogLevelError, @"Error: Received bad archive file type: %@", archiveAttributes[NSFileType]);
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Received bad archive file type: %@", archiveAttributes[NSFileType]] }]];
                 return;
             }
             
@@ -442,20 +438,18 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         id <SUInstallerProtocol> installer = [SUInstaller installerForHost:self.host expectedInstallationType:self.installationType updateDirectory:self.updateDirectoryPath error:&installerError];
         
         if (installer == nil) {
-            SULog(SULogLevelError, @"Error: Failed to create installer instance with error: %@", installerError);
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to create installer instance", NSUnderlyingErrorKey: installerError }]];
             });
             return;
         }
         
         NSError *firstStageError = nil;
         if (![installer performInitialInstallation:&firstStageError]) {
-            SULog(SULogLevelError, @"Error: Failed to start installer with error: %@", firstStageError);
             self.installer = nil;
             
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to start installer", NSUnderlyingErrorKey: firstStageError }]];
             });
             return;
         }
@@ -503,11 +497,10 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             [self.agentConnection.agent sendTerminationSignal];
         });
     } else {
-        SULog(SULogLevelError, @"Error: Failed to resume installer on stage 2 because installation cannot be installed silently");
         self.installer = nil;
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self cleanupAndExitWithStatus:EXIT_FAILURE];
+            [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to resume installer on stage 2 because installation cannot be installed silently" }]];
         });
     }
 }
@@ -516,8 +509,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
 {
     [self.terminationListener startListeningWithCompletion:^(BOOL success) {
         if (!success) {
-            SULog(SULogLevelError, @"Failed to listen for application termination");
-            [self cleanupAndExitWithStatus:EXIT_FAILURE];
+            [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to listen for application termination" }]];
             return;
         }
         
@@ -556,12 +548,10 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSError *thirdStageError = nil;
             if (![self.installer performFinalInstallationProgressBlock:nil error:&thirdStageError]) {
-                SULog(SULogLevelError, @"Failed to finalize installation with error: %@", thirdStageError);
-                
                 self.installer = nil;
                 
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [self cleanupAndExitWithStatus:EXIT_FAILURE];
+                    [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to finalize installation", NSUnderlyingErrorKey: thirdStageError }]];
                 });
                 return;
             }
@@ -591,14 +581,28 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                     [self.agentConnection.agent relaunchPath:pathToRelaunch];
                 }
                 
-                [self cleanupAndExitWithStatus:EXIT_SUCCESS];
+                [self cleanupAndExitWithStatus:EXIT_SUCCESS error:nil];
             });
         });
     }];
 }
 
-- (void)cleanupAndExitWithStatus:(int)status __attribute__((noreturn))
+- (void)cleanupAndExitWithStatus:(int)status error:(NSError * _Nullable)error __attribute__((noreturn))
 {
+    if (error != nil) {
+        SULog(SULogLevelError, @"Error: %@", error);
+        
+        NSError *underlyingError = error.userInfo[NSUnderlyingErrorKey];
+        if (underlyingError != nil) {
+            SULog(SULogLevelError, @"Error: %@", underlyingError);
+        }
+        
+        NSData *errorData = SPUArchiveRootObjectSecurely((NSError * _Nonnull)error);
+        if (errorData != nil) {
+            [self.communicator handleMessageWithIdentifier:SPUInstallerError data:errorData];
+        }
+    }
+    
     // It's nice to tell the other end we're invalidating
     
     [self.activeConnection invalidate];

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -279,7 +279,14 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
 - (void)agentConnectionDidInvalidate
 {
     if (!self.finishedValidation || !self.agentInitiatedConnection) {
-        [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Agent connection invalidated before installation began" }]];
+        NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey: @"Error: Agent connection invalidated before installation began" }];
+        
+        NSError *agentError = self.agentConnection.invalidationError;
+        if (agentError != nil) {
+            userInfo[NSUnderlyingErrorKey] = agentError;
+        }
+        
+        [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:userInfo]];
     }
 }
 

--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -38,11 +38,6 @@ typedef NS_ENUM(int32_t, SPUUpdaterMessageType)
     SPUUpdaterAlivePong = 3
 };
 
-typedef NS_ENUM(int32_t, SPUAgentMessageType)
-{
-    SPUAgentError = 100
-};
-
 BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUInstallerMessageType newMessageType);
 
 NSString *SPUInstallerServiceNameForBundleIdentifier(NSString *bundleIdentifier);

--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -38,6 +38,11 @@ typedef NS_ENUM(int32_t, SPUUpdaterMessageType)
     SPUUpdaterAlivePong = 3
 };
 
+typedef NS_ENUM(int32_t, SPUAgentMessageType)
+{
+    SPUAgentError = 100
+};
+
 BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUInstallerMessageType newMessageType);
 
 NSString *SPUInstallerServiceNameForBundleIdentifier(NSString *bundleIdentifier);

--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -26,7 +26,8 @@ typedef NS_ENUM(int32_t, SPUInstallerMessageType)
     SPUInstallationFinishedStage1 = 6,
     SPUInstallationFinishedStage2 = 7,
     SPUInstallationFinishedStage3 = 8,
-    SPUUpdaterAlivePing = 9
+    SPUUpdaterAlivePing = 9,
+    SPUInstallerError = 10
 };
 
 typedef NS_ENUM(int32_t, SPUUpdaterMessageType)

--- a/Autoupdate/SPUMessageTypes.m
+++ b/Autoupdate/SPUMessageTypes.m
@@ -55,9 +55,10 @@ BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUI
         case SPUInstallationFinishedStage3:
             legal = (oldMessageType == SPUInstallationFinishedStage2);
             break;
+        case SPUInstallerError:
         case SPUUpdaterAlivePing:
             // Having this state being dependent on other installation states would make the complicate our logic
-            // So just always allow this type of message
+            // So just always allow these type of messages
             legal = YES;
             break;
     }

--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -81,7 +81,10 @@
     // They could be potentially be preserved when archiving an application, but also an update could just be sitting on the system for a long time
     // before being installed
     if (![fileManager updateAccessTimeOfItemAtRootURL:newURL error:error]) {
-        SULog(SULogLevelError, @"Failed to recursively update new application's modification time before moving into temporary directory");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to recursively update new application's modification time before moving into temporary directory" }];
+        }
+        
         return NO;
     }
     
@@ -91,7 +94,10 @@
     NSURL *tempNewDirectoryURL = [fileManager makeTemporaryDirectoryWithPreferredName:preferredName appropriateForDirectoryURL:installationDirectory error:error];
     
     if (tempNewDirectoryURL == nil) {
-        SULog(SULogLevelError, @"Failed to make new temp directory");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to make new temporary directory" }];
+        }
+        
         return NO;
     }
 
@@ -103,7 +109,10 @@
     NSString *newURLLastPathComponent = newURL.lastPathComponent;
     NSURL *newTempURL = [tempNewDirectoryURL URLByAppendingPathComponent:newURLLastPathComponent];
     if (![fileManager moveItemAtURL:newURL toURL:newTempURL error:error]) {
-        SULog(SULogLevelError, @"Failed to move the new app from %@ to its temp directory at %@", newURL.path, newTempURL.path);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move the new app from %@ to its temp directory at %@", newURL.path, newTempURL.path] }];
+        }
+        
         [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
         return NO;
     }
@@ -145,7 +154,10 @@
     // it's not possible our new app can be left in an incomplete state at the final destination
     if (![fileManager changeOwnerAndGroupOfItemAtRootURL:newTempURL toMatchURL:oldURL error:error]) {
         // But this is big enough of a deal to fail
-        SULog(SULogLevelError, @"Failed to change owner and group of new app at %@ to match old app at %@", newTempURL.path, oldURL.path);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to change owner and group of new app at %@ to match old app at %@", newTempURL.path, oldURL.path] }];
+        }
+        
         [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
         return NO;
     }
@@ -174,7 +186,10 @@
     NSURL *oldDirectoryURL = oldURL.URLByDeletingLastPathComponent;
     NSURL *tempOldDirectoryURL = (oldDirectoryURL != nil) ? [fileManager makeTemporaryDirectoryWithPreferredName:oldDestinationName appropriateForDirectoryURL:oldDirectoryURL error:error] : nil;
     if (tempOldDirectoryURL == nil) {
-        SULog(SULogLevelError, @"Failed to create temporary directory for old app at %@", oldURL.path);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to create temporary directory for old app at %@", oldURL.path] }];
+        }
+        
         [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
         return NO;
     }
@@ -186,7 +201,9 @@
     // Move the old app to the temporary directory
     NSURL *oldTempURL = [tempOldDirectoryURL URLByAppendingPathComponent:oldDestinationNameWithPathExtension];
     if (![fileManager moveItemAtURL:oldURL toURL:oldTempURL error:error]) {
-        SULog(SULogLevelError, @"Failed to move the old app at %@ to a temporary location at %@", oldURL.path, oldTempURL.path);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move the old app at %@ to a temporary location at %@", oldURL.path, oldTempURL.path] }];
+        }
         
         // Just forget about our updated app on failure
         [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
@@ -201,7 +218,9 @@
 
     // Move the new app to its final destination
     if (![fileManager moveItemAtURL:newTempURL toURL:installationURL error:error]) {
-        SULog(SULogLevelError, @"Failed to move new app at %@ to final destination %@", newTempURL.path, installationURL.path);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move new app at %@ to final destination %@", newTempURL.path, installationURL.path] }];
+        }
         
         // Forget about our updated app on failure
         [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];

--- a/Autoupdate/main.m
+++ b/Autoupdate/main.m
@@ -23,7 +23,7 @@ int main(int __unused argc, const char __unused *argv[])
         
         dispatch_source_t sigtermSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue());
         dispatch_source_set_event_handler(sigtermSource, ^{
-            [appInstaller cleanupAndExitWithStatus:SIGTERM];
+            [appInstaller cleanupAndExitWithStatus:SIGTERM error:nil];
         });
         dispatch_resume(sigtermSource);
         

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.h
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)run;
 
-- (void)cleanupAndExitWithStatus:(int)status __attribute__((noreturn));
+- (void)cleanupAndExitWithStatus:(int)status error:(NSError * _Nullable)error __attribute__((noreturn));
 
 @end
 

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -115,7 +115,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
                     int exitStatus = (strongSelf.repliedToRegistration ? EXIT_SUCCESS : EXIT_FAILURE);
                     NSError *registrationError;
                     if (!strongSelf.repliedToRegistration) {
-                        registrationError = [NSError errorWithDomain:SUSparkleErrorDomain code:SPUAgentError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Agent Invalidating without having the chance to reply to installer" }];
+                        registrationError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUAgentInvalidationError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Agent Invalidating without having the chance to reply to installer" }];
                     } else {
                         registrationError = nil;
                     }
@@ -215,7 +215,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
         if (applicationBundlePath != nil && !self.willTerminate) {
             NSBundle *applicationBundle = [NSBundle bundleWithPath:applicationBundlePath];
             if (applicationBundle == nil) {
-                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUAgentError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Encountered invalid path for waiting termination: %@", applicationBundlePath] }]];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SUAgentInvalidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Encountered invalid path for waiting termination: %@", applicationBundlePath] }]];
             }
             
             NSArray<NSRunningApplication *> *runningApplications = [self runningApplicationsWithBundle:applicationBundle];
@@ -275,7 +275,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
             // We should at least make sure we're opening a bundle however
             NSBundle *relaunchBundle = [NSBundle bundleWithPath:pathToRelaunch];
             if (relaunchBundle == nil) {
-                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUAgentError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Encountered invalid path to relaunch: %@", pathToRelaunch] }]];
+                [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SUAgentInvalidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error: Encountered invalid path to relaunch: %@", pathToRelaunch] }]];
             }
             
             // We only launch applications, but I'm not sure how reliable -launchApplicationAtURL:options:config: is so we're not using it

--- a/Sparkle/InstallerProgress/SUInstallerAgentInitiationProtocol.h
+++ b/Sparkle/InstallerProgress/SUInstallerAgentInitiationProtocol.h
@@ -12,4 +12,6 @@
 
 - (void)connectionDidInitiateWithReply:(void (^)(void))acknowledgement;
 
+- (void)connectionWillInvalidateWithError:(NSError *)error;
+
 @end

--- a/Sparkle/InstallerProgress/main.m
+++ b/Sparkle/InstallerProgress/main.m
@@ -27,7 +27,7 @@ int main(int __unused argc, const char __unused *argv[])
         
         dispatch_source_t sigtermSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue());
         dispatch_source_set_event_handler(sigtermSource, ^{
-            [appController cleanupAndExitWithStatus:SIGTERM];
+            [appController cleanupAndExitWithStatus:SIGTERM error:nil];
         });
         dispatch_resume(sigtermSource);
         

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -49,7 +49,7 @@ typedef NS_ENUM(OSStatus, SUError) {
 
     // Extraction phase errors.
     SUUnarchivingError = 3000,
-    SUSignatureError = 3001,
+    SUValidationError = 3001,
     
     // Installation phase errors.
     SUFileCopyFailure = 4000,

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUInstallationCanceledError = 4007,
     SUInstallationAuthorizeLaterError = 4008,
     SUNotAllowedInteractionError = 4009,
+    SUAgentInvalidationError = 4010,
     
     // API misuse errors.
     SUIncorrectAPIUsageError = 5000

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -49,7 +49,8 @@ typedef NS_ENUM(OSStatus, SUError) {
 
     // Extraction phase errors.
     SUUnarchivingError = 3000,
-    SUValidationError = 3001,
+    SUSignatureError = 3001,
+    SUValidationError = 3002,
     
     // Installation phase errors.
     SUFileCopyFailure = 4000,

--- a/Sparkle/SUUpdateValidator.h
+++ b/Sparkle/SUUpdateValidator.h
@@ -18,10 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDownloadPath:(NSString *)downloadPath signatures:(SUSignatures *)signatures host:(SUHost *)host;
 
 // This is "pre" validation, before the archive has been extracted
- - (BOOL)validateDownloadPath;
+- (BOOL)validateDownloadPathWithError:(NSError **)error;
 
 // This is "post" validation, after an archive has been extracted
-- (BOOL)validateWithUpdateDirectory:(NSString *)updateDirectory;
+- (BOOL)validateWithUpdateDirectory:(NSString *)updateDirectory error:(NSError **)error;
 
 @end
 

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -223,7 +223,7 @@
         }
     } else {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus], NSUnderlyingErrorKey: innerError }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus] }];
         }
     }
 

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -13,6 +13,8 @@
 #import "SUHost.h"
 #import "SULog.h"
 #import "SUSignatures.h"
+#import "SUErrors.h"
+
 
 #include "AppKitPrevention.h"
 
@@ -43,23 +45,28 @@
     return self;
 }
 
-- (BOOL)validateDownloadPath {
+- (BOOL)validateDownloadPathWithError:(NSError * __autoreleasing *)error
+{
     SUPublicKeys *publicKeys = self.host.publicKeys;
     SUSignatures *signatures = self.signatures;
 
     if (!publicKeys.hasAnyKeys) {
-        SULog(SULogLevelError, @"Failed to validate update before unarchiving because no (Ed)DSA public key was found in the old app");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to validate update before unarchiving because no (Ed)DSA public key was found in the old app" }];
+        }
     } else {
         if ([SUSignatureVerifier validatePath:self.downloadPath withSignatures:signatures withPublicKeys:publicKeys]) {
             self.prevalidatedSignature = YES;
             return YES;
         }
-        SULog(SULogLevelError, @"(Ed)DSA signature validation before unarchiving failed for update %@", self.downloadPath);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"(Ed)DSA signature validation before unarchiving failed for update %@", self.downloadPath] }];
+        }
     }
     return NO;
 }
 
-- (BOOL)validateWithUpdateDirectory:(NSString *)updateDirectory
+- (BOOL)validateWithUpdateDirectory:(NSString *)updateDirectory error:(NSError * __autoreleasing *)error
 {
     SUSignatures *signatures = self.signatures;
     SUPublicKeys *publicKeys = self.host.publicKeys;
@@ -71,7 +78,9 @@
     // install source could point to a new bundle or a package
     NSString *installSource = [SUInstaller installSourcePathInUpdateFolder:updateDirectory forHost:host isPackage:&isPackage isGuided:NULL];
     if (installSource == nil) {
-        SULog(SULogLevelError, @"No suitable install is found in the update. The update will be rejected.");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"No suitable install is found in the update. The update will be rejected." }];
+        }
         return NO;
     }
 
@@ -84,12 +93,14 @@
             // For package type updates, all we do is check if the DSA signature is valid
             BOOL validationCheckSuccess = [SUSignatureVerifier validatePath:downloadPath withSignatures:signatures withPublicKeys:publicKeys];
             if (!validationCheckSuccess) {
-                SULog(SULogLevelError, @"DSA signature validation of the package failed. The update contains an installer package, and valid DSA signatures are mandatory for all installer packages. The update will be rejected. Sign the installer with a valid DSA key or use an .app bundle update instead.");
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"DSA signature validation of the package failed. The update contains an installer package, and valid DSA signatures are mandatory for all installer packages. The update will be rejected. Sign the installer with a valid DSA key or use an .app bundle update instead." }];
+                }
             }
             return validationCheckSuccess;
         } else {
             // For application bundle updates, we check both the DSA and Apple code signing signatures
-            return [self validateUpdateForHost:host downloadedToPath:downloadPath newBundleURL:installSourceURL signatures:signatures];
+            return [self validateUpdateForHost:host downloadedToPath:downloadPath newBundleURL:installSourceURL signatures:signatures error:error];
         }
     } else if (isPackage) {
         // We already prevalidated the package and nothing else needs to be done
@@ -98,9 +109,12 @@
         // Because we already validated the DSA signature, this is just a consistency check to see
         // if the developer signed their application properly with their Apple ID
         // Currently, this case only gets hit for binary delta updates
-        NSError *error = nil;
-        if ([SUCodeSigningVerifier bundleAtURLIsCodeSigned:installSourceURL] && ![SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:installSourceURL error:&error]) {
-            SULog(SULogLevelError, @"Failed to validate apple code sign signature on bundle after archive validation with error: %@", error);
+        NSError *innerError = nil;
+        if ([SUCodeSigningVerifier bundleAtURLIsCodeSigned:installSourceURL] && ![SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:installSourceURL error:&innerError]) {
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to validate apple code sign signature on bundle after archive validation", NSUnderlyingErrorKey: innerError }];
+            }
+            
             return NO;
         } else {
             return YES;
@@ -116,11 +130,13 @@
  *  * old and new Code Signing identity are the same and valid
  *
  */
-- (BOOL)validateUpdateForHost:(SUHost *)host downloadedToPath:(NSString *)downloadedPath newBundleURL:(NSURL *)newBundleURL signatures:(SUSignatures *)signatures
+- (BOOL)validateUpdateForHost:(SUHost *)host downloadedToPath:(NSString *)downloadedPath newBundleURL:(NSURL *)newBundleURL signatures:(SUSignatures *)signatures error:(NSError * __autoreleasing *)error
 {
     NSBundle *newBundle = [NSBundle bundleWithURL:newBundleURL];
     if (newBundle == nil) {
-        SULog(SULogLevelError, @"No suitable bundle is found in the update. The update will be rejected.");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"No suitable bundle is found in the update. The update will be rejected." }];
+        }
         return NO;
     }
 
@@ -140,7 +156,9 @@
 
     // This is not essential for security, only a policy
     if (oldHasAnyDSAKey && !newHasAnyDSAKey) {
-        SULog(SULogLevelError, @"A public (Ed)DSA key was found in the old bundle but no public (Ed)DSA key was found in the new update. Sparkle only supports rotation, but not removal of (Ed)DSA keys. Please add an EdDSA key to the new app.");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"A public (Ed)DSA key was found in the old bundle but no public (Ed)DSA key was found in the new update. Sparkle only supports rotation, but not removal of (Ed)DSA keys. Please add an EdDSA key to the new app." }];
+        }
         return NO;
     }
 
@@ -154,8 +172,8 @@
     }
 
     if (hostIsCodeSigned) {
-        NSError *error = nil;
-        passedCodeSigning = [SUCodeSigningVerifier codeSignatureAtBundleURL:host.bundle.bundleURL matchesSignatureAtBundleURL:newHost.bundle.bundleURL error:&error];
+        NSError *innerError = nil;
+        passedCodeSigning = [SUCodeSigningVerifier codeSignatureAtBundleURL:host.bundle.bundleURL matchesSignatureAtBundleURL:newHost.bundle.bundleURL error:&innerError];
     }
     // End of security-critical part
 
@@ -163,14 +181,18 @@
     // In that case, the check ensures that the app author has correctly used DSA keys, so that the app will be updateable in the next version.
     if (!passedDSACheck && newHasAnyDSAKey) {
         if (![SUSignatureVerifier validatePath:downloadedPath withSignatures:signatures withPublicKeys:newPublicKeys]) {
-            SULog(SULogLevelError, @"The update has a public (Ed)DSA key, but the public key shipped with the update doesn't match the signature. To prevent future problems, the update will be rejected.");
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"The update has a public (Ed)DSA key, but the public key shipped with the update doesn't match the signature. To prevent future problems, the update will be rejected." }];
+            }
             return NO;
         }
     }
 
-    NSError *error = nil;
-    if (passedDSACheck && updateIsCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:newHost.bundle.bundleURL error:&error]) {
-        SULog(SULogLevelError, @"The update archive has a valid (Ed)DSA signature, but the app is also signed with Code Signing, which is corrupted: %@. The update will be rejected.", error);
+    NSError *innerError = nil;
+    if (passedDSACheck && updateIsCodeSigned && ![SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:newHost.bundle.bundleURL error:&innerError]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"The update archive has a valid (Ed)DSA signature, but the app is also signed with Code Signing, which is corrupted. The update will be rejected.", NSUnderlyingErrorKey: innerError }];
+        }
         return NO;
     }
 
@@ -195,9 +217,14 @@
 
     if (!hostIsCodeSigned || !updateIsCodeSigned) {
         NSString *acsStatus = !hostIsCodeSigned ? @"old app hasn't been signed with app Code Signing" : @"new app isn't signed with app Code Signing";
-        SULog(SULogLevelError, @"The update archive %@, and the %@. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus, acsStatus);
+        
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The update archive %@, and the %@. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus, acsStatus] }];
+        }
     } else {
-        SULog(SULogLevelError, @"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app: %@. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus, error);
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus], NSUnderlyingErrorKey: innerError }];
+        }
     }
 
     return NO;

--- a/Tests/SUUpdateValidatorTest.swift
+++ b/Tests/SUUpdateValidatorTest.swift
@@ -87,7 +87,7 @@ class SUUpdateValidatorTest: XCTestCase {
 
         let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host)
 
-        let result = validator.validateDownloadPath()
+        let result = (try? validator.validateDownloadPath()) != nil
         XCTAssertEqual(result, expectedResult, "bundle: \(bundleConfig), signatures: \(signatureConfig)", line: line)
     }
 
@@ -112,7 +112,7 @@ class SUUpdateValidatorTest: XCTestCase {
         let newBundle = self.bundle(newBundleConfig)
         try! FileManager.default.copyItem(at: newBundle.bundleURL, to: URL(fileURLWithPath: updateDirectory).appendingPathComponent(oldBundle.bundleURL.lastPathComponent))
 
-        let result = validator.validate(withUpdateDirectory: updateDirectory)
+        let result = (try? validator.validate(withUpdateDirectory: updateDirectory)) != nil
         XCTAssertEqual(result, expectedResult, "oldBundle: \(oldBundleConfig), newBundle: \(newBundleConfig), signatures: \(signatureConfig)", line: line)
     }
 


### PR DESCRIPTION
Propagate errors from installer and agent to Sparkle. Errors that occur in the installer (Autoupdate) or agent (Updater.app) are now propagated back to updater app, and underlying errors are logged there.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x), if deemed necessary. Please create a separate pull request for 1.x, should it be backported.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Constructed cases where extraction/validation failed, installer failed & decided to exit, agent failed & decided to exit. Error messages are sent back to host app and logged there.

macOS version tested: 11.2 (20D64)
