### PR TITLE
Test App: Allow check for updates menu item to be invoked outside of settings

### DIFF
--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -12,16 +12,20 @@
 #import "SUTestWebServer.h"
 #import "TestAppHelperProtocol.h"
 #import "ed25519.h" // Run `git submodule update --init` if you get an error here
+#import <Sparkle/Sparkle.h>
+#import "SUPopUpTitlebarUserDriver.h"
 
 @interface SUTestApplicationDelegate ()
 
-@property (nonatomic) NSWindowController *updateSettingsWindowController;
+@property (nonatomic) SPUUpdater *updater;
+@property (nonatomic) SUUpdateSettingsWindowController *updateSettingsWindowController;
 @property (nonatomic) SUTestWebServer *webServer;
 
 @end
 
 @implementation SUTestApplicationDelegate
 
+@synthesize updater = _updater;
 @synthesize updateSettingsWindowController = _updateSettingsWindowController;
 @synthesize webServer = _webServer;
 
@@ -194,10 +198,40 @@ static NSString * const UPDATED_VERSION = @"2.0";
             }
             self.webServer = webServer;
             
-            // Show the Settings window
-            self.updateSettingsWindowController = [[SUUpdateSettingsWindowController alloc] initWithCustomUserDriver:shiftKeyHeldDown];
-            
-            [self.updateSettingsWindowController showWindow:nil];
+            // Set up updater and the updater settings window
+            {
+                self.updateSettingsWindowController = [[SUUpdateSettingsWindowController alloc] init];
+                
+                NSWindow *settingsWindow = self.updateSettingsWindowController.window;
+                
+                NSBundle *hostBundle = [NSBundle mainBundle];
+                NSBundle *applicationBundle = hostBundle;
+                
+                id<SPUUserDriver> userDriver;
+                if (shiftKeyHeldDown) {
+                    userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:settingsWindow];
+                } else {
+                    userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:nil];
+                }
+                
+                SPUUpdater *updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:applicationBundle userDriver:userDriver delegate:nil];
+                
+                self.updater = updater;
+                self.updateSettingsWindowController.updater = updater;
+                
+                NSError *updaterError = nil;
+                if (![updater startUpdater:&updaterError]) {
+                    NSLog(@"Failed to start updater with error: %@", updaterError);
+                    
+                    NSAlert *alert = [[NSAlert alloc] init];
+                    alert.messageText = @"Updater Error";
+                    alert.informativeText = @"The Updater failed to start. For detailed error information, check the Console.app log.";
+                    [alert addButtonWithTitle:@"OK"];
+                    [alert runModal];
+                }
+                
+                [self.updateSettingsWindowController showWindow:nil];
+            }
         });
     }];
 }
@@ -220,6 +254,19 @@ static NSString * const UPDATED_VERSION = @"2.0";
 - (void)applicationWillTerminate:(NSNotification * __unused)notification
 {
     [self.webServer close];
+}
+
+- (IBAction)checkForUpdates:(id __unused)sender
+{
+    [self.updater checkForUpdates];
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+    if (menuItem.action == @selector(checkForUpdates:)) {
+        return self.updater.canCheckForUpdates;
+    }
+    return YES;
 }
 
 @end

--- a/TestApplication/SUUpdateSettingsWindowController.h
+++ b/TestApplication/SUUpdateSettingsWindowController.h
@@ -8,8 +8,10 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class SPUUpdater;
+
 @interface SUUpdateSettingsWindowController : NSWindowController
 
-- (instancetype)initWithCustomUserDriver:(BOOL)customUserDriver;
+@property (nonatomic) SPUUpdater *updater;
 
 @end

--- a/TestApplication/SUUpdateSettingsWindowController.m
+++ b/TestApplication/SUUpdateSettingsWindowController.m
@@ -8,74 +8,15 @@
 
 #import "SUUpdateSettingsWindowController.h"
 #import <Sparkle/Sparkle.h>
-#import "SUPopUpTitlebarUserDriver.h"
 
-@interface SUUpdateSettingsWindowController ()
-
-@property (nonatomic) SPUUpdater *updater;
-@property (nonatomic, readonly) BOOL customUserDriver;
-@property (nonatomic) SPUStandardUserDriver *userDriver;
-
-@end
-
+// This class binds to various updater properties in the nib
 @implementation SUUpdateSettingsWindowController
 
 @synthesize updater = _updater;
-@synthesize customUserDriver = _customUserDriver;
-@synthesize userDriver = _userDriver;
-
-- (instancetype)initWithCustomUserDriver:(BOOL)customUserDriver
-{
-    self = [super init];
-    if (self != nil) {
-        _customUserDriver = customUserDriver;
-    }
-    return self;
-}
 
 - (NSString *)windowNibName
 {
     return NSStringFromClass([self class]);
-}
-
-- (void)windowDidLoad
-{
-    NSBundle *hostBundle = [NSBundle mainBundle];
-    NSBundle *applicationBundle = hostBundle;
-    
-    id<SPUUserDriver> userDriver;
-    if (self.customUserDriver) {
-        userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:self.window];
-    } else {
-        userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:nil];
-    }
-    
-    self.userDriver = userDriver;
-    self.updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:applicationBundle userDriver:userDriver delegate:nil];
-    
-    NSError *updaterError = nil;
-    if (![self.updater startUpdater:&updaterError]) {
-        NSLog(@"Failed to start updater with error: %@", updaterError);
-        
-        NSAlert *alert = [[NSAlert alloc] init];
-        alert.messageText = @"Updater Error";
-        alert.informativeText = @"The Updater failed to start. For detailed error information, check the Console.app log.";
-        [alert addButtonWithTitle:@"OK"];
-        [alert runModal];
-    }
-}
-
-- (IBAction)checkForUpdates:(id __unused)sender
-{
-    [self.updater checkForUpdates];
-}
-
-- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
-{
-    if (menuItem.action == @selector(checkForUpdates:)) {
-        return self.updater.canCheckForUpdates;
-    }
-    return YES;
 }
 
 @end


### PR DESCRIPTION
Allow check for updates menu item to be invoked outside of settings

Previously check for updates was only in responder chain of the settings window controller. Now it's in responder chain of the entire application (eg, from the about window, or from update alert window).

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app works and check for updates works in settings window and from about window and update alert window. Tested that updater settings bindings are still synchronized.

macOS version tested: 11.2.3 (20D91)
