### PR TITLE
Update authorization prompt when updating an app

### DIFF
--- a/InstallerLauncher/SUInstallerLauncherProtocol.h
+++ b/InstallerLauncher/SUInstallerLauncherProtocol.h
@@ -11,7 +11,7 @@
 
 @protocol SUInstallerLauncherProtocol
 
-- (void)launchInstallerWithHostBundlePath:(NSString *)hostBundlePath authorizationPrompt:(NSString *)authorizationPrompt installationType:(NSString *)installationType allowingDriverInteraction:(BOOL)allowingDriverInteraction allowingUpdaterInteraction:(BOOL)allowingUpdaterInteraction completion:(void (^)(SUInstallerLauncherStatus, BOOL))completionHandler;
+- (void)launchInstallerWithHostBundlePath:(NSString *)hostBundlePath updaterIdentifier:(NSString *)updaterBundleIdentifier authorizationPrompt:(NSString *)authorizationPrompt installationType:(NSString *)installationType allowingDriverInteraction:(BOOL)allowingDriverInteraction allowingUpdaterInteraction:(BOOL)allowingUpdaterInteraction completion:(void (^)(SUInstallerLauncherStatus, BOOL))completionHandler;
 
 - (void)checkIfApplicationInstallationRequiresAuthorizationWithHostBundlePath:(NSString *)hostBundlePath reply:(void(^)(BOOL requiresAuthorization))reply;
     

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -101,3 +101,9 @@
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You're up-to-date!" = "You’re up to date!";
+
+/* Authorization message shown when app wants permission to update itself. */
+"%1$@ wants permission to update." = "%1$@ wants permission to update.";
+
+/* Authorization message shown when app wants permission to update another app / bundle. */
+"%1$@ wants permission to update %2$@." = "%1$@ wants permission to update %2$@.";


### PR DESCRIPTION
We have a slightly different prompt for an app updating itself vs an app/tool updating another app. Also put prompt in the localization strings.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested Sparkle Test App updating itself with auth, and (with slight modifications) updating another app with auth.

macOS version tested: 11.2.3 (20D91)
