### PR TITLE
Fix analyzer warnings

### DIFF
--- a/Configurations/ed25519-Shared.xcconfig
+++ b/Configurations/ed25519-Shared.xcconfig
@@ -12,3 +12,6 @@ ALWAYS_SEARCH_USER_PATHS = NO
 
 // Disable Warnings - this is a third-party project, and we'll trust that the maintainers know what they're doing.
 WARNING_CFLAGS = $(inherited) -Wno-cast-qual -Wno-conversion -Wno-sign-conversion
+
+// Disable dead stores analyzer warning
+CLANG_ANALYZER_DEADCODE_DEADSTORES = NO

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -66,6 +66,10 @@
 
 "An important update to %@ is ready to install" = "An important update to %@ is ready to install";
 
+"Unable to Check For Updates" = "Unable to Check For Updates";
+
+"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version" = "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version";
+
 /* the unit for bytes */
 "B" = "B";
 

--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -83,7 +83,7 @@
     SULog(SULogLevelError, @"Error: resumeDownloadedUpdate:completion: called on SPUAutomaticUpdateDriver");
 }
 
-- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
+- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
 {
     self.updateItem = updateItem;
     

--- a/Sparkle/SPUBasicUpdateDriver.h
+++ b/Sparkle/SPUBasicUpdateDriver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SPUBasicUpdateDriverDelegate <NSObject>
 
-- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)appcastItem secondaryAppcastItem:(SUAppcastItem *)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate systemDomain:(NSNumber * _Nullable)systemDomain;
+- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)appcastItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate systemDomain:(NSNumber * _Nullable)systemDomain;
 
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error;
 

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -79,7 +79,7 @@
     }
 }
 
-- (void)notifyResumableUpdateItem:(SUAppcastItem *)updateItem secondaryUpdateItem:(SUAppcastItem *)secondaryUpdateItem systemDomain:(NSNumber * _Nullable)systemDomain
+- (void)notifyResumableUpdateItem:(SUAppcastItem *)updateItem secondaryUpdateItem:(SUAppcastItem * _Nullable)secondaryUpdateItem systemDomain:(NSNumber * _Nullable)systemDomain
 {
     if (updateItem == nil) {
         [self.delegate basicDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUResumeAppcastError userInfo:@{ NSLocalizedDescriptionKey: SULocalizedString(@"Failed to resume installing update.", nil) }]];
@@ -137,7 +137,7 @@
     }
 }
 
-- (void)notifyFoundValidUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate systemDomain:(NSNumber * _Nullable)systemDomain
+- (void)notifyFoundValidUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate systemDomain:(NSNumber * _Nullable)systemDomain
 {
     if (!self.aborted) {
         [[NSNotificationCenter defaultCenter] postNotificationName:SUUpdaterDidFindValidUpdateNotification
@@ -152,7 +152,7 @@
     }
 }
 
-- (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate
+- (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate
 {
     [self notifyFoundValidUpdateWithAppcastItem:updateItem secondaryAppcastItem:secondaryAppcastItem preventsAutoupdate:preventsAutoupdate systemDomain:nil];
 }

--- a/Sparkle/SPUCoreBasedUpdateDriver.h
+++ b/Sparkle/SPUCoreBasedUpdateDriver.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SPUCoreBasedUpdateDriverDelegate <NSObject>
 
-- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate;
+- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate;
 
 - (void)installerDidFinishPreparationAndWillInstallImmediately:(BOOL)willInstallImmediately silently:(BOOL)willInstallSilently;
 
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)downloadUpdateFromAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem inBackground:(BOOL)background;
 
-- (void)deferInformationalUpdate:(SUAppcastItem *)updateItem secondaryUpdate:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate;
+- (void)deferInformationalUpdate:(SUAppcastItem *)updateItem secondaryUpdate:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate;
 
 - (void)extractDownloadedUpdate;
 

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -32,7 +32,7 @@
 @property (nonatomic, readonly) SPUInstallerDriver *installerDriver;
 @property (nonatomic, weak, readonly) id<SPUCoreBasedUpdateDriverDelegate> delegate;
 @property (nonatomic) SUAppcastItem *updateItem;
-@property (nonatomic) SUAppcastItem *secondaryUpdateItem;
+@property (nonatomic, nullable) SUAppcastItem *secondaryUpdateItem;
 @property (nonatomic) id<SPUResumableUpdate> resumableUpdate;
 @property (nonatomic) SPUDownloadedUpdate *downloadedUpdateForRemoval;
 
@@ -149,7 +149,7 @@
     }
 }
 
-- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate systemDomain:(NSNumber * _Nullable)systemDomain
+- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate systemDomain:(NSNumber * _Nullable)systemDomain
 {
     self.updateItem = updateItem;
     self.secondaryUpdateItem = secondaryUpdateItem;
@@ -225,7 +225,7 @@
     [self extractUpdate:downloadedUpdate];
 }
 
-- (void)deferInformationalUpdate:(SUAppcastItem *)updateItem secondaryUpdate:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
+- (void)deferInformationalUpdate:(SUAppcastItem *)updateItem secondaryUpdate:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
 {
     self.resumableUpdate = [[SPUInformationalUpdate alloc] initWithAppcastItem:updateItem secondaryAppcastItem:secondaryUpdateItem preventsAutoupdate:preventsAutoupdate];
 }

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -28,7 +28,7 @@
 @property (nonatomic) id<SPUDownloaderProtocol> downloader;
 @property (nonatomic) NSXPCConnection *connection;
 @property (nonatomic, readonly) SUAppcastItem *updateItem;
-@property (nonatomic, readonly) SUAppcastItem *secondaryUpdateItem;
+@property (nonatomic, readonly, nullable) SUAppcastItem *secondaryUpdateItem;
 @property (nonatomic, readonly) SUHost *host;
 @property (nonatomic, copy) NSString *temporaryDirectory;
 @property (nonatomic, copy) NSString *downloadName;

--- a/Sparkle/SPUInformationalUpdate.h
+++ b/Sparkle/SPUInformationalUpdate.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPUInformationalUpdate : NSObject <SPUResumableUpdate>
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate;
 
 @end
 

--- a/Sparkle/SPUInformationalUpdate.m
+++ b/Sparkle/SPUInformationalUpdate.m
@@ -19,7 +19,7 @@
 @synthesize secondaryUpdateItem = _secondaryUpdateItem;
 @synthesize preventsAutoupdate = _preventsAutoupdate;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
 {
     self = [super init];
     if (self != nil) {

--- a/Sparkle/SPUProbingUpdateDriver.m
+++ b/Sparkle/SPUProbingUpdateDriver.m
@@ -54,7 +54,7 @@
     [self.basicDriver resumeUpdate:resumableUpdate completion:completionBlock];
 }
 
-- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)__unused appcastItem secondaryAppcastItem:(SUAppcastItem *)__unused secondaryAppcastItem preventsAutoupdate:(BOOL)__unused preventsAutoupdate systemDomain:(NSNumber * _Nullable)__unused systemDomain
+- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)__unused appcastItem secondaryAppcastItem:(SUAppcastItem * _Nullable)__unused secondaryAppcastItem preventsAutoupdate:(BOOL)__unused preventsAutoupdate systemDomain:(NSNumber * _Nullable)__unused systemDomain
 {
     // Stop as soon as we have an answer
     [self abortUpdate];

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -14,6 +14,7 @@
 #import "SPUStandardUserDriver.h"
 #import "SUConstants.h"
 #import "SULog.h"
+#import "SULocalizations.h"
 #import <AppKit/AppKit.h>
 
 static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaultsObservationContext";
@@ -76,9 +77,8 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         // Delay the alert four seconds so it doesn't show RIGHT as the app launches, but also doesn't interrupt the user once they really get to work.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             NSAlert *alert = [[NSAlert alloc] init];
-            alert.messageText = @"Unable to Check For Updates";
-            alert.informativeText = @"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version.";
-            [alert addButtonWithTitle:@"OK"];
+            alert.messageText = SULocalizedString(@"Unable to Check For Updates", nil);
+            alert.informativeText = SULocalizedString(@"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version.", nil);
             [alert runModal];
         });
     }

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -170,7 +170,7 @@
     }
 }
 
-- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem *)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
+- (void)basicDriverDidFindUpdateWithAppcastItem:(SUAppcastItem *)updateItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryUpdateItem preventsAutoupdate:(BOOL)preventsAutoupdate
 {
     if (self.userInitiated) {
         [SPUSkippedUpdate clearSkippedUpdateForHost:self.host];

--- a/Sparkle/SUAppcastDriver.h
+++ b/Sparkle/SUAppcastDriver.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didFailToFetchAppcastWithError:(NSError *)error;
 - (void)didFinishLoadingAppcast:(SUAppcast *)appcast;
-- (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)appcastItem secondaryAppcastItem:(SUAppcastItem *)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate;
+- (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)appcastItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryAppcastItem preventsAutoupdate:(BOOL)preventsAutoupdate;
 - (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult passesMinOSVersion:(BOOL)passesMinOSVersion passesMaxOSVersion:(BOOL)passesMaxOSVersion;
 
 @end

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -60,9 +60,11 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 // Returns the dictionary representing the appcast item; this might be useful later for extensions.
 @property (readonly, copy) NSDictionary *propertiesDictionary;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 // Initializes with data from a dictionary provided by the RSS class.
-- (instancetype)initWithDictionary:(NSDictionary *)dict;
-- (instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString * _Nullable __autoreleasing *_Nullable)error;
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dict;
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString * _Nullable __autoreleasing *_Nullable)error;
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dict relativeToURL:(NSURL * _Nullable)appcastURL failureReason:(NSString * _Nullable __autoreleasing *_Nullable)error;
 
 @end

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -214,12 +214,12 @@ static NSString *SUAppcastItemInstallationTypeKey = @"SUAppcastItemInstallationT
     return self.infoURL && !self.fileURL;
 }
 
-- (instancetype)initWithDictionary:(NSDictionary *)dict
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dict
 {
     return [self initWithDictionary:dict relativeToURL:nil failureReason:nil];
 }
 
-- (instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString *__autoreleasing *)error
+- (nullable instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString *__autoreleasing *)error
 {
     return [self initWithDictionary:dict relativeToURL:nil failureReason:error];
 }

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -93,12 +93,12 @@ NS_ASSUME_NONNULL_BEGIN
     return [self isValidVersion:[self _version]];
 }
 
-- (BOOL)isValidVersion:(NSString *)version
+- (BOOL)isValidVersion:(NSString * _Nullable)version
 {
     return (version != nil && version.length != 0);
 }
 
-- (NSString *)_version
+- (NSString * _Nullable)_version
 {
     NSString *version = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
     return ([self isValidVersion:version] ? version : nil);


### PR DESCRIPTION
Fix analyzer warnings. This is small cleanup task.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Just ran test app. Tested 0 analyzer warnings (nullability, missing localizations, dead stores) were emitted.

macOS version tested: 11.5 Beta (20G5042c)
