### PR TITLE
Don't hide standard updater window on deactivation

### DIFF
--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -20,12 +20,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window identifier="SUUpdateAlert" title="Software Update" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
+        <window identifier="SUUpdateAlert" title="Software Update" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <value key="minSize" type="size" width="550" height="150"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>

--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -34,11 +34,6 @@ SU_EXPORT @interface SPUStandardUserDriver : NSObject <SPUUserDriver>
  */
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle delegate:(nullable id<SPUStandardUserDriverDelegate>)delegate;
 
-/*!
- * Enable or disable hideOnDeactivate for standard update window.
- */
-@property (nonatomic) BOOL hideOnDeactivate;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -39,7 +39,6 @@
 @synthesize delegate = _delegate;
 @synthesize checkingController = _checkingController;
 @synthesize activeUpdateAlert = _activeUpdateAlert;
-@synthesize hideOnDeactivate = _hideOnDeactivate;
 @synthesize statusController = _statusController;
 
 #pragma mark Birth
@@ -51,7 +50,6 @@
         _host = [[SUHost alloc] initWithBundle:hostBundle];
         _delegate = delegate;
         _coreComponent = [[SPUUserDriverCoreComponent alloc] init];
-        _hideOnDeactivate = YES;
     }
     return self;
 }
@@ -83,15 +81,10 @@
     // Make sure the window is loaded in any case
     [self.activeUpdateAlert window];
     
-    if (!self.hideOnDeactivate) {
-        [self.activeUpdateAlert.window setHidesOnDeactivate:NO];
-    }
-    
     // If the app is a menubar app or the like, we need to focus it first and alter the
     // update prompt to behave like a normal window. Otherwise if the window were hidden
     // there may be no way for the application to be activated to make it visible again.
     if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) {
-        [self.activeUpdateAlert.window setHidesOnDeactivate:NO];
         [NSApp activateIgnoringOtherApps:YES];
     }
     

--- a/UITests/SUTestApplicationTest.swift
+++ b/UITests/SUTestApplicationTest.swift
@@ -47,7 +47,7 @@ class SUTestApplicationTest: XCTestCase
             menuBarsQuery.menuBarItems["Sparkle Test App"].click()
         }
 
-        app.dialogs["SUUpdateAlert"].buttons["Install Update"].click()
+        app.windows["SUUpdateAlert"].buttons["Install Update"].click()
         
         // Give some time for the update to finish downloading / extracting
         sleep(30)


### PR DESCRIPTION
Sometimes when the app is re-activated, the updater alert window is ordered back behind other applications. Also it may be useful to eg read the release notes when browsing another application. We still preserve the logic that defers showing the update alert when the application isn't initially frontmost, so if an app is brings up an update alert when it's not active you won't see it until the app is activated again.

--

There is some bug that drives me crazy where going back to the app orders the update alert back behind other applications (so it looks like the updater alert completely disappears / inaccessible). It only reproduces when you do a manual update check (also affects 1.x). I don't know why this happens, and it happens back to macOS 10.14.

On re-evaulation I don't think we should ever auto-hide the update alert on deactivation anyway hence this PR.

If interested, repro steps:

0. Open an app (I'm using Xcode) with some windows.
1. Open test app so its windows are in front of Xcode.
2. Check for updates manually
3. Mouse click to another app (I'm using Safari) that shows its window above test app window and note update alert is hidden
4. Mouse click back to test app options window
5. The update alert window is now behind Xcode's and other app's windows.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements - **Not right now, will do in future if needed**
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

See above.

macOS version tested:
11.2.3 (20D91)
10.14 latest for reproducing bug (VM)

cc @rob-patchett (re: #1273)
