### PR TITLE
Expose why new update is unavailable

### DIFF
--- a/Resources/SampleAppcast.xml
+++ b/Resources/SampleAppcast.xml
@@ -9,6 +9,7 @@
             <sparkle:releaseNotesLink>
                 http://you.com/app/2.0.html
             </sparkle:releaseNotesLink>
+            <link>http://sparkle-project.org</link>
             <pubDate>Wed, 09 Jan 2006 19:20:11 +0000</pubDate>
             <enclosure url="http://you.com/app/Your%20Great%20App%202.0.zip" sparkle:version="2.0" length="1623481" type="application/octet-stream" sparkle:edSignature="WVyVJpOx+a5+vNWJVY79TRjFKveNk+VhGJf2iti4CZtJsJewIUGvh/1AKKEAFbH1qUwx+vro1ECuzOsMmumoBA==" />
             <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>
@@ -19,6 +20,7 @@
             <sparkle:releaseNotesLink>
                 http://you.com/app/1.5.html
             </sparkle:releaseNotesLink>
+            <link>http://sparkle-project.org</link>
             <pubDate>Wed, 01 Jan 2006 12:20:11 +0000</pubDate>
             <enclosure url="http://you.com/app/Your%20Great%20App%201.5.zip" sparkle:version="1.5" length="1472893" type="application/octet-stream" sparkle:edSignature="pNFd7KbcQSu+Mq7UYrbQXTPq82luht2ACXm/r2utp1u/Uv/5hWqctdT2jwQgMejW7DRoeV/hVr6J4VdZYdwWDw==" />
             <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>
@@ -30,6 +32,7 @@
             <sparkle:releaseNotesLink>
                 http://you.com/app/1.4.html
             </sparkle:releaseNotesLink>
+            <link>http://sparkle-project.org</link>
             <pubDate>Wed, 25 Dec 2005 12:20:11 +0000</pubDate>
             <enclosure url="http://you.com/app/Your%20Great%20App%201.4.zip" sparkle:version="241" sparkle:shortVersionString="1.4" sparkle:edSignature="Ody3D/ybSMH4T+P/oNj3LN4F0SA8RJGLEr1TI4UemrBAiJ9aEcDnYV3u58P75AbcFjI13jPYmHDUHXMSTFQbDw==" length="1472349" type="application/octet-stream" />
             <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -146,6 +146,9 @@
 
 "%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@." = "%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@.";
 
+/* Used when a new update is not found */
+"Version History" = "Version History";
+
 /* Authorization message shown when app wants permission to update itself. */
 "%1$@ wants permission to update." = "%1$@ wants permission to update.";
 

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -116,6 +116,14 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * Before this point, -showUserInitiatedUpdateCheckWithCancellation: may be called.
  *
  * @param error The error associated with why a new update was not found.
+ *  There are various reasons a new update is unavailable and can't be installed.
+ *  This error object is populated with recovery and suggestion strings suitable to be shown in an alert.
+ *
+ *  The userInfo dictionary is also populated with two keys:
+ *  SPULatestAppcastItemFoundKey: if available, this may provide the latest SUAppcastItem that was found.
+ *  SPUNoUpdateFoundReasonKey: if available, this will provide the SUNoUpdateFoundReason. For example the reason could be because
+ *  the latest version in the feed requires a newer OS version or could be because the user is already on the latest version.
+ *
  * @param acknowledgement Acknowledge to the updater that no update found error was shown.
  */
 - (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -57,6 +57,8 @@ NSString *const SUEnableJavaScriptKey = @"SUEnableJavaScript";
 NSString *const SUFixedHTMLDisplaySizeKey = @"SUFixedHTMLDisplaySize";
 NSString *const SUDefaultsDomainKey = @"SUDefaultsDomain";
 NSString *const SUSparkleErrorDomain = @"SUSparkleErrorDomain";
+NSString *const SPUNoUpdateFoundReasonKey = @"SUNoUpdateFoundReason";
+NSString *const SPULatestAppcastItemFoundKey = @"SULatestAppcastItemFound";
 
 NSString *const SUAppendVersionNumberKey = @"SUAppendVersionNumber";
 NSString *const SUEnableAutomatedDowngradesKey = @"SUEnableAutomatedDowngrades";

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -78,4 +78,15 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUIncorrectAPIUsageError = 5000
 };
 
+typedef NS_ENUM(OSStatus, SPUNoUpdateFoundReason) {
+    SPUNoUpdateFoundReasonUnknown,
+    SPUNoUpdateFoundReasonOnLatestVersion,
+    SPUNoUpdateFoundReasonOnNewerThanLatestVersion,
+    SPUNoUpdateFoundReasonSystemIsTooOld,
+    SPUNoUpdateFoundReasonSystemIsTooNew
+};
+
+SU_EXPORT extern NSString *const SPUNoUpdateFoundReasonKey;
+SU_EXPORT extern NSString *const SPULatestAppcastItemFoundKey;
+
 #endif


### PR DESCRIPTION
I want to expose the reason why a new update is unavailable to the user driver and provide the latest appcast item found. Additionally for fun I'm also trying out to expose some of this to the user in the standard user driver.

If the latest appcast item has release notes available and the user is up to date, we can provide a link to the change-log (not done for inline release notes and I don't want to expose another web view).

If the latest appcast item has a link, we can provide a link to the website if the user is on a non-eligible OS version.

Would potentially resolve #1604

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update - yes, for providing a link to appcast items in the min/max OS case at least. New localization string too for version history.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Modified test app to test both cases. Example:

<img width="372" alt="Screen Shot 2021-06-26 at 6 34 17 PM" src="https://user-images.githubusercontent.com/857267/123530357-437f4580-d6ae-11eb-89fa-b193ac37d1ad.png">

macOS version tested: 11.5 Beta (20G5042c)
