### PR TITLE
Main development change

### DIFF
--- a/.github/ISSUE_TEMPLATE/fixes-and-enhancements.md
+++ b/.github/ISSUE_TEMPLATE/fixes-and-enhancements.md
@@ -1,0 +1,19 @@
+---
+name: Enhancements and Bug Fixes
+about: Found a bug? Want to implement a new feature?
+title: ''
+assignees: ''
+
+---
+
+## Summary
+
+[provide general summary to the issue or enhancement and its rationale]
+
+## Possible Fix
+
+[not obligatory, but suggest fixes or reasons for the bug]
+
+## Version
+
+[please specify versions of Sparkle this is applicable to; note new pull requests must be developed and landed in 2.x development branch first]

--- a/.github/ISSUE_TEMPLATE/fixes-and-enhancements.md
+++ b/.github/ISSUE_TEMPLATE/fixes-and-enhancements.md
@@ -16,4 +16,4 @@ assignees: ''
 
 ## Version
 
-[please specify versions of Sparkle this is applicable to; note new pull requests must be developed and landed in 2.x development branch first]
+[please specify versions of Sparkle this is applicable to; note new pull requests must be developed and landed in 2.x development branch first and the 1.x (master) branch is feature-frozen]

--- a/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-1.md
+++ b/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-1.md
@@ -1,0 +1,34 @@
+---
+name: Sparkle 1.x doesn't work in my app
+about: Problems with integration, unexpected errors
+title: ''
+labels: '1.x'
+assignees: ''
+
+---
+
+<!-- 
+
+The answer to your issue is probably already in Console.app on your computer.
+Please use Console.app and search for Sparkle.
+
+Please try troubleshooting steps:
+https://github.com/sparkle-project/Sparkle#troubleshooting
+
+-->
+
+### Description of the problem
+
+
+### Do you use Sandboxing in your app?
+
+### Version of `Sparkle.framework` in the latest version of your app
+
+### Version of `Sparkle.framework` in the old version of app that your users have (or N/A)
+
+### Sparkle's output from Console.app
+```
+
+```
+
+### Steps to reproduce the behavior

--- a/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-2.md
+++ b/.github/ISSUE_TEMPLATE/sparkle-doesn-t-work-in-my-app-2.md
@@ -1,0 +1,34 @@
+---
+name: Sparkle 2.x doesn't work in my app
+about: Problems with using the beta version of Sparkle 2
+title: ''
+labels: '2.x'
+assignees: ''
+
+---
+
+<!-- 
+
+The answer to your issue is probably already in Console.app on your computer.
+Please use Console.app and search for Sparkle.
+
+Please try troubleshooting steps:
+https://github.com/sparkle-project/Sparkle#troubleshooting
+
+-->
+
+### Description of the problem
+
+
+### Do you use Sandboxing in your app?
+
+### Version of `Sparkle.framework` in the latest version of your app
+
+### Version of `Sparkle.framework` in the old version of app that your users have (or N/A)
+
+### Sparkle's output from Console.app
+```
+
+```
+
+### Steps to reproduce the behavior

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+(Insert summary of your pull request here)
+
+Fixes # (issue)
+
+## Checklist:
+
+- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
+- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
+- [ ] I have reviewed and commented my code, particularly in hard-to-understand areas.
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] My change is or requires a documentation or localization update
+
+## Testing
+
+I tested and verified my change by using one or multiple of these methods:
+
+- [ ] Sparkle Test App
+- [ ] Unit Tests
+- [ ] My own app
+- [ ] Other (please specify)
+
+(Describe all the cases that were tested)
+
+macOS version tested: [place version here]

--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -19,8 +19,8 @@ if [ "$ACTION" = "" ] ; then
 
     mkdir -p "$CONFIGURATION_BUILD_DIR/staging"
     mkdir -p "$CONFIGURATION_BUILD_DIR/staging-spm"
-    cp "$SRCROOT/CHANGELOG" "$SRCROOT/LICENSE" "$SRCROOT/Resources/SampleAppcast.xml" "$CONFIGURATION_BUILD_DIR/staging"
-    cp "$SRCROOT/CHANGELOG" "$SRCROOT/LICENSE" "$SRCROOT/Resources/SampleAppcast.xml" "$CONFIGURATION_BUILD_DIR/staging-spm"
+    cp "$SRCROOT/CHANGELOG" "$SRCROOT/LICENSE" "$SRCROOT/INSTALL" "$SRCROOT/Resources/SampleAppcast.xml" "$CONFIGURATION_BUILD_DIR/staging"
+    cp "$SRCROOT/CHANGELOG" "$SRCROOT/LICENSE" "$SRCROOT/INSTALL" "$SRCROOT/Resources/SampleAppcast.xml" "$CONFIGURATION_BUILD_DIR/staging-spm"
     cp -R "$SRCROOT/bin" "$CONFIGURATION_BUILD_DIR/staging"
     cp "$CONFIGURATION_BUILD_DIR/BinaryDelta" "$CONFIGURATION_BUILD_DIR/staging/bin"
     cp "$CONFIGURATION_BUILD_DIR/generate_appcast" "$CONFIGURATION_BUILD_DIR/staging/bin"

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,5 @@
+For integration and usage, please visit Sparkle's Documentation:
+https://sparkle-project.org/documentation/
+
+For integrating XPC Services in a Sandboxed Application, please visit:
+https://sparkle-project.org/documentation/sandboxing/

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# Sparkle 2.x (Beta) ![Build Status](https://github.com/sparkle-project/Sparkle/workflows/Build%20%26%20Tests/badge.svg?branch=2.x) <a href="https://www.stackpath.com/?utm_source=sparkle-github&amp;utm_medium=badge&amp;utm_campaign=readme"><img src="https://img.shields.io/badge/sponsored%20by-StackPath-orange.svg" alt="sponsored by: StackPath"></a>
+# Sparkle 2 (Beta) ![Build Status](https://github.com/sparkle-project/Sparkle/workflows/Build%20%26%20Tests/badge.svg?branch=2.x) <a href="https://www.stackpath.com/?utm_source=sparkle-github&amp;utm_medium=badge&amp;utm_campaign=readme"><img src="https://img.shields.io/badge/sponsored%20by-StackPath-orange.svg" alt="sponsored by: StackPath"></a>
 
 Secure and reliable software update framework for Cocoa developers.
 
@@ -7,20 +7,15 @@ Secure and reliable software update framework for Cocoa developers.
 This is the upcoming new version of Sparkle.
 Major new features are support for sandboxing, custom user interfaces, updating other bundles, and a more modern secure architecture.
 
-For the production ready version of Sparkle, please see the [Sparkle 1.x (master) branch](https://github.com/sparkle-project/Sparkle/tree/master).
+For the production ready version of Sparkle, please see the [Sparkle 1.x (master) branch](https://github.com/sparkle-project/Sparkle/tree/master). Note development has shifted to Sparkle 2 and the 1.x branch is now only accepting bug fixes, localization updates, and adoption of critical upcoming OS features.
 
-Sparkle 2.x is currently in beta. Some people already use it in production, but some work is still required before it can be released:
-
-1. A transitional phase needs to be made for primary development, testing / bug-fixing, and migration.
-2. Changes from the master branch need to be re-evaluated and ported.
-
-The current status of Sparkle 2.x is tracked in issue [#1523](https://github.com/sparkle-project/Sparkle/issues/1523).
+Sparkle 2 is currently in beta. Applications, typically sandboxed, have already been using it in production, but some work including testing is still required before an official version can be released. In the meantime, a nightly build can be downloaded by selecting a recent [workflow run](https://github.com/sparkle-project/Sparkle/actions?query=event%3Apush+is%3Asuccess+branch%3A2.x) and downloading the corresponding Sparkle-distribution artifact. The current status of Sparkle 2 is tracked in issue [#1523](https://github.com/sparkle-project/Sparkle/issues/1523).
 
 If you can help with any of the above, please submit pull requests!
 
-New issues that are found should be [reported here](https://github.com/sparkle-project/Sparkle/issues). Internal design documents can be found in [Documentation](Documentation/). Discussion of this fork can be found in [this issue](https://github.com/sparkle-project/Sparkle/issues/363).
+New issues should be [reported here](https://github.com/sparkle-project/Sparkle/issues). Internal design documents can be found in [Documentation](Documentation/).
 
-Please visit [Sparkle's website](http://sparkle-project.org) for up to date documentation on using and migrating over to Sparkle 2.x. Refer to [Changelog](CHANGELOG) for a more detailed list of changes.
+Please visit [Sparkle's website](http://sparkle-project.org) for up to date documentation on using and migrating over to Sparkle 2. Refer to [Changelog](CHANGELOG) for a more detailed list of changes.
 
 ## Features
 
@@ -71,7 +66,7 @@ If you are adding a symbol to the public API you must decorate the declaration w
 
 ### Building the distribution package
 
-`cd` to the root of the Sparkle source tree and run `make release`. Sparkle-*VERSION*.tar.bz2 will be created in a temporary directory and revealed in Finder after the build has completed.
+`cd` to the root of the Sparkle source tree and run `make release`. Sparkle-*VERSION*.tar.xz (or .bz2) will be created in a temporary directory and revealed in Finder after the build has completed.
 
 Alternatively, build the Distribution scheme in the Xcode UI.
 


### PR DESCRIPTION
If approved, I'm going to:
* Make the big switch to change the `default` branch to `2.x`. `master` will be left in tact. Official releases from 1.x are tagged, so this shouldn't cause issues. This only changes main / default development up until we decide a 2.x pre-release is ready. (Incidentally this change also moves away from `master` name regarding code conduct implications)
* Feature-freeze `master` branch except for bug-fixes, localization updates, and critical OS adoptions, or at least try to see how this will go.

I updated the ReadMe, re-added an INSTALL file pointing to website documentation, and migrated (slightly adjusted) issue/PR templates over.