### PR TITLE
Provide reason update is not found to updater delegate

### DIFF
--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -159,7 +159,7 @@
     [self notifyFoundValidUpdateWithAppcastItem:updateItem secondaryAppcastItem:secondaryAppcastItem systemDomain:nil];
 }
 
-- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult
+- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult background:(BOOL)background
 {
     if (!self.aborted) {
         NSString *localizedDescription;
@@ -200,7 +200,7 @@
                         
                         reason = SPUNoUpdateFoundReasonSystemIsTooNew;
                     } else {
-                        // The new update may be skipped or not in the current phased rollout group
+                        // We shouldn't realistically get here
                         localizedDescription = SULocalizedString(@"You're up-to-date!", "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
                         
                         recoverySuggestion = [NSString stringWithFormat:SULocalizedString(@"%@ %@ is currently the newest version available.", nil), [self.host name], [self.host displayVersion]];
@@ -228,6 +228,7 @@
             NSLocalizedRecoverySuggestionErrorKey: recoverySuggestion,
             NSLocalizedRecoveryOptionsErrorKey: @[recoveryOption],
             SPUNoUpdateFoundReasonKey: @(reason),
+            SPUNoUpdateFoundUserInitiatedKey: @(!background),
         }];
         
         if (latestAppcastItem != nil) {

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -229,8 +229,8 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  \param error An error containing information on why a new valid update was not found
     There are various reasons a new update is unavailable and can't be installed.
     The userInfo dictionary on the error is also populated with three keys:
-    SPULatestAppcastItemFoundKey: if available, this may provide the latest SUAppcastItem that was found.
-    SPUNoUpdateFoundReasonKey: if available, this will provide the SUNoUpdateFoundReason.
+    SPULatestAppcastItemFoundKey: if available, this may provide the latest SUAppcastItem that was found. This will be nil if it's unavailable.
+    SPUNoUpdateFoundReasonKey: This will provide the SUNoUpdateFoundReason.
     For example the reason could be because the latest version in the feed requires a newer OS version or could be because the user is already on the latest version.
     SPUNoUpdateFoundUserInitiatedKey: A boolean that indicates if a new update was not found when the user intitiated an update check manually.
  */

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -228,12 +228,11 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  \param updater The updater instance.
  \param error An error containing information on why a new valid update was not found
     There are various reasons a new update is unavailable and can't be installed.
-    The userInfo dictionary on the error is also populated with two keys:
+    The userInfo dictionary on the error is also populated with three keys:
     SPULatestAppcastItemFoundKey: if available, this may provide the latest SUAppcastItem that was found.
     SPUNoUpdateFoundReasonKey: if available, this will provide the SUNoUpdateFoundReason.
     For example the reason could be because the latest version in the feed requires a newer OS version or could be because the user is already on the latest version.
-    If the reason is SPUNoUpdateFoundReasonUnknown, do not make any assumptions on the latest appcast item found.
-    For example ,this could actually include an update that is not ready to be notified to the user yet, or that the feed lacks update information.
+    SPUNoUpdateFoundUserInitiatedKey: A boolean that indicates if a new update was not found when the user intitiated an update check manually.
  */
 - (void)updaterDidNotFindUpdate:(SPUUpdater *)updater error:(NSError *)error;
 

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -226,6 +226,21 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  Called when a valid update is not found.
  
  \param updater The updater instance.
+ \param error An error containing information on why a new valid update was not found
+    There are various reasons a new update is unavailable and can't be installed.
+    The userInfo dictionary on the error is also populated with two keys:
+    SPULatestAppcastItemFoundKey: if available, this may provide the latest SUAppcastItem that was found.
+    SPUNoUpdateFoundReasonKey: if available, this will provide the SUNoUpdateFoundReason.
+    For example the reason could be because the latest version in the feed requires a newer OS version or could be because the user is already on the latest version.
+    If the reason is SPUNoUpdateFoundReasonUnknown, do not make any assumptions on the latest appcast item found.
+    For example ,this could actually include an update that is not ready to be notified to the user yet, or that the feed lacks update information.
+ */
+- (void)updaterDidNotFindUpdate:(SPUUpdater *)updater error:(NSError *)error;
+
+/*!
+ Called when a valid update is not found.
+ 
+ \param updater The updater instance.
  */
 - (void)updaterDidNotFindUpdate:(SPUUpdater *)updater;
 

--- a/Sparkle/SUAppcastDriver.h
+++ b/Sparkle/SUAppcastDriver.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didFailToFetchAppcastWithError:(NSError *)error;
 - (void)didFinishLoadingAppcast:(SUAppcast *)appcast;
 - (void)didFindValidUpdateWithAppcastItem:(SUAppcastItem *)appcastItem secondaryAppcastItem:(SUAppcastItem * _Nullable)secondaryAppcastItem;
-- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult;
+- (void)didNotFindUpdateWithLatestAppcastItem:(nullable SUAppcastItem *)latestAppcastItem hostToLatestAppcastItemComparisonResult:(NSComparisonResult)hostToLatestAppcastItemComparisonResult background:(BOOL)background;
 
 @end
 

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -223,17 +223,19 @@
         // We found a suitable update
         [self.delegate didFindValidUpdateWithAppcastItem:finalPrimaryItem secondaryAppcastItem:finalSecondaryItem];
     } else {
-        // Find the latest appcast item even if it fails min/max OS test
-        // We want to inform the user if an update requires a different OS version
-        // We only need to do this if an update is being checked by the user manually
-        SUAppcastItem *notFoundPrimaryItem;
+        // Find the latest appcast item that we can report to the user and updater delegates
+        // This excludes updates that are major upgrades. This may includes that fail due to OS version requirements.
+        // This may also include newer updates that fail because they are skipped or not in current phased rollout group
+        // Note if there is both a minor and major update are available, and neither are installable because
+        // of an OS requirement, we will want to prefer reporting the minor update.
+        SUAppcast *passesMinimumAutoupdateAndFailsOSAppcast = [[self class] filterSupportedAppcast:macOSAppcast phasedUpdateGroup:nil skippedUpdate:nil hostVersion:self.host.version versionComparator:applicationVersionComparator testOSVersion:NO testMinimumAutoupdateVersion:YES];
+        
+        SUAppcastItem *notFoundPrimaryItem = [self retrieveBestAppcastItemFromAppcast:passesMinimumAutoupdateAndFailsOSAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil];
+        
         NSComparisonResult hostToLatestAppcastItemComparisonResult;
-        if (!background) {
-            notFoundPrimaryItem = [self retrieveBestAppcastItemFromAppcast:macOSAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil];
-            
+        if (notFoundPrimaryItem != nil) {
             hostToLatestAppcastItemComparisonResult = [applicationVersionComparator compareVersion:self.host.version toVersion:notFoundPrimaryItem.versionString];
         } else {
-            notFoundPrimaryItem = nil;
             hostToLatestAppcastItemComparisonResult = 0;
         }
         

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -224,13 +224,11 @@
         [self.delegate didFindValidUpdateWithAppcastItem:finalPrimaryItem secondaryAppcastItem:finalSecondaryItem];
     } else {
         // Find the latest appcast item that we can report to the user and updater delegates
-        // This excludes updates that are major upgrades. This may includes that fail due to OS version requirements.
-        // This may also include newer updates that fail because they are skipped or not in current phased rollout group
-        // Note if there is both a minor and major update are available, and neither are installable because
-        // of an OS requirement, we will want to prefer reporting the minor update.
-        SUAppcast *passesMinimumAutoupdateAndFailsOSAppcast = [[self class] filterSupportedAppcast:macOSAppcast phasedUpdateGroup:nil skippedUpdate:nil hostVersion:self.host.version versionComparator:applicationVersionComparator testOSVersion:NO testMinimumAutoupdateVersion:YES];
+        // This may include updates that fail due to OS version requirements.
+        // This excludes newer backgrounded updates that fail because they are skipped or not in current phased rollout group
+        SUAppcast *notFoundAppcast = [[self class] filterSupportedAppcast:macOSAppcast phasedUpdateGroup:phasedUpdateGroup skippedUpdate:skippedUpdate hostVersion:self.host.version versionComparator:applicationVersionComparator testOSVersion:NO testMinimumAutoupdateVersion:NO];
         
-        SUAppcastItem *notFoundPrimaryItem = [self retrieveBestAppcastItemFromAppcast:passesMinimumAutoupdateAndFailsOSAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil];
+        SUAppcastItem *notFoundPrimaryItem = [self retrieveBestAppcastItemFromAppcast:notFoundAppcast versionComparator:applicationVersionComparator secondaryUpdate:nil];
         
         NSComparisonResult hostToLatestAppcastItemComparisonResult;
         if (notFoundPrimaryItem != nil) {
@@ -239,7 +237,7 @@
             hostToLatestAppcastItemComparisonResult = 0;
         }
         
-        [self.delegate didNotFindUpdateWithLatestAppcastItem:notFoundPrimaryItem hostToLatestAppcastItemComparisonResult:hostToLatestAppcastItemComparisonResult];
+        [self.delegate didNotFindUpdateWithLatestAppcastItem:notFoundPrimaryItem hostToLatestAppcastItemComparisonResult:hostToLatestAppcastItemComparisonResult background:background];
     }
 }
 

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -58,6 +58,7 @@ NSString *const SUFixedHTMLDisplaySizeKey = @"SUFixedHTMLDisplaySize";
 NSString *const SUDefaultsDomainKey = @"SUDefaultsDomain";
 NSString *const SUSparkleErrorDomain = @"SUSparkleErrorDomain";
 NSString *const SPUNoUpdateFoundReasonKey = @"SUNoUpdateFoundReason";
+NSString *const SPUNoUpdateFoundUserInitiatedKey = @"SPUNoUpdateUserInitiated";
 NSString *const SPULatestAppcastItemFoundKey = @"SULatestAppcastItemFound";
 
 NSString *const SUAppendVersionNumberKey = @"SUAppendVersionNumber";

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -88,5 +88,6 @@ typedef NS_ENUM(OSStatus, SPUNoUpdateFoundReason) {
 
 SU_EXPORT extern NSString *const SPUNoUpdateFoundReasonKey;
 SU_EXPORT extern NSString *const SPULatestAppcastItemFoundKey;
+SU_EXPORT extern NSString *const SPUNoUpdateFoundUserInitiatedKey;
 
 #endif


### PR DESCRIPTION
Provide reason update is not found and latest appcast item to updater delegate and not just the user driver.

This would also be a delegate point that allows developers to fetch custom information from the latest available appcast item if applicable (like an informative message or something).

Fixes #900 potentially too.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested implementing update not found delegate in test app and made sure all reasons were hit and appcast item was retrievable.

macOS version tested: 11.5 Beta (20G5042c)
