### PR TITLE
Disable hardened runtime for sparkle-cli

### DIFF
--- a/Configurations/ConfigSparkleTool.xcconfig
+++ b/Configurations/ConfigSparkleTool.xcconfig
@@ -4,3 +4,4 @@ INFOPLIST_FILE = sparkle-cli/Info.plist
 PRODUCT_BUNDLE_IDENTIFIER = org.sparkle-project.sparkle-cli
 PRODUCT_NAME = sparkle
 LD_RUNPATH_SEARCH_PATHS = @executable_path/../Frameworks/
+ENABLE_HARDENED_RUNTIME = NO


### PR DESCRIPTION
Disable hardened runtime for sparkle-cli. It doesn't run properly due to not using a sufficient certificate in combination with hardened runtime. Hardened runtime is only necessary for apps that want to harden and sign everything. I just want to run & debug sparkle-cli out of the box though and the people embedding sparkle-cli are probably few enough they can re-sign it with hardened runtime if necessary.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running sparkle-cli.

macOS version tested: [place version here]
