### PR TITLE
Universally start update cycle one runloop cycle later

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -60,11 +60,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         self.updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self.updaterDelegate];
         self.userDriver = userDriver;
         
-        // In the case this is being called right as an application is being launched,
-        // the application may not have finished launching - we shouldn't do anything before the main runloop is started
-        // Note we can't say, register for an application did finish launching notification
-        // because we can't assume when our framework or this class will be loaded/instantiated before that
-        [self performSelector:@selector(startUpdater) withObject:nil afterDelay:0];
+        [self startUpdater];
     }
 }
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -54,12 +54,12 @@ SU_EXPORT @interface SPUUpdater : NSObject
  This method checks if Sparkle is configured properly. A valid feed URL should be set before this method is invoked.
  Other properties of this SPUUpdater instance can be set before this method is invoked as well, such as automatic update checks.
 
- If the configuration is valid, this method may bring up a permission prompt (if needed) for checking if the user wants automatic update checking.
- This method then starts the regular update cycle if automatic update checks are enabled.
+ If the configuration is valid, an update cycle is started in the next main runloop cycle.
+ During this cycle, a permission prompt may be brought up (if needed) for checking if the user wants automatic update checking.
+ Otherwise if automatic update checks are enabled, a scheduled update alert may be brought up if enough time has elapsed since the last check.
 
- One of -checkForUpdates, -checkForUpdatesInBackground, or -checkForUpdateInformation can be invoked before starting the updater.
- This preschedules an update action before starting the updater. When the updater is started, the prescheduled action is immediately invoked.
- This may be useful for example if you want to check for updates right away without a permission prompt potentially showing.
+ After starting the updater and before the next runloop cycle, one of -checkForUpdates, -checkForUpdatesInBackground, or -checkForUpdateInformation can be invoked.
+ This may be useful if you want to check for updates immediately or without showing a permission prompt.
 
  This must be called on the main thread.
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -544,6 +544,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     }
 
     self.driver = d;
+    assert(self.driver != nil);
 
     // Because an application can change the configuration (eg: the feed url) at any point, we should always check if it's valid
     NSError *configurationError = nil;

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -79,15 +79,11 @@ static NSMutableDictionary *sharedUpdaters = nil;
         // See -[SUUpdater _standardUserDriverRequestsPathToRelaunch] and -[SUUpdater _pathToRelaunchForUpdater:] implemented below which resolves this
         _userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:bundle delegate:self];
         _updater = [[SPUUpdater alloc] initWithHostBundle:bundle applicationBundle:bundle userDriver:_userDriver delegate:self];
-
-        // Delay starting the updater, so that the host has a chance to configure the updater
-        // either in applicationWillFinishLaunching: or by setting properties right after initialisation
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSError *updaterError = nil;
-            if (![self.updater startUpdater:&updaterError]) {
-                SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
-            }
-        });
+        
+        NSError *updaterError = nil;
+        if (![self.updater startUpdater:&updaterError]) {
+            SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
+        }
     }
     return self;
 }

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -145,20 +145,21 @@
 
 - (void)runAndCheckForUpdatesNow:(BOOL)checkForUpdatesNow
 {
+    [self startUpdater];
+    
     if (checkForUpdatesNow) {
         // When we start the updater, this scheduled check will start afterwards too
         [self.updater checkForUpdates];
     }
-    
-    [self startUpdater];
 }
 
 - (void)probeForUpdates
 {
+    [self startUpdater];
+    
     // When we start the updater, this info check will start afterwards too
     self.probingForUpdates = YES;
     [self.updater checkForUpdateInformation];
-    [self startUpdater];
 }
 
 @end

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -57,27 +57,20 @@
     return self;
 }
 
-// Because the user driver dispatches to the main queue asynchronously, we should do so here too
-// to preserve the order of handled events
-
-- (void)updater:(SPUUpdater *)__unused updater willScheduleUpdateCheckAfterDelay:(NSTimeInterval)delay
+- (void)updater:(SPUUpdater *)__unused updater willScheduleUpdateCheckAfterDelay:(NSTimeInterval)delay __attribute__((noreturn))
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Last update check occurred too soon. Try again after %0.0f second(s).", delay);
-        }
-        exit(EXIT_SUCCESS);
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Last update check occurred too soon. Try again after %0.0f second(s).", delay);
+    }
+    exit(EXIT_SUCCESS);
 }
 
-- (void)updaterWillIdleSchedulingUpdates:(SPUUpdater *)__unused updater
+- (void)updaterWillIdleSchedulingUpdates:(SPUUpdater *)__unused updater __attribute__((noreturn))
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "Automatic update checks are disabled. Exiting.\n");
-        }
-        exit(EXIT_SUCCESS);
-    });
+    if (self.verbose) {
+        fprintf(stderr, "Automatic update checks are disabled. Exiting.\n");
+    }
+    exit(EXIT_SUCCESS);
 }
 
 // If the installation is interactive, we can show an authorization prompt for requesting additional privileges,
@@ -99,24 +92,20 @@
 // In case we find an update during probing, otherwise we leave this to the user driver
 - (void)updater:(SPUUpdater *)__unused updater didFindValidUpdate:(SUAppcastItem *)__unused item
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.probingForUpdates) {
-            if (self.verbose) {
-                fprintf(stderr, "Update available!\n");
-            }
-            exit(EXIT_SUCCESS);
+    if (self.probingForUpdates) {
+        if (self.verbose) {
+            fprintf(stderr, "Update available!\n");
         }
-    });
+        exit(EXIT_SUCCESS);
+    }
 }
 
-- (void)updaterDidNotFindUpdate:(SPUUpdater *)__unused updater
+- (void)updaterDidNotFindUpdate:(SPUUpdater *)__unused updater __attribute__((noreturn))
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.verbose) {
-            fprintf(stderr, "No update available!\n");
-        }
-        exit(EXIT_FAILURE);
-    });
+    if (self.verbose) {
+        fprintf(stderr, "No update available!\n");
+    }
+    exit(EXIT_FAILURE);
 }
 
 - (void)updater:(SPUUpdater *)__unused updater didAbortWithError:(NSError *)error


### PR DESCRIPTION
Universally start update cycle one runloop later. Before it was only done for SUUpdater stub and SPUStandardUpdaterController, but now it's done for SPUUpdater which both of those classes use. This is to avoid UI being shown too early which is too easy to do, and gives a chance for developer to check for updates immediately instead of update cycle starting if using SPUUpdater directly. Basically mirrors behavior in 1.x (initially I wanted to avoid deferral behavior in the core updater, but now I'm realizing this was a bad idea).

Improved code that signals when updates can be checked too.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - Logs are outputted in the case anyone was trying to check for updates before starting the updater. Now you need to check for updates after starting the updater which makes more sense, if you want to bypass the scheduler.
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [x] Other (please specify) - sparkle-cli

Tested sparkle test app still works, tested permission prompt still works, tested sparkle-cli still works with and without `--check--immediately`, tested prefpane plugin.

macOS version tested: 11.2 (20D64)
