### PR TITLE
Remove localizing authorization prompt

### DIFF
--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -448,11 +448,13 @@
     // Changing this authorization prompt is a little complicated because the
     // Auth database retains and caches the right we use, and there isn't a good way
     // of updating the prompt. See code in SUInstallerLauncher.m
+    // For this reason, we don't provide localized strings for this prompt yet
+    // (and I believe, the authorization framework has a different way of specifying localizations..)
     NSString *authorizationPrompt;
     if ([mainBundleName isEqualToString:hostName]) {
-        authorizationPrompt = [NSString stringWithFormat:SULocalizedString(@"%1$@ wants permission to update.", nil), hostName];
+        authorizationPrompt = [NSString stringWithFormat:@"%1$@ wants permission to update.", hostName];
     } else {
-        authorizationPrompt = [NSString stringWithFormat:SULocalizedString(@"%1$@ wants permission to update %2$@.", nil), mainBundleName, hostName];
+        authorizationPrompt = [NSString stringWithFormat:@"%1$@ wants permission to update %2$@.", mainBundleName, hostName];
     }
     
     NSString *mainBundleIdentifier;


### PR DESCRIPTION
Remove localizing authorization prompt.

The message string gets cached and I don't think this is the proper way to localize the auth dialog (which I think has some other mechanism). So I am removing localization here for now until this can possibly be done properly.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested auth prompt in test app.

macOS version tested: 11.2.3 (20D91)
