### PR TITLE
Pass http headers and user agent when downloading release notes (1.x)

### DIFF
--- a/Sparkle/SUUIBasedUpdateDriver.m
+++ b/Sparkle/SUUIBasedUpdateDriver.m
@@ -83,7 +83,7 @@
         return;
     }
 
-    self.updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:updateItem host:self.host completionBlock:^(SUUpdateAlertChoice choice) {
+    self.updateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:updateItem httpHeaders:updater.httpHeaders userAgent:updater.userAgentString host:self.host completionBlock:^(SUUpdateAlertChoice choice) {
         [self updateAlertFinishedWithChoice:choice forItem:updateItem];
     }];
 

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, SUUpdateAlertChoice) {
 
 @property (weak) id<SUVersionDisplay> versionDisplayer;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item host:(SUHost *)host completionBlock:(void(^)(SUUpdateAlertChoice))c;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item httpHeaders:(NSDictionary *)httpHeaders userAgent:(NSString *)userAgent host:(SUHost *)host completionBlock:(void(^)(SUUpdateAlertChoice))c;
 
 - (IBAction)installUpdate:sender;
 - (IBAction)skipThisVersion:sender;


### PR DESCRIPTION
Pass http headers and user agent when downloading release notes (see #1872)

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

Same testing procedure as #1872
