### PR TITLE
Don't bring up authorization just because group ID doesn't match

### DIFF
--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -103,6 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If the owner and group IDs match on the root items of targetURL and matchURL, this method stops and assumes that nothing needs to be done.
  * Otherwise this method recursively changes the IDs if the target is a directory. If an item in the directory is encountered that is unable to be changed,
  * then this method stops and returns NO.
+ * While this method will try to change the group ID, being unable to change the group ID does not result in a failure if the owner ID can be changed or matched.
  *
  * This is not an atomic operation.
  */


### PR DESCRIPTION
Don't bring up authorization just because group ID doesn't match

Let us not bother the user in the more unusual case the group can't be changed. I think this is the right thing to do for most apps.. Apps that want auth should be owned by root user, Sparkle tools like BinaryDelta also don't support weird permission modes like 0770 last I recall.

This change is **not** back-portable to 1.x (see below).

Fixes #1108

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements - **No, more work is required to do this properly in 1.x to ensure group is still changed when auth will otherwise be needed for moving the apps, which may be risky / difficult and I don't want to do the testing & refactoring work there. Also not critical enough of an issue to back port considering how long it's been around and few developers noticed.**
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

With Sparkle Test App, tested:
Regular app update with user:staff (no auth)
App update that is root:wheel (auth)
App update that is user:wheel (no auth)
App update whose parent directory is root:wheel (auth)

macOS version tested: 11.2.3 (20D91)
