### PR TITLE
Avoid DSA verification if EdDSA verification passes

### DIFF
--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -113,7 +113,7 @@
     case SUSigningInputStatusPresent:
         switch (signatures.ed25519SignatureStatus) {
         case SUSigningInputStatusAbsent:
-            SULog(SULogLevelError, @"The app has an EdDSA signature, but there is no EdDSA signature in the update.");
+            SULog(SULogLevelError, @"The app has an EdDSA public key, but there is no EdDSA signature in the update, so the update will be rejected.");
             return NO;
         case SUSigningInputStatusInvalid:
             // We will have already logged an error for this failure when the signature was read in, so just do an informational log here.

--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -128,8 +128,11 @@
             }
             if (ed25519_verify(signatures.ed25519Signature, data.bytes, data.length, self.pubKeys.ed25519PubKey)) {
                 SULog(SULogLevelDefault, @"OK: EdDSA signature is correct");
-                // No need to check DSA when EdDSA verification succeeded
-                return YES;
+                // No need to check DSA when EdDSA verification succeeded, unless a DSA signature is provided and it's
+                // erroneously invalid
+                if (signatures.dsaSignatureStatus != SUSigningInputStatusInvalid) {
+                    return YES;
+                }
             } else {
                 SULog(SULogLevelError, @"EdDSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set.");
                 if (signatures.dsaSignatureStatus != SUSigningInputStatusAbsent) {

--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -96,8 +96,6 @@
         return NO;
     }
 
-    //self.pubKeys == keys in the app
-    //signatures from the appcast
     switch (self.pubKeys.ed25519PubKeyStatus) {
     case SUSigningInputStatusAbsent:
         if (signatures.ed25519SignatureStatus != SUSigningInputStatusAbsent) {

--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -113,8 +113,8 @@
     case SUSigningInputStatusPresent:
         switch (signatures.ed25519SignatureStatus) {
         case SUSigningInputStatusAbsent:
-            SULog(SULogLevelDefault, @"The update has an EdDSA signature, but it won't be used, because the old app doesn't have an EdDSA public key");
-            break;
+            SULog(SULogLevelError, @"The update has an EdDSA signature, but there is no EdDSA signature in the update.");
+            return NO;
         case SUSigningInputStatusInvalid:
             // We will have already logged an error for this failure when the signature was read in, so just do an informational log here.
             SULog(SULogLevelDefault, @"The update has an EdDSA signature, but it's invalid, so the update will automatically be rejected.");

--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -113,7 +113,7 @@
     case SUSigningInputStatusPresent:
         switch (signatures.ed25519SignatureStatus) {
         case SUSigningInputStatusAbsent:
-            SULog(SULogLevelError, @"The update has an EdDSA signature, but there is no EdDSA signature in the update.");
+            SULog(SULogLevelError, @"The app has an EdDSA signature, but there is no EdDSA signature in the update.");
             return NO;
         case SUSigningInputStatusInvalid:
             // We will have already logged an error for this failure when the signature was read in, so just do an informational log here.

--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -96,6 +96,8 @@
         return NO;
     }
 
+    //self.pubKeys == keys in the app
+    //signatures from the appcast
     switch (self.pubKeys.ed25519PubKeyStatus) {
     case SUSigningInputStatusAbsent:
         if (signatures.ed25519SignatureStatus != SUSigningInputStatusAbsent) {
@@ -128,11 +130,8 @@
             }
             if (ed25519_verify(signatures.ed25519Signature, data.bytes, data.length, self.pubKeys.ed25519PubKey)) {
                 SULog(SULogLevelDefault, @"OK: EdDSA signature is correct");
-                if (self.pubKeys.dsaPubKeyStatus == SUSigningInputStatusAbsent) {
-                    return YES;
-                } else {
-                    SULog(SULogLevelDefault, @"This app has a DSA public key, so a DSA signature is required too");
-                }
+                // No need to check DSA when EdDSA verification succeeded
+                return YES;
             } else {
                 SULog(SULogLevelError, @"EdDSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set.");
                 if (signatures.dsaSignatureStatus != SUSigningInputStatusAbsent) {

--- a/Tests/SUSignatureVerifierTest.m
+++ b/Tests/SUSignatureVerifierTest.m
@@ -121,13 +121,7 @@
     XCTAssertNotNil(dsaKey, @"Public key must be readable");
 
     SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:dsaKey ed:self.pubEdKey];
-    
-    SUPublicKeys *pubKeysWithDSAOnly = [[SUPublicKeys alloc] initWithDsa:dsaKey ed:nil];
-    SUPublicKeys *pubKeysWithEdDSAOnly = [[SUPublicKeys alloc] initWithDsa:nil ed:self.pubEdKey];
-    
     SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
-    SUSignatureVerifier *dsaOnlyVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeysWithDSAOnly];
-    SUSignatureVerifier *edDSAOnlyVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeysWithEdDSAOnly];
 
     XCTAssertFalse([v verifyFileAtPath:self.testFile
                             signatures:[[SUSignatures alloc] initWithDsa:nil ed:nil]],
@@ -144,38 +138,6 @@
     XCTAssertFalse([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
                   @"EdDSA signature must be present if app has EdDSA key");
-    
-    XCTAssertTrue([dsaOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
-                  @"Allow good DSA signature on app that only has DSA");
-    
-    XCTAssertFalse([dsaOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:nil]],
-                  @"Reject bad DSA signature on app that only has DSA");
-    
-    XCTAssertFalse([dsaOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:nil]],
-                  @"Fail on no DSA signature present on app that only has DSA");
-    
-    XCTAssertFalse([dsaOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
-                  @"Fail on no DSA signature present on app that only has DSA but has EdDSA");
-    
-    XCTAssertTrue([edDSAOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
-                  @"Pass valid EdDSA signature on app that only has EdDSA");
-    
-    XCTAssertFalse([edDSAOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:@"lol"]],
-                  @"Fail on invalid EdDSA signature on app that only has EdDSA");
-    
-    XCTAssertFalse([edDSAOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:nil]],
-                  @"Fail on no EdDSA signature on app that only has EdDSA");
-    
-    XCTAssertFalse([edDSAOnlyVerifier verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
-                  @"Fail on DSA signature on app that only has EdDSA");
     
     XCTAssertTrue([v verifyFileAtPath:self.testFile
                             signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
@@ -194,10 +156,6 @@
     XCTAssertFalse([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:edSig]],
                    @"Fail if invalid DSA signature is used even if EdDSA signature is good.");
-    
-    XCTAssertTrue([v verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
-                   @"Allow no DSA signature if EdDSA signature is good.");
 
     XCTAssertTrue([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:edSig]],

--- a/Tests/SUSignatureVerifierTest.m
+++ b/Tests/SUSignatureVerifierTest.m
@@ -191,9 +191,9 @@
     XCTAssertFalse([v verifyFileAtPath:self.testFile
                             signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:@"lol"]],
                    @"Fail if the Ed25519 signature is invalid.");
-    XCTAssertTrue([v verifyFileAtPath:self.testFile
+    XCTAssertFalse([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:edSig]],
-                   @"Allow invalid DSA signature if EdDSA signature is good.");
+                   @"Fail if invalid DSA signature is used even if EdDSA signature is good.");
     
     XCTAssertTrue([v verifyFileAtPath:self.testFile
                            signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],

--- a/Tests/SUUpdateValidatorTest.swift
+++ b/Tests/SUUpdateValidatorTest.swift
@@ -62,14 +62,16 @@ class SUUpdateValidatorTest: XCTestCase {
         let dsaSig: String?
         switch config.dsa {
         case .none: dsaSig = nil
-        case .invalid: dsaSig = "MCwCFCIHCiYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
+        // Use some invalid base64 characters
+        case .invalid: dsaSig = "^%wCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
         case .valid: dsaSig = "MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
         }
 
         let edSig: String?
         switch config.ed {
         case .none: edSig = nil
-        case .invalid: edSig = "wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="
+        // Use some invalid base64 characters
+        case .invalid: edSig = "%%cpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="
         case .valid: edSig = "EIawm2YkDZ2gBfkEMF2+1VuuTeXnCGZOdnMdVgPPvDZioq7bvDayXqKkIIzSjKMmeFdcFJOHdnba5ZV60+gPBw=="
         }
 
@@ -84,7 +86,6 @@ class SUUpdateValidatorTest: XCTestCase {
     func testPrevalidation(bundle bundleConfig: BundleConfig, signatures signatureConfig: SignatureConfig, expectedResult: Bool, line: UInt = #line) {
         let host = SUHost(bundle: self.bundle(bundleConfig))
         let signatures = self.signatures(signatureConfig)
-
         let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host)
 
         let result = (try? validator.validateDownloadPath()) != nil
@@ -95,8 +96,8 @@ class SUUpdateValidatorTest: XCTestCase {
         for signatureConfig in SignatureConfig.allCases {
             testPrevalidation(bundle: .none, signatures: signatureConfig, expectedResult: false)
             testPrevalidation(bundle: .dsaOnly, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid)
-            testPrevalidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
-            testPrevalidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
+            testPrevalidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
+            testPrevalidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
         }
     }
 
@@ -124,15 +125,15 @@ class SUUpdateValidatorTest: XCTestCase {
         for signatureConfig in SignatureConfig.allCases {
             testPostValidation(bundle: .none, signatures: signatureConfig, expectedResult: false)
             testPostValidation(bundle: .dsaOnly, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid)
-            testPostValidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
-            testPostValidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
+            testPostValidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
+            testPostValidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
         }
     }
 
     func testPostValidationWithCodeSigning() {
         for signatureConfig in SignatureConfig.allCases {
             testPostValidation(bundle: .codeSignedOnly, signatures: signatureConfig, expectedResult: true)
-            testPostValidation(bundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
+            testPostValidation(bundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
 
             testPostValidation(bundle: .codeSignedInvalidOnly, signatures: signatureConfig, expectedResult: false)
             testPostValidation(bundle: .codeSignedInvalid, signatures: signatureConfig, expectedResult: false)
@@ -150,7 +151,7 @@ class SUUpdateValidatorTest: XCTestCase {
 
     func testPostValidationWithKeyRotation() {
         for signatureConfig in SignatureConfig.allCases {
-            let signatureIsValid = signatureConfig.ed == .valid
+            let signatureIsValid = (signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
 
             // It's okay to add DSA keys or add code signing.
             testPostValidation(oldBundle: .codeSignedOnly, newBundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureIsValid)

--- a/Tests/SUUpdateValidatorTest.swift
+++ b/Tests/SUUpdateValidatorTest.swift
@@ -62,16 +62,14 @@ class SUUpdateValidatorTest: XCTestCase {
         let dsaSig: String?
         switch config.dsa {
         case .none: dsaSig = nil
-        // Use some invalid base64 characters
-        case .invalid: dsaSig = "^%wCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
+        case .invalid: dsaSig = "ABwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
         case .valid: dsaSig = "MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
         }
 
         let edSig: String?
         switch config.ed {
         case .none: edSig = nil
-        // Use some invalid base64 characters
-        case .invalid: edSig = "%%cpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="
+        case .invalid: edSig = "wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="
         case .valid: edSig = "EIawm2YkDZ2gBfkEMF2+1VuuTeXnCGZOdnMdVgPPvDZioq7bvDayXqKkIIzSjKMmeFdcFJOHdnba5ZV60+gPBw=="
         }
 
@@ -96,8 +94,8 @@ class SUUpdateValidatorTest: XCTestCase {
         for signatureConfig in SignatureConfig.allCases {
             testPrevalidation(bundle: .none, signatures: signatureConfig, expectedResult: false)
             testPrevalidation(bundle: .dsaOnly, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid)
-            testPrevalidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
-            testPrevalidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
+            testPrevalidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
+            testPrevalidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
         }
     }
 
@@ -125,15 +123,15 @@ class SUUpdateValidatorTest: XCTestCase {
         for signatureConfig in SignatureConfig.allCases {
             testPostValidation(bundle: .none, signatures: signatureConfig, expectedResult: false)
             testPostValidation(bundle: .dsaOnly, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid)
-            testPostValidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
-            testPostValidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
+            testPostValidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
+            testPostValidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
         }
     }
 
     func testPostValidationWithCodeSigning() {
         for signatureConfig in SignatureConfig.allCases {
             testPostValidation(bundle: .codeSignedOnly, signatures: signatureConfig, expectedResult: true)
-            testPostValidation(bundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
+            testPostValidation(bundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
 
             testPostValidation(bundle: .codeSignedInvalidOnly, signatures: signatureConfig, expectedResult: false)
             testPostValidation(bundle: .codeSignedInvalid, signatures: signatureConfig, expectedResult: false)
@@ -151,7 +149,7 @@ class SUUpdateValidatorTest: XCTestCase {
 
     func testPostValidationWithKeyRotation() {
         for signatureConfig in SignatureConfig.allCases {
-            let signatureIsValid = (signatureConfig.ed == .valid && signatureConfig.dsa != .invalid)
+            let signatureIsValid = (signatureConfig.ed == .valid)
 
             // It's okay to add DSA keys or add code signing.
             testPostValidation(oldBundle: .codeSignedOnly, newBundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureIsValid)

--- a/Tests/SUUpdateValidatorTest.swift
+++ b/Tests/SUUpdateValidatorTest.swift
@@ -96,7 +96,7 @@ class SUUpdateValidatorTest: XCTestCase {
             testPrevalidation(bundle: .none, signatures: signatureConfig, expectedResult: false)
             testPrevalidation(bundle: .dsaOnly, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid)
             testPrevalidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
-            testPrevalidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid && signatureConfig.ed != .invalid)
+            testPrevalidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
         }
     }
 
@@ -125,14 +125,14 @@ class SUUpdateValidatorTest: XCTestCase {
             testPostValidation(bundle: .none, signatures: signatureConfig, expectedResult: false)
             testPostValidation(bundle: .dsaOnly, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid)
             testPostValidation(bundle: .edOnly, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
-            testPostValidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid && signatureConfig.ed != .invalid)
+            testPostValidation(bundle: .both, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
         }
     }
 
     func testPostValidationWithCodeSigning() {
         for signatureConfig in SignatureConfig.allCases {
             testPostValidation(bundle: .codeSignedOnly, signatures: signatureConfig, expectedResult: true)
-            testPostValidation(bundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureConfig.dsa == .valid && signatureConfig.ed != .invalid)
+            testPostValidation(bundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureConfig.ed == .valid)
 
             testPostValidation(bundle: .codeSignedInvalidOnly, signatures: signatureConfig, expectedResult: false)
             testPostValidation(bundle: .codeSignedInvalid, signatures: signatureConfig, expectedResult: false)
@@ -150,7 +150,7 @@ class SUUpdateValidatorTest: XCTestCase {
 
     func testPostValidationWithKeyRotation() {
         for signatureConfig in SignatureConfig.allCases {
-            let signatureIsValid = signatureConfig.dsa == .valid && (signatureConfig.ed == .valid || signatureConfig.ed == .none)
+            let signatureIsValid = signatureConfig.ed == .valid
 
             // It's okay to add DSA keys or add code signing.
             testPostValidation(oldBundle: .codeSignedOnly, newBundle: .codeSignedBoth, signatures: signatureConfig, expectedResult: signatureIsValid)


### PR DESCRIPTION
If EdDSA verification passes we don't need to have DSA verification pass, and don't need to require the new update to contain a DSA signature or keys.

We should also require EdDSA signature to be present in appcast if the app has EdDSA key. We ignore DSA unless the signature in the appcast is erroneously invalid.

The developer can omit the DSA signature in the appcast and if EdDSA verification passes, all is good.
The worst I see that can happen is that an unintentional/malicious change to appcast removes DSA signature on an update item, but that would just reject old app updates that don't have EdDSA keys.

Refs #1355

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements. - *I probably will after this is approved*
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

I will get to documentation/migration as part of another change. I also want to emit a log indicating DSA-only is deprecated soon.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other - custom test app to test DSA + EdDSA -> EdDSA

Tested Sparkle Test App (EdDSA -> EdDSA)
Tested custom app dropping DSA for app path (DSA + EdDSA -> EdDSA) (New allowed path)
Tested custom app dropping DSA for pkg path (DSA + EdDSA -> EdDSA) (New allowed path)
Tested sparkle-cli against an app that only used DSA (DSA -> DSA)
Tested sparkle-cli against an app that migrated to EdDSA (DSA -> DSA + EdDSA)
Updated unit tests testing input combinations of signatures and public keys to see what updates are valid

macOS version tested: 11.5 Beta (20G5042c)
