### PR TITLE
Fix the build with Xcode 13 by explcitly importing ImageIO

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -14,8 +14,8 @@
 #import "SPULocalCacheDirectory.h"
 #import "SPUInstallationType.h"
 #import "SUHost.h"
+#import <ImageIO/ImageIO.h>
 #import <ServiceManagement/ServiceManagement.h>
-
 
 #include "AppKitPrevention.h"
 


### PR DESCRIPTION
Fix the build with Xcode 13 by explicitly importing ImageIO. Previously it was being implicitly imported along with Foundation.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Other: It's a build-only fix that doesn't impact the functionality of the framework.

