### PR TITLE
Better appcast selection

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		725264A91D5FBD9100CD6400 /* Sparkle.strings in Resources */ = {isa = PBXBuildFile; fileRef = 61AAE8220A321A7F00D8810D /* Sparkle.strings */; };
 		725602D51C83551C00DAA70E /* SUApplicationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 725602D31C83551C00DAA70E /* SUApplicationInfo.h */; };
 		725602D61C83551C00DAA70E /* SUApplicationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 725602D41C83551C00DAA70E /* SUApplicationInfo.m */; };
+		725B3A82263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml in Resources */ = {isa = PBXBuildFile; fileRef = 725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */; };
 		725CB9571C7120410064365A /* SPUUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 725CB9561C7120410064365A /* SPUUserDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		725CB95A1C7121830064365A /* SPUStandardUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 725CB9581C7121830064365A /* SPUStandardUserDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		725CB95B1C7121830064365A /* SPUStandardUserDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 725CB9591C7121830064365A /* SPUStandardUserDriver.m */; };
@@ -1181,6 +1182,7 @@
 		724BB3B51D35AAC3005D534A /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
 		725602D31C83551C00DAA70E /* SUApplicationInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUApplicationInfo.h; sourceTree = "<group>"; };
 		725602D41C83551C00DAA70E /* SUApplicationInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUApplicationInfo.m; sourceTree = "<group>"; };
+		725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast_minimumAutoupdateVersion.xml; sourceTree = "<group>"; };
 		725CB9561C7120410064365A /* SPUUserDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUUserDriver.h; sourceTree = "<group>"; };
 		725CB9581C7121830064365A /* SPUStandardUserDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUStandardUserDriver.h; sourceTree = "<group>"; };
 		725CB9591C7121830064365A /* SPUStandardUserDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUStandardUserDriver.m; sourceTree = "<group>"; };
@@ -1763,6 +1765,7 @@
 				14958C6C19AEBC610061B14F /* test-pubkey.pem */,
 				5AF6C74E1AEA46D10014A3AB /* test.pkg */,
 				5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */,
+				725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */,
 				5F1510A11C96E591006E1629 /* testnamespaces.xml */,
 				FA30773C24CBC295007BA37D /* testlocalizedreleasenotesappcast.xml */,
 				5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */,
@@ -3046,6 +3049,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				725B3A82263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml in Resources */,
 				14958C6E19AEBC950061B14F /* signed-test-file.txt in Resources */,
 				72AC6B2E1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg in Resources */,
 				C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */,

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -128,7 +128,7 @@
 
 "Your macOS version is too new" = "Your macOS version is too new";
 
-"Your macOS version is too new" = "%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@.";
+"%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@." = "%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@.";
 
 /* Authorization message shown when app wants permission to update itself. */
 "%1$@ wants permission to update." = "%1$@ wants permission to update.";

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -122,6 +122,14 @@
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You're up-to-date!" = "You’re up to date!";
 
+"Your macOS version is too old" = "Your macOS version is too old";
+
+"%1$@ %2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required." = "%1$@ %2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required.";
+
+"Your macOS version is too new" = "Your macOS version is too new";
+
+"Your macOS version is too new" = "%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@.";
+
 /* Authorization message shown when app wants permission to update itself. */
 "%1$@ wants permission to update." = "%1$@ wants permission to update.";
 

--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -60,7 +60,7 @@
         if (error != nil) {
             [self abortUpdateWithError:error];
         } else {
-            [self.coreDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES includesSkippedUpdates:NO requiresSilentInstall:YES];
+            [self.coreDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES requiresSilentInstall:YES];
         }
     }];
 }

--- a/Sparkle/SPUBasicUpdateDriver.h
+++ b/Sparkle/SPUBasicUpdateDriver.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)prepareCheckForUpdatesWithCompletion:(SPUUpdateDriverCompletion)completionBlock;
 
-- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates;
+- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background;
 
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock;
 

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -206,6 +206,7 @@
         } else {
             // When no updates are found in the appcast, or latest appcast item info
             // was not provided (i.e, for a background update check)
+            // In the case no info was provided ofr a background check, the error isn't shown anywhere
             localizedDescription = SULocalizedString(@"Update Error!", nil);
             recoverySuggestion = SULocalizedString(@"No valid update information could be loaded.", nil);
             recoveryOption = SULocalizedString(@"Cancel Update", nil);

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -65,7 +65,7 @@
     self.completionBlock = completionBlock;
 }
 
-- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates
+- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background
 {
     if ([self.host isRunningOnReadOnlyVolume]) {
         NSString *hostName = self.host.name;
@@ -75,7 +75,7 @@
             [self.delegate basicDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SURunningFromDiskImageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:SULocalizedString(@"%1$@ can't be updated, because it was opened from a read-only or a temporary location.", nil), hostName], NSLocalizedRecoverySuggestionErrorKey: [NSString stringWithFormat:SULocalizedString(@"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again.", nil), hostName] }]];
         }
     } else {
-        [self.appcastDriver loadAppcastFromURL:appcastURL userAgent:userAgent httpHeaders:httpHeaders inBackground:background includesSkippedUpdates:includesSkippedUpdates];
+        [self.appcastDriver loadAppcastFromURL:appcastURL userAgent:userAgent httpHeaders:httpHeaders inBackground:background];
     }
 }
 
@@ -169,7 +169,7 @@
         NSString *recoverySuggestion;
         NSString *recoveryOption;
         
-        if (latestAppcastItem != nil) { // if the appcast was successfully loaded
+        if (latestAppcastItem != nil) {
             switch (hostToLatestAppcastItemComparisonResult) {
                 case NSOrderedDescending:
                     // This means the user is a 'newer than latest' version. give a slight hint to the user instead of wrongly claiming this version is identical to the latest feed version.
@@ -204,7 +204,8 @@
             
             recoveryOption = @"OK";
         } else {
-            // When no updates are found in the appcast
+            // When no updates are found in the appcast, or latest appcast item info
+            // was not provided (i.e, for a background update check)
             localizedDescription = SULocalizedString(@"Update Error!", nil);
             recoverySuggestion = SULocalizedString(@"No valid update information could be loaded.", nil);
             recoveryOption = SULocalizedString(@"Cancel Update", nil);

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -206,7 +206,7 @@
         } else {
             // When no updates are found in the appcast, or latest appcast item info
             // was not provided (i.e, for a background update check)
-            // In the case no info was provided ofr a background check, the error isn't shown anywhere
+            // In the case no info was provided for a background check, the error isn't shown anywhere
             localizedDescription = SULocalizedString(@"Update Error!", nil);
             recoverySuggestion = SULocalizedString(@"No valid update information could be loaded.", nil);
             recoveryOption = SULocalizedString(@"Cancel Update", nil);

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -157,7 +157,7 @@
     [self notifyFoundValidUpdateWithAppcastItem:updateItem secondaryAppcastItem:secondaryAppcastItem preventsAutoupdate:preventsAutoupdate systemDomain:nil];
 }
 
-- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult
+- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult passesMinOSVersion:(BOOL)passesMinOSVersion passesMaxOSVersion:(BOOL)passesMaxOSVersion
 {
     if (!self.aborted) {
         if ([self.updaterDelegate respondsToSelector:@selector((updaterDidNotFindUpdate:))]) {
@@ -170,16 +170,41 @@
         NSString *recoveryOption;
         
         if (latestAppcastItem != nil) { // if the appcast was successfully loaded
-            localizedDescription = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
-            
-            if (hostToLatestAppcastItemComparisonResult == NSOrderedDescending) { // this means the user is a 'newer than latest' version. give a slight hint to the user instead of wrongly claiming this version is identical to the latest feed version.
-                recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.\n(You are currently running version %@.)", nil), [self.host name], latestAppcastItem.displayVersionString, [self.host displayVersion]];
-            } else {
-                recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
+            switch (hostToLatestAppcastItemComparisonResult) {
+                case NSOrderedDescending:
+                    // This means the user is a 'newer than latest' version. give a slight hint to the user instead of wrongly claiming this version is identical to the latest feed version.
+                    localizedDescription = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+                    
+                    recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.\n(You are currently running version %@.)", nil), [self.host name], latestAppcastItem.displayVersionString, [self.host displayVersion]];
+                    break;
+                case NSOrderedSame:
+                    // No new update is available and we're on the latest
+                    localizedDescription = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+                    
+                    recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
+                    break;
+                case NSOrderedAscending:
+                    // This means a new update doesn't match the OS requirements
+                    if (!passesMinOSVersion) {
+                        localizedDescription = SULocalizedString(@"Your macOS version is too old", nil);
+                        
+                        recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required.", nil), [self.host name], latestAppcastItem.versionString, latestAppcastItem.minimumSystemVersion];
+                    } else if (!passesMaxOSVersion) {
+                        localizedDescription = SULocalizedString(@"Your macOS version is too new", nil);
+                        
+                        recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@.", nil), [self.host name], latestAppcastItem.versionString, latestAppcastItem.maximumSystemVersion];
+                    } else {
+                        // We shouldn't realistically get here
+                        localizedDescription = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+                        
+                        recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
+                    }
+                    break;
             }
             
             recoveryOption = @"OK";
         } else {
+            // When no updates are found in the appcast
             localizedDescription = SULocalizedString(@"Update Error!", nil);
             recoverySuggestion = SULocalizedString(@"No valid update information could be loaded.", nil);
             recoveryOption = SULocalizedString(@"Cancel Update", nil);

--- a/Sparkle/SPUCoreBasedUpdateDriver.h
+++ b/Sparkle/SPUCoreBasedUpdateDriver.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)preflightForUpdatePermissionPreventingInstallerInteraction:(BOOL)preventsInstallerInteraction reply:(void (^)(NSError * _Nullable))reply;
 
-- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates requiresSilentInstall:(BOOL)silentInstall;
+- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background requiresSilentInstall:(BOOL)silentInstall;
 
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock;
 

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -114,13 +114,13 @@
     }
 }
 
-- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates requiresSilentInstall:(BOOL)silentInstall
+- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background requiresSilentInstall:(BOOL)silentInstall
 {
     self.userAgent = userAgent;
     self.httpHeaders = httpHeaders;
     self.silentInstall = silentInstall;
     
-    [self.basicDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:background includesSkippedUpdates:includesSkippedUpdates];
+    [self.basicDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:background];
 }
 
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock

--- a/Sparkle/SPUProbingUpdateDriver.m
+++ b/Sparkle/SPUProbingUpdateDriver.m
@@ -39,7 +39,7 @@
     
     [self.basicDriver prepareCheckForUpdatesWithCompletion:completionBlock];
     
-    [self.basicDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES includesSkippedUpdates:NO];
+    [self.basicDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES];
 }
 
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -45,7 +45,7 @@
             // Don't tell the user about the permission error for scheduled update checks
             [self abortUpdateWithError:nil];
         } else {
-            [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES includesSkippedUpdates:NO];
+            [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES];
         }
     }];
 }

--- a/Sparkle/SPUUIBasedUpdateDriver.h
+++ b/Sparkle/SPUUIBasedUpdateDriver.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)preflightForUpdatePermissionPreventingInstallerInteraction:(BOOL)preventsInstallerInteraction reply:(void (^)(NSError * _Nullable))reply;
 
-- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates;
+- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background;
 
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock;
 

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -131,9 +131,9 @@
     [self.coreDriver preflightForUpdatePermissionPreventingInstallerInteraction:preventsInstallerInteraction reply:reply];
 }
 
-- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates
+- (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background
 {
-    [self.coreDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:background includesSkippedUpdates:includesSkippedUpdates requiresSilentInstall:NO];
+    [self.coreDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:background requiresSilentInstall:NO];
 }
 
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)completionBlock

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -167,6 +167,11 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  implement this to use your own logic for finding a valid update, if any,
  in the given appcast.
  
+ Do not base your logic by filtering out items with a minimum or maximum OS or application system version,
+ because Sparkle already has logic for determining whether or not those items should be filtered out.
+ 
+ This method may be called multiple times for different selections and filters. This method should be efficient.
+ 
  \param appcast The appcast that was downloaded from the remote server.
  \param updater The updater instance.
  \return The best valid appcast item, or nil if you don't want to be delegated this task.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -169,6 +169,8 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  Do not base your logic by filtering out items with a minimum or maximum OS or application system version,
  because Sparkle already has logic for determining whether or not those items should be filtered out.
+ Also do not return a non-top level item from the appcast such as a delta item. Delta items will be ignored.
+ Sparkle picks the delta item from your selection if the appropriate one is available.
  
  This method may be called multiple times for different selections and filters. This method should be efficient.
  

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -167,7 +167,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  implement this to use your own logic for finding a valid update, if any,
  in the given appcast.
  
- Do not base your logic by filtering out items with a minimum or maximum OS or application system version,
+ Do not base your logic by filtering out items with a minimum or maximum OS version or minimum autoupdate version,
  because Sparkle already has logic for determining whether or not those items should be filtered out.
  Also do not return a non-top level item from the appcast such as a delta item. Delta items will be ignored.
  Sparkle picks the delta item from your selection if the appropriate one is available.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -172,6 +172,10 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  Also do not return a non-top level item from the appcast such as a delta item. Delta items will be ignored.
  Sparkle picks the delta item from your selection if the appropriate one is available.
  
+ This method will not be invoked with an appcast that has zero items. Pick the best item from the appcast.
+ If an item is available that has the same version as the application or bundle to update,
+ do not pick an item that is worse than that version.
+ 
  This method may be called multiple times for different selections and filters. This method should be efficient.
  
  \param appcast The appcast that was downloaded from the remote server.

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -79,7 +79,7 @@
                     }];
                 }
                 
-                [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:NO includesSkippedUpdates:YES];
+                [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:NO];
             }
         }
     }];

--- a/Sparkle/SUAppcastDriver.h
+++ b/Sparkle/SUAppcastDriver.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didFailToFetchAppcastWithError:(NSError *)error;
 - (void)didFinishLoadingAppcast:(SUAppcast *)appcast;
 - (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)appcastItem secondaryAppcastItem:(SUAppcastItem *)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate;
-- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult;
+- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult passesMinOSVersion:(BOOL)passesMinOSVersion passesMaxOSVersion:(BOOL)passesMaxOSVersion;
 
 @end
 

--- a/Sparkle/SUAppcastDriver.h
+++ b/Sparkle/SUAppcastDriver.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithHost:(SUHost *)host updater:(id)updater updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate delegate:(nullable id <SUAppcastDriverDelegate>)delegate;
 
-- (void)loadAppcastFromURL:(NSURL *)appcastURL userAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates;
+- (void)loadAppcastFromURL:(NSURL *)appcastURL userAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background;
 
 - (void)cleanup:(void (^)(void))completionHandler;
 

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -120,8 +120,9 @@
 - (SUAppcastItem *)retrieveBestAppcastItemFromAppcast:(SUAppcast *)appcast versionComparator:(id<SUVersionComparison>)versionComparator secondaryUpdate:(SUAppcastItem * __autoreleasing _Nullable *)secondaryAppcastItem
 {
     // Find the best valid update in the appcast by asking the delegate
+    // Don't ask the delegate if the appcast has no items though
     SUAppcastItem *regularItemFromDelegate;
-    if ([self.updaterDelegate respondsToSelector:@selector((bestValidUpdateInAppcast:forUpdater:))]) {
+    if (appcast.items.count > 0 && [self.updaterDelegate respondsToSelector:@selector((bestValidUpdateInAppcast:forUpdater:))]) {
         SUAppcastItem *candidateItem = [self.updaterDelegate bestValidUpdateInAppcast:appcast forUpdater:(id _Nonnull)self.updater];
         
         assert(!candidateItem.deltaUpdate);

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -199,15 +199,27 @@
     } else {
         // Find the latest appcast item even if it fails min/max OS test
         // We want to inform the user if an update requires a different OS version
-        // We only need to do this if an update is being checked automatically in the background
-        SUAppcastItem *notFoundPrimaryItem = background ? [self retrieveBestAppcastItemFromAppcast:macOSAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil] : nil;
-        
-        NSComparisonResult hostToLatestAppcastItemComparisonResult = (notFoundPrimaryItem != nil) ? [applicationVersionComparator compareVersion:self.host.version toVersion:notFoundPrimaryItem.versionString] : 0;
-        
-        SUStandardVersionComparator *standardVersionComparator = (notFoundPrimaryItem != nil) ? [[SUStandardVersionComparator alloc] init] : nil;
-        
-        BOOL passesMinOSVersion = (notFoundPrimaryItem != nil) ? [[self class] isItemMinimumOperatingSystemVersionOK:notFoundPrimaryItem versionComparator:standardVersionComparator] : YES;
-        BOOL passesMaxOSVersion = (notFoundPrimaryItem != nil) ? [[self class] isItemMaximumOperatingSystemVersionOK:notFoundPrimaryItem versionComparator:standardVersionComparator] : YES;
+        // We only need to do this if an update is being checked by the user manually
+        SUAppcastItem *notFoundPrimaryItem;
+        NSComparisonResult hostToLatestAppcastItemComparisonResult;
+        BOOL passesMinOSVersion;
+        BOOL passesMaxOSVersion;
+        if (!background) {
+            notFoundPrimaryItem = [self retrieveBestAppcastItemFromAppcast:macOSAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil];
+            
+            hostToLatestAppcastItemComparisonResult = [applicationVersionComparator compareVersion:self.host.version toVersion:notFoundPrimaryItem.versionString];
+            
+            SUStandardVersionComparator *standardVersionComparator = [[SUStandardVersionComparator alloc] init];
+            
+            passesMinOSVersion = [[self class] isItemMinimumOperatingSystemVersionOK:notFoundPrimaryItem versionComparator:standardVersionComparator];
+            
+            passesMaxOSVersion = [[self class] isItemMaximumOperatingSystemVersionOK:notFoundPrimaryItem versionComparator:standardVersionComparator];
+        } else {
+            notFoundPrimaryItem = nil;
+            hostToLatestAppcastItemComparisonResult = 0;
+            passesMinOSVersion = YES;
+            passesMaxOSVersion = YES;
+        }
         
         [self.delegate didNotFindUpdateWithLatestAppcastItem:notFoundPrimaryItem hostToLatestAppcastItemComparisonResult:hostToLatestAppcastItemComparisonResult passesMinOSVersion:passesMinOSVersion passesMaxOSVersion:passesMaxOSVersion];
     }

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -121,20 +121,12 @@
     }
 }
 
-- (void)appcastDidFinishLoading:(SUAppcast *)loadedAppcast inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates
+- (SUAppcastItem *)retrieveBestAppcastItemFromAppcast:(SUAppcast *)appcast versionComparator:(id<SUVersionComparison>)versionComparator secondaryUpdate:(SUAppcastItem * __autoreleasing _Nullable *)secondaryAppcastItem
 {
-    [self.delegate didFinishLoadingAppcast:loadedAppcast];
-    
-    NSDictionary *userInfo = @{ SUUpdaterAppcastNotificationKey: loadedAppcast };
-    [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterDidFinishLoadingAppCastNotification object:self.updater userInfo:userInfo];
-    
-    NSNumber *phasedUpdateGroup = background ? @([SUPhasedUpdateGroupInfo updateGroupForHost:self.host]) : nil;
-    SUAppcast *supportedAppcast = [[self class] filterSupportedAppcast:loadedAppcast phasedUpdateGroup:phasedUpdateGroup];
-    
     // Find the best valid update in the appcast by asking the delegate
     SUAppcastItem *regularItemFromDelegate;
     if ([self.updaterDelegate respondsToSelector:@selector((bestValidUpdateInAppcast:forUpdater:))]) {
-        SUAppcastItem *candidateItem = [self.updaterDelegate bestValidUpdateInAppcast:supportedAppcast forUpdater:(id _Nonnull)self.updater];
+        SUAppcastItem *candidateItem = [self.updaterDelegate bestValidUpdateInAppcast:appcast forUpdater:(id _Nonnull)self.updater];
         
         assert(!candidateItem.deltaUpdate);
         if (candidateItem.deltaUpdate) {
@@ -152,7 +144,7 @@
     // Take care of finding best appcast item ourselves if delegate does not
     SUAppcastItem *regularItem;
     if (regularItemFromDelegate == nil) {
-        regularItem = [[self class] bestItemFromAppcastItems:supportedAppcast.items comparator:[self versionComparator]];
+        regularItem = [[self class] bestItemFromAppcastItems:appcast.items comparator:versionComparator];
     } else {
         regularItem = regularItemFromDelegate;
     }
@@ -160,25 +152,90 @@
     // Retrieve the preferred primary and secondary update items
     // In the case of a delta update, the preferred primary item will be the delta update,
     // and the secondary item will be the regular update.
-    SUAppcastItem *secondaryItem = nil;
-    SUAppcastItem *primaryItem = [self preferredUpdateForRegularAppcastItem:regularItem secondaryUpdate:&secondaryItem];
+    return [self preferredUpdateForRegularAppcastItem:regularItem secondaryUpdate:secondaryAppcastItem];
+}
+
+- (void)appcastDidFinishLoading:(SUAppcast *)loadedAppcast inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates
+{
+    [self.delegate didFinishLoadingAppcast:loadedAppcast];
     
-    if ([self itemContainsValidUpdate:primaryItem inBackground:background includesSkippedUpdates:includesSkippedUpdates]) {
-        [self.delegate didFindValidUpdateWithAppcastItem:primaryItem secondaryAppcastItem:secondaryItem preventsAutoupdate:[self itemPreventsAutoupdate:primaryItem]];
-    } else {
-        NSComparisonResult hostToLatestAppcastItemComparisonResult = (primaryItem != nil) ? [[self versionComparator] compareVersion:self.host.version toVersion:primaryItem.versionString] : NSOrderedSame;
+    NSDictionary *userInfo = @{ SUUpdaterAppcastNotificationKey: loadedAppcast };
+    [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterDidFinishLoadingAppCastNotification object:self.updater userInfo:userInfo];
+    
+    // We will never care about other OS's
+    SUAppcast *macOSAppcast = [loadedAppcast copyByFilteringItems:^(SUAppcastItem *item) {
+        return (BOOL)[item isMacOsUpdate];
+    }];
+    
+    id<SUVersionComparison> applicationVersionComparator = [self versionComparator];
+    
+    NSNumber *phasedUpdateGroup = background ? @([SUPhasedUpdateGroupInfo updateGroupForHost:self.host]) : nil;
+    
+    NSString *skippedVersion = !includesSkippedUpdates ? [self.host objectForUserDefaultsKey:SUSkippedVersionKey] : nil;
+    
+    // First filter out min/max OS version and see if there's an update that passes
+    // the minimum autoupdate version. We filter out updates that fail the minimum
+    // autoupdate version test because we have a preference over minor updates that can be
+    // downloaded and installed with less disturbance
+    SUAppcast *passesMinimumAutoupdateAppcast = [[self class] filterSupportedAppcast:macOSAppcast phasedUpdateGroup:phasedUpdateGroup skippedVersion:skippedVersion hostVersion:self.host.version versionComparator:applicationVersionComparator testOSVersion:YES testMinimumAutoupdateVersion:YES];
+    
+    SUAppcastItem *secondaryItemPassesMinimumAutoupdate = nil;
+    SUAppcastItem *primaryItemPassesMinimumAutoupdate = [self retrieveBestAppcastItemFromAppcast:passesMinimumAutoupdateAppcast versionComparator:applicationVersionComparator secondaryUpdate:&secondaryItemPassesMinimumAutoupdate];
+    
+    // If we weren't able to find a valid update, try to find an update that
+    // doesn't pass the minimum autoupdate version
+    SUAppcastItem *finalPrimaryItem;
+    SUAppcastItem *finalSecondaryItem = nil;
+    if (![self isItemNewer:primaryItemPassesMinimumAutoupdate]) {
+        SUAppcast *failsMinimumAutoupdateAppcast = [[self class] filterSupportedAppcast:macOSAppcast phasedUpdateGroup:phasedUpdateGroup skippedVersion:skippedVersion hostVersion:self.host.version versionComparator:applicationVersionComparator testOSVersion:YES testMinimumAutoupdateVersion:NO];
         
-        [self.delegate didNotFindUpdateWithLatestAppcastItem:primaryItem hostToLatestAppcastItemComparisonResult:hostToLatestAppcastItemComparisonResult];
+        finalPrimaryItem = [self retrieveBestAppcastItemFromAppcast:failsMinimumAutoupdateAppcast versionComparator:applicationVersionComparator secondaryUpdate:&finalSecondaryItem];
+    } else {
+        finalPrimaryItem = primaryItemPassesMinimumAutoupdate;
+        finalSecondaryItem = secondaryItemPassesMinimumAutoupdate;
+    }
+    
+    if ([self isItemNewer:finalPrimaryItem]) {
+        // We found a suitable update
+        BOOL preventsAutoupdate = ![[self class] isItemMinimumAutoupdateVersionOK:finalPrimaryItem hostVersion:self.host.version versionComparator:applicationVersionComparator];
+        
+        [self.delegate didFindValidUpdateWithAppcastItem:finalPrimaryItem secondaryAppcastItem:finalSecondaryItem preventsAutoupdate:preventsAutoupdate];
+    } else {
+        // Find the latest appcast item even if it fails min/max OS test
+        // We want to inform the user if an update requires a different OS version
+        SUAppcastItem *notFoundPrimaryItem = [self retrieveBestAppcastItemFromAppcast:macOSAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil];
+        
+        NSComparisonResult hostToLatestAppcastItemComparisonResult = (notFoundPrimaryItem != nil) ? [applicationVersionComparator compareVersion:self.host.version toVersion:notFoundPrimaryItem.versionString] : 0;
+        
+        SUStandardVersionComparator *standardVersionComparator = [[SUStandardVersionComparator alloc] init];
+        
+        BOOL passesMinOSVersion = (notFoundPrimaryItem != nil) ? [[self class] isItemMinimumOperatingSystemVersionOK:notFoundPrimaryItem versionComparator:standardVersionComparator] : YES;
+        BOOL passesMaxOSVersion = (notFoundPrimaryItem != nil) ? [[self class] isItemMaximumOperatingSystemVersionOK:notFoundPrimaryItem versionComparator:standardVersionComparator] : YES;
+        
+        [self.delegate didNotFindUpdateWithLatestAppcastItem:notFoundPrimaryItem hostToLatestAppcastItemComparisonResult:hostToLatestAppcastItemComparisonResult passesMinOSVersion:passesMinOSVersion passesMaxOSVersion:passesMaxOSVersion];
     }
 }
 
 // This method is used by unit tests
 + (SUAppcast *)filterSupportedAppcast:(SUAppcast *)appcast phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup
 {
+    return [self filterSupportedAppcast:appcast phasedUpdateGroup:phasedUpdateGroup skippedVersion:nil hostVersion:nil versionComparator:nil testOSVersion:YES testMinimumAutoupdateVersion:NO];
+}
+
++ (SUAppcast *)filterSupportedAppcast:(SUAppcast *)appcast phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup skippedVersion:(NSString * _Nullable)skippedVersion hostVersion:(NSString * _Nullable)hostVersion versionComparator:(id<SUVersionComparison> _Nullable)versionComparator testOSVersion:(BOOL)testOSVersion testMinimumAutoupdateVersion:(BOOL)testMinimumAutoupdateVersion
+{
     NSDate *currentDate = [NSDate date];
     
     return [appcast copyByFilteringItems:^(SUAppcastItem *item) {
-        return (BOOL)([[self class] itemOperatingSystemIsOK:item] && [[self class] itemIsReadyForPhasedRollout:item phasedUpdateGroup:phasedUpdateGroup currentDate:currentDate]);
+        BOOL passesOSVersion = (!testOSVersion || [self isItemMinimumAndMaximumOperatingSystemVersionOK:item]);
+        
+        BOOL passesPhasedRollout = [self itemIsReadyForPhasedRollout:item phasedUpdateGroup:phasedUpdateGroup currentDate:currentDate];
+        
+        BOOL passesMinimumAutoupdateVersion = (!testMinimumAutoupdateVersion || hostVersion == nil || versionComparator == nil || [self isItemMinimumAutoupdateVersionOK:item hostVersion:hostVersion versionComparator:versionComparator]);
+        
+        BOOL passesSkippedUpdates = (skippedVersion == nil || versionComparator == nil || ![self item:item containsSkippedVersion:(NSString * _Nonnull)skippedVersion versionComparator:versionComparator]);
+        
+        return (BOOL)(passesOSVersion && passesPhasedRollout && passesMinimumAutoupdateVersion && passesSkippedUpdates);
     }];
 }
 
@@ -210,34 +267,39 @@
     return item;
 }
 
-+ (BOOL)itemOperatingSystemIsOK:(SUAppcastItem *)ui
++ (BOOL)isItemMinimumOperatingSystemVersionOK:(SUAppcastItem *)ui versionComparator:(SUStandardVersionComparator *)versionComparator
 {
-    BOOL osOK = [ui isMacOsUpdate];
-    
-    NSString *minimumSystemVersion = ui.minimumSystemVersion;
-    NSString *maximumSystemVersion = ui.maximumSystemVersion;
-    
-    if ((minimumSystemVersion == nil || [minimumSystemVersion isEqualToString:@""]) &&
-        (maximumSystemVersion == nil || [maximumSystemVersion isEqualToString:@""])) {
-        return osOK;
-    }
-    
     BOOL minimumVersionOK = YES;
-    BOOL maximumVersionOK = YES;
-    
-    // We don't want to use delegate's comparator for comparing OS versions
-    id<SUVersionComparison> versionComparator = [[SUStandardVersionComparator alloc] init];
-    
-    // Check minimum and maximum System Version
+    NSString *minimumSystemVersion = ui.minimumSystemVersion;
     if (minimumSystemVersion != nil && ![minimumSystemVersion isEqualToString:@""]) {
         minimumVersionOK = [versionComparator compareVersion:minimumSystemVersion toVersion:[SUOperatingSystem systemVersionString]] != NSOrderedDescending;
     }
+    return minimumVersionOK;
+}
+
+// We don't want to use delegate's comparator for comparing OS versions
++ (BOOL)isItemMaximumOperatingSystemVersionOK:(SUAppcastItem *)ui versionComparator:(SUStandardVersionComparator *)versionComparator
+{
+    BOOL maximumVersionOK = YES;
+    NSString *maximumSystemVersion = ui.maximumSystemVersion;
     if (maximumSystemVersion != nil && ![maximumSystemVersion isEqualToString:@""]) {
         maximumVersionOK = [versionComparator compareVersion:maximumSystemVersion toVersion:[SUOperatingSystem systemVersionString]] != NSOrderedAscending;
     }
-    
-    return minimumVersionOK && maximumVersionOK && osOK;
+    return maximumVersionOK;
 }
+
++ (BOOL)isItemMinimumAndMaximumOperatingSystemVersionOK:(SUAppcastItem *)ui
+{
+    SUStandardVersionComparator *versionComparator = [[SUStandardVersionComparator alloc] init];
+    
+    return [self isItemMinimumOperatingSystemVersionOK:ui versionComparator:versionComparator] && [self isItemMaximumOperatingSystemVersionOK:ui versionComparator:versionComparator];
+}
+
++ (BOOL)isItemMinimumAutoupdateVersionOK:(SUAppcastItem *)ui hostVersion:(NSString *)hostVersion versionComparator:(id<SUVersionComparison>)versionComparator
+ {
+     NSString *minimumAutoupdateVersion = ui.minimumAutoupdateVersion;
+     return (minimumAutoupdateVersion.length == 0 || ([versionComparator compareVersion:hostVersion toVersion:minimumAutoupdateVersion] != NSOrderedAscending));
+ }
 
 - (id<SUVersionComparison>)versionComparator
 {
@@ -261,18 +323,11 @@
     return ui != nil && [[self versionComparator] compareVersion:self.host.version toVersion:ui.versionString] == NSOrderedAscending;
 }
 
-- (BOOL)itemPreventsAutoupdate:(SUAppcastItem *)ui
- {
-     NSString *minimumAutoupdateVersion = ui.minimumAutoupdateVersion;
-     return (minimumAutoupdateVersion.length > 0 && ([[self versionComparator] compareVersion:[self.host version] toVersion:minimumAutoupdateVersion] == NSOrderedAscending));
- }
-
-- (BOOL)itemContainsSkippedVersion:(SUAppcastItem *)ui
++ (BOOL)item:(SUAppcastItem *)ui containsSkippedVersion:(NSString * _Nullable)skippedVersion versionComparator:(id<SUVersionComparison>)versionComparator
 {
-    NSString *skippedVersion = [self.host objectForUserDefaultsKey:SUSkippedVersionKey];
     if (skippedVersion == nil) { return NO; }
     
-    return [[self versionComparator] compareVersion:ui.versionString toVersion:skippedVersion] != NSOrderedDescending;
+    return [versionComparator compareVersion:ui.versionString toVersion:(NSString * _Nonnull)skippedVersion] != NSOrderedDescending;
 }
 
 + (BOOL)itemIsReadyForPhasedRollout:(SUAppcastItem *)ui phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup currentDate:(NSDate *)currentDate
@@ -301,25 +356,6 @@
     }
     
     return NO;
-}
-
-- (BOOL)itemContainsValidUpdate:(SUAppcastItem *)ui inBackground:(BOOL)background includesSkippedUpdates:(BOOL)includesSkippedUpdates
-{
-    if (ui == nil) {
-        return NO;
-    }
-    
-    // Check that we have a newer appcast item than host
-    if (![self isItemNewer:ui]) {
-        return NO;
-    }
-    
-    // Check for skipped updates
-    if (!includesSkippedUpdates && [self itemContainsSkippedVersion:ui]) {
-        return NO;
-    }
-    
-    return YES;
 }
 
 - (void)cleanup:(void (^)(void))completionHandler

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -226,11 +226,6 @@
 }
 
 // This method is used by unit tests
-+ (SUAppcast *)filterSupportedAppcast:(SUAppcast *)appcast phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup
-{
-    return [self filterSupportedAppcast:appcast phasedUpdateGroup:phasedUpdateGroup skippedVersion:nil hostVersion:nil versionComparator:nil testOSVersion:YES testMinimumAutoupdateVersion:NO];
-}
-
 + (SUAppcast *)filterSupportedAppcast:(SUAppcast *)appcast phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup skippedVersion:(NSString * _Nullable)skippedVersion hostVersion:(NSString * _Nullable)hostVersion versionComparator:(id<SUVersionComparison> _Nullable)versionComparator testOSVersion:(BOOL)testOSVersion testMinimumAutoupdateVersion:(BOOL)testMinimumAutoupdateVersion
 {
     NSDate *currentDate = [NSDate date];

--- a/Tests/Resources/testappcast_minimumAutoupdateVersion.xml
+++ b/Tests/Resources/testappcast_minimumAutoupdateVersion.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 3.0</title>
+        <sparkle:minimumAutoupdateVersion>2.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="3.0" length="1346234" />
+    </item>
+    <item>
+        <title>Version 2.0</title>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="2.0" length="1346234" />
+    </item>
+  </channel>
+</rss>

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -38,7 +38,7 @@ static const char *SUAppleQuarantineIdentifier = "com.apple.quarantine";
 
 + (SUAppcastItem *)bestItemFromAppcastItems:(NSArray *)appcastItems getDeltaItem:(SUAppcastItem *_Nullable __autoreleasing *_Nullable)deltaItem withHostVersion:(NSString *)hostVersion comparator:(id<SUVersionComparison>)comparator;
 
-+ (SUAppcast *)filterSupportedAppcast:(SUAppcast *)appcast phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup;
++ (SUAppcast *)filterSupportedAppcast:(SUAppcast *)appcast phasedUpdateGroup:(NSNumber * _Nullable)phasedUpdateGroup skippedVersion:(NSString * _Nullable)skippedVersion hostVersion:(NSString * _Nullable)hostVersion versionComparator:(id<SUVersionComparison> _Nullable)versionComparator testOSVersion:(BOOL)testOSVersion testMinimumAutoupdateVersion:(BOOL)testMinimumAutoupdateVersion;
 
 @end
 


### PR DESCRIPTION
* Prefer updates that pass minimumAutoupdateVersion (but fallback on ones that fail if no valid ones are found); this is so that minor updates are preferred before a major one (#329)
* Filter out skipped updates before appcast selection
* When update is not found, use the latest item that fails min/max OS test for reporting purposes. Inform the user that their OS version is unsupported. We otherwise still use only passing min/max OS items for finding an available update.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested:
Skipped update is appropriately skipped
Update that passes minimumAutoupdateVersion is preferred
Update that fails min/max OS lets user know their OS is too old or too new.

Added some unit tests for testing minimum auto update version and skipping versions there.

macOS version tested: 11.3 (20E232)
