### PR TITLE
Add NS_UNAVAILABLE attributes to user driver classes

### DIFF
--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -34,6 +34,11 @@ SU_EXPORT @interface SPUStandardUserDriver : NSObject <SPUUserDriver>
  */
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle delegate:(nullable id<SPUStandardUserDriverDelegate>)delegate;
 
+/*!
+ Use initWithHostBundle:delegate: instead.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -29,6 +29,11 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
  */
 - (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks sendSystemProfile:(BOOL)sendSystemProfile;
 
+/*
+ Use -initWithAutomaticUpdateChecks:sendSystemProfile: instead.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 /*!
  A read-only property indicating whether automatic update checks are allowed or not.
  */


### PR DESCRIPTION
Add NS_UNAVAILABLE attributes to user driver classes I previously missed so developers won't accidentally use -init assuming it does something meaningful by default.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [ ] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested [[SPUStandardUserDriver alloc] init] fails with compiler error.

macOS version tested: 11.3 (20E232)
