### PR TITLE
Defer requiring feed URL until checking for updates

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -152,7 +152,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  This property must be called on the main thread; calls from background threads will return nil.
  */
-@property (nonatomic, readonly) NSURL *feedURL;
+@property (nonatomic, readonly, nullable) NSURL *feedURL;
 
 /*!
  Set the URL of the appcast used to download update information. Using this method is discouraged.


### PR DESCRIPTION
Defer requiring/validating feed URL until checking for updates. Also don't automatically reset update cycle if updater hasn't been started yet.

This avoids issues if developer doesn't supply feed URL before starting the updater but provides one before the automatic update cycle starts. Which I didn't consider when making #1809.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested code in sample app that sets properties like automaticallyDownloadsUpdates and invokes checkForUpdatesInBackground after implicitly starting updater but before automatic update cycle is started using SPUStandardUpdaterController or (deprecated) SUUpdater.

macOS version tested: 11.2.3 (20D91)
