### PR TITLE
sparkle-cli: Make installing major upgrades opt-in

### DIFF
--- a/sparkle-cli/SPUCommandLineDriver.h
+++ b/sparkle-cli/SPUCommandLineDriver.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPUCommandLineDriver : NSObject
 
-- (nullable instancetype)initWithUpdateBundlePath:(NSString *)updateBundlePath applicationBundlePath:(nullable NSString *)applicationBundlePath allowedChannels:(NSSet<NSString *> *)allowedChannels customFeedURL:(nullable NSString *)customFeedURL updatePermissionResponse:(nullable SUUpdatePermissionResponse *)updatePermissionResponse deferInstallation:(BOOL)deferInstallation interactiveInstallation:(BOOL)interactiveInstallation verbose:(BOOL)verbose;
+- (nullable instancetype)initWithUpdateBundlePath:(NSString *)updateBundlePath applicationBundlePath:(nullable NSString *)applicationBundlePath allowedChannels:(NSSet<NSString *> *)allowedChannels customFeedURL:(nullable NSString *)customFeedURL updatePermissionResponse:(nullable SUUpdatePermissionResponse *)updatePermissionResponse deferInstallation:(BOOL)deferInstallation interactiveInstallation:(BOOL)interactiveInstallation allowMajorUpgrades:(BOOL)allowMajorUpgrades verbose:(BOOL)verbose;
 
 - (void)runAndCheckForUpdatesNow:(BOOL)checkForUpdatesNow;
 

--- a/sparkle-cli/main.m
+++ b/sparkle-cli/main.m
@@ -21,10 +21,11 @@
 #define INTERACTIVE_FLAG "interactive"
 #define FEED_URL_FLAG "feed-url"
 #define CHANNELS_FLAG "channels"
+#define ALLOW_MAJOR_UPGRADES_FLAG "allow-major-upgrades"
 
 static void printUsage(char **argv)
 {
-    fprintf(stderr, "Usage: %s bundle [--%s app-path] [--%s] [--%s] [--%s chan1,chan2,…] [--%s feed-url] [--%s] [--%s] [--%s] [--%s] [--%s]\n", argv[0], APPLICATION_FLAG, CHECK_NOW_FLAG, PROBE_FLAG, CHANNELS_FLAG, FEED_URL_FLAG, GRANT_AUTOMATIC_CHECKING_FLAG, SEND_PROFILE_FLAG, DEFER_FLAG, INTERACTIVE_FLAG, VERBOSE_FLAG);
+    fprintf(stderr, "Usage: %s bundle [--%s app-path] [--%s] [--%s] [--%s chan1,chan2,…] [--%s feed-url] [--%s] [--%s] [--%s] [--%s] [--%s] [--%s]\n", argv[0], APPLICATION_FLAG, CHECK_NOW_FLAG, PROBE_FLAG, CHANNELS_FLAG, FEED_URL_FLAG, GRANT_AUTOMATIC_CHECKING_FLAG, SEND_PROFILE_FLAG, DEFER_FLAG, INTERACTIVE_FLAG, ALLOW_MAJOR_UPGRADES_FLAG, VERBOSE_FLAG);
     fprintf(stderr, "Description:\n");
     fprintf(stderr, "  Check if any new updates for a Sparkle supported bundle need to be installed.\n\n");
     fprintf(stderr, "  If any new updates need to be installed, the user application\n  is terminated and the update is installed immediately unless --%s\n  is specified. If the application was alive, then it will be relaunched after.\n\n", DEFER_FLAG);
@@ -37,6 +38,7 @@ static void printUsage(char **argv)
     fprintf(stderr, " --%s\n    Path to the application to watch for termination and to relaunch.\n    If not provided, this is assumed to be the same as the bundle.\n", APPLICATION_FLAG);
     fprintf(stderr, " --%s\n    Immediately checks for updates to install.\n    Without this, updates are checked only when needed on a scheduled basis.\n", CHECK_NOW_FLAG);
     fprintf(stderr, " --%s\n    Probe for updates. Check if any updates are available but do not install.\n    An exit status of 0 is returned if a new update is available.\n", PROBE_FLAG);
+    fprintf(stderr, " --%s\n    Allows probing and installing major upgrades. Without passing this, an exit\n    status of 2 is returned if a major upgrade is found.\n", ALLOW_MAJOR_UPGRADES_FLAG);
     fprintf(stderr, " --%s\n    List of allowed Sparkle channels to look for updates in. By default,\n    only the default channel is used.\n", CHANNELS_FLAG);
     fprintf(stderr, " --%s\n    URL for appcast feed. This URL will be used for the feed instead of the one\n    in the bundle's Info.plist or in the bundle's user defaults.\n", FEED_URL_FLAG);
     fprintf(stderr, " --%s\n    Allows prompting the user for an authorization dialog prompt if the\n    installer needs elevated privileges, or allows performing an interactive\n    installer package.\n", INTERACTIVE_FLAG);
@@ -66,6 +68,7 @@ int main(int argc, char **argv)
             {SEND_PROFILE_FLAG, no_argument, NULL, 0},
             {PROBE_FLAG, no_argument, NULL, 0},
             {INTERACTIVE_FLAG, no_argument, NULL, 0},
+            {ALLOW_MAJOR_UPGRADES_FLAG, no_argument, NULL, 0},
             {0, 0, 0, 0}
         };
         
@@ -79,6 +82,7 @@ int main(int argc, char **argv)
         BOOL sendProfile = NO;
         BOOL probeForUpdates = NO;
         BOOL interactive = NO;
+        BOOL allowMajorUpgrades = NO;
         
         while (YES) {
             int optionIndex = 0;
@@ -130,6 +134,8 @@ int main(int argc, char **argv)
                         probeForUpdates = YES;
                     } else if (strcmp(INTERACTIVE_FLAG, longOptions[optionIndex].name) == 0) {
                         interactive = YES;
+                    } else if (strcmp(ALLOW_MAJOR_UPGRADES_FLAG, longOptions[optionIndex].name) == 0) {
+                        allowMajorUpgrades = YES;
                     }
                 case ':':
                     break;
@@ -162,7 +168,7 @@ int main(int argc, char **argv)
             updatePermissionResponse = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:YES sendSystemProfile:sendProfile];
         }
         
-        SPUCommandLineDriver *driver = [[SPUCommandLineDriver alloc] initWithUpdateBundlePath:updatePath applicationBundlePath:applicationPath allowedChannels:channels customFeedURL:feedURL updatePermissionResponse:updatePermissionResponse deferInstallation:deferInstall interactiveInstallation:interactive verbose:verbose];
+        SPUCommandLineDriver *driver = [[SPUCommandLineDriver alloc] initWithUpdateBundlePath:updatePath applicationBundlePath:applicationPath allowedChannels:channels customFeedURL:feedURL updatePermissionResponse:updatePermissionResponse deferInstallation:deferInstall interactiveInstallation:interactive allowMajorUpgrades:allowMajorUpgrades verbose:verbose];
         if (driver == nil) {
             fprintf(stderr, "Error: Failed to initialize updater. Are the bundle paths provided valid?\n");
             return EXIT_FAILURE;


### PR DESCRIPTION
Make installing major upgrades opt-in. Add flag to allow installing major upgrades in sparkle-cli.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other - sparkle-cli

Tested major upgrades are not automatically installed by default and exit(2)
Tested major upgrades are installed when allow-major-upgrades flag is passed.

macOS version tested: 11.5 Beta (20G5042c)
