### PR TITLE
Allow delegate to pick no valid items

### DIFF
--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -209,9 +209,10 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  \param appcast The appcast that was downloaded from the remote server.
  \param updater The updater instance.
- \return The best valid appcast item, or nil if you don't want to be delegated this task.
+ \return The best valid appcast item. Return NSNull.null if no appcast item is valid. Return nil if you don't want to be delegated this task and
+         want to let Sparkle handle picking the best valid update.
  */
-- (nullable SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;
+- (nullable id)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;
 
 /*!
  Called when a valid update is found by the update driver.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -209,10 +209,10 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  \param appcast The appcast that was downloaded from the remote server.
  \param updater The updater instance.
- \return The best valid appcast item. Return NSNull.null if no appcast item is valid. Return nil if you don't want to be delegated this task and
+ \return The best valid appcast item. Return SUAppcastItem.emptyAppcastItem if no appcast item is valid. Return nil if you don't want to be delegated this task and
          want to let Sparkle handle picking the best valid update.
  */
-- (nullable id)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;
+- (nullable SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;
 
 /*!
  Called when a valid update is found by the update driver.

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -131,26 +131,25 @@
     SUAppcastItem *regularItemFromDelegate;
     BOOL delegateOptedOutOfSelection;
     if (appcast.items.count > 0 && [self.updaterDelegate respondsToSelector:@selector((bestValidUpdateInAppcast:forUpdater:))]) {
-        id candidateItem = [self.updaterDelegate bestValidUpdateInAppcast:appcast forUpdater:(id _Nonnull)self.updater];
+        SUAppcastItem *candidateItem = [self.updaterDelegate bestValidUpdateInAppcast:appcast forUpdater:(id _Nonnull)self.updater];
         
-        if ([(NSObject *)candidateItem isKindOfClass:[SUAppcastItem class]]) {
-            SUAppcastItem *candidateAppcastItem = candidateItem;
-            assert(!candidateAppcastItem.deltaUpdate);
-            if (candidateAppcastItem.deltaUpdate) {
+        if (candidateItem == SUAppcastItem.emptyAppcastItem) {
+            regularItemFromDelegate = nil;
+            delegateOptedOutOfSelection = YES;
+        } else if (candidateItem == nil) {
+            regularItemFromDelegate = nil;
+            delegateOptedOutOfSelection = NO;
+        } else if (candidateItem != nil) {
+            assert(!candidateItem.deltaUpdate);
+            if (candidateItem.deltaUpdate) {
                 // Client would have to go out of their way to examine the .deltaUpdates to return one
                 // We need them to give us a regular update item back instead..
                 SULog(SULogLevelError, @"Error: -bestValidUpdateInAppcast:forUpdater: cannot return a delta update item");
                 regularItemFromDelegate = nil;
             } else {
-                regularItemFromDelegate = candidateAppcastItem;
+                regularItemFromDelegate = candidateItem;
             }
             
-            delegateOptedOutOfSelection = NO;
-        } else if (candidateItem == [NSNull null]) {
-            regularItemFromDelegate = nil;
-            delegateOptedOutOfSelection = YES;
-        } else {
-            regularItemFromDelegate = nil;
             delegateOptedOutOfSelection = NO;
         }
     } else {

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -68,6 +68,8 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 
 - (instancetype)init NS_UNAVAILABLE;
 
++ (instancetype)emptyAppcastItem;
+
 // Deprecated initializers
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dict __deprecated_msg("Properties that depend on the system or application version are not supported when used with this initializer. The designated initializer is available in SUAppcastItem+Private.h. Please first explore other APIs or contact us to describe your use case.");
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dict failureReason:(NSString * _Nullable __autoreleasing *_Nullable)error __deprecated_msg("Properties that depend on the system or application version are not supported when used with this initializer. The designated initializer is available in SUAppcastItem+Private.h. Please first explore other APIs or contact us to describe your use case.");

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -285,6 +285,16 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
     }
 }
 
++ (instancetype)emptyAppcastItem
+{
+    static SUAppcastItem *emptyAppcastItem;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        emptyAppcastItem = [[SUAppcastItem alloc] init];
+    });
+    return emptyAppcastItem;
+}
+
 // Initializer used for making delta items
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dict relativeToURL:(NSURL * _Nullable)appcastURL state:(SPUAppcastItemState * _Nullable)state
 {


### PR DESCRIPTION
We now allow returning NSNull.null in -bestValidUpdateInAppcast:forUpdater: to indicate no update should be picked.

We preserve returning nil to indicate Sparkle handles the best appcast selection instead.

People have expressed needs for both of these decisions (and deprecated SUUpdater relies on the nil behavior).

Fixes #1399 (allowing no fall back)

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested implementing delegate method in test app and that returning appcast item, returning nil, returning NSNull.null work expectably.

macOS version tested: 11.5 Beta (20G5042c)
