### PR TITLE
Add missing Japanese localization strings

### DIFF
--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -14,6 +14,17 @@
 
 "%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@は現在入手できる最新バージョンです。\n（現在使用中のバージョンは%3$@です。）";
 
+/* An appcast feed error when checking for updates and no appcast items are retrieved */
+"No valid update information could be loaded." = "有効なアップデート情報が取得できませんでした。";
+
+"An error occurred while running the updater. Please try again later." = "アップデータを実行中にエラーが発生しました。あとでやり直してください。";
+
+"An error occurred while starting the installer. Please try again later." = "インストーラを始動中にエラーが発生しました。あとでやり直してください。";
+
+"An error occurred while connecting to the installer. Please try again later." = "インストーラに接続中にエラーが発生しました。あとでやり直してください。";
+
+"An error occurred while launching the installer. Please try again later." = "インストーラを起動中にエラーが発生しました。あとでやり直してください。";
+
 "Update Installed" = "アップデートがインストールされました";
 
 "%@ is now updated to version %@!" = "%@はバージョン%@にアップデートされました!";
@@ -25,6 +36,9 @@
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
 "%@ %@ is now available--you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@が入手できます（使用中のバージョンは%3$@です）。このアップデートの詳しい情報をWebで確認しますか?";
+
+/* Critical downloadable update */
+"%@ %@ is now available--you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@が入手できます（使用中のバージョンは%3$@です）。これは重要なアップデートです。今すぐダウンロードしますか?";
 
 "%@ downloaded" = "%@ダウンロード済み";
 
@@ -43,6 +57,10 @@
 "An error occurred while installing the update. Please try again later." = "アップデートをインストール中にエラーが発生しました。あとでやり直してください。";
 
 "An error occurred while parsing the update feed." = "アップデートフィードを解析中にエラーが発生しました。";
+
+"An error occurred while downloading the update feed." = "アップデートフィードをダウンロード中にエラーが発生しました。";
+
+"Failed to resume installing update." = "アップデートのインストール再開に失敗しました。";
 
 "An error occurred while relaunching %1$@, but the new version will be available next time you run %1$@." = "%1$@を再起動中にエラーが発生しましたが、次回%1$@の実行時に新しいバージョンが利用できます。";
 
@@ -67,6 +85,8 @@
 "GB" = "GB";
 
 "Install and Relaunch" = "インストールして再起動";
+
+"Install on Quit" = "終了時にインストール";
 
 /* Take care not to overflow the status window. */
 "Installing update..." = "アップデートをインストールしています…";


### PR DESCRIPTION
Another localization for the strings that were added in #1833.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 11.2.3 (20D91)
