### PR TITLE
Propagate validation errors

### DIFF
--- a/Autoupdate/SUSignatureVerifier.h
+++ b/Autoupdate/SUSignatureVerifier.h
@@ -21,11 +21,11 @@
 
 @interface SUSignatureVerifier : NSObject
 
-+ (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys;
++ (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys error:(NSError * __autoreleasing *)error;
 
 - (instancetype)initWithPublicKeys:(SUPublicKeys *)pkeys;
 
-- (BOOL)verifyFileAtPath:(NSString *)path signatures:(SUSignatures *)signatures;
+- (BOOL)verifyFileAtPath:(NSString *)path signatures:(SUSignatures *)signatures error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -15,6 +15,7 @@
 #import "SUSignatureVerifier.h"
 #import "SULog.h"
 #import "SUSignatures.h"
+#import "SUErrors.h"
 #include <CommonCrypto/CommonDigest.h>
 #import "ed25519.h" // Run `git submodule update --init` if you get an error here
 
@@ -30,22 +31,26 @@
 
 @synthesize pubKeys = _pubKeys;
 
-+ (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys
++ (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys error:(NSError * __autoreleasing *)error
 {
     SUSignatureVerifier *verifier = [(SUSignatureVerifier *)[self alloc] initWithPublicKeys:pkeys];
 
-    if (!verifier) {
+    if (verifier == nil) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to create SUSignatureVerifier instance" }];
+        }
         return NO;
     }
 
-    return [verifier verifyFileAtPath:path signatures:signatures];
+    return [verifier verifyFileAtPath:path signatures:signatures error:error];
 }
 
 - (instancetype)initWithPublicKeys:(SUPublicKeys *)pubkeys
 {
     self = [super init];
-    _pubKeys = pubkeys;
-
+    if (self != nil) {
+        _pubKeys = pubkeys;
+    }
     return self;
 }
 
@@ -85,14 +90,19 @@
     return dsaPubKeySecKey;
 }
 
-- (BOOL)verifyFileAtPath:(NSString *)path signatures:(SUSignatures *)signatures
+- (BOOL)verifyFileAtPath:(NSString *)path signatures:(SUSignatures *)signatures error:(NSError * __autoreleasing *)error
 {
     if (!path || !path.length) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"Path passed to verify has zero length and is not valid" }];
+        }
         return NO;
     }
 
     if (!signatures) {
-        SULog(SULogLevelDefault, @"No signatures given to verifyFileAtPath");
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"No signatures given to verifyFileAtPath" }];
+        }
         return NO;
     }
 
@@ -104,26 +114,49 @@
         break;
     case SUSigningInputStatusInvalid:
         if (signatures.ed25519SignatureStatus != SUSigningInputStatusAbsent) {
-            // We will have already logged an error for this failure when the public key was read in, so just do an informational log here.
-            SULog(SULogLevelDefault, @"The update has an EdDSA signature, but the app has an invalid EdDSA public key, so the update will automatically be rejected.");
+            NSString *message = @"The update has an EdDSA signature, but the app has an invalid EdDSA public key, so the update will automatically be rejected.";
+            SULog(SULogLevelError, @"%@", message);
+            
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: message }];
+            }
+            
             return NO;
         }
         SULog(SULogLevelDefault, @"The app has an invalid EdDSA public key, but there is no EdDSA signature in the update. Falling back to DSA.");
         break;
     case SUSigningInputStatusPresent:
         switch (signatures.ed25519SignatureStatus) {
-        case SUSigningInputStatusAbsent:
-            SULog(SULogLevelError, @"The app has an EdDSA public key, but there is no EdDSA signature in the update, so the update will be rejected.");
+        case SUSigningInputStatusAbsent: {
+            NSString *message = @"The app has an EdDSA public key, but there is no EdDSA signature in the update, so the update will be rejected.";
+            SULog(SULogLevelError, @"%@", message);
+                
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: message }];
+            }
+            
             return NO;
-        case SUSigningInputStatusInvalid:
-            // We will have already logged an error for this failure when the signature was read in, so just do an informational log here.
-            SULog(SULogLevelDefault, @"The update has an EdDSA signature, but it's invalid, so the update will automatically be rejected.");
+        }
+        case SUSigningInputStatusInvalid: {
+            NSString *message = @"The update has an EdDSA signature, but it's invalid, so the update will automatically be rejected.";
+            
+            SULog(SULogLevelError, @"%@", message);
+                
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: message }];
+            }
             return NO;
+        }
         case SUSigningInputStatusPresent: {
-            NSError *error = nil;
-            NSData *data = [NSData dataWithContentsOfFile:path options:NSDataReadingMappedAlways error:&error];
+            NSError *dataError = nil;
+            NSData *data = [NSData dataWithContentsOfFile:path options:NSDataReadingMappedAlways error:&dataError];
             if (!data || !data.length) {
-                SULog(SULogLevelError, @"Failed to load file %@: %@", path, error);
+                SULog(SULogLevelError, @"Failed to load file %@: %@", path, dataError);
+                
+                if (error != NULL) {
+                    *error = dataError;
+                }
+                
                 return NO;
             }
             if (ed25519_verify(signatures.ed25519Signature, data.bytes, data.length, self.pubKeys.ed25519PubKey)) {
@@ -134,10 +167,18 @@
                     return YES;
                 }
             } else {
-                SULog(SULogLevelError, @"EdDSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set.");
+                NSString *message = @"EdDSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set.";
+                
+                SULog(SULogLevelError, @"%@", message);
+                
                 if (signatures.dsaSignatureStatus != SUSigningInputStatusAbsent) {
                     SULog(SULogLevelDefault, @"DSA signature won't be checked, because EdDSA verification has already failed");
                 }
+                
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: message }];
+                }
+                
                 return NO;
             }
         }
@@ -154,7 +195,14 @@
     case SUSigningInputStatusInvalid:
         if (signatures.dsaSignatureStatus != SUSigningInputStatusAbsent) {
             // We will have already logged an error for this failure when the public key was read in, so just do an informational log here.
-            SULog(SULogLevelDefault, @"The update has a DSA signature, but the app has an invalid DSA public key, so the update will automatically be rejected.");
+            NSString *message = @"The update has a DSA signature, but the app has an invalid DSA public key, so the update will automatically be rejected.";
+            
+            SULog(SULogLevelError, @"%@", message);
+            
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: message }];
+            }
+            
             return NO;
         }
         SULog(SULogLevelDefault, @"The app has an invalid DSA public key, but there is no DSA signature in the update.");
@@ -164,29 +212,50 @@
         case SUSigningInputStatusAbsent:
             SULog(SULogLevelError, @"There is no DSA signature in the update");
             break;
-        case SUSigningInputStatusInvalid:
-            // We will have already logged an error for this failure when the signature was read in, so just do an informational log here.
-            SULog(SULogLevelDefault, @"The update has a DSA signature, but it's invalid, so the update will automatically be rejected.");
+        case SUSigningInputStatusInvalid: {
+            NSString *message = @"The update has a DSA signature, but it's invalid, so the update will automatically be rejected.";
+            
+            SULog(SULogLevelError, @"%@", message);
+                
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: message }];
+            }
+            
             return NO;
+        }
         case SUSigningInputStatusPresent: {
             NSInputStream *dataInputStream = [NSInputStream inputStreamWithFileAtPath:path];
-            return [self verifyDSASignatureOfStream:dataInputStream dsaSignature:signatures.dsaSignature];
+            return [self verifyDSASignatureOfStream:dataInputStream dsaSignature:signatures.dsaSignature error:error];
         }
         }
     }
 
+    if (error != NULL) {
+        // Use generic failure
+        *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"EdDSA and DSA verification for the update has failed" }];
+    }
+    
     return NO;
 }
 
-- (BOOL)verifyDSASignatureOfStream:(NSInputStream *)stream dsaSignature:(NSData *)dsaSignature
+- (BOOL)verifyDSASignatureOfStream:(NSInputStream *)stream dsaSignature:(NSData *)dsaSignature error:(NSError * __autoreleasing *)outError
 {
     if (!stream || !dsaSignature) {
         SULog(SULogLevelError, @"Invalid arguments to verifyStream");
+        
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"Invalid arguments to verifyStream" }];
+        }
+        
         return NO;
     }
 
     SecKeyRef dsaPubKeySecKey = [self dsaSecKeyRef];
     if (!dsaPubKeySecKey) {
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to create DSA Sec Key Ref" }];
+        }
+        
         return NO;
     }
 
@@ -208,12 +277,18 @@
 
     dataReadTransform = SecTransformCreateReadTransformWithReadStream((__bridge CFReadStreamRef)stream);
     if (!dataReadTransform) {
-        SULog(SULogLevelError, @"File containing update archive could not be read (failed to create SecTransform for input stream)");
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"File containing update archive could not be read (failed to create SecTransform for input stream)" }];
+        }
         return cleanup();
     }
 
     dataDigestTransform = SecDigestTransformCreate(kSecDigestSHA1, CC_SHA1_DIGEST_LENGTH, NULL);
     if (!dataDigestTransform) {
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"File containing update archive could not be read (failed to create SecDigest for input stream)" }];
+        }
+        
         return cleanup();
     }
 
@@ -223,29 +298,45 @@
 #pragma clang diagnostic pop
     if (!dataVerifyTransform || error) {
         SULog(SULogLevelError, @"Could not understand format of the signature: %@; Signature data: %@", error, dsaSignature);
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Could not understand format of the signature data %@", dsaSignature], NSUnderlyingErrorKey: (__bridge NSError *)error}];
+        }
+        
         return cleanup();
     }
 
     SecTransformConnectTransforms(dataReadTransform, kSecTransformOutputAttributeName, dataDigestTransform, kSecTransformInputAttributeName, group, &error);
     if (error) {
-        SULog(SULogLevelError, @"%@", error);
+        if (outError != NULL) {
+            *outError = (__bridge NSError *)error;
+        }
+        
         return cleanup();
     }
 
     SecTransformConnectTransforms(dataDigestTransform, kSecTransformOutputAttributeName, dataVerifyTransform, kSecTransformInputAttributeName, group, &error);
     if (error) {
-        SULog(SULogLevelError, @"%@", error);
+        if (outError != NULL) {
+            *outError = (__bridge NSError *)error;
+        }
+        
         return cleanup();
     }
 
     NSNumber *result = CFBridgingRelease(SecTransformExecute(group, &error));
     if (error) {
         SULog(SULogLevelError, @"DSA signature verification failed: %@", error);
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"DSA signature verification failed", NSUnderlyingErrorKey: (__bridge NSError *)error}];
+        }
+        
         return cleanup();
     }
 
     if (!result.boolValue) {
-        SULog(SULogLevelError, @"DSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set.");
+        if (outError != NULL) {
+            *outError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"DSA signature does not match. Data of the update file being checked is different than data that has been signed, or the public key and the private key are not from the same set"}];
+        }
     }
 
     cleanup();

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 // Version is technically not required here, SPM doesn't check
 let version = "2.0.0"
 // Tag is required to point towards the right asset. SPM requires the tag to follow semantic versioning to be able to resolve it.
-let tag = "2.0.0"
-let checksum = "ef0d0cc46421f8644f455b62537f4e4db2c97bdca5820641219a1836f3782878"
+let tag = "1.20.0"
+let checksum = "d7876f73ceaa22b7cef010051cdf059250002e92f828dc1305d3a66fa281dcef"
 let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/Sparkle-for-Swift-Package-Manager.zip"
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 // Version is technically not required here, SPM doesn't check
 let version = "2.0.0"
 // Tag is required to point towards the right asset. SPM requires the tag to follow semantic versioning to be able to resolve it.
-let tag = "1.20.0"
-let checksum = "d7876f73ceaa22b7cef010051cdf059250002e92f828dc1305d3a66fa281dcef"
+let tag = "2.0.0"
+let checksum = "ef0d0cc46421f8644f455b62537f4e4db2c97bdca5820641219a1836f3782878"
 let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/Sparkle-for-Swift-Package-Manager.zip"
 
 let package = Package(

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -67,6 +67,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
 
  After starting the updater and before the next runloop cycle, one of -checkForUpdates, -checkForUpdatesInBackground, or -checkForUpdateInformation can be invoked.
  This may be useful if you want to check for updates immediately or without showing a permission prompt.
+ 
+ If the updater cannot be started (i.e, due to a configuration issue in the application), you may want to fall back appropriately.
+ For example, the standard updater controller (SPUStandardUpdaterController) alerts the user that the app is misconfigured and to contact the developer.
 
  This must be called on the main thread.
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -258,6 +258,14 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             return NO;
         }
     }
+    
+    // Don't allow invalid EdDSA public keys
+    if (publicKeys.ed25519PubKeyStatus == SUSigningInputStatusInvalid) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The EdDSA public key is not valid for %@.", hostName] }];
+        }
+        return NO;
+    }
 
     if (!hasAnyPublicKey) {
         if ((feedURL != nil && !servingOverHttps) || ![SUCodeSigningVerifier bundleAtURLIsCodeSigned:[[self hostBundle] bundleURL]]) {

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -55,12 +55,13 @@
             *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to validate update before unarchiving because no (Ed)DSA public key was found in the old app" }];
         }
     } else {
-        if ([SUSignatureVerifier validatePath:self.downloadPath withSignatures:signatures withPublicKeys:publicKeys]) {
+        NSError *innerError = nil;
+        if ([SUSignatureVerifier validatePath:self.downloadPath withSignatures:signatures withPublicKeys:publicKeys error:&innerError]) {
             self.prevalidatedSignature = YES;
             return YES;
         }
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"(Ed)DSA signature validation before unarchiving failed for update %@", self.downloadPath] }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"(Ed)DSA signature validation before unarchiving failed for update %@", self.downloadPath], NSUnderlyingErrorKey: innerError }];
         }
     }
     return NO;
@@ -90,23 +91,24 @@
         // Check to see if we have a package or bundle to validate
         if (isPackage) {
             // If we get here, then the appcast installation type was lying to us.. This error will be caught later when starting the installer.
-            // For package type updates, all we do is check if the DSA signature is valid
-            BOOL validationCheckSuccess = [SUSignatureVerifier validatePath:downloadPath withSignatures:signatures withPublicKeys:publicKeys];
+            // For package type updates, all we do is check if the EdDSA signature is valid
+            NSError *innerError = nil;
+            BOOL validationCheckSuccess = [SUSignatureVerifier validatePath:downloadPath withSignatures:signatures withPublicKeys:publicKeys error:&innerError];
             if (!validationCheckSuccess) {
                 if (error != NULL) {
-                    *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"DSA signature validation of the package failed. The update contains an installer package, and valid DSA signatures are mandatory for all installer packages. The update will be rejected. Sign the installer with a valid DSA key or use an .app bundle update instead." }];
+                    *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"EdDSA signature validation of the package failed. The update contains an installer package, and valid EdDSA signatures are mandatory for all installer packages. The update will be rejected. Sign the installer with a valid EdDSA key or use an .app bundle update instead.", NSUnderlyingErrorKey: innerError }];
                 }
             }
             return validationCheckSuccess;
         } else {
-            // For application bundle updates, we check both the DSA and Apple code signing signatures
+            // For application bundle updates, we check both the EdDSA and Apple code signing signatures
             return [self validateUpdateForHost:host downloadedToPath:downloadPath newBundleURL:installSourceURL signatures:signatures error:error];
         }
     } else if (isPackage) {
         // We already prevalidated the package and nothing else needs to be done
         return YES;
     } else {
-        // Because we already validated the DSA signature, this is just a consistency check to see
+        // Because we already validated the EdDSA signature, this is just a consistency check to see
         // if the developer signed their application properly with their Apple ID
         // Currently, this case only gets hit for binary delta updates
         NSError *innerError = nil;
@@ -166,23 +168,25 @@
     BOOL passedDSACheck = NO;
     BOOL passedCodeSigning = NO;
 
+    NSError *dsaError = nil;
     if (oldHasAnyDSAKey) {
         // it's critical to check against the old public key, rather than the new key
-        passedDSACheck = [SUSignatureVerifier validatePath:downloadedPath withSignatures:signatures withPublicKeys:publicKeys];
+        passedDSACheck = [SUSignatureVerifier validatePath:downloadedPath withSignatures:signatures withPublicKeys:publicKeys error:&dsaError];
     }
 
+    NSError *codeSignedError = nil;
     if (hostIsCodeSigned) {
-        NSError *innerError = nil;
-        passedCodeSigning = [SUCodeSigningVerifier codeSignatureAtBundleURL:host.bundle.bundleURL matchesSignatureAtBundleURL:newHost.bundle.bundleURL error:&innerError];
+        passedCodeSigning = [SUCodeSigningVerifier codeSignatureAtBundleURL:host.bundle.bundleURL matchesSignatureAtBundleURL:newHost.bundle.bundleURL error:&codeSignedError];
     }
     // End of security-critical part
 
     // If the new DSA key differs from the old, then this check is not a security measure, because the new key is not trusted.
     // In that case, the check ensures that the app author has correctly used DSA keys, so that the app will be updateable in the next version.
     if (!passedDSACheck && newHasAnyDSAKey) {
-        if (![SUSignatureVerifier validatePath:downloadedPath withSignatures:signatures withPublicKeys:newPublicKeys]) {
+        NSError *innerError = nil;
+        if (![SUSignatureVerifier validatePath:downloadedPath withSignatures:signatures withPublicKeys:newPublicKeys error:&innerError]) {
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"The update has a public (Ed)DSA key, but the public key shipped with the update doesn't match the signature. To prevent future problems, the update will be rejected." }];
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: @"The update has a public (Ed)DSA key, but the public key shipped with the update doesn't match the signature. To prevent future problems, the update will be rejected.", NSUnderlyingErrorKey: innerError }];
             }
             return NO;
         }
@@ -219,11 +223,25 @@
         NSString *acsStatus = !hostIsCodeSigned ? @"old app hasn't been signed with app Code Signing" : @"new app isn't signed with app Code Signing";
         
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The update archive %@, and the %@. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus, acsStatus] }];
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+            userInfo[NSLocalizedDescriptionKey] = [NSString stringWithFormat:@"The update archive %@, and the %@. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus, acsStatus];
+            
+            if (dsaError != nil) {
+                userInfo[NSUnderlyingErrorKey] = dsaError;
+            }
+            
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:[userInfo copy]];
         }
     } else {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus] }];
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+            userInfo[NSLocalizedDescriptionKey] = [NSString stringWithFormat:@"The update archive %@, and the app is signed with a new Code Signing identity that doesn't match code signing of the original app. At least one method of signature verification must be valid. The update will be rejected.", dsaStatus];
+            
+            if (codeSignedError != nil) {
+                userInfo[NSUnderlyingErrorKey] = codeSignedError;
+            }
+            
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUValidationError userInfo:[userInfo copy]];
         }
     }
 

--- a/Tests/SUSignatureVerifierTest.m
+++ b/Tests/SUSignatureVerifierTest.m
@@ -34,85 +34,100 @@
 
     NSString *validSig = @"MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
 
+    NSError *error = nil;
+    
     XCTAssertTrue([self checkFile:self.testFile
                        withDSAKey:pubKey
-                        signature:validSig],
-                  @"Expected valid signature");
+                        signature:validSig
+                            error:&error],
+                  @"Expected valid signature: %@", error);
 
     XCTAssertFalse([self checkFile:self.testFile
                         withDSAKey:@"lol"
-                         signature:validSig],
-                   @"Invalid pubkey");
+                         signature:validSig
+                             error:&error],
+                   @"Invalid pubkey: %@", error);
 
     XCTAssertFalse([self checkFile:self.pubDSAKeyFile
                         withDSAKey:pubKey
-                         signature:validSig],
-                   @"Wrong file checked");
+                         signature:validSig
+                             error:&error],
+                   @"Wrong file checked: %@", error);
 
     XCTAssertFalse([self checkFile:self.testFile
                         withDSAKey:pubKey
-                         signature:@"MCwCFCIHCiYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="],
-                   @"Expected invalid signature");
+                         signature:@"MCwCFCIHCiYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ=="
+                             error:&error],
+                   @"Expected invalid signature: %@", error);
 
     XCTAssertTrue([self checkFile:self.testFile
                        withDSAKey:pubKey
-                        signature:@"MC0CFAsKO7cq2q7L5/FWe6ybVIQkwAwSAhUA2Q8GKsE309eugi/v3Kh1W3w3N8c="],
-                  @"Expected valid signature");
+                        signature:@"MC0CFAsKO7cq2q7L5/FWe6ybVIQkwAwSAhUA2Q8GKsE309eugi/v3Kh1W3w3N8c="
+                            error:&error],
+                  @"Expected valid signature: %@", error);
 
     XCTAssertFalse([self checkFile:self.testFile
                         withDSAKey:pubKey
-                         signature:@"MC0CFAsKO7cq2q7L5/FWe6ybVIQkwAwSAhUA2Q8GKsE309eugi/v3Kh1W3w3N8"],
-                   @"Expected invalid signature");
+                         signature:@"MC0CFAsKO7cq2q7L5/FWe6ybVIQkwAwSAhUA2Q8GKsE309eugi/v3Kh1W3w3N8"
+                             error:&error],
+                   @"Expected invalid signature: %@", error);
 }
 
 - (void)testVerifyFileAtPathUsingED25519
 {
     NSString *validSig = @"EIawm2YkDZ2gBfkEMF2+1VuuTeXnCGZOdnMdVgPPvDZioq7bvDayXqKkIIzSjKMmeFdcFJOHdnba5ZV60+gPBw==";
 
+    NSError *error = nil;
+    
     XCTAssertTrue([self checkFile:self.testFile
                         withEdKey:self.pubEdKey
-                        signature:validSig],
-                  @"Expected valid signature");
+                        signature:validSig
+                            error:&error],
+                  @"Expected valid signature: %@", error);
 
     XCTAssertFalse([self checkFile:self.testFile
                          withEdKey:@"lol"
-                         signature:validSig],
-                   @"Invalid pubkey");
+                         signature:validSig
+                             error:&error],
+                   @"Invalid pubkey: %@", error);
 
     XCTAssertFalse([self checkFile:self.pubDSAKeyFile
                          withEdKey:self.pubEdKey
-                         signature:validSig],
-                   @"Wrong file checked");
+                         signature:validSig
+                             error:&error],
+                   @"Wrong file checked: %@", error);
 
     XCTAssertFalse([self checkFile:self.testFile
                          withEdKey:self.pubEdKey
-                         signature:@"wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="],
-                   @"Expected wrong signature");
+                         signature:@"wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ=="
+                             error:&error],
+                   @"Expected wrong signature: %@", error);
 
     XCTAssertFalse([self checkFile:self.testFile
                          withEdKey:self.pubEdKey
-                         signature:@"lol"],
-                   @"Invalid signature");
+                         signature:@"lol"
+                             error:&error],
+                   @"Invalid signature: %@", error);
 }
 
-- (BOOL)checkFile:(NSString *)aFile withDSAKey:(NSString *)pubKey signature:(NSString *)sigString
+- (BOOL)checkFile:(NSString *)aFile withDSAKey:(NSString *)pubKey signature:(NSString *)sigString error:(NSError * __autoreleasing *)error
 {
     SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:pubKey ed:nil];
     SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
 
     SUSignatures *sig = [[SUSignatures alloc] initWithDsa:sigString ed:nil];
 
-    return [v verifyFileAtPath:aFile signatures:sig];
+    return [v verifyFileAtPath:aFile signatures:sig error:error];
 }
 
-- (BOOL)checkFile:(NSString *)aFile withEdKey:(NSString *)pubKey signature:(NSString *)sigString
+- (BOOL)checkFile:(NSString *)aFile withEdKey:(NSString *)pubKey signature:(NSString *)sigString error:(NSError * __autoreleasing *)error
 {
     SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:nil ed:pubKey];
     SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
 
     SUSignatures *sig = [[SUSignatures alloc] initWithDsa:nil ed:sigString];
 
-    return [v verifyFileAtPath:aFile signatures:sig];
+    return [v verifyFileAtPath:aFile signatures:sig error:error];
 }
 
 - (void)testVerifyFileWithBothKeys
@@ -122,13 +137,14 @@
 
     SUPublicKeys *pubKeys = [[SUPublicKeys alloc] initWithDsa:dsaKey ed:self.pubEdKey];
     SUSignatureVerifier *v = [[SUSignatureVerifier alloc] initWithPublicKeys:pubKeys];
+    NSError *error = nil;
 
     XCTAssertFalse([v verifyFileAtPath:self.testFile
-                            signatures:[[SUSignatures alloc] initWithDsa:nil ed:nil]],
-                   @"Fail if no signatures are provided");
+                            signatures:[[SUSignatures alloc] initWithDsa:nil ed:nil] error:&error],
+                   @"Fail if no signatures are provided: %@", error);
     XCTAssertFalse([v verifyFileAtPath:self.testFile
-                            signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:@"lol"]],
-                   @"Fail if both signatures are invalid");
+                            signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:@"lol"] error:&error],
+                   @"Fail if both signatures are invalid: %@", error);
 
     NSString *dsaSig = @"MCwCFCIHCIYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
     NSString *wrongDSASig = @"MCwCFCIHCiYYkfZavNzTitTW5tlRp/k5AhQ40poFytqcVhIYdCxQznaXeJPJDQ==";
@@ -136,30 +152,30 @@
     NSString *wrongEdSig = @"wTcpXCgWoa4NrJpsfzS61FXJIbv963//12U2ef9xstzVOLPHYK2N4/ojgpDV5N1/NGG1uWMBgK+kEWp0Z5zMDQ==";
 
     XCTAssertFalse([v verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
-                  @"EdDSA signature must be present if app has EdDSA key");
+                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil] error:&error],
+                  @"EdDSA signature must be present if app has EdDSA key: %@", error);
     
     XCTAssertTrue([v verifyFileAtPath:self.testFile
-                            signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
-                   @"Allow just an EdDSA signature if that's all that's available");
+                           signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig] error:&error],
+                   @"Allow just an EdDSA signature if that's all that's available: %@", error);
 
     XCTAssertFalse([v verifyFileAtPath:self.testFile
-                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:wrongEdSig]],
-                   @"Fail on a bad Ed25519 signature regardless");
+                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:wrongEdSig] error:&error],
+                   @"Fail on a bad Ed25519 signature regardless: %@", error);
     XCTAssertTrue([v verifyFileAtPath:self.testFile
-                            signatures:[[SUSignatures alloc] initWithDsa:wrongDSASig ed:edSig]],
-                   @"Allow bad DSA signature if EdDSA signature is good");
+                           signatures:[[SUSignatures alloc] initWithDsa:wrongDSASig ed:edSig] error:&error],
+                   @"Allow bad DSA signature if EdDSA signature is good: %@", error);
 
     XCTAssertFalse([v verifyFileAtPath:self.testFile
-                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:@"lol"]],
-                   @"Fail if the Ed25519 signature is invalid.");
+                            signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:@"lol"] error:&error],
+                   @"Fail if the Ed25519 signature is invalid: %@", error);
     XCTAssertFalse([v verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:edSig]],
-                   @"Fail if invalid DSA signature is used even if EdDSA signature is good.");
+                            signatures:[[SUSignatures alloc] initWithDsa:@"lol" ed:edSig] error:&error],
+                   @"Fail if invalid DSA signature is used even if EdDSA signature is good: %@", error);
 
     XCTAssertTrue([v verifyFileAtPath:self.testFile
-                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:edSig]],
-                  @"Pass if both are valid");
+                           signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:edSig] error:&error],
+                  @"Pass if both are valid: %@", error);
 }
 
 - (void)testVerifyFileWithWrongKey
@@ -173,16 +189,17 @@
     SUPublicKeys *dsaOnlyKeys = [[SUPublicKeys alloc] initWithDsa:dsaKey ed:nil];
     SUSignatureVerifier *dsaOnlyVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:dsaOnlyKeys];
 
+    NSError *error = nil;
     XCTAssertFalse([dsaOnlyVerifier verifyFileAtPath:self.testFile
-                                          signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig]],
-                   @"DSA cannot verify an Ed signature");
+                                          signatures:[[SUSignatures alloc] initWithDsa:nil ed:edSig] error:&error],
+                   @"DSA cannot verify an Ed signature: %@", error);
 
     SUPublicKeys *edOnlyKeys = [[SUPublicKeys alloc] initWithDsa:nil ed:self.pubEdKey];
     SUSignatureVerifier *edOnlyVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:edOnlyKeys];
 
     XCTAssertFalse([edOnlyVerifier verifyFileAtPath:self.testFile
-                                         signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil]],
-                   @"Ed cannot verify an DSA signature");
+                                         signatures:[[SUSignatures alloc] initWithDsa:dsaSig ed:nil] error:&error],
+                   @"Ed cannot verify an DSA signature: %@", error);
 
 }
 
@@ -198,7 +215,8 @@
     XCTAssertNotNil(sig);
     XCTAssertNotNil(sig.dsaSignature);
 
-    XCTAssertTrue([SUSignatureVerifier validatePath:self.testFile withSignatures:sig withPublicKeys:pubkeys], @"Expected valid signature");
+    NSError *error = nil;
+    XCTAssertTrue([SUSignatureVerifier validatePath:self.testFile withSignatures:sig withPublicKeys:pubkeys error:&error], @"Expected valid signature: %@", error);
 }
 
 @end


### PR DESCRIPTION
Better propagate validation errors in the code signing signature and Ed(DSA) validation methods by propagating the error object info in each potential failure point.

This enables the developer to get better error messages logged out when validation fails from Autoupdate. I retained the code that still logged messages though.

I also made starting the updater fail if the public EdDSA key included in the app has an invalid format, and made this a configuration issue.

Fixes #1904

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested some potential error messages in a custom test app.
Unit tests succeeded.

macOS version tested: 11.5 (20G71)
