### PR TITLE
Port #1504 (dash separators in version strings) to 2.x

### DIFF
--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -153,6 +153,7 @@
 {
     SUAppcastItem *item = nil;
     for(SUAppcastItem *candidate in appcastItems) {
+        // Note if two items are equal, we must select the first matching one
         if (!item || [comparator compareVersion:item.versionString toVersion:candidate.versionString] == NSOrderedAscending) {
             item = candidate;
         }

--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -33,12 +33,15 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     kNumberType,
     kStringType,
     kSeparatorType,
+    kDashType,
 };
 
 - (SUCharacterType)typeOfCharacter:(NSString *)character
 {
     if ([character isEqualToString:@"."]) {
         return kSeparatorType;
+    } else if ([character isEqualToString:@"-"]) {
+        return kDashType;
     } else if ([[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
         return kNumberType;
     } else if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
@@ -67,6 +70,9 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     for (i = 1; i <= n; ++i) {
         character = [version substringWithRange:NSMakeRange(i, 1)];
         newType = [self typeOfCharacter:character];
+        if (newType == kDashType) {
+            break;
+        }
         if (oldType != newType || oldType == kSeparatorType) {
             // We've reached a new segment
             NSString *aPart = [[NSString alloc] initWithString:s];

--- a/Tests/SUVersionComparisonTest.m
+++ b/Tests/SUVersionComparisonTest.m
@@ -33,6 +33,15 @@
     SUAssertAscending(comparator, @"0.1", @"0.1.2");
 }
 
+- (void)testCommitSHAs
+{
+    SUStandardVersionComparator *comparator = [[SUStandardVersionComparator alloc] init];
+    
+    SUAssertAscending(comparator, @"1.5.5-335d3e2", @"1.5.6-b252311");
+    SUAssertEqual(comparator, @"1.5.5-335d3e2", @"1.5.5-a655360");
+    SUAssertDescending(comparator, @"1.5.6-b252311", @"1.5.5-335d3e2");
+}
+
 - (void)testPrereleases
 {
     SUStandardVersionComparator *comparator = [[SUStandardVersionComparator alloc] init];


### PR DESCRIPTION
On second thought I realized we can support this without doing any date comparison because the code just picks the first item if two are equal.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested when two items are equal in test app feed, first one is picked.
Ran unit tests.

macOS version tested: 11.3 (20E232)
