### PR TITLE
Backport security and DSA changes to 1.x

### DIFF
--- a/Sparkle/SUSignatureVerifier.m
+++ b/Sparkle/SUSignatureVerifier.m
@@ -103,7 +103,8 @@
     const unsigned char *edPubKey = self.pubKeys.ed25519PubKey;
 
     if (edPubKey && !edSignature) {
-        SULog(SULogLevelDefault, @"There is no EdDSA signature in the update, but the app is capable of verifying them");
+        SULog(SULogLevelError, @"The app has an EdDSA public key, but there is no EdDSA signature in the update, so the update will be rejected.");
+        return NO;
     } if (!edPubKey && edSignature) {
         SULog(SULogLevelDefault, @"The update has an EdDSA signature, but it won't be used, because the old app doesn't have an EdDSA public key");
     } else if (edPubKey && edSignature) {
@@ -114,12 +115,9 @@
             return NO;
         }
         if (ed25519_verify(edSignature, data.bytes, data.length, edPubKey)) {
+            // No need to check DSA when EdDSA verification succeeded
             SULog(SULogLevelDefault, @"OK: EdDSA signature is correct");
-            if (!dsaPubKey) {
-                return YES;
-            } else {
-                SULog(SULogLevelDefault, @"This app has a DSA public key, so a DSA signature is required too");
-            }
+            return YES;
         } else {
             SULog(SULogLevelError, @"EdDSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set.");
             if (dsaSignature) {

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -169,6 +169,12 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
             } else if (!servingOverHttps) {
                 [self showAlertText:SULocalizedString(@"Auto-update not configured", nil)
                     informativeText:[NSString stringWithFormat:SULocalizedString(@"For security reasons, updates to %@ need to be served over HTTPS and/or signed with an EdDSA key. See https://sparkle-project.org/documentation/ for more information.", nil), name]];
+            } else {
+                if (!self.loggedNoSecureKeyWarning) {
+                    SULog(SULogLevelError, @"Error: Serving updates without an EdDSA key and only using Apple Code Signing is deprecated and may be unsupported in a future release. Visit Sparkle's documentation for more information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns");
+                    
+                    self.loggedNoSecureKeyWarning = YES;
+                }
             }
         }
     } else if (!hasEdDSAPublicKey) {

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -40,6 +40,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @property (strong) NSTimer *checkTimer;
 @property (assign) BOOL shouldRescheduleOnWake;
 @property (strong) NSBundle *sparkleBundle;
+@property (nonatomic) BOOL loggedNoSecureKeyWarning;
 
 - (instancetype)initForBundle:(NSBundle *)bundle;
 - (void)startUpdateCycle;
@@ -69,6 +70,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize sparkleBundle;
 @synthesize decryptionPassword;
 @synthesize updateLastCheckedDate;
+@synthesize loggedNoSecureKeyWarning = _loggedNoSecureKeyWarning;
 
 static NSMutableDictionary *sharedUpdaters = nil;
 static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaultsObservationContext";
@@ -147,7 +149,9 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 }
 
 -(void)checkIfConfiguredProperly {
-    BOOL hasPublicKey = self.host.publicKeys.dsaPubKey != nil || self.host.publicKeys.ed25519PubKey != nil;
+    BOOL hasDSAPublicKey = (self.host.publicKeys.dsaPubKey != nil);
+    BOOL hasEdDSAPublicKey = (self.host.publicKeys.ed25519PubKey != nil);
+    BOOL hasPublicKey = (hasDSAPublicKey || hasEdDSAPublicKey);
     BOOL isMainBundle = [self.host.bundle isEqualTo:[NSBundle mainBundle]];
     BOOL hostIsCodeSigned = [SUCodeSigningVerifier bundleAtURLIsCodeSigned:self.host.bundle.bundleURL];
     NSURL *feedURL = [self feedURL];
@@ -166,6 +170,12 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
                 [self showAlertText:SULocalizedString(@"Auto-update not configured", nil)
                     informativeText:[NSString stringWithFormat:SULocalizedString(@"For security reasons, updates to %@ need to be served over HTTPS and/or signed with an EdDSA key. See https://sparkle-project.org/documentation/ for more information.", nil), name]];
             }
+        }
+    } else if (!hasEdDSAPublicKey) {
+        if (!self.loggedNoSecureKeyWarning) {
+            SULog(SULogLevelError, @"Error: Serving updates without an EdDSA key is insecure and deprecated. DSA support may be removed in a future Sparkle release. Please migrate to using EdDSA (ed25519). Visit Sparkle's documentation for migration information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns");
+            
+            self.loggedNoSecureKeyWarning = YES;
         }
     }
 


### PR DESCRIPTION
Backport the recent DSA deprecation changes and allowing dropping of DSA signatures in new updates more easily.

Backport logging that not using any Sparkle signing keys is deprecated (more on this in a bit).

Tested:
DSA -> DSA
EdDSA -> EdDSA
DSA + EdDSA -> DSA + EdDSA
DSA + EdDSA -> EdDSA

