### PR TITLE
Provide option to open host bundle path instead of app path

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -13,6 +13,7 @@ SPARKLE_AUTOMATED_DOWNGRADES = 0
 // following on to always reset the name back to "MyApp"
 // If you are using this option to change the name of your app, you should
 // disable the option again when you no longer need it
+// Note this option is only supported for regular application updates and not plug-ins
 SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME = 0
 
 SPARKLE_ICON_NAME = AppIcon

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -42,7 +42,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Related: See SPUStandardUpdaterController which wraps a SPUUpdater instance and is suitable for instantiating in nib files
  
  @param hostBundle The bundle that should be targetted for updating. This must not be nil.
- @param applicationBundle The application bundle that should be relaunched and waited for termination. Usually this can be the same as hostBundle. This may differ when updating a plug-in or other non-application bundle.
+ @param applicationBundle The application bundle that should be waited for termination and relaunched (unless overridden). Usually this can be the same as hostBundle. This may differ when updating a plug-in or other non-application bundle.
  @param userDriver The user driver that Sparkle uses for user update interaction
  @param delegate The delegate for SPUUpdater. This may be nil.
  */

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -38,7 +38,7 @@ extern NSString *const SUTechnicalErrorInformationKey;
 
 extern NSString *const SUFeedURLKey;
 extern NSString *const SUHasLaunchedBeforeKey;
-extern NSString *const SUUpdateRelaunchingMarkerKey;
+extern NSString *const SURelaunchHostBundleKey;
 extern NSString *const SUShowReleaseNotesKey;
 extern NSString *const SUSkippedVersionKey;
 extern NSString *const SUScheduledCheckIntervalKey;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -34,7 +34,7 @@ NSString *const SUTechnicalErrorInformationKey = @"SUTechnicalErrorInformation";
 
 NSString *const SUFeedURLKey = @"SUFeedURL";
 NSString *const SUHasLaunchedBeforeKey = @"SUHasLaunchedBefore";
-NSString *const SUUpdateRelaunchingMarkerKey = @"SUUpdateRelaunchingMarker";
+NSString *const SURelaunchHostBundleKey = @"SURelaunchHostBundle";
 NSString *const SUShowReleaseNotesKey = @"SUShowReleaseNotes";
 NSString *const SUSkippedVersionKey = @"SUSkippedVersion";
 NSString *const SUScheduledCheckIntervalKey = @"SUScheduledCheckInterval";


### PR DESCRIPTION
This is useful for plug-ins that may want Sparkle to open eg a .prefpane or .saver instead of re-launching System Preferences (which is the app used to wait for termination; normally we only relaunch an app that was proven to be alive).

In a plug-in world, it may not be always possible to tell which of the app or bundle is more desirable to relaunch so we provide both options. In 1.x, there was a delegate -pathToRelaunchForUpdater: method to pick between these, however in 2.x for hardening sake, there isn't an API to open any arbitrary bundle path so we provide explicit options.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update - I'll get to migration docs later.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify) - screensaver, pref pane plugin.

Tested setting new Info.plist key on and off in screensaver plugin. Tested test app still works normally.

macOS version tested: 11.2 (20D64)
