### PR TITLE
Compute app path normalization in progress agent

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -573,17 +573,8 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                 [self.communicator handleMessageWithIdentifier:SPUInstallationFinishedStage3 data:[NSData data]];
                 
                 if (self.shouldRelaunch) {
-                    NSString *pathToRelaunch = nil;
-                    // If the relaunch path is the same as the host bundle path, use the installation path from the installer which may be normalized
-                    // Otherwise use the requested relaunch path in all other cases
-                    if ([self.relaunchPath.pathComponents isEqualToArray:self.host.bundlePath.pathComponents]) {
-                        pathToRelaunch = installationPath;
-                    } else {
-                        pathToRelaunch = self.relaunchPath;
-                    }
-                    
                     // This will also signal to the agent that it will terminate soon
-                    [self.agentConnection.agent relaunchPath:pathToRelaunch];
+                    [self.agentConnection.agent relaunchApplication];
                 }
                 
                 [self.installer performCleanup];

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -10,7 +10,9 @@ SPARKLE_AUTOMATED_DOWNGRADES = 0
 
 // If your app file on disk is named "MyApp 1.1b4", Sparkle usually updates it
 // in place, giving you an app named 1.1b4 that is actually 1.2. Turn the
-// following on to always reset the name back to "MyApp":
+// following on to always reset the name back to "MyApp"
+// If you are using this option to change the name of your app, you should
+// disable the option again when you no longer need it
 SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME = 0
 
 SPARKLE_ICON_NAME = AppIcon

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		7229E1BA1C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7229E1B81C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m */; };
 		7229E1BD1C98EFF200CB50D0 /* SPUDownloadDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7229E1BB1C98EFF200CB50D0 /* SPUDownloadDriver.h */; };
 		7229E1BE1C98EFF200CB50D0 /* SPUDownloadDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7229E1BC1C98EFF200CB50D0 /* SPUDownloadDriver.m */; };
+		722FB7E5260EE53F00EB571C /* SUNormalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 722FB7E4260EE53F00EB571C /* SUNormalization.m */; };
+		722FB7E6260EE53F00EB571C /* SUNormalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 722FB7E4260EE53F00EB571C /* SUNormalization.m */; };
 		72316BD31E0DA8430039EFD9 /* SUUnarchiverNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 72316BD21E0DA8430039EFD9 /* SUUnarchiverNotifier.m */; };
 		72316BD41E0DB37E0039EFD9 /* SUUnarchiverNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 72316BD21E0DA8430039EFD9 /* SUUnarchiverNotifier.m */; };
 		723ABD38259A9BA500BDB4FA /* SUUpdateAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 723ABD36259A9BA500BDB4FA /* SUUpdateAlert.xib */; };
@@ -1059,6 +1061,8 @@
 		7229E1BB1C98EFF200CB50D0 /* SPUDownloadDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUDownloadDriver.h; sourceTree = "<group>"; };
 		7229E1BC1C98EFF200CB50D0 /* SPUDownloadDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUDownloadDriver.m; sourceTree = "<group>"; };
 		722FB7CA1DD69897001D40CE /* ConfigSwift.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigSwift.xcconfig; sourceTree = "<group>"; };
+		722FB7E3260EE53F00EB571C /* SUNormalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUNormalization.h; sourceTree = "<group>"; };
+		722FB7E4260EE53F00EB571C /* SUNormalization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUNormalization.m; sourceTree = "<group>"; };
 		72316BD11E0DA8430039EFD9 /* SUUnarchiverNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SUUnarchiverNotifier.h; path = Autoupdate/SUUnarchiverNotifier.h; sourceTree = SOURCE_ROOT; };
 		72316BD21E0DA8430039EFD9 /* SUUnarchiverNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SUUnarchiverNotifier.m; path = Autoupdate/SUUnarchiverNotifier.m; sourceTree = SOURCE_ROOT; };
 		723ABCD7259A9A9D00BDB4FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Sparkle.strings; sourceTree = "<group>"; };
@@ -1924,6 +1928,8 @@
 				7267E5BB1D3D8B2700D1BF90 /* SUGuidedPackageInstaller.m */,
 				7267E5BC1D3D8B2700D1BF90 /* SUInstaller.h */,
 				7267E5BD1D3D8B2700D1BF90 /* SUInstaller.m */,
+				722FB7E3260EE53F00EB571C /* SUNormalization.h */,
+				722FB7E4260EE53F00EB571C /* SUNormalization.m */,
 				7267E5B91D3D8B0B00D1BF90 /* SUInstallerProtocol.h */,
 				7267E5BE1D3D8B2700D1BF90 /* SUPackageInstaller.h */,
 				7267E5BF1D3D8B2700D1BF90 /* SUPackageInstaller.m */,
@@ -3400,6 +3406,7 @@
 				7267E5FA1D3DAC3600D1BF90 /* StatusInfo.m in Sources */,
 				720595EF1D700568000572E8 /* SUApplicationInfo.m in Sources */,
 				7214B8831D456C2400CB5CED /* SUBundleIcon.m in Sources */,
+				722FB7E6260EE53F00EB571C /* SUNormalization.m in Sources */,
 				721C245E1CB757DE005440CB /* SUConstants.m in Sources */,
 				7267E5EB1D3D90C200D1BF90 /* SUFileManager.m in Sources */,
 				721C24611CB75C5D005440CB /* SUHost.m in Sources */,
@@ -3578,6 +3585,7 @@
 				72316BD31E0DA8430039EFD9 /* SUUnarchiverNotifier.m in Sources */,
 				729924941DF4A45000DBCDF5 /* SUUpdateValidator.m in Sources */,
 				7267E5AB1D3D8AA800D1BF90 /* TerminationListener.m in Sources */,
+				722FB7E5260EE53F00EB571C /* SUNormalization.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sparkle/InstallerProgress/SPUInstallerAgentProtocol.h
+++ b/Sparkle/InstallerProgress/SPUInstallerAgentProtocol.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stopProgress;
 
-- (void)relaunchPath:(NSString *)pathToRelaunch;
+- (void)relaunchApplication;
 
 @end
 

--- a/Sparkle/SUNormalization.h
+++ b/Sparkle/SUNormalization.h
@@ -1,0 +1,16 @@
+//
+//  SUNormalization.h
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 3/26/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SUHost.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSString *SUNormalizedInstallationPath(SUHost *host);
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUNormalization.m
+++ b/Sparkle/SUNormalization.m
@@ -1,0 +1,35 @@
+//
+//  SUNormalization.m
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 3/26/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import "SUNormalization.h"
+
+
+#include "AppKitPrevention.h"
+
+NSString *SUNormalizedInstallationPath(SUHost *host)
+{
+    NSBundle *bundle = host.bundle;
+    assert(bundle != nil);
+   
+    NSString * baseBundleName = [host objectForInfoDictionaryKey:@"SUBundleName"];
+   
+    if (baseBundleName == nil) {
+        baseBundleName = [host objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
+    }
+    
+    NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", baseBundleName, [[bundle bundlePath] pathExtension]]];
+
+    // Roundtrip string through fileSystemRepresentation to ensure it uses filesystem's Unicode normalization
+    // rather than arbitrary Unicode form from Info.plist - #1017
+    NSString *unicodeNormalizedPath = [NSString stringWithUTF8String:[normalizedAppPath fileSystemRepresentation]];
+    if (unicodeNormalizedPath != nil) {
+        return unicodeNormalizedPath;
+    } else {
+        return normalizedAppPath;
+    }
+}


### PR DESCRIPTION
Compute path instead of having installer (Autoupdate) pass over arbitrary path to progress agent app (that relaunches target app).

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [ ] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

With normalization:
Tested updating "Sparkle Test App 2" -> renamed to "Sparkle Test App"
Tested updating "Sparkle Test App" 
Tested updating "Sparkle Test App 2" but "Sparkle Test App" already existing, so no rename.

Without normalization: things work as expected.
Tested updating "Sparkle Test App"
Tested updating "Sparkle Test App 2" -> no rename.

macOS version tested: 11.2 (20D64)
