### PR TITLE
Enforce the updater session is in progress

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -423,6 +423,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (self.sessionInProgress) {
         SULog(SULogLevelError, @"Error: -checkForUpdatesInBackground called but .sessionInProgress == YES");
+        return;
     }
     
     self.sessionInProgress = YES;
@@ -488,6 +489,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (self.sessionInProgress) {
         SULog(SULogLevelError, @"Error: -checkForUpdates called but .sessionInProgress == YES");
+        return;
     }
     
     if (self.driver != nil) {
@@ -529,6 +531,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (self.sessionInProgress) {
         SULog(SULogLevelError, @"Error: -checkForUpdateInformation called but .sessionInProgress == YES");
+        return;
     }
     
     self.sessionInProgress = YES;


### PR DESCRIPTION
We should enforce update session is in progress before checking for new updates.

An update check could have been made while the permission request was in flight, which we don't want to happen.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

I've tested checking for updates regularly, in background, informational updates, and resuming already downloaded/installed updates and making sure dismissing update session and starting new one works properly.

macOS version tested: 11.3 (20E232)
