### PR TITLE
Show the present update in focus when checkForUpdates is invoked

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -89,6 +89,11 @@
     }
 }
 
+- (BOOL)showingUpdate
+{
+    return NO;
+}
+
 - (void)installerDidFinishPreparationAndWillInstallImmediately:(BOOL)willInstallImmediately silently:(BOOL)willInstallSilently
 {
     self.willInstallSilently = willInstallSilently;

--- a/Sparkle/SPUProbingUpdateDriver.m
+++ b/Sparkle/SPUProbingUpdateDriver.m
@@ -60,6 +60,11 @@
     [self abortUpdate];
 }
 
+- (BOOL)showingUpdate
+{
+    return NO;
+}
+
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error
 {
     [self abortUpdateWithError:error];

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -19,6 +19,7 @@
 
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
 @property (nonatomic) BOOL showedUpdate;
+@property (nonatomic) BOOL showingUpdate;
 
 @end
 
@@ -26,6 +27,7 @@
 
 @synthesize uiDriver = _uiDriver;
 @synthesize showedUpdate = _showedUpdate;
+@synthesize showingUpdate = _showingUpdate;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle sparkleBundle:(NSBundle *)sparkleBundle updater:(id)updater userDriver:(id <SPUUserDriver>)userDriver updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate
 {
@@ -63,6 +65,12 @@
 - (void)uiDriverDidShowUpdate
 {
     self.showedUpdate = YES;
+    self.showingUpdate = YES;
+}
+
+- (void)uiDriverFinishedShowingUpdate
+{
+    self.showingUpdate = NO;
 }
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -19,7 +19,6 @@
 
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
 @property (nonatomic) BOOL showedUpdate;
-@property (nonatomic) BOOL showingUpdate;
 
 @end
 
@@ -27,7 +26,6 @@
 
 @synthesize uiDriver = _uiDriver;
 @synthesize showedUpdate = _showedUpdate;
-@synthesize showingUpdate = _showingUpdate;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle sparkleBundle:(NSBundle *)sparkleBundle updater:(id)updater userDriver:(id <SPUUserDriver>)userDriver updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate
 {
@@ -65,12 +63,11 @@
 - (void)uiDriverDidShowUpdate
 {
     self.showedUpdate = YES;
-    self.showingUpdate = YES;
 }
 
-- (void)uiDriverFinishedShowingUpdate
+- (BOOL)showingUpdate
 {
-    self.showingUpdate = NO;
+    return self.uiDriver.showingUpdate;
 }
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -67,7 +67,7 @@
 
 - (BOOL)showingUpdate
 {
-    return self.uiDriver.showingUpdate;
+    return self.showedUpdate;
 }
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *) error

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -57,13 +57,6 @@
     return self;
 }
 
-#pragma mark Is Update Busy?
-
-- (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates
-{
-    assert(NSThread.isMainThread);
-}
-
 #pragma mark Update Permission
 
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply
@@ -99,9 +92,7 @@
     
     // Only show the update alert if the app is active; otherwise, we'll wait until it is.
     if ([NSApp isActive]) {
-        if (!userInitiated) {
-            [self.activeUpdateAlert disableKeyboardShortcutForInstallButton];
-        }
+        [self.activeUpdateAlert setInstallButtonFocus:userInitiated];
         [self.activeUpdateAlert.window makeKeyAndOrderFront:self];
     } else {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:NSApplicationDidBecomeActiveNotification object:NSApp];
@@ -193,6 +184,11 @@
     // For our purposes we just ignore it and continue on..
     NSLog(@"Failed to download release notes with error: %@", error);
     [self.activeUpdateAlert showReleaseNotesFailedToDownload];
+}
+
+- (void)showUpdateInFocus
+{
+    [self setUpFocusForActiveUpdateAlertWithUserInitiation:YES];
 }
 
 #pragma mark Install & Relaunch Update

--- a/Sparkle/SPUUIBasedUpdateDriver.h
+++ b/Sparkle/SPUUIBasedUpdateDriver.h
@@ -17,11 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)coreDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error;
 - (void)uiDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error;
 
-- (void)uiDriverDidShowUpdate;
-- (void)uiDriverFinishedShowingUpdate;
-
 @optional
 
+- (void)uiDriverDidShowUpdate;
 - (void)basicDriverDidFinishLoadingAppcast;
 
 @end
@@ -42,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock;
 
 - (void)resumeUpdate:(id<SPUResumableUpdate>)resumableUpdate completion:(SPUUpdateDriverCompletion)completionBlock;
+
+@property (nonatomic, readonly) BOOL showingUpdate;
 
 - (void)abortUpdateWithError:(nullable NSError *)error;
 

--- a/Sparkle/SPUUIBasedUpdateDriver.h
+++ b/Sparkle/SPUUIBasedUpdateDriver.h
@@ -17,10 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)coreDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error;
 - (void)uiDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error;
 
+- (void)uiDriverDidShowUpdate;
+- (void)uiDriverFinishedShowingUpdate;
+
 @optional
 
 - (void)basicDriverDidFinishLoadingAppcast;
-- (void)uiDriverDidShowUpdate;
 
 @end
 

--- a/Sparkle/SPUUIBasedUpdateDriver.h
+++ b/Sparkle/SPUUIBasedUpdateDriver.h
@@ -41,8 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)resumeUpdate:(id<SPUResumableUpdate>)resumableUpdate completion:(SPUUpdateDriverCompletion)completionBlock;
 
-@property (nonatomic, readonly) BOOL showingUpdate;
-
 - (void)abortUpdateWithError:(nullable NSError *)error;
 
 @end

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -115,6 +115,8 @@
         
         [self.userDriver showInformationalUpdateFoundWithAppcastItem:updateItem userInitiated:self.userInitiated reply:^(SPUInformationalUpdateAlertChoice choice) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                [self.delegate uiDriverFinishedShowingUpdate];
+                
                 switch (choice) {
                     case SPUSkipThisInformationalVersionChoice:
                         [self.host setObject:[updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
@@ -132,6 +134,8 @@
     } else if (self.resumingDownloadedUpdate) {
         [self.userDriver showDownloadedUpdateFoundWithAppcastItem:updateItem userInitiated:self.userInitiated reply:^(SPUUpdateAlertChoice choice) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                [self.delegate uiDriverFinishedShowingUpdate];
+                
                 [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
                 switch (choice) {
                     case SPUInstallUpdateChoice:
@@ -154,6 +158,8 @@
     } else if (!self.resumingInstallingUpdate) {
         [self.userDriver showUpdateFoundWithAppcastItem:updateItem userInitiated:self.userInitiated reply:^(SPUUpdateAlertChoice choice) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                [self.delegate uiDriverFinishedShowingUpdate];
+                
                 [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
                 switch (choice) {
                     case SPUInstallUpdateChoice:
@@ -175,15 +181,15 @@
     } else {
         [self.userDriver showResumableUpdateFoundWithAppcastItem:updateItem userInitiated:self.userInitiated reply:^(SPUInstallUpdateStatus choice) {
             dispatch_async(dispatch_get_main_queue(), ^{
+                [self.delegate uiDriverFinishedShowingUpdate];
+                
                 [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
                 [self.coreDriver finishInstallationWithResponse:choice displayingUserInterface:!self.preventsInstallerInteraction];
             });
         }];
     }
     
-    if ([self.delegate respondsToSelector:@selector(uiDriverDidShowUpdate)]) {
-        [self.delegate uiDriverDidShowUpdate];
-    }
+    [self.delegate uiDriverDidShowUpdate];
     
     if (updateItem.releaseNotesURL != nil && (![updaterDelegate respondsToSelector:@selector(updaterShouldDownloadReleaseNotes:)] || [updaterDelegate updaterShouldDownloadReleaseNotes:self.updater])) {
         NSURLRequest *request = [NSURLRequest requestWithURL:updateItem.releaseNotesURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30];

--- a/Sparkle/SPUUpdateDriver.h
+++ b/Sparkle/SPUUpdateDriver.h
@@ -25,6 +25,8 @@ typedef void (^SPUUpdateDriverCompletion)(BOOL shouldShowUpdateImmediately, id<S
 
 - (void)resumeUpdate:(id<SPUResumableUpdate>)resumableUpdate completion:(SPUUpdateDriverCompletion)completionBlock;
 
+@property (nonatomic, readonly) BOOL showingUpdate;
+
 // A likely implementation of -abortUpdate is invoking -abortUpdateWithError: by passing nil
 - (void)abortUpdate;
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -76,16 +76,15 @@ SU_EXPORT @interface SPUUpdater : NSObject
 - (BOOL)startUpdater:(NSError * __autoreleasing *)error;
 
 /*!
- Checks for updates, and displays progress while doing so.
+ Checks for updates, and displays progress while doing so if needed.
  
- This is meant for users initiating an update check.
+ This is meant for users initiating a new update check or checking the current update progress.
  
- If an update session isn't in progress, the user will be shown that a check for new updates is occurring.
- If a new update is already being shown, that update will be shown to the user in active focus.
+ If an update hasn't started, the user may be shown that a new check for updates is occurring.
+ If an update has already been downloaded or begun installing, the user may be presented to install that update.
+ If the user is already being presented with an update, that update will be shown to the user in active focus.
  
- This may find a resumable update that has already been downloaded or has begun installing, or
- this may find a new update that can start to be downloaded if the user requests it.
- This will find updates that the user has opted into skipping.
+ This will find updates that the user has previously opted into skipping.
  
  See canCheckForUpdates property which can determine if this method may be invoked.
  */
@@ -135,8 +134,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  An active session is when Sparkle's fired scheduler is running.
  
  Note an update session may be inactive even though Sparkle's installer (ran as a separate process) may be running,
- or even though the update has been downloaded but the installation has been deferred. In both of these cases, an update session
- may be activated and resumed at a later point (automatically or manually).
+ or even though the update has been downloaded but the installation has been deferred. In both of these cases, a new update session
+ may be activated with the update resumed at a later point (automatically or manually).
  
  See also canCheckForUpdates property which is more suited for menu item validation.
  */

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -79,9 +79,15 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Checks for updates, and displays progress while doing so.
  
  This is meant for users initiating an update check.
+ 
+ If an update session isn't in progress, the user will be shown that a check for new updates is occurring.
+ If a new update is already being shown, that update will be shown to the user in active focus.
+ 
  This may find a resumable update that has already been downloaded or has begun installing, or
  this may find a new update that can start to be downloaded if the user requests it.
  This will find updates that the user has opted into skipping.
+ 
+ See canCheckForUpdates property which can determine if this method may be invoked.
  */
 - (void)checkForUpdates;
 
@@ -111,15 +117,29 @@ SU_EXPORT @interface SPUUpdater : NSObject
 - (void)checkForUpdateInformation;
 
 /*!
- A property indicating whether or not updates can be checked.
+ A property indicating whether or not updates can be checked by the user.
  
- This property is useful for determining whether update checks can be made programatically or by the user.
- An update check cannot be made when an on-going update check is in progress.
+ An update check can be made by the user when an update session isn't in progress, or when an update is presently being shown.
  
- Note this property does not reflect whether or not an update itself is in progress. For example,
- an update check can be done to check if there's an already started update that can be resumed.
+ This property is suitable to use for menu item validation for seeing if -checkForUpdates can be invoked.
+ 
+ Note this property does not reflect whether or not an update session is in progress. Please see sessionInProgress property instead.
  */
 @property (nonatomic, readonly) BOOL canCheckForUpdates;
+
+/*!
+ A property indicating whether or not an update session is in progress.
+ 
+ An update session is in progress when the appcast is being downloaded, an update is being downloaded,
+ an update is being shown, or the installer is being started. An active session is when Sparkle's fired scheduler is running.
+ 
+ Note an update session may be inactive even though Sparkle's installer (ran as a separate process) may be running,
+ or even though the update has been downloaded but the installation has been deferred. In both of these cases, an update session
+ may be activated and resumed at a later point (automatically or manually).
+ 
+ See also canCheckForUpdates property which is more suited for menu item validation.
+ */
+@property (nonatomic, readonly) BOOL sessionInProgress;
 
 /*!
  A property indicating whether or not to check for updates automatically.

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -119,7 +119,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
 /*!
  A property indicating whether or not updates can be checked by the user.
  
- An update check can be made by the user when an update session isn't in progress, or when an update is presently being shown.
+ An update check can be made by the user when an update session isn't in progress, or when an update or its progress is being shown to the user.
  
  This property is suitable to use for menu item validation for seeing if -checkForUpdates can be invoked.
  
@@ -131,7 +131,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  A property indicating whether or not an update session is in progress.
  
  An update session is in progress when the appcast is being downloaded, an update is being downloaded,
- an update is being shown, or the installer is being started. An active session is when Sparkle's fired scheduler is running.
+ an update is being shown, update permission is being requested, or the installer is being started.
+ An active session is when Sparkle's fired scheduler is running.
  
  Note an update session may be inactive even though Sparkle's installer (ran as a separate process) may be running,
  or even though the update has been downloaded but the installation has been deferred. In both of these cases, an update session

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -33,13 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 SU_EXPORT @protocol SPUUserDriver <NSObject>
 
 /*!
- * Show that an update can be checked by the user or not
- *
- * A client may choose to update the interface letting the user know if they can check for updates.
- */
-- (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates;
-
-/*!
  * Show an updater permission request to the user
  *
  * Ask the user for their permission regarding update checks.
@@ -130,6 +123,13 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * unless they initiate an update check themselves.
  */
 - (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply;
+
+/*!
+ * Show the user currently presented update in utmost focus
+ *
+ * Sparkle uses this to make its update frontmost again
+ */
+- (void)showUpdateInFocus;
 
 /*!
  * Show the user the release notes for the new update

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -125,13 +125,6 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply;
 
 /*!
- * Show the user currently presented update in utmost focus
- *
- * Sparkle uses this to make its update frontmost again
- */
-- (void)showUpdateInFocus;
-
-/*!
  * Show the user the release notes for the new update
  *
  * Display the release notes to the user. This will be called after showing the new update.
@@ -262,6 +255,14 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param acknowledgement Acknowledge to the updater that the installation finish was shown.
  */
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement;
+
+/*!
+ * Show the user the current presented update or its progress in utmost focus
+ *
+ * The user wishes to check for updates while the user is being shown update progress.
+ * Bring whatever is on screen to frontmost focus (permission request, update information, downloading or extraction status, choice to install update, etc).
+ */
+- (void)showUpdateInFocus;
 
 /*!
  * Dismiss the current update installation

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -18,6 +18,7 @@
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
 @property (nonatomic, readonly) id<SPUUserDriver> userDriver;
 @property (nonatomic) BOOL showingUserInitiatedProgress;
+@property (nonatomic) BOOL showingUpdate;
 @property (nonatomic) BOOL aborted;
 
 @end
@@ -26,6 +27,7 @@
 
 @synthesize uiDriver = _uiDriver;
 @synthesize userDriver = _userDriver;
+@synthesize showingUpdate = _showingUpdate;
 @synthesize showingUserInitiatedProgress = _showingUserInitiatedProgress;
 @synthesize aborted = _aborted;
 
@@ -89,6 +91,16 @@
 - (void)resumeUpdate:(id<SPUResumableUpdate>)resumableUpdate completion:(SPUUpdateDriverCompletion)completionBlock
 {
     [self.uiDriver resumeUpdate:resumableUpdate completion:completionBlock];
+}
+
+- (void)uiDriverDidShowUpdate
+{
+    self.showingUpdate = YES;
+}
+
+- (void)uiDriverFinishedShowingUpdate
+{
+    self.showingUpdate = NO;
 }
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -18,7 +18,6 @@
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
 @property (nonatomic, readonly) id<SPUUserDriver> userDriver;
 @property (nonatomic) BOOL showingUserInitiatedProgress;
-@property (nonatomic) BOOL showingUpdate;
 @property (nonatomic) BOOL aborted;
 
 @end
@@ -27,7 +26,6 @@
 
 @synthesize uiDriver = _uiDriver;
 @synthesize userDriver = _userDriver;
-@synthesize showingUpdate = _showingUpdate;
 @synthesize showingUserInitiatedProgress = _showingUserInitiatedProgress;
 @synthesize aborted = _aborted;
 
@@ -93,14 +91,9 @@
     [self.uiDriver resumeUpdate:resumableUpdate completion:completionBlock];
 }
 
-- (void)uiDriverDidShowUpdate
+- (BOOL)showingUpdate
 {
-    self.showingUpdate = YES;
-}
-
-- (void)uiDriverFinishedShowingUpdate
-{
-    self.showingUpdate = NO;
+    return self.uiDriver.showingUpdate;
 }
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -18,6 +18,7 @@
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
 @property (nonatomic, readonly) id<SPUUserDriver> userDriver;
 @property (nonatomic) BOOL showingUserInitiatedProgress;
+@property (nonatomic) BOOL showingUpdate;
 @property (nonatomic) BOOL aborted;
 
 @end
@@ -27,6 +28,7 @@
 @synthesize uiDriver = _uiDriver;
 @synthesize userDriver = _userDriver;
 @synthesize showingUserInitiatedProgress = _showingUserInitiatedProgress;
+@synthesize showingUpdate = _showingUpdate;
 @synthesize aborted = _aborted;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle sparkleBundle:(NSBundle *)sparkleBundle updater:(id)updater userDriver:(id <SPUUserDriver>)userDriver updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate
@@ -57,6 +59,8 @@
                         }
                     });
                 };
+                
+                self.showingUpdate = YES;
                 
                 if ([self.userDriver respondsToSelector:@selector(showUserInitiatedUpdateCheckWithCancellation:)]) {
                     [self.userDriver showUserInitiatedUpdateCheckWithCancellation:cancelUpdateCheck];
@@ -89,11 +93,6 @@
 - (void)resumeUpdate:(id<SPUResumableUpdate>)resumableUpdate completion:(SPUUpdateDriverCompletion)completionBlock
 {
     [self.uiDriver resumeUpdate:resumableUpdate completion:completionBlock];
-}
-
-- (BOOL)showingUpdate
-{
-    return self.uiDriver.showingUpdate;
 }
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -32,7 +32,8 @@
 - (IBAction)installUpdate:sender;
 - (IBAction)skipThisVersion:sender;
 - (IBAction)remindMeLater:sender;
-- (void)disableKeyboardShortcutForInstallButton;
+
+- (void)setInstallButtonFocus:(BOOL)focus;
 
 @end
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -133,8 +133,13 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], [self.host bundlePath]]; }
 
-- (void)disableKeyboardShortcutForInstallButton {
-    self.installButton.keyEquivalent = @"";
+- (void)setInstallButtonFocus:(BOOL)focus
+{
+    if (focus) {
+        self.installButton.keyEquivalent = @"\r";
+    } else {
+        self.installButton.keyEquivalent = @"";
+    }
 }
 
 - (void)endWithSelection:(SPUUpdateAlertChoice)choice

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -212,7 +212,7 @@ static NSMutableDictionary *sharedUpdaters = nil;
 {
     // This is not quite true -- we may be able to check / resume an update if one is in progress
     // But this is a close enough approximation for 1.x updater API
-    return !self.updater.canCheckForUpdates;
+    return self.updater.sessionInProgress;
 }
 
 // Not implemented properly at the moment - leaning towards it not be in the future

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -165,6 +165,15 @@
 - (void)showUpdateInFocus
 {
     [self.window makeKeyAndOrderFront:nil];
+    
+    if (self.updateButton.enabled) {
+        // Not the proper way to do things but ignoring warnings in Test App.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-messaging-id"
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [self.updateButton.target performSelector:self.updateButton.action withObject:self.updateButton];
+#pragma clang diagnostic pop
+    }
 }
 
 #pragma mark Install & Relaunch Update

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -96,12 +96,6 @@
     self.updateButtonAction = nil;
 }
 
-#pragma mark Can Check for Updates?
-
-- (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates
-{
-}
-
 #pragma mark Update Permission
 
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)__unused request reply:(void (^)(SUUpdatePermissionResponse *))reply
@@ -180,6 +174,11 @@
 
 - (void)showUpdateReleaseNotesFailedToDownloadWithError:(NSError *)__unused error
 {
+}
+
+- (void)showUpdateInFocus
+{
+    [self.window makeKeyAndOrderFront:nil];
 }
 
 #pragma mark Install & Relaunch Update

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -41,10 +41,6 @@
     return self;
 }
 
-- (void)showCanCheckForUpdates:(BOOL)canCheckForUpdates
-{
-}
-
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)__unused request reply:(void (^)(SUUpdatePermissionResponse *))reply
 {
     if (self.updatePermissionResponse == nil) {
@@ -136,6 +132,10 @@
     fprintf(stderr, "Found information for new update: %s\n", appcastItem.infoURL.absoluteString.UTF8String);
     
     reply(SPUDismissInformationalNoticeChoice);
+}
+
+- (void)showUpdateInFocus
+{
 }
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData


### PR DESCRIPTION
When the update is shown to the user, the menu item for checking for updates is no longer disabled. Instead it is enabled, and when invoked, will bring the update to utmost focus back to the user again.

This is consistent with other options (eg Preferences...) that bring up windows. Improved user experience here is that 1) updates are now less "lost" and 2) checking for updates now does something when update is present (especially nice if developer forgets to enforce menu item validation in a nibless approach).

We (re)define properties on SPUUpdater:

canCheckForUpdates - to mean that the user can checkForUpdates (start a new update check or show the already present update frontmost)

sessionInProgress - to mean if Sparkle's internal driver / scheduler is running (i.e, downloading appcast or update, showing update, starting installation).

I removed some setCanCheckForUpdates methods that I added/anticipated recently but in reality were never used. I wanted to make this change so that the updater & user driver has correct or reasonable API and user experience here going forward.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

This shouldn't be a breaking change. The recommendation / approach before was to use canCheckForUpdates property for menu item validation; that stays the same.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [x] Other (please specify) - ImageOptim

Tested:
When update check is occurring, menu item is disabled.
When update is shown, menu item is enabled, and when invoked brings update alert up front. If the install button had no keyboard shortcut (from non-initiated check), it's re-activated again.
When update is extracting or installing, menu item is disabled.
Tested app using SUUpdater (ImageOptim)
Tested one of my apps that didn't do any menu item validation, and checkForUpdates was ignored in appropriate scenarios.

macOS version tested: 11.2.3 (20D91)
