### PR TITLE
Don't ignore -Wcompletion-handler if compiler doesn't understand it

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -66,7 +66,9 @@
 }
 
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
 - (void)resumeInstallingUpdateWithCompletion:(SPUUpdateDriverCompletion)__unused completionBlock
 #pragma clang diagnostic pop
 {
@@ -75,7 +77,9 @@
 }
 
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
 - (void)resumeUpdate:(id<SPUResumableUpdate>)__unused resumableUpdate completion:(SPUUpdateDriverCompletion)__unused completionBlock
 #pragma clang diagnostic pop
 {

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -347,7 +347,9 @@
         launcherConnection.invalidationHandler = ^{
             dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
                 if (!madeReply) {
 #pragma clang diagnostic pop
                     // If something went horribly wrong, just guess that we won't require authorization
@@ -371,7 +373,9 @@
     [installerLauncher checkIfApplicationInstallationRequiresAuthorizationWithHostBundlePath:self.host.bundlePath reply:^(BOOL requiresAuthorization) {
         dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
             if (!madeReply) {
 #pragma clang diagnostic pop
                 madeReply = YES;
@@ -410,7 +414,9 @@
         launcherConnection.invalidationHandler = ^{
             dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
                 if (!retrievedLaunchStatus) {
 #pragma clang diagnostic pop
                     NSError *error =

--- a/Sparkle/SPUProbeInstallStatus.m
+++ b/Sparkle/SPUProbeInstallStatus.m
@@ -39,7 +39,9 @@
     [installerStatus setInvalidationHandler:^{
         dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
             if (!handledCompletion) {
 #pragma clang diagnostic pop
                 completionHandler(NO);
@@ -54,7 +56,9 @@
     [installerStatus probeStatusConnectivityWithReply:^{
         dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
             if (!handledCompletion) {
 #pragma clang diagnostic pop
                 completionHandler(YES);
@@ -65,7 +69,9 @@
     }];
     
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(PROBE_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!handledCompletion) {
 #pragma clang diagnostic pop
@@ -96,7 +102,9 @@
     [installerStatus setInvalidationHandler:^{
         dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
             if (!handledCompletion) {
 #pragma clang diagnostic pop
                 completionHandler(nil);
@@ -116,7 +124,9 @@
         
         dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
             if (!handledCompletion) {
 #pragma clang diagnostic pop
                 completionHandler(installationInfo);
@@ -128,7 +138,9 @@
     }];
     
 #pragma clang diagnostic push
+#if __has_warning("-Wcompletion-handler")
 #pragma clang diagnostic ignored "-Wcompletion-handler"
+#endif
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(PROBE_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!handledCompletion) {
 #pragma clang diagnostic pop

--- a/Sparkle/SUWKWebView.m
+++ b/Sparkle/SUWKWebView.m
@@ -68,7 +68,10 @@ static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
         // that involves implementing a delegate method that is only available on macOS 11.. to get it properly working.
         // To simplify things, just rely on deprecated property for now.
         // Future reader: if you change how JS is disabled, please be sure to test that JS code is properly disabled in HTML release notes.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         configuration.preferences.javaScriptEnabled = javaScriptEnabled;
+#pragma clang diagnostic pop
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = NO;
         
         NSError *colorStyleContentsError = nil;


### PR DESCRIPTION
Older Xcode versions (12.5) threw a warning at not recognizing this warning.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested distribution built without warnings.

macOS version tested: 11.5 Beta (20G5042c)
