### PR TITLE
Merge show update methods

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -99,7 +99,7 @@
         if (self.willInstallSilently && [updaterDelegate respondsToSelector:@selector(updater:willInstallUpdateOnQuit:immediateInstallationBlock:)]) {
             __weak SPUAutomaticUpdateDriver *weakSelf = self;
             installationHandledByDelegate = [updaterDelegate updater:self.updater willInstallUpdateOnQuit:self.updateItem immediateInstallationBlock:^{
-                [weakSelf.coreDriver finishInstallationWithResponse:SPUInstallAndRelaunchUpdateNow displayingUserInterface:NO];
+                [weakSelf.coreDriver finishInstallationWithResponse:SPUUserUpdateChoiceInstall displayingUserInterface:NO];
             }];
         }
         

--- a/Sparkle/SPUCoreBasedUpdateDriver.h
+++ b/Sparkle/SPUCoreBasedUpdateDriver.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearDownloadedUpdate;
 
-- (void)finishInstallationWithResponse:(SPUInstallUpdateStatus)installUpdateStatus displayingUserInterface:(BOOL)displayingUserInterface;
+- (void)finishInstallationWithResponse:(SPUUserUpdateChoice)installUpdateStatus displayingUserInterface:(BOOL)displayingUserInterface;
 
 - (void)abortUpdateAndShowNextUpdateImmediately:(BOOL)shouldShowUpdateImmediately error:(nullable NSError *)error;
 

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -297,16 +297,14 @@
     [self.delegate installerDidFinishPreparationAndWillInstallImmediately:willInstallImmediately silently:willInstallSilently];
 }
 
-- (void)finishInstallationWithResponse:(SPUInstallUpdateStatus)installUpdateStatus displayingUserInterface:(BOOL)displayingUserInterface
+- (void)finishInstallationWithResponse:(SPUUserUpdateChoice)response displayingUserInterface:(BOOL)displayingUserInterface
 {
-    switch (installUpdateStatus) {
-        case SPUDismissUpdateInstallation:
+    switch (response) {
+        case SPUUserUpdateChoiceDismiss:
+        case SPUUserUpdateChoiceSkip:
             [self.delegate coreDriverIsRequestingAbortUpdateWithError:nil];
             break;
-        case SPUInstallUpdateNow:
-            [self.installerDriver installWithToolAndRelaunch:NO displayingUserInterface:displayingUserInterface];
-            break;
-        case SPUInstallAndRelaunchUpdateNow:
+        case SPUUserUpdateChoiceInstall:
             [self.installerDriver installWithToolAndRelaunch:YES displayingUserInterface:displayingUserInterface];
             break;
     }

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -28,7 +28,7 @@
 
 @property (nonatomic, weak, nullable, readonly) id <SPUStandardUserDriverDelegate> delegate;
 
-@property (nonatomic, copy) void (^installUpdateHandler)(SPUInstallUpdateStatus);
+@property (nonatomic, copy) void (^installUpdateHandler)(SPUUserUpdateChoice);
 @property (nonatomic, copy) void (^cancellation)(void);
 
 @property (nonatomic) SUStatusController *checkingController;
@@ -124,66 +124,22 @@
 
 #pragma mark Update Found
 
-- (void)showUpdateFoundWithAlertHandler:(SUUpdateAlert *(^)(SPUStandardUserDriver *, SUHost *, id<SUVersionDisplay>))alertHandler userInitiated:(BOOL)userInitiated
+- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply
 {
+    assert(NSThread.isMainThread);
+    
     id <SUVersionDisplay> versionDisplayer = nil;
     if ([self.delegate respondsToSelector:@selector(standardUserDriverRequestsVersionDisplayer)]) {
         versionDisplayer = [self.delegate standardUserDriverRequestsVersionDisplayer];
     }
     
     __weak SPUStandardUserDriver *weakSelf = self;
-    SUHost *host = self.host;
-    self.activeUpdateAlert = alertHandler(weakSelf, host, versionDisplayer);
+    self.activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:self.host versionDisplayer:versionDisplayer completionBlock:^(SPUUserUpdateChoice choice) {
+        reply(choice);
+        weakSelf.activeUpdateAlert = nil;
+    }];
     
     [self setUpFocusForActiveUpdateAlertWithUserInitiation:userInitiated];
-}
-
-- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
-{
-    assert(NSThread.isMainThread);
-    
-    [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
-        return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem alreadyDownloaded:NO host:host versionDisplayer:versionDisplayer completionBlock:^(SPUUpdateAlertChoice choice) {
-            reply(choice);
-            weakSelf.activeUpdateAlert = nil;
-        }];
-    } userInitiated:userInitiated];
-}
-
-- (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
-{
-    assert(NSThread.isMainThread);
-    
-    [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
-        return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem alreadyDownloaded:YES host:host versionDisplayer:versionDisplayer completionBlock:^(SPUUpdateAlertChoice choice) {
-            reply(choice);
-            weakSelf.activeUpdateAlert = nil;
-        }];
-    } userInitiated:userInitiated];
-}
-
-- (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply
-{
-    assert(NSThread.isMainThread);
-    
-    [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
-        return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem host:host versionDisplayer:versionDisplayer resumableCompletionBlock:^(SPUInstallUpdateStatus choice) {
-            reply(choice);
-            weakSelf.activeUpdateAlert = nil;
-        }];
-    } userInitiated:userInitiated];
-}
-
-- (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply
-{
-    assert(NSThread.isMainThread);
-    
-    [self showUpdateFoundWithAlertHandler:^SUUpdateAlert *(SPUStandardUserDriver *weakSelf, SUHost *host, id<SUVersionDisplay> versionDisplayer) {
-        return [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem host:host versionDisplayer:versionDisplayer informationalCompletionBlock:^(SPUInformationalUpdateAlertChoice choice) {
-            reply(choice);
-            weakSelf.activeUpdateAlert = nil;
-        }];
-    } userInitiated:userInitiated];
 }
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
@@ -205,7 +161,7 @@
 
 #pragma mark Install & Relaunch Update
 
-- (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
+- (void)showReadyToInstallAndRelaunch:(void (^)(SPUUserUpdateChoice))installUpdateHandler
 {
     assert(NSThread.isMainThread);
     
@@ -222,7 +178,7 @@
 - (void)installAndRestart:(id)__unused sender
 {
     if (self.installUpdateHandler != nil) {
-        self.installUpdateHandler(SPUInstallAndRelaunchUpdateNow);
+        self.installUpdateHandler(SPUUserUpdateChoiceInstall);
         self.installUpdateHandler = nil;
     }
 }

--- a/Sparkle/SPUStatusCompletionResults.h
+++ b/Sparkle/SPUStatusCompletionResults.h
@@ -18,21 +18,38 @@
 #import <Foundation/Foundation.h>
 #endif
 
+// The value ordering here intentionally aligns with replacing SPUInstallUpdateStatus
+typedef NS_ENUM(NSInteger, SPUUserUpdateChoice) {
+    SPUUserUpdateChoiceSkip,
+    SPUUserUpdateChoiceInstall,
+    SPUUserUpdateChoiceDismiss,
+};
+
+typedef NS_ENUM(NSInteger, SPUUserUpdateState) {
+    SPUUserUpdateStateNotDownloaded,
+    SPUUserUpdateStateDownloaded,
+    SPUUserUpdateStateInstalling,
+    SPUUserUpdateStateInformational
+};
+
+// Deprecated
+typedef NS_ENUM(NSInteger, SPUInformationalUpdateAlertChoice) {
+    SPUDismissInformationalNoticeChoice,
+    SPUSkipThisInformationalVersionChoice
+};
+
+// Deprecated
 typedef NS_ENUM(NSUInteger, SPUInstallUpdateStatus) {
     SPUInstallUpdateNow,
     SPUInstallAndRelaunchUpdateNow,
     SPUDismissUpdateInstallation
 };
 
+// Deprecated
 typedef NS_ENUM(NSInteger, SPUUpdateAlertChoice) {
     SPUInstallUpdateChoice,
     SPUInstallLaterChoice,
     SPUSkipThisVersionChoice
-};
-
-typedef NS_ENUM(NSInteger, SPUInformationalUpdateAlertChoice) {
-    SPUDismissInformationalNoticeChoice,
-    SPUSkipThisInformationalVersionChoice
 };
 
 // Deprecated

--- a/Sparkle/SPUStatusCompletionResults.h
+++ b/Sparkle/SPUStatusCompletionResults.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, SPUUserUpdateChoice) {
 };
 
 typedef NS_ENUM(NSInteger, SPUUserUpdateState) {
-    SPUUserUpdateStateNotDownloaded,
+    SPUUserUpdateStateNew,
     SPUUserUpdateStateDownloaded,
     SPUUserUpdateStateInstalling,
     SPUUserUpdateStateInformational

--- a/Sparkle/SPUStatusCompletionResults.h
+++ b/Sparkle/SPUStatusCompletionResults.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, SPUUserUpdateChoice) {
 };
 
 typedef NS_ENUM(NSInteger, SPUUserUpdateState) {
-    SPUUserUpdateStateNew,
+    SPUUserUpdateStateNotDownloaded,
     SPUUserUpdateStateDownloaded,
     SPUUserUpdateStateInstalling,
     SPUUserUpdateStateInformational

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -178,6 +178,7 @@
             });
         }];
     } else {
+        // Legacy path that will be removed eventually
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         if (updateItem.isInformationOnlyUpdate) {

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -157,6 +157,8 @@
                             [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
                         }
                         
+                        [self.coreDriver clearDownloadedUpdate];
+                        
                         [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
                         
                         break;

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -117,7 +117,7 @@
         } else if (self.resumingInstallingUpdate) {
             state = SPUUserUpdateStateInstalling;
         } else {
-            state = SPUUserUpdateStateNew;
+            state = SPUUserUpdateStateNotDownloaded;
         }
         
         [self.userDriver showUpdateFoundWithAppcastItem:updateItem userInitiated:self.userInitiated state:state reply:^(SPUUserUpdateChoice userChoice) {
@@ -142,7 +142,7 @@
                             case SPUUserUpdateStateInstalling:
                                 [self.coreDriver finishInstallationWithResponse:validatedChoice displayingUserInterface:!self.preventsInstallerInteraction];
                                 break;
-                            case SPUUserUpdateStateNew:
+                            case SPUUserUpdateStateNotDownloaded:
                                 [self.coreDriver downloadUpdateFromAppcastItem:updateItem inBackground:NO];
                                 break;
                             case SPUUserUpdateStateInformational:
@@ -163,7 +163,7 @@
                     case SPUUserUpdateChoiceDismiss:
                         switch (state) {
                             case SPUUserUpdateStateDownloaded:
-                            case SPUUserUpdateStateNew:
+                            case SPUUserUpdateStateNotDownloaded:
                             case SPUUserUpdateStateInformational:
                                 [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
                                 [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -117,7 +117,7 @@
         } else if (self.resumingInstallingUpdate) {
             state = SPUUserUpdateStateInstalling;
         } else {
-            state = SPUUserUpdateStateNotDownloaded;
+            state = SPUUserUpdateStateNew;
         }
         
         [self.userDriver showUpdateFoundWithAppcastItem:updateItem userInitiated:self.userInitiated state:state reply:^(SPUUserUpdateChoice userChoice) {
@@ -142,7 +142,7 @@
                             case SPUUserUpdateStateInstalling:
                                 [self.coreDriver finishInstallationWithResponse:validatedChoice displayingUserInterface:!self.preventsInstallerInteraction];
                                 break;
-                            case SPUUserUpdateStateNotDownloaded:
+                            case SPUUserUpdateStateNew:
                                 [self.coreDriver downloadUpdateFromAppcastItem:updateItem inBackground:NO];
                                 break;
                             case SPUUserUpdateStateInformational:
@@ -163,7 +163,7 @@
                     case SPUUserUpdateChoiceDismiss:
                         switch (state) {
                             case SPUUserUpdateStateDownloaded:
-                            case SPUUserUpdateStateNotDownloaded:
+                            case SPUUserUpdateStateNew:
                             case SPUUserUpdateStateInformational:
                                 [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
                                 [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -77,7 +77,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param userInitiated A flag indicating whether or not a user initiated this update check
  *
  * @param state The current state of the update.
- *  SPUUserUpdateStateNew - Update has not been downloaded yet.
+ *  SPUUserUpdateStateNotDownloaded - Update has not been downloaded yet.
  *  SPUUserUpdateStateDownloaded - Update has already been downloaded but not started installing yet.
  *  SPUUserUpdateStateInstalling - Update has been downloaded and already started installing.
  *  SPUUserUpdateStateInformational - Update is only informational and has no download. You can direct the user to the the infoURL property of the appcastItem in their web browser. The informationOnlyUpdate property of the appcastItem will be YES.

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -251,7 +251,6 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 
 // Clients should move to non-deprecated methods
 // Deprecated methods are only (temporarily) kept around for binary compatibility reasons
-#if DEBUG
 
 - (void)showUserInitiatedUpdateCheckWithCompletion:(void (^)(SPUUserInitiatedCheckStatus))updateCheckStatusCompletion __deprecated_msg("Implement -showUserInitiatedUpdateCheckWithCancellation: instead");
 
@@ -268,8 +267,6 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUserUpdateChoice))reply __deprecated_msg("Implement -showUpdateFoundWithAppcastItem:userInitiated:state:reply: instead");
 
 - (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply __deprecated_msg("Implement -showUpdateFoundWithAppcastItem:userInitiated:state:reply: instead");
-
-#endif
 
 @end
 

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -68,68 +68,34 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)dismissUserInitiatedUpdateCheck;
 
 /*!
- * Show the user a new update is found and can be downloaded and installed
+ * Show the user a new update is found.
  *
  * Let the user know a new update is found and ask them what they want to do.
  *
- * @param appcastItem The Appcast Item containing information that reflects the new update
- *
- * @param userInitiated A flag indicating whether or not a user initiated this update check
- *
- * @param reply
- * A reply of SPUInstallUpdateChoice begins downloading and installing the new update.
- *
- * A reply of SPUInstallLaterChoice reminds the user later of the update, which can act as a "do nothing" option.
- *
- * A reply of SPUSkipThisVersionChoice skips this particular version and won't bother the user again,
- * unless they initiate an update check themselves.
- */
-- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply;
-
-/*!
- * Show the user a new update has been downloaded and can be installed
- *
- * This method behaves just like -showUpdateFoundWithAppcastItem:reply: except the update has already been downloaded.
- */
-- (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply;
-
-/*!
- * Show the user an update that has started installing can be resumed and installed immediately
- *
- * Let the user know an update that has already been downloaded and started installing can be resumed.
- * Note at this point the update cannot be canceled.
- *
- * @param appcastItem The Appcast Item containing information that reflects the new update
- *
- * @param userInitiated A flag indicating whether or not a user initiated this update check
- *
- * @param reply
- * A reply of SPUInstallAndRelaunchUpdateNow installs the update immediately and relaunches the new update.
- * Note: the application is not relaunched if it was not running before installing the update.
- * A reply of SPUInstallUpdateNow installs the update immediately but does not relaunch the new update.
- * A reply of SPUDismissUpdateInstallation dismisses the update installation. Note the update will attempt to finish installation
- * after the application terminates.
- */
-- (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply;
-
-/*!
- * Show the user a new informational only update has been found
- *
- * Let the user know a new informational update is found and ask them what they want to do.
- *
  * @param appcastItem The Appcast Item containing information that reflects the new update.
- * The infoURL property for the appcastItem may be of interest.
  *
  * @param userInitiated A flag indicating whether or not a user initiated this update check
  *
- * @param reply
- * A reply of SPUDismissInformationalNoticeChoice dismisses this notice.
- * An implementor may decide to invoke another action before dismissing the notice.
+ * @param state The current state of the update.
+ *  SPUUserUpdateStateNotDownloaded - Update has not been downloaded yet.
+ *  SPUUserUpdateStateDownloaded - Update has already been downloaded but not started installing yet.
+ *  SPUUserUpdateStateInstalling - Update has been downloaded and already started installing.
+ *  SPUUserUpdateStateInformational - Update is only informational and has no download. You can direct the user to the the infoURL property of the appcastItem in their web browser. The informationOnlyUpdate property of the appcastItem will be YES.
  *
- * A reply of SPUSkipThisInformationalVersionChoice skips this particular version and won't bother the user again,
- * unless they initiate an update check themselves.
+ * Additionally, you may want to check the criticalUpdate property of the appcastItem to let the user know if the update is critical.
+ *
+ * @param reply
+ * A reply of SPUUserUpdateChoiceInstall begins or resumes downloading or installing the update.
+ * If the state is SPUUserUpdateStateInstalling, this may send a quit event to the application and relaunch it immediately (in this state, this behaves as a fast "install and Relaunch").
+ *
+ * A reply of SPUUserUpdateChoiceDismiss dismisses the update for the time being. The user may be reminded of the update at a later point.
+ * If the state is SPUUserUpdateStateDownloaded, the downloaded update is kept upon dismissing until the next time an update is shown to the user.
+ * If the state is SPUUserUpdateStateInstalling, the installing update is also preserved upon dismissing. In this state however, the update will still be installed after the application is terminated.
+ *
+ * A reply of SPUUserUpdateChoiceSkip skips this particular version and won't notify the user again, unless they initiate an update check themselves.
+ * If the state is SPUUserUpdateStateInstalling, the update cannot be skipped, only dismissed or installed.
  */
-- (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply;
+- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply;
 
 /*!
  * Show the user the release notes for the new update
@@ -220,19 +186,20 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)showExtractionReceivedProgress:(double)progress;
 
 /*!
- * Show the user that the update is ready to install
+ * Show the user that the update is ready to install & relaunch
  *
- * Let the user know that the update is ready and ask them whether they want to install or not.
- * Note if the target application is already terminated and an update can be performed silently, this method may not be invoked.
+ * Let the user know that the update is ready to install and relaunch, and ask them whether they want to proceed.
+ * Note if the target application has already terminated, this method may not be invoked.
  *
- * @param installUpdateHandler
- * A reply of SPUInstallAndRelaunchUpdateNow installs the update immediately and relaunches the new update.
- * Note: the application is not relaunched if it was not running before installing the update.
- * A reply of SPUInstallUpdateNow installes the update immediately but does not relaunch the new update.
- * A reply of SPUDismissUpdateInstallation dismisses the update installation. Note the update may still be installed after
- * the application terminates, however there is not a strong guarantee that this will happen.
+ * @param reply
+ * A reply of SPUUserUpdateChoiceInstall installs the update and relaunches the new update immediately.
+ *
+ * A reply of SPUUserUpdateChoiceDismiss dismisses the update installation for the time being. Note the update may still be installed automatically after
+ * the application terminates.
+ *
+ * A reply of SPUUserUpdateChoiceSkip acts the same as dismissing. This update which has started installing cannot be skipped.
  */
-- (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler;
+- (void)showReadyToInstallAndRelaunch:(void (^)(SPUUserUpdateChoice))reply;
 
 /*!
  * Show the user that the update is installing
@@ -282,6 +249,10 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  */
 @optional
 
+// Clients should move to non-deprecated methods
+// Deprecated methods are only (temporarily) kept around for binary compatibility reasons
+#if DEBUG
+
 - (void)showUserInitiatedUpdateCheckWithCompletion:(void (^)(SPUUserInitiatedCheckStatus))updateCheckStatusCompletion __deprecated_msg("Implement -showUserInitiatedUpdateCheckWithCancellation: instead");
 
 - (void)showDownloadInitiatedWithCompletion:(void (^)(SPUDownloadUpdateStatus))downloadUpdateStatusCompletion __deprecated_msg("Implement -showDownloadInitiatedWithCancellation: instead");
@@ -289,6 +260,16 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)showUpdateNotFoundWithAcknowledgement:(void (^)(void))acknowledgement __deprecated_msg("Implement -showUpdateNotFoundWithError:acknowledgement: instead");
 
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement __deprecated_msg("Implement -showUpdateInstalledAndRelaunched:acknowledgement: instead");
+
+- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply __deprecated_msg("Implement -showUpdateFoundWithAppcastItem:userInitiated:state:reply: instead");
+
+- (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply __deprecated_msg("Implement -showUpdateFoundWithAppcastItem:userInitiated:state:reply: instead");
+
+- (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUUserUpdateChoice))reply __deprecated_msg("Implement -showUpdateFoundWithAppcastItem:userInitiated:state:reply: instead");
+
+- (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply __deprecated_msg("Implement -showUpdateFoundWithAppcastItem:userInitiated:state:reply: instead");
+
+#endif
 
 @end
 

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -77,7 +77,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param userInitiated A flag indicating whether or not a user initiated this update check
  *
  * @param state The current state of the update.
- *  SPUUserUpdateStateNotDownloaded - Update has not been downloaded yet.
+ *  SPUUserUpdateStateNew - Update has not been downloaded yet.
  *  SPUUserUpdateStateDownloaded - Update has already been downloaded but not started installing yet.
  *  SPUUserUpdateStateInstalling - Update has been downloaded and already started installing.
  *  SPUUserUpdateStateInformational - Update is only informational and has no download. You can direct the user to the the infoURL property of the appcastItem in their web browser. The informationOnlyUpdate property of the appcastItem will be YES.
@@ -89,8 +89,8 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * If the state is SPUUserUpdateStateInstalling, this may send a quit event to the application and relaunch it immediately (in this state, this behaves as a fast "install and Relaunch").
  *
  * A reply of SPUUserUpdateChoiceDismiss dismisses the update for the time being. The user may be reminded of the update at a later point.
- * If the state is SPUUserUpdateStateDownloaded, the downloaded update is kept upon dismissing until the next time an update is shown to the user.
- * If the state is SPUUserUpdateStateInstalling, the installing update is also preserved upon dismissing. In this state however, the update will still be installed after the application is terminated.
+ * If the state is SPUUserUpdateStateDownloaded, the downloaded update is kept after dismissing until the next time an update is shown to the user.
+ * If the state is SPUUserUpdateStateInstalling, the installing update is also preserved after dismissing. In this state however, the update will also still be installed after the application is terminated.
  *
  * A reply of SPUUserUpdateChoiceSkip skips this particular version and won't notify the user again, unless they initiate an update check themselves.
  * If the state is SPUUserUpdateStateInstalling, the update cannot be skipped, only dismissed or installed.

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -20,11 +20,7 @@
 
 @property (nonatomic, weak, readonly) id <SUVersionDisplay> versionDisplayer;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item alreadyDownloaded:(BOOL)alreadyDownloaded host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUpdateAlertChoice))block;
-
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer resumableCompletionBlock:(void (^)(SPUInstallUpdateStatus))block;
-
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer informationalCompletionBlock:(void (^)(SPUInformationalUpdateAlertChoice))block;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))block;
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData;
 - (void)showReleaseNotesFailedToDownload;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -33,12 +33,10 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 @interface SUUpdateAlert () <NSTouchBarDelegate>
 
 @property (strong) SUAppcastItem *updateItem;
-@property (nonatomic) BOOL alreadyDownloaded;
 @property (strong) SUHost *host;
 @property (nonatomic) BOOL allowsAutomaticUpdates;
-@property (nonatomic, copy, nullable) void(^completionBlock)(SPUUpdateAlertChoice);
-@property (nonatomic, copy, nullable) void(^resumableCompletionBlock)(SPUInstallUpdateStatus);
-@property (nonatomic, copy, nullable) void(^informationalCompletionBlock)(SPUInformationalUpdateAlertChoice);
+@property (nonatomic, copy, nullable) void(^completionBlock)(SPUUserUpdateChoice);
+@property (nonatomic) SPUUserUpdateState state;
 
 @property (strong) NSProgressIndicator *releaseNotesSpinner;
 
@@ -60,9 +58,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 @implementation SUUpdateAlert
 
 @synthesize completionBlock = _completionBlock;
-@synthesize alreadyDownloaded = _alreadyDownloaded;
-@synthesize resumableCompletionBlock = _resumableCompletionBlock;
-@synthesize informationalCompletionBlock = _informationalCompletionBlock;
+@synthesize state = _state;
 @synthesize versionDisplayer;
 
 @synthesize updateItem;
@@ -84,7 +80,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 @synthesize webView = _webView;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))block
 {
     self = [super initWithWindowNibName:@"SUUpdateAlert"];
     if (self != nil) {
@@ -92,41 +88,12 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         updateItem = item;
         versionDisplayer = aVersionDisplayer;
         
+        _state = state;
+        _completionBlock = [block copy];
+        
         SPUUpdaterSettings *updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:host.bundle];
         _allowsAutomaticUpdates = updaterSettings.allowsAutomaticUpdates && !item.isInformationOnlyUpdate;
         [self setShouldCascadeWindows:NO];
-    }
-    return self;
-}
-
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item alreadyDownloaded:(BOOL)alreadyDownloaded host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUpdateAlertChoice))block
-{
-    self = [self initWithAppcastItem:item host:aHost versionDisplayer:aVersionDisplayer];
-	if (self != nil)
-	{
-        _completionBlock = [block copy];
-        _alreadyDownloaded = alreadyDownloaded;
-    }
-    return self;
-}
-
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer resumableCompletionBlock:(void (^)(SPUInstallUpdateStatus))block
-{
-    self = [self initWithAppcastItem:item host:aHost versionDisplayer:aVersionDisplayer];
-    if (self != nil)
-    {
-        _resumableCompletionBlock = [block copy];
-        _alreadyDownloaded = YES;
-    }
-    return self;
-}
-
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer informationalCompletionBlock:(void (^)(SPUInformationalUpdateAlertChoice))block
-{
-    self = [self initWithAppcastItem:item host:aHost versionDisplayer:aVersionDisplayer];
-    if (self != nil)
-    {
-        _informationalCompletionBlock = [block copy];
     }
     return self;
 }
@@ -137,7 +104,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     self.installButton.keyEquivalent = @"";
 }
 
-- (void)endWithSelection:(SPUUpdateAlertChoice)choice
+- (void)endWithSelection:(SPUUserUpdateChoice)choice
 {
     [self.webView stopLoading];
     [self.webView.view removeFromSuperview]; // Otherwise it gets sent Esc presses (why?!) and gets very confused.
@@ -146,52 +113,29 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     if (self.completionBlock != nil) {
         self.completionBlock(choice);
         self.completionBlock = nil;
-    } else if (self.resumableCompletionBlock != nil) {
-        switch (choice) {
-            case SPUInstallUpdateChoice:
-                self.resumableCompletionBlock(SPUInstallAndRelaunchUpdateNow);
-                break;
-            case SPUInstallLaterChoice:
-                self.resumableCompletionBlock(SPUDismissUpdateInstallation);
-                break;
-            case SPUSkipThisVersionChoice:
-                abort();
-        }
-        self.resumableCompletionBlock = nil;
-    } else if (self.informationalCompletionBlock != nil) {
-        switch (choice) {
-            case SPUInstallLaterChoice:
-                self.informationalCompletionBlock(SPUDismissInformationalNoticeChoice);
-                break;
-            case SPUSkipThisVersionChoice:
-                self.informationalCompletionBlock(SPUSkipThisInformationalVersionChoice);
-                break;
-            case SPUInstallUpdateChoice:
-                abort();
-        }
     }
 }
 
 - (IBAction)installUpdate:(id)__unused sender
 {
-    [self endWithSelection:SPUInstallUpdateChoice];
+    [self endWithSelection:SPUUserUpdateChoiceInstall];
 }
 
 - (IBAction)openInfoURL:(id)__unused sender
 {
     [[NSWorkspace sharedWorkspace] openURL:self.updateItem.infoURL];
     
-    [self endWithSelection:SPUInstallLaterChoice];
+    [self endWithSelection:SPUUserUpdateChoiceDismiss];
 }
 
 - (IBAction)skipThisVersion:(id)__unused sender
 {
-    [self endWithSelection:SPUSkipThisVersionChoice];
+    [self endWithSelection:SPUUserUpdateChoiceSkip];
 }
 
 - (IBAction)remindMeLater:(id)__unused sender
 {
-    [self endWithSelection:SPUInstallLaterChoice];
+    [self endWithSelection:SPUUserUpdateChoiceDismiss];
 }
 
 - (void)displayReleaseNotes
@@ -407,8 +351,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         }
     }
     
-    BOOL startedInstalling = (self.resumableCompletionBlock != nil);
-    if (startedInstalling) {
+    if (self.state == SPUUserUpdateStateInstalling) {
         // An already downloaded & resumable update can't be skipped
         self.skipButton.hidden = YES;
         
@@ -434,7 +377,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (BOOL)windowShouldClose:(NSNotification *) __unused note
 {
-	[self endWithSelection:SPUInstallLaterChoice];
+	[self endWithSelection:SPUUserUpdateChoiceDismiss];
 	return YES;
 }
 
@@ -449,7 +392,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     {
         return [NSString stringWithFormat:SULocalizedString(@"An important update to %@ is ready to install", nil), [self.host name]];
     }
-    else if (self.alreadyDownloaded)
+    else if (self.state == SPUUserUpdateStateDownloaded || self.state == SPUUserUpdateStateInstalling)
     {
         return [NSString stringWithFormat:SULocalizedString(@"A new version of %@ is ready to install!", nil), [self.host name]];
     }
@@ -477,13 +420,13 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     if (self.updateItem.isInformationOnlyUpdate) {
         finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?", @"Description text for SUUpdateAlert when the update informational with no download."), self.host.name, updateItemVersion, hostVersion];
     } else if ([self.updateItem isCriticalUpdate]) {
-        if (!self.alreadyDownloaded) {
+        if (self.state == SPUUserUpdateStateNotDownloaded) {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. This is an important update; would you like to download it now?", @"Description text for SUUpdateAlert when the critical update is downloadable."), self.host.name, updateItemVersion, hostVersion];
         } else {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?", @"Description text for SUUpdateAlert when the critical update has already been downloaded and ready to install."), self.host.name, updateItemVersion];
         }
     } else {
-        if (!self.alreadyDownloaded) {
+        if (self.state == SPUUserUpdateStateNotDownloaded) {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. Would you like to download it now?", @"Description text for SUUpdateAlert when the update is downloadable."), self.host.name, updateItemVersion, hostVersion];
         } else {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?", @"Description text for SUUpdateAlert when the update has already been downloaded and ready to install."), self.host.name, updateItemVersion];

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -420,13 +420,13 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     if (self.updateItem.isInformationOnlyUpdate) {
         finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?", @"Description text for SUUpdateAlert when the update informational with no download."), self.host.name, updateItemVersion, hostVersion];
     } else if ([self.updateItem isCriticalUpdate]) {
-        if (self.state == SPUUserUpdateStateNew) {
+        if (self.state == SPUUserUpdateStateNotDownloaded) {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. This is an important update; would you like to download it now?", @"Description text for SUUpdateAlert when the critical update is downloadable."), self.host.name, updateItemVersion, hostVersion];
         } else {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?", @"Description text for SUUpdateAlert when the critical update has already been downloaded and ready to install."), self.host.name, updateItemVersion];
         }
     } else {
-        if (self.state == SPUUserUpdateStateNew) {
+        if (self.state == SPUUserUpdateStateNotDownloaded) {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. Would you like to download it now?", @"Description text for SUUpdateAlert when the update is downloadable."), self.host.name, updateItemVersion, hostVersion];
         } else {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?", @"Description text for SUUpdateAlert when the update has already been downloaded and ready to install."), self.host.name, updateItemVersion];

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -420,13 +420,13 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     if (self.updateItem.isInformationOnlyUpdate) {
         finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?", @"Description text for SUUpdateAlert when the update informational with no download."), self.host.name, updateItemVersion, hostVersion];
     } else if ([self.updateItem isCriticalUpdate]) {
-        if (self.state == SPUUserUpdateStateNotDownloaded) {
+        if (self.state == SPUUserUpdateStateNew) {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. This is an important update; would you like to download it now?", @"Description text for SUUpdateAlert when the critical update is downloadable."), self.host.name, updateItemVersion, hostVersion];
         } else {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?", @"Description text for SUUpdateAlert when the critical update has already been downloaded and ready to install."), self.host.name, updateItemVersion];
         }
     } else {
-        if (self.state == SPUUserUpdateStateNotDownloaded) {
+        if (self.state == SPUUserUpdateStateNew) {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is now available--you have %@. Would you like to download it now?", @"Description text for SUUpdateAlert when the update is downloadable."), self.host.name, updateItemVersion, hostVersion];
         } else {
             finalString = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?", @"Description text for SUUpdateAlert when the update has already been downloaded and ready to install."), self.host.name, updateItemVersion];

--- a/TestApplication/SUInstallUpdateViewController.h
+++ b/TestApplication/SUInstallUpdateViewController.h
@@ -11,7 +11,7 @@
 
 @interface SUInstallUpdateViewController : NSViewController
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)appcastItem skippable:(BOOL)skippable reply:(void (^)(SPUUpdateAlertChoice))reply;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)appcastItem skippable:(BOOL)skippable reply:(void (^)(SPUUserUpdateChoice))reply;
 
 - (void)showReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData;
 

--- a/TestApplication/SUInstallUpdateViewController.m
+++ b/TestApplication/SUInstallUpdateViewController.m
@@ -14,7 +14,7 @@
 @property (nonatomic) IBOutlet NSTextView *textView;
 @property (nonatomic, readonly) SUAppcastItem *appcastItem;
 @property (nonatomic, nullable) NSAttributedString *preloadedReleaseNotes;
-@property (nonatomic, copy) void (^reply)(SPUUpdateAlertChoice);
+@property (nonatomic, copy) void (^reply)(SPUUserUpdateChoice);
 @property (nonatomic, readonly) BOOL skippable;
 
 @end
@@ -28,7 +28,7 @@
 @synthesize reply = _reply;
 @synthesize skippable = _skippable;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)appcastItem skippable:(BOOL)skippable reply:(void (^)(SPUUpdateAlertChoice))reply
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)appcastItem skippable:(BOOL)skippable reply:(void (^)(SPUUserUpdateChoice))reply
 {
     self = [super initWithNibName:@"SUInstallUpdateViewController" bundle:nil];
     if (self != nil) {
@@ -109,7 +109,7 @@
 - (IBAction)installUpdate:(id)__unused sender
 {
     if (self.reply != nil) {
-        self.reply(SPUInstallUpdateChoice);
+        self.reply(SPUUserUpdateChoiceInstall);
         self.reply = nil;
     }
 }
@@ -117,7 +117,7 @@
 - (IBAction)installUpdateLater:(id)__unused sender
 {
     if (self.reply != nil) {
-        self.reply(SPUInstallLaterChoice);
+        self.reply(SPUUserUpdateChoiceDismiss);
         self.reply = nil;
     }
 }
@@ -125,7 +125,7 @@
 - (IBAction)skipUpdate:(id)__unused sender
 {
     if (self.reply != nil) {
-        self.reply(SPUSkipThisVersionChoice);
+        self.reply(SPUUserUpdateChoiceSkip);
         self.reply = nil;
     }
 }

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -149,7 +149,7 @@
             reply(SPUUserUpdateChoiceDismiss);
             
             break;
-        case SPUUserUpdateStateNew:
+        case SPUUserUpdateStateNotDownloaded:
         case SPUUserUpdateStateDownloaded:
             [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
             break;

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -149,12 +149,12 @@
             reply(SPUUserUpdateChoiceDismiss);
             
             break;
-        case SPUUserUpdateStateNotDownloaded:
+        case SPUUserUpdateStateNew:
         case SPUUserUpdateStateDownloaded:
             [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
             break;
         case SPUUserUpdateStateInstalling:
-            [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
+            [self showUpdateWithAppcastItem:appcastItem skippable:NO reply:reply];
             break;
     }
 }

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -113,7 +113,7 @@
 
 #pragma mark Update Found
 
-- (void)showUpdateWithAppcastItem:(SUAppcastItem *)appcastItem skippable:(BOOL)skippable reply:(void (^)(SPUUpdateAlertChoice))reply
+- (void)showUpdateWithAppcastItem:(SUAppcastItem *)appcastItem skippable:(BOOL)skippable reply:(void (^)(SPUUserUpdateChoice))reply
 {
     NSPopover *popover = [[NSPopover alloc] init];
     popover.behavior = NSPopoverBehaviorTransient;
@@ -121,7 +121,7 @@
     __weak SUPopUpTitlebarUserDriver *weakSelf = self;
     __block NSButton *actionButton = nil;
     
-    SUInstallUpdateViewController *viewController = [[SUInstallUpdateViewController alloc] initWithAppcastItem:appcastItem skippable:skippable reply:^(SPUUpdateAlertChoice choice) {
+    SUInstallUpdateViewController *viewController = [[SUInstallUpdateViewController alloc] initWithAppcastItem:appcastItem skippable:skippable reply:^(SPUUserUpdateChoice choice) {
         reply(choice);
         
         [popover close];
@@ -139,38 +139,24 @@
     }];
 }
 
-- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
+- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply
 {
-    [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
-}
-
-- (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
-{
-    [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
-}
-
-- (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply
-{
-    [self showUpdateWithAppcastItem:appcastItem skippable:NO reply:^(SPUUpdateAlertChoice choice) {
-        switch (choice) {
-            case SPUInstallUpdateChoice:
-                reply(SPUInstallAndRelaunchUpdateNow);
-                break;
-            case SPUInstallLaterChoice:
-                reply(SPUDismissUpdateInstallation);
-                break;
-            case SPUSkipThisVersionChoice:
-                abort();
-        }
-    }];
-}
-
-- (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply
-{
-    // Todo: show user interface for this
-    NSLog(@"Found info URL: %@", appcastItem.infoURL);
-    
-    reply(SPUDismissInformationalNoticeChoice);
+    switch (state) {
+        case SPUUserUpdateStateInformational:
+            // Todo: show user interface for this
+            NSLog(@"Found info URL: %@", appcastItem.infoURL);
+            
+            reply(SPUUserUpdateChoiceDismiss);
+            
+            break;
+        case SPUUserUpdateStateNotDownloaded:
+        case SPUUserUpdateStateDownloaded:
+            [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
+            break;
+        case SPUUserUpdateStateInstalling:
+            [self showUpdateWithAppcastItem:appcastItem skippable:YES reply:reply];
+            break;
+    }
 }
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
@@ -184,10 +170,10 @@
 
 #pragma mark Install & Relaunch Update
 
-- (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
+- (void)showReadyToInstallAndRelaunch:(void (^)(SPUUserUpdateChoice))installUpdateHandler
 {
     [self addUpdateButtonWithTitle:@"Install & Relaunch" action:^(NSButton *__unused button) {
-        installUpdateHandler(SPUInstallAndRelaunchUpdateNow);
+        installUpdateHandler(SPUUserUpdateChoiceInstall);
     }];
 }
 

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -108,7 +108,7 @@
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply
 {
     switch (state) {
-        case SPUUserUpdateStateNew:
+        case SPUUserUpdateStateNotDownloaded:
             [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
             reply(SPUUserUpdateChoiceInstall);
             break;

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -108,7 +108,7 @@
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply
 {
     switch (state) {
-        case SPUUserUpdateStateNotDownloaded:
+        case SPUUserUpdateStateNew:
             [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
             reply(SPUUserUpdateChoiceInstall);
             break;

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -105,37 +105,32 @@
     }
 }
 
-- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
+- (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply
 {
-    [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
-    reply(SPUInstallUpdateChoice);
-}
-
-- (void)showDownloadedUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUUpdateAlertChoice))reply
-{
-    [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"downloaded"];
-    reply(SPUInstallUpdateChoice);
-}
-
-- (void)showResumableUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInstallUpdateStatus))reply
-{
-    [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"resumable"];
-    
-    if (self.deferInstallation) {
-        if (self.verbose) {
-            fprintf(stderr, "Deferring Installation.\n");
-        }
-        reply(SPUDismissUpdateInstallation);
-    } else {
-        reply(SPUInstallAndRelaunchUpdateNow);
+    switch (state) {
+        case SPUUserUpdateStateNotDownloaded:
+            [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"new"];
+            reply(SPUUserUpdateChoiceInstall);
+            break;
+        case SPUUserUpdateStateDownloaded:
+            [self showUpdateWithAppcastItem:appcastItem updateAdjective:@"downloaded"];
+            reply(SPUUserUpdateChoiceInstall);
+            break;
+        case SPUUserUpdateStateInstalling:
+            if (self.deferInstallation) {
+                if (self.verbose) {
+                    fprintf(stderr, "Deferring Installation.\n");
+                }
+                reply(SPUUserUpdateChoiceDismiss);
+            } else {
+                reply(SPUUserUpdateChoiceInstall);
+            }
+            break;
+        case SPUUserUpdateStateInformational:
+            fprintf(stderr, "Found information for new update: %s\n", appcastItem.infoURL.absoluteString.UTF8String);
+            reply(SPUUserUpdateChoiceDismiss);
+            break;
     }
-}
-
-- (void)showInformationalUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)__unused userInitiated reply:(void (^)(SPUInformationalUpdateAlertChoice))reply
-{
-    fprintf(stderr, "Found information for new update: %s\n", appcastItem.infoURL.absoluteString.UTF8String);
-    
-    reply(SPUDismissInformationalNoticeChoice);
 }
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
@@ -225,15 +220,15 @@
     }
 }
 
-- (void)showReadyToInstallAndRelaunch:(void (^)(SPUInstallUpdateStatus))installUpdateHandler
+- (void)showReadyToInstallAndRelaunch:(void (^)(SPUUserUpdateChoice))installUpdateHandler
 {
     if (self.deferInstallation) {
         if (self.verbose) {
             fprintf(stderr, "Deferring Installation.\n");
         }
-        installUpdateHandler(SPUDismissUpdateInstallation);
+        installUpdateHandler(SPUUserUpdateChoiceDismiss);
     } else {
-        installUpdateHandler(SPUInstallAndRelaunchUpdateNow);
+        installUpdateHandler(SPUUserUpdateChoiceInstall);
     }
 }
 


### PR DESCRIPTION
Merge show update methods in the user driver.

Handling the different variations with different completion blocks is a pain when ultimately clients want to display a mostly unified user interface. So it's worth putting up with a couple bad combinations being "ignored"

Removed the user driver option to only install the update but not relaunch it as I'm doubtful anyone was using it (automatic updates still install silently without relaunch).

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app but will test changes more thoroughly when I get the chance. Putting up for review right now.

macOS version tested: 11.2.3 (20D91)
