### PR TITLE
Fix interactive flag being ignored in sparkle-cli

### DIFF
--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -75,7 +75,7 @@
 
 // If the installation is interactive, we can show an authorization prompt for requesting additional privileges,
 // along with allowing the installer to show UI when installing
-- (BOOL)updater:(SPUUpdater *)__unused updater shouldAllowInstallerInteractionForScheduledChecks:(SPUUpdateCheck)updateCheck
+- (BOOL)updater:(SPUUpdater *)__unused updater shouldAllowInstallerInteractionForUpdateCheck:(SPUUpdateCheck)updateCheck
 {
     switch (updateCheck) {
         case SPUUpdateCheckUserInitiated:


### PR DESCRIPTION
sparkle-cli is not supposed to show any interaction (i.e, authorization prompt or interactive pkg install) unless --interactive is passed. Just a misspelling in delegate method name.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [ ] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested sparkle-cli without interactive does not install an update requiring authorization, and does install it if interactive is passed.

macOS version tested: 11.2.3 (20D91)
