### PR TITLE
Increase max mach service name length to 127 characters

### DIFF
--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -10,10 +10,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SUHost;
-
-extern NSString *SPUAppcastItemArchiveKey;
-
 // Order matters; higher stages have higher values.
 typedef NS_ENUM(int32_t, SPUInstallerMessageType)
 {

--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -36,10 +36,13 @@ typedef NS_ENUM(int32_t, SPUUpdaterMessageType)
 
 BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUInstallerMessageType newMessageType);
 
+// Used by framework to communicate to installer (Autoupdate)
 NSString *SPUInstallerServiceNameForBundleIdentifier(NSString *bundleIdentifier);
 
+// Used by framework to communicate to progress agent tool (Updater)
 NSString *SPUStatusInfoServiceNameForBundleIdentifier(NSString *bundleIdentifier);
 
+// Used by progress agent tool to communicate to installer (Autoupdate)
 NSString *SPUProgressAgentServiceNameForBundleIdentifier(NSString *bundleIdentifier);
 
 NS_ASSUME_NONNULL_END

--- a/Autoupdate/SPUMessageTypes.m
+++ b/Autoupdate/SPUMessageTypes.m
@@ -7,12 +7,9 @@
 //
 
 #import "SPUMessageTypes.h"
-#import "SUHost.h"
 
 
 #include "AppKitPrevention.h"
-
-NSString *SPUAppcastItemArchiveKey = @"SPUAppcastItemArchive";
 
 // Tags added to the bundle identifier which is used as Mach service names
 // These should be very short because length restrictions exist on earlier versions of macOS
@@ -21,10 +18,9 @@ NSString *SPUAppcastItemArchiveKey = @"SPUAppcastItemArchive";
 #define SPARKLE_PROGRESS_TAG @"-spkp"
 #define SPARKLE_PROGRESS_LAUNCH_INSTALLER_TAG @"-spkl"
 
-// macOS 10.8 at least can't handle service names that are 64 characters or longer
-// This was fixed some point after 10.8, but I'm not sure if it was fixed in 10.9 or 10.10 or 10.11
-// If we knew when it was fixed, this could only be relevant to OS versions prior to that
-#define MAX_SERVICE_NAME_LENGTH 63u
+// macOS 10.8 couldn't handle service names that are >= 64 characters,
+// but 10.9 raised this to >= 128 characters
+#define MAX_SERVICE_NAME_LENGTH 127u
 
 BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUInstallerMessageType newMessageType)
 {

--- a/Autoupdate/SPUMessageTypes.m
+++ b/Autoupdate/SPUMessageTypes.m
@@ -12,11 +12,10 @@
 #include "AppKitPrevention.h"
 
 // Tags added to the bundle identifier which is used as Mach service names
-// These should be very short because length restrictions exist on earlier versions of macOS
+// These should be very short because of length restrictions
 #define SPARKLE_INSTALLER_TAG @"-spki"
 #define SPARKLE_STATUS_TAG @"-spks"
 #define SPARKLE_PROGRESS_TAG @"-spkp"
-#define SPARKLE_PROGRESS_LAUNCH_INSTALLER_TAG @"-spkl"
 
 // macOS 10.8 couldn't handle service names that are >= 64 characters,
 // but 10.9 raised this to >= 128 characters


### PR DESCRIPTION
Increase max mach service name length to 127 characters.

The installer and progress tool broadcast mach service names that are prefixed with the host bundle's identifier. Previously this would be truncated from the right to 63 characters but we can increase the limit to 127 characters as 10.8 is no longer supported.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested max service name with 127 characters works but 128 characters doesn't work.

macOS version tested:
latest 10.9 in VM
11.2.3 (20D91)
