### PR TITLE
Create valid xar files

### DIFF
--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -186,6 +186,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         // Don't use -[NSFileManager fileExistsAtPath:] because it will follow symbolic links
         BOOL fileExisted = verbose && [fileManager attributesOfItemAtPath:destinationFilePath error:nil];
         BOOL removedFile = NO;
+        
+        // Files that have no property set that we check for will get ignored
+        // This is important because they aren't part of the delta, just part of the directory structure
 
         const char *value;
         if (!xar_prop_get(file, DELETE_KEY, &value) || (!hasExtractKeyAvailable && !xar_prop_get(file, DELETE_THEN_EXTRACT_OLD_KEY, &value))) {

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -61,7 +61,6 @@ typedef NS_ENUM(uint16_t, SUBinaryDeltaMajorVersion)
 #define LATEST_DELTA_DIFF_MAJOR_VERSION SUBeigeMajorVersion
 
 extern int compareFiles(const FTSENT **a, const FTSENT **b);
-extern NSData *hashOfFileContents(FTSENT *ent);
 extern NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion);
 extern NSString *hashOfTree(NSString *path);
 extern BOOL removeTree(NSString *path);

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -137,15 +137,6 @@ static BOOL _hashOfFileContents(unsigned char *hash, FTSENT *ent)
     return YES;
 }
 
-NSData *hashOfFileContents(FTSENT *ent)
-{
-    unsigned char fileHash[CC_SHA1_DIGEST_LENGTH];
-    if (!_hashOfFileContents(fileHash, ent)) {
-        return nil;
-    }
-    return [NSData dataWithBytes:fileHash length:CC_SHA1_DIGEST_LENGTH];
-}
-
 NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
 {
     char pathBuffer[PATH_MAX] = { 0 };

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -45,7 +45,7 @@ int latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion)
         case SUAzureMajorVersion:
             return 1;
         case SUBeigeMajorVersion:
-            return 2;
+            return 3;
     }
     return 0;
 }

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -233,6 +233,52 @@ static BOOL shouldChangePermissions(NSDictionary *originalInfo, NSDictionary *ne
     return YES;
 }
 
+static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTable, xar_t x, NSString *relativePath, NSString *filePath)
+{
+    NSArray<NSString *> *rootRelativePathComponents = relativePath.pathComponents;
+    // Relative path must at least have starting "/" component and one more path component
+    if (rootRelativePathComponents.count < 2) {
+        return NULL;
+    }
+    
+    NSArray<NSString *> *relativePathComponents = [rootRelativePathComponents subarrayWithRange:NSMakeRange(1, rootRelativePathComponents.count - 1)];
+    
+    NSUInteger relativePathComponentsCount = relativePathComponents.count;
+    
+    // Build parent files as needed until we get to our final file we want to add
+    // So if we get "Contents/Resources/foo.txt", we will first add "Contents" parent,
+    // then "Resources" parent, then "foo.txt" as the final entry we want to add
+    // We store every file we add into a fileTable for easy referencing
+    // Note if a diff has Contents/Resources/foo/ and Contents/Resources/foo/bar.txt,
+    // due to sorting order we will add the foo directory first and won't end up with
+    // mis-ordering bugs
+    xar_file_t lastParent = NULL;
+    for (NSUInteger componentIndex = 0; componentIndex < relativePathComponentsCount; componentIndex++) {
+        NSArray<NSString *> *subpathComponents = [relativePathComponents subarrayWithRange:NSMakeRange(0, componentIndex + 1)];
+        NSString *subpathKey = [subpathComponents componentsJoinedByString:@"/"];
+        
+        xar_file_t cachedFile = [fileTable[subpathKey] pointerValue];
+        if (cachedFile != NULL) {
+            lastParent = cachedFile;
+        } else {
+            xar_file_t newParent;
+            
+            BOOL atLastIndex = (componentIndex == relativePathComponentsCount - 1);
+            
+            NSString *lastPathComponent = subpathComponents.lastObject;
+            if (atLastIndex && filePath != nil) {
+                newParent = xar_add_frompath(x, lastParent, lastPathComponent.fileSystemRepresentation, filePath.fileSystemRepresentation);
+            } else {
+                newParent = xar_add_frombuffer(x, lastParent, lastPathComponent.fileSystemRepresentation, "", 1);
+            }
+            
+            lastParent = newParent;
+            fileTable[subpathKey] = [NSValue valueWithPointer:newParent];
+        }
+    }
+    return lastParent;
+}
+
 BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose, NSError *__autoreleasing *error)
 {
     assert(source);
@@ -489,11 +535,14 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
       return originalTreeState[key1] ? NSOrderedAscending : NSOrderedDescending;
     }];
+    
+    NSMutableDictionary<NSString *, NSValue *> *fileTable = [NSMutableDictionary dictionary];
+    
     for (NSString *key in keys) {
         id value = [newTreeState valueForKey:key];
 
         if ([(NSObject *)value isEqual:[NSNull null]]) {
-            xar_file_t newFile = xar_add_frombuffer(x, 0, [key fileSystemRepresentation], (char *)"", 1);
+            xar_file_t newFile = _xarAddFile(fileTable, x, key, NULL);
             assert(newFile);
             xar_prop_set(newFile, DELETE_KEY, "true");
 
@@ -508,7 +557,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         if (shouldSkipDeltaCompression(originalInfo, newInfo)) {
             if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBeigeMajorVersion) && shouldSkipExtracting(originalInfo, newInfo)) {
                 if (shouldChangePermissions(originalInfo, newInfo)) {
-                    xar_file_t newFile = xar_add_frombuffer(x, 0, [key fileSystemRepresentation], (char *)"", 1);
+                    xar_file_t newFile = _xarAddFile(fileTable, x, key, NULL);
                     assert(newFile);
                     xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [[NSString stringWithFormat:@"%u", [(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]] UTF8String]);
 
@@ -518,7 +567,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 }
             } else {
                 NSString *path = [destination stringByAppendingPathComponent:key];
-                xar_file_t newFile = xar_add_frompath(x, 0, [key fileSystemRepresentation], [path fileSystemRepresentation]);
+                xar_file_t newFile = _xarAddFile(fileTable, x, key, path);
                 assert(newFile);
 
                 if (shouldDeleteThenExtract(originalInfo, newInfo)) {
@@ -570,7 +619,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             fprintf(stderr, "\n🔨  %s %s", VERBOSE_DIFFED, [[operation relativePath] fileSystemRepresentation]);
         }
 
-        xar_file_t newFile = xar_add_frompath(x, 0, [[operation relativePath] fileSystemRepresentation], [resultPath fileSystemRepresentation]);
+        xar_file_t newFile = _xarAddFile(fileTable, x, [operation relativePath], resultPath);
         assert(newFile);
         xar_prop_set(newFile, BINARY_DELTA_KEY, "true");
         unlink([resultPath fileSystemRepresentation]);


### PR DESCRIPTION
Create valid xar files by creating file nodes, eg Contents -> Resources -> foo.txt
Before we were just creating all top-level items with paths that had multiple path components, instead of any parent entries, but doing this was wrong.

I also noticed and fixed some incorrect logic determining file equality in creation by the file hash. Now it makes sure the file/symlink contents are equal or they're both directory entires.

This does not break older clients. The applying logic was fortunately written in a way where no changes there are required.
We thus do not need to bump the major version, but we are bumping the minor version of the format here.

I will cherry-pick this change to 1.x once approved / merged.

Fixes #1899

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

All unit tests pass.
Tested creating and applying new binary delta files between two different versions of an app.
Tested applying a newly generated binary delta file using an older binary delta version works.

Tested both of these combinations on Big Sur and Monterey beta machines.

macOS version tested:
11.5 (20G71)
12.0 Beta (21A5284e)
