### PR TITLE
Don't make changing owner/group a hard fatal error

### DIFF
--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -152,16 +152,13 @@
     
     // We must leave moving the app to its destination as the final step in installing it, so that
     // it's not possible our new app can be left in an incomplete state at the final destination
-    if (![fileManager changeOwnerAndGroupOfItemAtRootURL:newTempURL toMatchURL:oldURL error:error]) {
-        // But this is big enough of a deal to fail
-        if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to change owner and group of new app at %@ to match old app at %@", newTempURL.path, oldURL.path] }];
-        }
-        
-        [fileManager removeItemAtURL:tempNewDirectoryURL error:NULL];
-        return NO;
-    }
     
+    NSError *changeOwnerAndGroupError = nil;
+    if (![fileManager changeOwnerAndGroupOfItemAtRootURL:newTempURL toMatchURL:oldURL error:&changeOwnerAndGroupError]) {
+        // Not a fatal error
+        SULog(SULogLevelError, @"Failed to change owner and group of new app at %@ to match old app at %@", newTempURL.path, oldURL.path);
+        SULog(SULogLevelError, @"Error: %@", changeOwnerAndGroupError);
+    }
 
     if (progress) {
         progress(5/10.0);


### PR DESCRIPTION
There hasn't been any reports of issues or widespread issues (indeed 1.x has similar logic except it may bring up authorization prompt for the first time from this call unlike 2.x which must decide that earlier), but this seems scary to make a fatal error, so handling it more gracefully.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested normal authenticated install.

macOS version tested: 11.2 (20D64)
