### PR TITLE
Update and replace bundle directories even more atomically on apfs

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -552,6 +552,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSError *thirdStageError = nil;
             if (![self.installer performFinalInstallationProgressBlock:nil error:&thirdStageError]) {
+                [self.installer performCleanup];
                 self.installer = nil;
                 
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -584,6 +585,8 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                     // This will also signal to the agent that it will terminate soon
                     [self.agentConnection.agent relaunchPath:pathToRelaunch];
                 }
+                
+                [self.installer performCleanup];
                 
                 [self cleanupAndExitWithStatus:EXIT_SUCCESS error:nil];
             });

--- a/Autoupdate/SUGuidedPackageInstaller.m
+++ b/Autoupdate/SUGuidedPackageInstaller.m
@@ -70,6 +70,10 @@
     return success;
 }
 
+- (void)performCleanup
+{
+}
+
 - (BOOL)canInstallSilently
 {
     return YES;

--- a/Autoupdate/SUInstallerProtocol.h
+++ b/Autoupdate/SUInstallerProtocol.h
@@ -22,6 +22,12 @@ NS_ASSUME_NONNULL_BEGIN
 // Should be able to be called from non-main thread
 - (BOOL)performFinalInstallationProgressBlock:(nullable void(^)(double))cb error:(NSError **)error;
 
+// Any clean up work can be done here
+// This is work that may be performed after the user application may have been updated / relaunched,
+// or after an error occurred in the previous stages.
+// Should be able to be called from any thread
+- (void)performCleanup;
+
 // Indicates whether or not this installer can install the update silently in the background, without hindering the user
 // If this returns NO, then the installation can fail if the user did not directly request for the install to occur.
 // Should be thread safe

--- a/Autoupdate/SUPackageInstaller.m
+++ b/Autoupdate/SUPackageInstaller.m
@@ -73,6 +73,10 @@ static NSString *SUOpenUtilityPath = @"/usr/bin/open";
     return YES;
 }
 
+- (void)performCleanup
+{
+}
+
 - (BOOL)canInstallSilently
 {
     return NO;

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -60,6 +60,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)moveItemAtURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL error:(NSError **)error;
 
 /**
+ * Replaces an original item with a new item atomically.
+ * @param originalItemURL A URL pointing to the original item to replace. The item at this URL must exist.
+ * @param newItemURL A URL pointing to the new item that will replace the original item.
+ * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
+ * @return YES if the original item was replaced with the new item successfully, otherwise NO along with a populated error object
+ *
+ * originalItemURL and newItemURL must reside on the same volume. If the operation succeeds, this will be be an atomic operation.
+ * Otherwise on failure you may need to re-try using move operations. This operation will fail on non-apfs volumes or volumes that don't support rename swapping.
+ * Both originalItemURL and newItemURL must exist.
+ */
+- (BOOL)replaceItemAtURL:(NSURL *)originalItemURL withItemAtURL:(NSURL *)newItemURL error:(NSError **)error __OSX_AVAILABLE(10.13);
+
+/**
  * Copies an item from a source to a destination
  * @param sourceURL A URL pointing to the item to move. The item at this URL must exist.
  * @param destinationURL A URL pointing to the destination the item will be moved at. An item must not already exist at this URL.


### PR DESCRIPTION
With these changes, it should not be possible for neither an old or new bundle to be at the destination. That is, the old bundle directory is replaced by the new one in one step (instead of us moving the old bundle away, and putting the new bundle in its place).

We also perform temporary directory cleanup after final installation stage and relaunching an app is performed because we can save some time (150 ms+ in one of my cases with VLC).

Fixes #1416

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [x] Other (please specify): injecting framework into VLC

Tested updating on apfs volume, non-apfs USB drive, apfs USB drive, SMB mount, tested with `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME` on. Note in normalization, non-apfs volume, or old OS cases, we fall back to legacy path of moving old bundle aside which is what we do today.

macOS version tested:
11.2.3 (20D91)
10.14 latest (VM)
10.9 latest (VM)
