### PR TITLE
Set $USER and $HOME variables when running guided pkg installers

### DIFF
--- a/Autoupdate/AppInstaller.h
+++ b/Autoupdate/AppInstaller.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AppInstaller : NSObject
 
-- (instancetype)initWithHostBundleIdentifier:(NSString *)hostBundleIdentifier;
+- (instancetype)initWithHostBundleIdentifier:(NSString *)hostBundleIdentifier homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName;
 
 - (void)start;
 

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -55,6 +55,8 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
 @property (nonatomic) SUUpdateValidator *updateValidator;
 
 @property (nonatomic, readonly, copy) NSString *hostBundleIdentifier;
+@property (nonatomic, readonly) NSString *homeDirectory;
+@property (nonatomic, readonly) NSString *userName;
 @property (nonatomic) SUHost *host;
 @property (nonatomic, copy) NSString *updateDirectoryPath;
 @property (nonatomic, copy) NSString *downloadName;
@@ -86,6 +88,8 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
 @synthesize agentConnection = _agentConnection;
 @synthesize receivedUpdaterPong = _receivedUpdaterPong;
 @synthesize hostBundleIdentifier = _hostBundleIdentifier;
+@synthesize homeDirectory = _homeDirectory;
+@synthesize userName = _userName;
 @synthesize terminationListener = _terminationListener;
 @synthesize updateValidator = _updateValidator;
 @synthesize host = _host;
@@ -107,13 +111,16 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
 @synthesize finishedValidation = _finishedValidation;
 @synthesize agentInitiatedConnection = _agentInitiatedConnection;
 
-- (instancetype)initWithHostBundleIdentifier:(NSString *)hostBundleIdentifier
+- (instancetype)initWithHostBundleIdentifier:(NSString *)hostBundleIdentifier homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName
 {
     if (!(self = [super init])) {
         return nil;
     }
     
     _hostBundleIdentifier = [hostBundleIdentifier copy];
+    
+    _homeDirectory = [homeDirectory copy];
+    _userName = [userName copy];
     
     _xpcListener = [[NSXPCListener alloc] initWithMachServiceName:SPUInstallerServiceNameForBundleIdentifier(hostBundleIdentifier)];
     _xpcListener.delegate = self;
@@ -454,7 +461,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     
     dispatch_async(self.installerQueue, ^{
         NSError *installerError = nil;
-        id <SUInstallerProtocol> installer = [SUInstaller installerForHost:self.host expectedInstallationType:self.installationType updateDirectory:self.updateDirectoryPath error:&installerError];
+        id <SUInstallerProtocol> installer = [SUInstaller installerForHost:self.host expectedInstallationType:self.installationType updateDirectory:self.updateDirectoryPath homeDirectory:self.homeDirectory userName:self.userName error:&installerError];
         
         if (installer == nil) {
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/Autoupdate/SUGuidedPackageInstaller.h
+++ b/Autoupdate/SUGuidedPackageInstaller.h
@@ -21,6 +21,6 @@ A guided installation can be started by applications other than the application 
 
 @interface SUGuidedPackageInstaller : NSObject <SUInstallerProtocol>
 
-- (instancetype)initWithPackagePath:(NSString *)packagePath;
+- (instancetype)initWithPackagePath:(NSString *)packagePath homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName;
 
 @end

--- a/Autoupdate/SUGuidedPackageInstaller.m
+++ b/Autoupdate/SUGuidedPackageInstaller.m
@@ -16,18 +16,24 @@
 @interface SUGuidedPackageInstaller ()
 
 @property (nonatomic, readonly, copy) NSString *packagePath;
+@property (nonatomic, readonly, copy) NSString *homeDirectory;
+@property (nonatomic, readonly, copy) NSString *userName;
 
 @end
 
 @implementation SUGuidedPackageInstaller
 
 @synthesize packagePath = _packagePath;
+@synthesize homeDirectory = _homeDirectory;
+@synthesize userName = _userName;
 
-- (instancetype)initWithPackagePath:(NSString *)packagePath
+- (instancetype)initWithPackagePath:(NSString *)packagePath homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName
 {
     self = [super init];
     if (self != nil) {
         _packagePath = [packagePath copy];
+        _homeDirectory = [homeDirectory copy];
+        _userName = [userName copy];
     }
     return self;
 }
@@ -45,6 +51,8 @@
     NSTask *task = [[NSTask alloc] init];
     task.launchPath = installerPath;
     task.arguments = @[@"-pkg", self.packagePath, @"-target", @"/"];
+    // Set the $HOME and $USER variables so pre/post install scripts reference the correct user environment
+    task.environment = @{@"HOME": self.homeDirectory, @"USER": self.userName};
     task.standardError = [NSPipe pipe];
     task.standardOutput = [NSPipe pipe];
     

--- a/Autoupdate/SUInstaller.h
+++ b/Autoupdate/SUInstaller.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUInstaller : NSObject
 
-+ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host expectedInstallationType:(NSString *)expectedInstallationType updateDirectory:(NSString *)updateDirectory error:(NSError **)error;
++ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host expectedInstallationType:(NSString *)expectedInstallationType updateDirectory:(NSString *)updateDirectory homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName error:(NSError **)error;
 
 + (nullable NSString *)installSourcePathInUpdateFolder:(NSString *)inUpdateFolder forHost:(SUHost *)host isPackage:(BOOL *)isPackagePtr isGuided:(nullable BOOL *)isGuidedPtr;
 

--- a/Autoupdate/SUInstaller.m
+++ b/Autoupdate/SUInstaller.m
@@ -112,7 +112,7 @@
     return newAppDownloadPath;
 }
 
-+ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host expectedInstallationType:(NSString *)expectedInstallationType updateDirectory:(NSString *)updateDirectory error:(NSError * __autoreleasing *)error
++ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host expectedInstallationType:(NSString *)expectedInstallationType updateDirectory:(NSString *)updateDirectory homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName error:(NSError * __autoreleasing *)error
 {
     BOOL isPackage = NO;
     BOOL isGuided = NO;
@@ -135,7 +135,7 @@
                 *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Found guided package installer but '%@=%@' was probably missing in the appcast item enclosure", SUAppcastAttributeInstallationType, SPUInstallationTypeGuidedPackage] }];
             }
         } else {
-            installer = [[SUGuidedPackageInstaller alloc] initWithPackagePath:newDownloadPath];
+            installer = [[SUGuidedPackageInstaller alloc] initWithPackagePath:newDownloadPath homeDirectory:homeDirectory userName:userName];
         }
     } else if (isPackage) {
         if (![expectedInstallationType isEqualToString:SPUInstallationTypeInteractivePackage]) {

--- a/Autoupdate/main.m
+++ b/Autoupdate/main.m
@@ -9,13 +9,15 @@ int main(int __unused argc, const char __unused *argv[])
     @autoreleasepool
     {
         NSArray<NSString *> *args = [[NSProcessInfo processInfo] arguments];
-        if (args.count != 2) {
+        if (args.count != 4) {
             return EXIT_FAILURE;
         }
         
         NSString *hostBundleIdentifier = args[1];
+        NSString *homeDirectory = args[2];
+        NSString *userName = args[3];
         
-        AppInstaller *appInstaller = [[AppInstaller alloc] initWithHostBundleIdentifier:hostBundleIdentifier];
+        AppInstaller *appInstaller = [[AppInstaller alloc] initWithHostBundleIdentifier:hostBundleIdentifier homeDirectory:homeDirectory userName:userName];
         [appInstaller start];
         
         // Ignore SIGTERM because we are going to catch it ourselves

--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -109,11 +109,19 @@
     NSString *hostBundleIdentifier = hostBundle.bundleIdentifier;
     assert(hostBundleIdentifier != nil);
     
+    NSString *homeDirectory = NSHomeDirectory();
+    assert(homeDirectory != nil);
+    
+    NSString *userName = NSUserName();
+    assert(userName != nil);
+    
     // The first argument has to be the path to the program, and the second is a host identifier so that the installer knows what mach services to host
+    // The third and forth arguments are for home directory and user name which only pkg installer scripts may need
     // We intentionally do not pass any more arguments. Anything else should be done via IPC.
     // This is compatible to SMJobBless() which does not allow arguments
     // Even though we aren't using that function for now, it'd be wise to not decrease compatibility to it
-    NSArray<NSString *> *arguments = @[installerPath, hostBundleIdentifier];
+    
+    NSArray<NSString *> *arguments = @[installerPath, hostBundleIdentifier, homeDirectory, userName];
     
     AuthorizationRef auth = NULL;
     OSStatus createStatus = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment, kAuthorizationFlagDefaults, &auth);

--- a/Tests/SUInstallerTest.m
+++ b/Tests/SUInstallerTest.m
@@ -54,7 +54,9 @@
     SUHost *host = [[SUHost alloc] initWithBundle:bundle];
 
     NSError *installerError = nil;
-    id<SUInstallerProtocol> installer = [SUInstaller installerForHost:host expectedInstallationType:SPUInstallationTypeGuidedPackage updateDirectory:[path stringByDeletingLastPathComponent] error:&installerError];
+    // Note: we may not be using the "correct" home directory or user name (they will be root) but our test pkg does not have
+    // pre/post install scripts so it doesn't matter
+    id<SUInstallerProtocol> installer = [SUInstaller installerForHost:host expectedInstallationType:SPUInstallationTypeGuidedPackage updateDirectory:[path stringByDeletingLastPathComponent] homeDirectory:NSHomeDirectory() userName:NSUserName() error:&installerError];
     
     if (installer == nil) {
         XCTFail(@"Installer is nil with error: %@", installerError);


### PR DESCRIPTION
This allows pre/post install scripts to reference the user's environment correctly. The standard pkg installer GUI preserves these two variables.

Fixes #1882

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other - custom app that updates via pkg

I tested that a post install script correctly uses appropriate $USER and $HOME (by echo'ing them to a file in /tmp). My pkg file didn't correctly install the app but that's probably because I didn't create the pkg correctly as the same happens when I run with `sudo installer` .. and they're a pain to figure out generating correctly.

macOS version tested: 11.5 Beta (20G5042c)
