### PR TITLE
Add missing Japanese localization strings

### DIFF
--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -91,6 +91,18 @@
 /* Take care not to overflow the status window. */
 "Installing update..." = "アップデートをインストールしています…";
 
+/* Title confirmation for skipping major upgrade and future updates */
+"Are you sure you want to skip this upgrade?" = "このアップグレードをスキップしてもよろしいですか?";
+
+/* Confirmation message for skipping major upgrade and future updates */
+"Skipping this major upgrade will opt out of alerts for future updates." = "このメジャーアップグレードをスキップすると、今後のアップデートも通知されなくなります。";
+
+/* Skipping major upgrade */
+"Skip Upgrade" = "アップグレードをスキップ";
+
+/* Not skipping a major upgrade */
+"Don't Skip" = "スキップしない";
+
 /* the unit for kilobytes */
 "KB" = "KB";
 


### PR DESCRIPTION
that were added in #1853.


Fixes # (issue)

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: 11.3.1 (20E241)
