### PR TITLE
Deprecate -dismissUserInitiatedUpdateCheck user driver method

### DIFF
--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -128,6 +128,8 @@
 {
     assert(NSThread.isMainThread);
     
+    [self closeCheckingWindow];
+    
     id <SUVersionDisplay> versionDisplayer = nil;
     if ([self.delegate respondsToSelector:@selector(standardUserDriverRequestsVersionDisplayer)]) {
         versionDisplayer = [self.delegate standardUserDriverRequestsVersionDisplayer];
@@ -209,8 +211,9 @@
 {
     if (self.checkingController != nil)
     {
-        [[self.checkingController window] close];
+        [self.checkingController close];
         self.checkingController = nil;
+        self.cancellation = nil;
     }
 }
 
@@ -223,19 +226,16 @@
     [self closeCheckingWindow];
 }
 
-- (void)dismissUserInitiatedUpdateCheck
-{
-    assert(NSThread.isMainThread);
-    
-    self.cancellation = nil;
-    [self closeCheckingWindow];
-}
-
 #pragma mark Update Errors
 
 - (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
     assert(NSThread.isMainThread);
+    
+    [self closeCheckingWindow];
+    
+    [self.statusController close];
+    self.statusController = nil;
     
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = SULocalizedString(@"Update Error!", nil);
@@ -249,6 +249,8 @@
 - (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement
 {
     assert(NSThread.isMainThread);
+    
+    [self closeCheckingWindow];
     
     NSAlert *alert = [NSAlert alertWithError:error];
     alert.alertStyle = NSAlertStyleInformational;

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -110,7 +110,12 @@
 {
     if (self.showingUserInitiatedProgress) {
         self.showingUserInitiatedProgress = NO;
-        [self.userDriver dismissUserInitiatedUpdateCheck];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if ([self.userDriver respondsToSelector:@selector(dismissUserInitiatedUpdateCheck)]) {
+            [self.userDriver dismissUserInitiatedUpdateCheck];
+        }
+#pragma clang diagnostic pop
     }
 }
 
@@ -122,7 +127,12 @@
 - (void)abortUpdateWithError:(nullable NSError *)error
 {
     if (self.showingUserInitiatedProgress) {
-        [self.userDriver dismissUserInitiatedUpdateCheck];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if ([self.userDriver respondsToSelector:@selector(dismissUserInitiatedUpdateCheck)]) {
+            [self.userDriver dismissUserInitiatedUpdateCheck];
+        }
+#pragma clang diagnostic pop
         self.showingUserInitiatedProgress = NO;
     }
     self.aborted = YES;

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -146,6 +146,9 @@
             // Todo: show user interface for this
             NSLog(@"Found info URL: %@", appcastItem.infoURL);
             
+            // Remove UI from user initiated check
+            [self removeUpdateButton];
+            
             reply(SPUUserUpdateChoiceDismiss);
             
             break;
@@ -182,11 +185,6 @@
 - (void)showUserInitiatedUpdateCheckWithCancellation:(void (^)(void))__unused cancellation
 {
     [self addUpdateButtonWithTitle:@"Checking for Updates…"];
-}
-
-- (void)dismissUserInitiatedUpdateCheck
-{
-    [self removeUpdateButton];
 }
 
 #pragma mark Update Errors

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -66,10 +66,6 @@
     }
 }
 
-- (void)dismissUserInitiatedUpdateCheck
-{
-}
-
 - (void)displayReleaseNotes:(const char * _Nullable)releaseNotes
 {
     if (releaseNotes != NULL) {


### PR DESCRIPTION
We don't have a dismiss method for every transition state and we don't want to. This should be up to the UI to determine how to transition from one UI state to another UI state. Also document the transition states a bit better in the user driver docs.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested transition states in Sparkle Test App (user initiated -> update shown or error occurred, update installing -> ready to relaunch, ready to relaunch -> update installed).

macOS version tested: 11.2.3 (20D91)
