### PR TITLE
Allow skipping/canceling of an update that is currently installing

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -437,6 +437,10 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                 });
             }
         });
+    } else if (identifier == SPUCancelInstallation) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self cleanupAndExitWithStatus:0 error:nil];
+        });
     } else if (identifier == SPUUpdaterAlivePong) {
         self.receivedUpdaterPong = YES;
     }

--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -31,7 +31,8 @@ typedef NS_ENUM(int32_t, SPUUpdaterMessageType)
     SPUInstallationData = 0,
     SPUSentUpdateAppcastItemData = 1,
     SPUResumeInstallationToStage2 = 2,
-    SPUUpdaterAlivePong = 3
+    SPUUpdaterAlivePong = 3,
+    SPUCancelInstallation = 4
 };
 
 BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUInstallerMessageType newMessageType);

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -331,8 +331,10 @@
 {
     switch (response) {
         case SPUUserUpdateChoiceDismiss:
-        case SPUUserUpdateChoiceSkip:
             [self.delegate coreDriverIsRequestingAbortUpdateWithError:nil];
+            break;
+        case SPUUserUpdateChoiceSkip:
+            [self.installerDriver cancelUpdate];
             break;
         case SPUUserUpdateChoiceInstall:
             [self.installerDriver installWithToolAndRelaunch:YES displayingUserInterface:displayingUserInterface];

--- a/Sparkle/SPUInstallerDriver.h
+++ b/Sparkle/SPUInstallerDriver.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)installWithToolAndRelaunch:(BOOL)relaunch displayingUserInterface:(BOOL)showUI;
 
+- (void)cancelUpdate;
+
 - (void)abortInstall;
 
 @end

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -141,8 +141,6 @@
     assert(installationType != nil);
     
     [self.installerConnection setServiceName:serviceName systemDomain:self.systemDomain];
-    
-    [self sendInstallationData];
 }
 
 // This can be called multiple times (eg: if a delta update fails, this may be called again with a regular update item)
@@ -482,6 +480,7 @@
                 case SUInstallerLauncherSuccess:
                     self.systemDomain = systemDomain;
                     [self setUpConnection];
+                    [self sendInstallationData];
                     completionHandler(nil);
                     break;
             }
@@ -532,6 +531,18 @@
     [self.installerConnection handleMessageWithIdentifier:SPUResumeInstallationToStage2 data:responseData];
     
     // the installer will send us SPUInstallationFinishedStage2 when stage 2 is done
+}
+
+- (void)cancelUpdate
+{
+    // Set up connection to the installer if one is not set up already
+    [self setUpConnection];
+    
+    self.aborted = YES;
+    
+    [self.installerConnection handleMessageWithIdentifier:SPUCancelInstallation data:[NSData data]];
+    
+    [self.delegate installerIsRequestingAbortInstallWithError:nil];
 }
 
 - (void)abortInstall

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -125,14 +125,14 @@
                 
                 // Rule out invalid choices
                 SPUUserUpdateChoice validatedChoice;
-                if ((state == SPUUserUpdateStateInstalling && userChoice == SPUUserUpdateChoiceSkip) || (state == SPUUserUpdateStateInformational && userChoice == SPUUserUpdateChoiceInstall)) {
+                if (state == SPUUserUpdateStateInformational && userChoice == SPUUserUpdateChoiceInstall) {
                     validatedChoice = SPUUserUpdateChoiceDismiss;
                 } else {
                     validatedChoice = userChoice;
                 }
                 
                 switch (validatedChoice) {
-                    case SPUUserUpdateChoiceInstall:
+                    case SPUUserUpdateChoiceInstall: {
                         [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
                         
                         switch (state) {
@@ -150,29 +150,26 @@
                                 break;
                         }
                         break;
-                    case SPUUserUpdateChoiceSkip:
+                    }
+                    case SPUUserUpdateChoiceSkip: {
                         [self.host setObject:[updateItem versionString] forUserDefaultsKey:SUSkippedVersionKey];
                         
                         if ([self.updaterDelegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
                             [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
                         }
                         
-                        // Informational updates can be resumed too, so make sure we check
-                        // self.resumingDownloadedUpdate instead of the state we pass to user driver
-                        if (self.resumingDownloadedUpdate) {
-                            [self.coreDriver clearDownloadedUpdate];
-                        }
-                        
-                        [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
-                        
-                        break;
-                    case SPUUserUpdateChoiceDismiss:
                         switch (state) {
                             case SPUUserUpdateStateDownloaded:
                             case SPUUserUpdateStateNotDownloaded:
                             case SPUUserUpdateStateInformational:
-                                [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
+                                // Informational updates can be resumed too, so make sure we check
+                                // self.resumingDownloadedUpdate instead of the state we pass to user driver
+                                if (self.resumingDownloadedUpdate) {
+                                    [self.coreDriver clearDownloadedUpdate];
+                                }
+                                
                                 [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
+                                
                                 break;
                             case SPUUserUpdateStateInstalling:
                                 [self.coreDriver finishInstallationWithResponse:validatedChoice displayingUserInterface:!self.preventsInstallerInteraction];
@@ -180,6 +177,25 @@
                         }
                         
                         break;
+                    }
+                    case SPUUserUpdateChoiceDismiss: {
+                        [self.host setObject:nil forUserDefaultsKey:SUSkippedVersionKey];
+                        
+                        switch (state) {
+                            case SPUUserUpdateStateDownloaded:
+                            case SPUUserUpdateStateNotDownloaded:
+                            case SPUUserUpdateStateInformational: {
+                                [self.delegate uiDriverIsRequestingAbortUpdateWithError:nil];
+                                break;
+                            }
+                            case SPUUserUpdateStateInstalling: {
+                                [self.coreDriver finishInstallationWithResponse:validatedChoice displayingUserInterface:!self.preventsInstallerInteraction];
+                                break;
+                            }
+                        }
+                        
+                        break;
+                    }
                 }
             });
         }];

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -79,7 +79,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * If the state is SPUUserUpdateStateInstalling, the installing update is also preserved after dismissing. In this state however, the update will also still be installed after the application is terminated.
  *
  * A reply of SPUUserUpdateChoiceSkip skips this particular version and won't notify the user again, unless they initiate an update check themselves.
- * If the state is SPUUserUpdateStateInstalling, the update cannot be skipped, only dismissed or installed.
+ * If the state is SPUUserUpdateStateInstalling, the installation is also canceled when the update is skipped.
  */
 - (void)showUpdateFoundWithAppcastItem:(SUAppcastItem *)appcastItem userInitiated:(BOOL)userInitiated state:(SPUUserUpdateState)state reply:(void (^)(SPUUserUpdateChoice))reply;
 
@@ -194,10 +194,9 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param reply
  * A reply of SPUUserUpdateChoiceInstall installs the update the new update immediately. The application is relaunched only if it is still running by the time this reply is invoked. If the application terminates on its own, Sparkle will attempt to automatically install the update.
  *
- * A reply of SPUUserUpdateChoiceDismiss dismisses the update installation for the time being. Note the update may still be installed automatically after
- * the application terminates.
+ * A reply of SPUUserUpdateChoiceDismiss dismisses the update installation for the time being. Note the update may still be installed automatically after the application terminates.
  *
- * A reply of SPUUserUpdateChoiceSkip acts the same as dismissing. This update which has started installing cannot be skipped.
+ * A reply of SPUUserUpdateChoiceSkip cancels the current update that has begun installing and dismisses the update. In this circumstance, the update is canceled but this update version is not skipped in the future.
  *
  * Before this point, -showInstallingUpdate will be called.
  */

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -357,9 +357,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     }
     
     if (self.state == SPUUserUpdateStateInstalling) {
-        // An already downloaded & resumable update can't be skipped
-        self.skipButton.hidden = YES;
-        
         // We're going to be relaunching pretty instantaneously
         self.installButton.title = SULocalizedString(@"Install and Relaunch", nil);
         


### PR DESCRIPTION
Allow skipping/canceling of an update that is currently installing.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested that skipping/canceling an update or installing update works in all states (not downloaded update, downloaded update, downloaded & installing update where Autoupdate is running).

macOS version tested: 11.3 (20E232)
