### PR TITLE
Log more sandbox errors

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -427,6 +427,7 @@ static BOOL SPUNeedsSystemAuthorizationAccess(NSString *path, NSString *installa
             }
         } else if (installerStatus == SUInstallerLauncherFailure) {
             SULog(SULogLevelError, @"Failed to submit installer job");
+            SULog(SULogLevelError, @"If your application is sandboxed please follow steps at: https://sparkle-project.org/documentation/sandboxing/");
         }
         
         if (installerStatus == SUInstallerLauncherCanceled) {

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
@@ -37,9 +37,11 @@
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -123,7 +123,7 @@
                 
                 NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{
                     NSLocalizedDescriptionKey: SULocalizedString(@"An error occurred while running the updater. Please try again later.", nil),
-                    NSLocalizedFailureReasonErrorKey:@"The remote port connection was invalidated from the updater. For additional details, please check Console logs for "@SPARKLE_RELAUNCH_TOOL_NAME
+                    NSLocalizedFailureReasonErrorKey:@"The remote port connection was invalidated from the updater. For additional details, please check Console logs for "@SPARKLE_RELAUNCH_TOOL_NAME". If your application is sandboxed, please also ensure Installer Connection & Status entitlements are correctly set up: https://sparkle-project.org/documentation/sandboxing/"
                 }];
                 
                 NSError *installerError = strongSelf.installerError;


### PR DESCRIPTION
Log more sandbox errors with incorrect development configurations.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested accidentally sandboxing launcher service, tested not applying installer connection entitlement, tested sandboxing app without any XPC Services. Logs emitted in all cases.

macOS version tested: 11.3 (20E232)
