### PR TITLE
Add/port update relaunched API

### DIFF
--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -331,8 +331,19 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
             }
             
             // Note: we can launch application bundles or open plug-in bundles
-            if (![[NSWorkspace sharedWorkspace] openFile:pathToRelaunch]) {
-                SULog(SULogLevelError, @"Error: Failed to relaunch bundle at %@", pathToRelaunch);
+            if ([pathToRelaunch.pathExtension isEqualToString:@"app"]) {
+                // Looks like an application bundle
+                // Launch application with environment variable letting the app know it's been relaunched due to an update
+                NSDictionary<NSWorkspaceLaunchConfigurationKey, id> *launchConfiguration = @{NSWorkspaceLaunchConfigurationEnvironment: @{SURelaunchedApplicationUpdateKey: @"1"}};
+                NSError *launchError = nil;
+                if ([[NSWorkspace sharedWorkspace] launchApplicationAtURL:[NSURL fileURLWithPath:pathToRelaunch] options:NSWorkspaceLaunchDefault configuration:launchConfiguration error:&launchError] == nil) {
+                    SULog(SULogLevelError, @"Error: Failed to relaunch application at %@ with error: %@", pathToRelaunch, launchError);
+                }
+            } else {
+                // Most likely a plug-in bundle
+                if (![[NSWorkspace sharedWorkspace] openFile:pathToRelaunch]) {
+                    SULog(SULogLevelError, @"Error: Failed to relaunch bundle at %@", pathToRelaunch);
+                }
             }
             
             // Delay termination for a little bit to better increase the chance the updated application when relaunched will be the frontmost application

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -218,11 +218,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  The keys of this dictionary are HTTP header fields (NSString) and values are corresponding values (NSString)
  */
-#if __has_feature(objc_generics)
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *httpHeaders;
-#else
-@property (nonatomic, copy, nullable) NSDictionary *httpHeaders;
-#endif
 
 /*!
  A property indicating whether or not the user's system profile information is sent when checking for updates.
@@ -252,6 +248,16 @@ SU_EXPORT @interface SPUUpdater : NSObject
  The system profile information that is sent when checking for updates
  */
 @property (nonatomic, readonly, copy) NSArray<NSDictionary<NSString *, NSString *> *> *systemProfileArray;
+
+/*!
+ Specifies whether the main bundle was relanched from an update installed by Sparkle.
+ 
+ This property works by checking the presence of a Sparkle specific environment variable that Sparkle inserts on application re-launch.
+ 
+ Do not use this API in scenarios where you need to also take in account of application updates being installed by the user manually and not through Sparkle
+ (i.e, a user downloading an update from the web replacing the app bundle themselves)
+ */
+@property (nonatomic, class, readonly) BOOL mainBundleRelaunchedFromUpdate;
 
 @end
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -913,4 +913,11 @@ static NSString *escapeURLComponent(NSString *str) {
 
 - (NSBundle *)hostBundle { return [self.host bundle]; }
 
++ (BOOL)mainBundleRelaunchedFromUpdate
+{
+    NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+    NSString *relaunchedVariable = processInfo.environment[SURelaunchedApplicationUpdateKey];
+    return (relaunchedVariable != nil && relaunchedVariable.integerValue == 1);
+}
+
 @end

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -109,11 +109,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  \return An array of dictionaries with keys: "key", "value", "displayKey", "displayValue", the latter two being specifically for display to the user.
  */
-#if __has_feature(objc_generics)
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
-#else
-- (NSArray *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
-#endif
 
 /*!
  Returns a list of system profile keys to be appended to the appcast URL's query string.
@@ -124,11 +120,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 
  \return An array of system profile keys to include in the appcast URL's query string. Elements must be one of the SUSystemProfiler*Key constants
  */
-#if __has_feature(objc_generics)
 - (NSArray<NSString *> *)allowedSystemProfileKeysForUpdater:(SPUUpdater *)updater;
-#else
-- (NSArray *)allowedSystemProfileKeysForUpdater:(SPUUpdater *)updater;
-#endif
 
 /*!
  Returns a custom appcast URL.

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -23,6 +23,7 @@ extern const uint64_t SULeewayUpdateCheckInterval;
 extern const NSTimeInterval SUImpatientUpdateCheckInterval;
 
 extern NSString *const SUBundleIdentifier;
+extern NSString *const SURelaunchedApplicationUpdateKey;
 
 extern NSString *const SUAppcastAttributeValueMacOS;
 

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -28,6 +28,8 @@ const NSTimeInterval SUImpatientUpdateCheckInterval = DEBUG ? (60 * 2) : (60 * 6
 
 NSString *const SUBundleIdentifier = @SPARKLE_BUNDLE_IDENTIFIER;
 
+NSString *const SURelaunchedApplicationUpdateKey = @"SPARKLE_RELAUNCHED_APPLICATION_UPDATE";
+
 NSString *const SUAppcastAttributeValueMacOS = @"macos";
 
 NSString *const SUTechnicalErrorInformationKey = @"SUTechnicalErrorInformation";

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -86,6 +86,13 @@ static NSMutableDictionary *sharedUpdaters = nil;
         NSError *updaterError = nil;
         if (![self.updater startUpdater:&updaterError]) {
             SULog(SULogLevelError, @"Error: Failed to start updater with error: %@", updaterError);
+        } else if ([bundle isEqual:NSBundle.mainBundle] && SPUUpdater.mainBundleRelaunchedFromUpdate) {
+            // Give another runloop cycle's chance for delegate to be set
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if ([self.delegate respondsToSelector:@selector(updaterDidRelaunchApplication:)]) {
+                    [self.delegate updaterDidRelaunchApplication:self];
+                }
+            });
         }
     }
     return self;

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -38,7 +38,14 @@ static NSString * const UPDATED_VERSION = @"2.0";
     // Check if we are already up to date
     if ([(NSString *)[mainBundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey] isEqualToString:UPDATED_VERSION]) {
         NSAlert *alreadyUpdatedAlert = [[NSAlert alloc] init];
-        alreadyUpdatedAlert.messageText = @"Update succeeded!";
+        if (SPUUpdater.mainBundleRelaunchedFromUpdate) {
+            // UI Tests expect this string
+            alreadyUpdatedAlert.messageText = @"Update succeeded!";
+        } else {
+            // If update was already installed another time, show a different message that
+            // the UI tests don't expect.
+            alreadyUpdatedAlert.messageText = @"Update was already installed!";
+        }
         alreadyUpdatedAlert.informativeText = @"This is the updated version of Sparkle Test App.\n\nDelete and rebuild the app to test updates again.";
         [alreadyUpdatedAlert runModal];
         


### PR DESCRIPTION
Add/port update relaunched API from #1115.

This inserts an environment variable on relaunch rather than mutating the host bundle defaults and favors exposing a class property in 2.x over exposing a delegate call in 1.x

I decided to port the ability to detect this as there may be legitimate use cases, but with a doc note that it should not be used in cases where manual updates must be handled.

Removed some dated __has_feature(objc_generics) checks I noticed too.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests (UI tests in this case)
- [ ] My own app
- [ ] Other (please specify)

Adjust UI test to take this API in account, tested it (and SUUpdater stub) with the test app.

macOS version tested: 11.5 Beta (20G5042c)
