### PR TITLE
Refine standard updater controller

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -26,16 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  A controller class that instantiates a SPUUpdater and allows binding UI to it.
  
- This class can be instantiated in a nib or created using initWithUpdaterDelegate:userDriverDelegate:. The controller's updater targets the application's main bundle
- and uses Sparkle's standard user interface. Typically, this class is used by sticking it as a custom NSObject subclass in an Interface Builder nib (probably in MainMenu).
+ This class can be instantiated in a nib or created programatically using initWithUpdaterDelegate:userDriverDelegate: or initWithStartingUpdater:updaterDelegate:userDriverDelegate:.
+ 
+ The controller's updater targets the application's main bundle and uses Sparkle's standard user interface.
+ Typically, this class is used by sticking it as a custom NSObject subclass in an Interface Builder nib (probably in MainMenu) but it works well programatically too.
  
  The controller creates an SPUUpdater instance and allows hooking up the check for updates action and menu item validation. It also allows hooking
  up the updater's and user driver's delegates.
  
- This controller class may not be valuable to you if:
- * You want to control or defer starting the SPUUpdater, or don't want to be tied into a nib's instantiation, or don't want to use a nib
- * You want to target a bundle that's not the main bundle
- * You want to provide a custom user interface (SPUUserDriver), or perhaps one that provides little-to-none
+ If you need more control over what bundle you want to update or you want to provide a custom user interface (via SPUUserDriver), please use SPUUpdater directly instead.
   */
 SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 
@@ -70,14 +69,34 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 @property (nonatomic, readonly, nullable) SPUStandardUserDriver *userDriver;
 
 /*!
- Use initWithUpdaterDelegate:userDriverDelegate: instead.
+ Use initWithUpdaterDelegate:userDriverDelegate: or initWithStartingUpdater:updaterDelegate:userDriverDelegate: instead.
  */
 - (instancetype)init NS_UNAVAILABLE;
 
 /*!
  Create a new SPUStandardUpdaterController programmatically.
+ 
+ The updater is started automatically. See -[SPUStandardUpdaterController startUpdater]  for more information.
  */
 - (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate;
+
+/*!
+ Create a new SPUStandardUpdaterController programmatically.
+ 
+ You can specify whether or not you want to start the updater immediately. If you do not start the updater, you
+ must invoke -[SPUStandardUpdaterController startUpdater] at a later time to start it.
+ */
+- (instancetype)initWithStartingUpdater:(BOOL)startUpdater updaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate;
+
+/*!
+ Starts the updater if it has not already been started.
+ 
+ You should only call this method yourself if you chose not to start the updater on initialization.
+ 
+ This invokes  -[SPUUpdater startUpdater:]. If an error is returned, the error is logged and an alert is shown to the user (after a few seconds) to contact the developer.
+ If you want more control over this behavior, you can create your own SPUUpdater instead.
+ */
+- (void)startUpdater;
 
 /*!
  Explicitly checks for updates and displays a progress dialog while doing so.

--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -41,35 +41,35 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 /*!
  Interface builder outlet for the updater's delegate.
  
- This property should only be set using Interface Builder by creating a connection using the outlet
+ This property should only be set using Interface Builder by creating a connection using the outlet.
  */
 @property (nonatomic, weak, nullable) IBOutlet id<SPUUpdaterDelegate> updaterDelegate;
 
 /*!
  Interface builder outlet for the user driver's delegate.
  
- This property should only be set using Interface Builder by creating a connection using the outlet
+ This property should only be set using Interface Builder by creating a connection using the outlet.
  */
 @property (nonatomic, weak, nullable) IBOutlet id<SPUStandardUserDriverDelegate> userDriverDelegate;
 
 /*!
  Accessible property for the updater. Some properties on the updater can be binded via KVO
  
- This is nil before being loaded from the nib.
- You may access this property after your application has finished launching, or after your window controller has finished loading.
+ When instantiated from a nib, don't perform update checks before the application has finished launching in a MainMenu nib (i.e applicationDidFinishLaunching:) or before the corresponding window/view controller has been loaded (i.e, windowDidLoad or viewDidLoad). The updater is not guaranteed to be started yet before these points.
  */
-@property (nonatomic, readonly, nullable) SPUUpdater *updater;
+@property (nonatomic, readonly) SPUUpdater *updater;
 
 /*!
  Accessible property for the updater's user driver.
- 
- This is nil before being loaded from the nib.
- You may access this property after your application has finished launching, or after your window controller has finished loading.
  */
-@property (nonatomic, readonly, nullable) SPUStandardUserDriver *userDriver;
+@property (nonatomic, readonly) SPUStandardUserDriver *userDriver;
 
 /*!
- Use initWithUpdaterDelegate:userDriverDelegate: or initWithStartingUpdater:updaterDelegate:userDriverDelegate: instead.
+ Create a new SPUStandardUpdaterController from a nib.
+ 
+ You cannot call this initializer directly. You must instantiate a SPUStandardUpdaterController inside of a nib (typically the MainMenu nib) to use it.
+ 
+ To create a SPUStandardUpdaterController programatically, use initWithUpdaterDelegate:userDriverDelegate: or initWithStartingUpdater:updaterDelegate:userDriverDelegate: instead.
  */
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -81,7 +81,7 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 - (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate;
 
 /*!
- Create a new SPUStandardUpdaterController programmatically.
+ Create a new SPUStandardUpdaterController programmatically allowing you to specify whether or not to start the updater immediately.
  
  You can specify whether or not you want to start the updater immediately. If you do not start the updater, you
  must invoke -[SPUStandardUpdaterController startUpdater] at a later time to start it.
@@ -91,9 +91,10 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 /*!
  Starts the updater if it has not already been started.
  
- You should only call this method yourself if you chose not to start the updater on initialization.
+ You should only call this method yourself if you opted out of starting the updater on initialization.
+ Hence, do not call this yourself if you are instantiating this controller from a nib.
  
- This invokes  -[SPUUpdater startUpdater:]. If an error is returned, the error is logged and an alert is shown to the user (after a few seconds) to contact the developer.
+ This invokes  -[SPUUpdater startUpdater:]. If the application is misconfigured with Sparkle, an error is logged and an alert is shown to the user (after a few seconds) to contact the developer.
  If you want more control over this behavior, you can create your own SPUUpdater instead.
  */
 - (void)startUpdater;
@@ -108,7 +109,7 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
  
  This action checks updates by invoking -[SPUUpdater checkForUpdates]
  */
-- (IBAction)checkForUpdates:(id)sender;
+- (IBAction)checkForUpdates:(nullable id)sender;
 
 /*!
  Validates if the menu item for checkForUpdates: can be invoked or not

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -39,7 +39,18 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     // awakeFromNib might be called more than once; guard against that
     // We have to use awakeFromNib otherwise the delegate outlets may not be connected yet,
     // and we aren't a proper window or view controller, so we don't have a proper "did load" point
-    [self initializeUpdater];
+    [self initializeUpdaterAndStartUpdater:YES];
+}
+
+- (instancetype)initWithStartingUpdater:(BOOL)startUpdater updaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate
+{
+    if ((self = [super init])) {
+        _updaterDelegate = updaterDelegate;
+        _userDriverDelegate = userDriverDelegate;
+
+        [self initializeUpdaterAndStartUpdater:startUpdater];
+    }
+    return self;
 }
 
 - (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate
@@ -48,12 +59,12 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         _updaterDelegate = updaterDelegate;
         _userDriverDelegate = userDriverDelegate;
 
-        [self initializeUpdater];
+        [self initializeUpdaterAndStartUpdater:YES];
     }
     return self;
 }
 
-- (void)initializeUpdater
+- (void)initializeUpdaterAndStartUpdater:(BOOL)startUpdater
 {
     if (!self.initializedUpdater) {
         self.initializedUpdater = YES;
@@ -63,7 +74,9 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         self.updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self.updaterDelegate];
         self.userDriver = userDriver;
         
-        [self startUpdater];
+        if (startUpdater) {
+            [self startUpdater];
+        }
     }
 }
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -144,6 +144,10 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (BOOL)startUpdater:(NSError * __autoreleasing *)error
 {
+    if (self.startedUpdater) {
+        return YES;
+    }
+    
     if (![self checkIfConfiguredProperlyAndRequireFeedURL:NO error:error]) {
         return NO;
     }

--- a/Sparkle/SUUpdater.h
+++ b/Sparkle/SUUpdater.h
@@ -34,7 +34,7 @@
  
  Note: This class is now deprecated and acts as a thin wrapper around SPUUpdater and SPUStandardUserDriver
  */
-__deprecated_msg("Deprecated in Sparkle 2. Use SPUStandardUpdaterController or SPUUpdater instead")
+__deprecated_msg("Deprecated in Sparkle 2. Use SPUStandardUpdaterController instead, or SPUUpdater if you need more control.")
 SU_EXPORT @interface SUUpdater : NSObject
 
 @property (unsafe_unretained, nonatomic) IBOutlet id<SUUpdaterDelegate> delegate;

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -94,7 +94,6 @@ static NSMutableDictionary *sharedUpdaters = nil;
 // This will be used when the updater is instantiated in a nib such as MainMenu
 - (instancetype)init
 {
-    SULog(SULogLevelDefault, @"DEPRECATION: SUUpdater is deprecated in Sparkle 2 but functional for transitional purposes. Please migrate to SPUStandardUpdaterController as a nib instantiated replacement, or SPUUpdater.");
     return [self initForBundle:[NSBundle mainBundle]];
 }
 


### PR DESCRIPTION
Refine SPUStandardUpdaterController API

* Make updater/userDriver properties non-null
* Expose starting the updater and allowing it to be done later instead of at instantiation (so clients in some cases will not need to make their controller declared as an optional)
* Make sender in checkForUpdates: nullable
* Remove run-time deprecation log for SUUpdater (compile-time deprecation is sufficient)

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other - my own test app

Tested instantiating SPUStandardUpdaterController from a nib and programmatically in a sample test app.

macOS version tested: 11.5 Beta (20G5042c)
