### PR TITLE
Clean up downloads better

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -242,6 +242,17 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     }
 }
 
+- (void)clearUpdateDirectory
+{
+    if (self.updateDirectoryPath != nil) {
+        NSError *theError = nil;
+        if (![[[SUFileManager alloc] init] removeItemAtURL:[NSURL fileURLWithPath:self.updateDirectoryPath] error:&theError]) {
+            SULog(SULogLevelError, @"Couldn't remove update folder: %@.", theError);
+        }
+        self.updateDirectoryPath = nil;
+    }
+}
+
 - (void)unarchiverDidFailWithError:(NSError *)error
 {
     SULog(SULogLevelError, @"Failed to unarchive file");
@@ -254,7 +265,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     // Eg: one common case is if a delta update fails, client may want to fall back to regular update
     // We really only need to set updateDirectoryPath to nil since that's the field we check if we've received installation data,
     // but may as well set other fields to nil too
-    self.updateDirectoryPath = nil;
+    [self clearUpdateDirectory];
     self.downloadName = nil;
     self.decryptionPassword = nil;
     self.signatures = nil;
@@ -607,12 +618,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     [self.agentConnection invalidate];
     self.agentConnection = nil;
     
-    if (self.updateDirectoryPath != nil) {
-        NSError *theError = nil;
-        if (![[[SUFileManager alloc] init] removeItemAtURL:[NSURL fileURLWithPath:self.updateDirectoryPath] error:&theError]) {
-            SULog(SULogLevelError, @"Couldn't remove update folder: %@.", theError);
-        }
-    }
+    [self clearUpdateDirectory];
     
     exit(status);
 }

--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -118,6 +118,10 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 
 - (void)removeDownloadDirectory:(NSString *)directoryName bundleIdentifier:(NSString *)bundleIdentifier
 {
+    // Only take the directory name and compute most of the base path ourselves
+    // This way we do not have to send/trust an absolute path
+    // The downloader instance that creates this temp directory isn't necessarily the same as the one
+    // that clears it (eg upon skipping an already downloaded update), so we can't just preserve it here too
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *rootPersistentDownloadCachePath = [self rootPersistentDownloadCachePathForBundleIdentifier:bundleIdentifier];
         if (rootPersistentDownloadCachePath != nil) {

--- a/Downloader/SPUDownloaderProtocol.h
+++ b/Downloader/SPUDownloaderProtocol.h
@@ -19,8 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startTemporaryDownloadWithRequest:(SPUURLRequest *)request;
 
-// Cancels any ongoing download
-- (void)cancelDownload;
+- (void)removeDownloadDirectory:(NSString *)directoryName bundleIdentifier:(NSString *)bundleIdentifier;
+
+- (void)cleanup:(void (^)(void))completionHandler;
 
 @end
 

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -272,6 +272,7 @@
         } else {
             // If the installer started properly, we can't use the downloaded update archive anymore
             // Especially if the installer fails later and we try resuming the update with a missing archive file
+            // We must clear the download after the installer begins using it however (in -installerDidStartInstalling)
             self.downloadedUpdateForRemoval = downloadedUpdate;
             self.resumableUpdate = nil;
             

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -33,6 +33,7 @@
 @property (nonatomic, weak, readonly) id<SPUCoreBasedUpdateDriverDelegate> delegate;
 @property (nonatomic) SUAppcastItem *updateItem;
 @property (nonatomic) id<SPUResumableUpdate> resumableUpdate;
+@property (nonatomic) SPUDownloadedUpdate *downloadedUpdateForRemoval;
 
 @property (nonatomic, readonly) SUHost *host;
 @property (nonatomic) BOOL resumingInstallingUpdate;
@@ -61,6 +62,7 @@
 @synthesize userAgent = _userAgent;
 @synthesize httpHeaders = _httpHeaders;
 @synthesize resumableUpdate = _resumableUpdate;
+@synthesize downloadedUpdateForRemoval = _downloadedUpdateForRemoval;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle sparkleBundle:(NSBundle *)sparkleBundle updater:(id)updater updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate delegate:(id<SPUCoreBasedUpdateDriverDelegate>)delegate
 {
@@ -233,6 +235,19 @@
 
 - (void)clearDownloadedUpdate
 {
+    id<NSObject> downloadedUpdateObject = (self.resumableUpdate != nil) ? self.resumableUpdate : self.downloadedUpdateForRemoval;
+    assert(downloadedUpdateObject != nil);
+    
+    if (downloadedUpdateObject != nil && [downloadedUpdateObject isKindOfClass:[SPUDownloadedUpdate class]]) {
+        if (self.downloadDriver == nil) {
+            self.downloadDriver = [[SPUDownloadDriver alloc] initWithHost:self.host];
+        }
+        
+        SPUDownloadedUpdate *downloadedUpdate = (SPUDownloadedUpdate *)downloadedUpdateObject;
+        [self.downloadDriver removeDownloadedUpdate:downloadedUpdate];
+    }
+    
+    // Clear any type of resumable update
     self.resumableUpdate = nil;
 }
 
@@ -249,11 +264,16 @@
     
     [self.installerDriver extractDownloadedUpdate:downloadedUpdate silently:self.silentInstall preventsInstallerInteraction:self.preventsInstallerInteraction completion:^(NSError * _Nullable error) {
         if (error != nil) {
+            if (error.code != SUInstallationAuthorizeLaterError) {
+                [self clearDownloadedUpdate];
+            }
+            
             [self.delegate coreDriverIsRequestingAbortUpdateWithError:error];
         } else {
             // If the installer started properly, we can't use the downloaded update archive anymore
             // Especially if the installer fails later and we try resuming the update with a missing archive file
-            [self clearDownloadedUpdate];
+            self.downloadedUpdateForRemoval = downloadedUpdate;
+            self.resumableUpdate = nil;
             
             if ([self.updaterDelegate respondsToSelector:@selector(updater:didExtractUpdate:)]) {
                 [self.updaterDelegate updater:self.updater didExtractUpdate:self.updateItem];
@@ -283,6 +303,12 @@
     if ([self.delegate respondsToSelector:@selector(installerDidStartInstalling)]) {
         [self.delegate installerDidStartInstalling];
     }
+}
+
+- (void)installerDidStartExtracting
+{
+    // The installer has moved the archive and no longer needs the download directory
+    [self clearDownloadedUpdate];
 }
 
 - (void)installerDidExtractUpdateWithProgress:(double)progress
@@ -369,11 +395,20 @@
 - (void)abortUpdateAndShowNextUpdateImmediately:(BOOL)shouldShowUpdateImmediately error:(nullable NSError *)error
 {
     [self.installerDriver abortInstall];
-    [self.downloadDriver cleanup];
     
-    id<SPUResumableUpdate> resumableUpdate = (error == nil || error.code == SUInstallationAuthorizeLaterError) ? self.resumableUpdate : nil;
+    void (^basicDriverAbort)(void) = ^{
+        id<SPUResumableUpdate> resumableUpdate = (error == nil || error.code == SUInstallationAuthorizeLaterError) ? self.resumableUpdate : nil;
+        
+        [self.basicDriver abortUpdateAndShowNextUpdateImmediately:shouldShowUpdateImmediately resumableUpdate:resumableUpdate error:error];
+    };
     
-    [self.basicDriver abortUpdateAndShowNextUpdateImmediately:shouldShowUpdateImmediately resumableUpdate:resumableUpdate error:error];
+    if (self.downloadDriver != nil) {
+        [self.downloadDriver cleanup:^{
+            basicDriverAbort();
+        }];
+    } else {
+        basicDriverAbort();
+    }
 }
 
 @end

--- a/Sparkle/SPUDownloadDriver.h
+++ b/Sparkle/SPUDownloadDriver.h
@@ -30,12 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUpdateItem:(SUAppcastItem *)updateItem host:(SUHost *)host userAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background delegate:(id<SPUDownloadDriverDelegate>)delegate;
 
+- (instancetype)initWithHost:(SUHost *)host;
+
 - (void)downloadUpdate;
+
+- (void)removeDownloadedUpdate:(SPUDownloadedUpdate *)downloadedUpdate;
 
 @property (nonatomic, readonly) NSMutableURLRequest *request;
 @property (nonatomic, readonly) BOOL inBackground;
 
-- (void)cleanup;
+- (void)cleanup:(void (^)(void))completionHandler;
 
 @end
 

--- a/Sparkle/SPUInstallerDriver.h
+++ b/Sparkle/SPUInstallerDriver.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol SPUInstallerDriverDelegate <NSObject>
 
 - (void)installerDidStartInstalling;
+- (void)installerDidStartExtracting;
 - (void)installerDidExtractUpdateWithProgress:(double)progress;
 - (void)installerDidFinishPreparationAndWillInstallImmediately:(BOOL)willInstallImmediately silently:(BOOL)willInstallSilently;
 - (void)installerIsSendingAppTerminationSignal;

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -229,6 +229,7 @@
     if (identifier == SPUExtractionStarted) {
         self.extractionAttempts++;
         self.currentStage = identifier;
+        [self.delegate installerDidStartExtracting];
     } else if (identifier == SPUExtractedArchiveWithProgress) {
         if (data.length == sizeof(double) && sizeof(double) == sizeof(uint64_t)) {
             uint64_t progressValue = CFSwapInt64LittleToHost(*(const uint64_t *)data.bytes);

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -157,7 +157,11 @@
                             [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
                         }
                         
-                        [self.coreDriver clearDownloadedUpdate];
+                        // Informational updates can be resumed too, so make sure we check
+                        // self.resumingDownloadedUpdate instead of the state we pass to user driver
+                        if (self.resumingDownloadedUpdate) {
+                            [self.coreDriver clearDownloadedUpdate];
+                        }
                         
                         [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
                         

--- a/Sparkle/SPUURLDownload.m
+++ b/Sparkle/SPUURLDownload.m
@@ -51,14 +51,20 @@
 
 - (void)downloaderDidFinishWithTemporaryDownloadData:(SPUDownloadData * _Nullable)downloadData
 {
-    self.completionBlock(downloadData, nil);
-    self.completionBlock = nil;
+    assert(self.completionBlock != nil);
+    if (self.completionBlock != nil) {
+        self.completionBlock(downloadData, nil);
+        self.completionBlock = nil;
+    }
 }
 
 - (void)downloaderDidFailWithError:(NSError *)error
 {
-    self.completionBlock(nil, error);
-    self.completionBlock = nil;
+    assert(self.completionBlock != nil);
+    if (self.completionBlock != nil) {
+        self.completionBlock(nil, error);
+        self.completionBlock = nil;
+    }
 }
 
 @end


### PR DESCRIPTION
Clean up downloads more immediately when they aren't needed.

* Clear download if extraction fails (esp if delta update fails to apply)
* Clean up download in framework if already downloaded (but not installer-started) update to be resumed is skipped
* Fix download cancellation when using downloaded XPC Service + clean up download driver only at end of scheduler cycle
* Remove empty temporary directory that was containing agent / progress tool on clean up

We already have some fallback code that cleans up old temp cache directories when starting new downloads / installs, but we can do better job to make sure directories are cleaned up more promptly.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)
macOS version tested: 11.2.3 (20D91)

Tested download is cleared upon skipping download resumed update, download is cleaned on extraction failure, regular installation with test app, cancellation of downloading update, downloader XPC Service with these cases.