### PR TITLE
Don't make permission prompt a modal window

### DIFF
--- a/Sparkle/SUUpdatePermissionPrompt.h
+++ b/Sparkle/SUUpdatePermissionPrompt.h
@@ -15,10 +15,8 @@
 
 @interface SUUpdatePermissionPrompt : NSWindowController
 
-+ (void)promptWithHost:(SUHost *)host request:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply;
+- (instancetype)initPromptWithHost:(SUHost *)theHost request:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply;
 
-- (IBAction)toggleMoreInfo:(id)sender;
-- (IBAction)finishPrompt:(NSButton *)sender;
 @end
 
 #endif

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -66,24 +66,6 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     return self;
 }
 
-+ (void)promptWithHost:(SUHost *)host request:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply
-{
-    // If this is a background application we need to focus it in order to bring the prompt
-    // to the user's attention. Otherwise the prompt would be hidden behind other applications and
-    // the user would not know why the application was paused.
-    if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) {
-        [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
-    }
-    
-    if (![NSApp modalWindow]) { // do not prompt if there is is another modal window on screen
-        SUUpdatePermissionPrompt *prompt = [(SUUpdatePermissionPrompt *)[[self class] alloc] initPromptWithHost:host request:request reply:reply];
-        NSWindow *window = [prompt window];
-        if (window) {
-            [NSApp runModalForWindow:window];
-        }
-    }
-}
-
 - (BOOL)shouldAskAboutProfile
 {
     return [(NSNumber *)[self.host objectForInfoDictionaryKey:SUEnableSystemProfilingKey] boolValue];
@@ -93,6 +75,8 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (void)windowDidLoad
 {
+    [self.window center];
+    
 	if (![self shouldAskAboutProfile])
 	{
         NSRect frame = [[self window] frame];
@@ -165,8 +149,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) sendSystemProfile:self.shouldSendProfile];
     self.reply(response);
     
-    [[self window] close];
-    [NSApp stopModal];
+    [self close];
 }
 
 - (NSTouchBar *)makeTouchBar


### PR DESCRIPTION
This can block the rest of the UI from being loaded on an app that is just starting. I saw this myself in a pref pane plugin.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify) - pref pane app.

Tested permission prompt shows up centered in Sparkle Test App and that it works in a pref pane plugin.

macOS version tested: 11.2 (20D64)
