### PR TITLE
Don't expose NSMenuItemValidation programmatically

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  The controller's updater targets the application's main bundle and uses Sparkle's standard user interface.
  Typically, this class is used by sticking it as a custom NSObject subclass in an Interface Builder nib (probably in MainMenu) but it works well programatically too.
  
- The controller creates an SPUUpdater instance and allows hooking up the check for updates action and menu item validation. It also allows hooking
+ The controller creates an SPUUpdater instance and allows hooking up the check for updates action and handling menu item validation. It also allows hooking
  up the updater's and user driver's delegates.
  
  If you need more control over what bundle you want to update or you want to provide a custom user interface (via SPUUserDriver), please use SPUUpdater directly instead.
@@ -103,20 +103,17 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
  Explicitly checks for updates and displays a progress dialog while doing so.
  
  This method is meant for a main menu item.
- Connect any menu item to this action in Interface Builder,
+ Connect any NSMenuItem to this action in Interface Builder or programmatically,
  and Sparkle will check for updates and report back its findings verbosely
  when it is invoked.
+ 
+ When the target/action of the menu item is set to this controller and this method,
+ this controller also handles enabling/disabling the menu item by checking
+ -[SPUUpdater canCheckForUpdates]
  
  This action checks updates by invoking -[SPUUpdater checkForUpdates]
  */
 - (IBAction)checkForUpdates:(nullable id)sender;
-
-/*!
- Validates if the menu item for checkForUpdates: can be invoked or not
- 
- This validates the menu item by checking -SPUUpdater.canCheckForUpdates
- */
-- (BOOL)validateMenuItem:(NSMenuItem *)item;
 
 @end
 

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -17,6 +17,10 @@
 #import "SULocalizations.h"
 #import <AppKit/AppKit.h>
 
+@interface SPUStandardUpdaterController () <NSMenuItemValidation>
+
+@end
+
 @implementation SPUStandardUpdaterController
 
 @synthesize updater = _updater;


### PR DESCRIPTION
It doesn't make much sense to call this method programmatically due to it checking for a specific selector. A client should set the menu item's target/action to the controller/checkForUpdates: action or call SPUUpdater methods directly for checking for updates or if updates can be checked.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app works.

macOS version tested: 11.5 Beta (20G5042c)
