### PR TITLE
Update missing localizations strings

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -14,14 +14,18 @@
 
 "%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ is currently the newest version available.\n(You are currently running version %3$@.)";
 
+/* An appcast feed error when checking for updates and no appcast items are retrieved */
 "No valid update information could be loaded." = "No valid update information could be loaded.";
 
+/* An installer error that is rare to occur when the updater opts into preventing interaction; may not be worthwhile translating */
 "No new update has been checked because the installation will require interaction, which has been prevented." = "No new update has been checked because the installation will require interaction, which has been prevented.";
 
+/* An installer error that is rare to occur when the updater opts into preventing interaction; may not be worthwhile translating */
 "A new update is available but cannot be installed because interaction has been prevented." = "A new update is available but cannot be installed because interaction has been prevented.";
 
 "An error occurred while running the updater. Please try again later." = "An error occurred while running the updater. Please try again later.";
 
+/* An installer error that is rare to occur; may not be worthwhile translating */
 "An error occurred while encoding the installer parameters. Please try again later." = "An error occurred while encoding the installer parameters. Please try again later.";
 
 "An error occurred while starting the installer. Please try again later." = "An error occurred while starting the installer. Please try again later.";

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -17,16 +17,7 @@
 /* An appcast feed error when checking for updates and no appcast items are retrieved */
 "No valid update information could be loaded." = "No valid update information could be loaded.";
 
-/* An installer error that is rare to occur when the updater opts into preventing interaction; may not be worthwhile translating */
-"No new update has been checked because the installation will require interaction, which has been prevented." = "No new update has been checked because the installation will require interaction, which has been prevented.";
-
-/* An installer error that is rare to occur when the updater opts into preventing interaction; may not be worthwhile translating */
-"A new update is available but cannot be installed because interaction has been prevented." = "A new update is available but cannot be installed because interaction has been prevented.";
-
 "An error occurred while running the updater. Please try again later." = "An error occurred while running the updater. Please try again later.";
-
-/* An installer error that is rare to occur; may not be worthwhile translating */
-"An error occurred while encoding the installer parameters. Please try again later." = "An error occurred while encoding the installer parameters. Please try again later.";
 
 "An error occurred while starting the installer. Please try again later." = "An error occurred while starting the installer. Please try again later.";
 

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -14,6 +14,22 @@
 
 "%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ is currently the newest version available.\n(You are currently running version %3$@.)";
 
+"No valid update information could be loaded." = "No valid update information could be loaded.";
+
+"No new update has been checked because the installation will require interaction, which has been prevented." = "No new update has been checked because the installation will require interaction, which has been prevented.";
+
+"A new update is available but cannot be installed because interaction has been prevented." = "A new update is available but cannot be installed because interaction has been prevented.";
+
+"An error occurred while running the updater. Please try again later." = "An error occurred while running the updater. Please try again later.";
+
+"An error occurred while encoding the installer parameters. Please try again later." = "An error occurred while encoding the installer parameters. Please try again later.";
+
+"An error occurred while starting the installer. Please try again later." = "An error occurred while starting the installer. Please try again later.";
+
+"An error occurred while connecting to the installer. Please try again later." = "An error occurred while connecting to the installer. Please try again later.";
+
+"An error occurred while launching the installer. Please try again later." = "An error occurred while launching the installer. Please try again later.";
+
 "Update Installed" = "Update Installed";
 
 "%@ is now updated to version %@!" = "%@ is now updated to version %@!";
@@ -25,6 +41,9 @@
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
 "%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ is now available—you have %3$@. Would you like to learn more about this update on the web?";
+
+/* Critical downloadable update */
+"%@ %@ is now available--you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@ is now available--you have %3$@. This is an important update; would you like to download it now?";
 
 "%@ downloaded" = "%@ downloaded";
 
@@ -43,6 +62,10 @@
 "An error occurred while installing the update. Please try again later." = "An error occurred while installing the update. Please try again later.";
 
 "An error occurred while parsing the update feed." = "An error occurred while parsing the update feed.";
+
+"An error occurred while downloading the update feed." = "An error occurred while downloading the update feed.";
+
+"Failed to resume installing update." = "Failed to resume installing update.";
 
 "An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@.";
 
@@ -67,6 +90,8 @@
 "GB" = "GB";
 
 "Install and Relaunch" = "Install and Relaunch";
+
+"Install on Quit" = "Install on Quit";
 
 /* Take care not to overflow the status window. */
 "Installing update..." = "Installing update…";

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -187,7 +187,7 @@
         } else {
             localizedDescription = SULocalizedString(@"Update Error!", nil);
             recoverySuggestion = SULocalizedString(@"No valid update information could be loaded.", nil);
-            recoveryOption = @"Cancel Update";
+            recoveryOption = SULocalizedString(@"Cancel Update", nil);
         }
         
         NSError *notFoundError =

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -102,7 +102,7 @@
         // Otherwise check if we have sufficient privileges to update without interaction
         [self.installerDriver checkIfApplicationInstallationRequiresAuthorizationWithReply:^(BOOL requiresAuthorization) {
             if (requiresAuthorization) {
-                reply([NSError errorWithDomain:SUSparkleErrorDomain code:SUNotAllowedInteractionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"No new update has been checked because the installation will require interaction, which has been prevented.", nil)] }]);
+                reply([NSError errorWithDomain:SUSparkleErrorDomain code:SUNotAllowedInteractionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No new update has been checked because the installation will require interaction, which has been prevented."] }]);
             } else {
                 reply(nil);
             }
@@ -161,7 +161,7 @@
             // Package type installations will always require installer interaction as long as we don't support running as root
             // If it's not a package type installation, we should be okay since we did an auth check before checking for updates above
             if (![updateItem.installationType isEqualToString:SPUInstallationTypeApplication]) {
-                [self.delegate coreDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUNotAllowedInteractionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"A new update is available but cannot be installed because interaction has been prevented.", nil)] }]];
+                [self.delegate coreDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUNotAllowedInteractionError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new update is available but cannot be installed because interaction has been prevented."] }]];
             } else {
                 [self.delegate basicDriverDidFindUpdateWithAppcastItem:updateItem preventsAutoupdate:preventsAutoupdate];
             }

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -189,7 +189,7 @@
     
     NSData *archivedData = SPUArchiveRootObjectSecurely(installationData);
     if (archivedData == nil) {
-        [self.delegate installerIsRequestingAbortInstallWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey:SULocalizedString(@"An error occurred while encoding the installer parameters. Please try again later.", nil) }]];
+        [self.delegate installerIsRequestingAbortInstallWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey:@"An error occurred while encoding the installer parameters. Please try again later." }]];
         return;
     }
     

--- a/Sparkle/ca.lproj/Sparkle.strings
+++ b/Sparkle/ca.lproj/Sparkle.strings
@@ -42,6 +42,8 @@
 
 "Install and Relaunch" = "Instal·la i reinicia";
 
+"Install on Quit" = "Reinicia el programa més tard";
+
 "Installing update..." = "Instal·lant l'actualització…";
 
 "No" = "No";

--- a/Sparkle/cs.lproj/Sparkle.strings
+++ b/Sparkle/cs.lproj/Sparkle.strings
@@ -62,6 +62,8 @@
 
 "Install and Relaunch" = "Instalovat a znovu spustit";
 
+"Install on Quit" = "Instalovat a ukončit";
+
 /* Take care not to overflow the status window. */
 "Installing update..." = "Instaluje se aktualizace…";
 

--- a/Sparkle/he.lproj/Sparkle.strings
+++ b/Sparkle/he.lproj/Sparkle.strings
@@ -40,6 +40,8 @@
 
 "Install and Relaunch" = "התקן ואתחל";
 
+"Install on Quit" = "אתחל מאוחר יותר";
+
 "Installing update..." = "מתקין עידכון…";
 
 "No" = "לא";


### PR DESCRIPTION
Update missing localizations. Install on Quit ones I took from automatic update alert ones in 1.x.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)
