### PR TITLE
Support appcast selection features in generate_appcast

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 // Version is technically not required here, SPM doesn't check
 let version = "2.0.0"
 // Tag is required to point towards the right asset. SPM requires the tag to follow semantic versioning to be able to resolve it.
-let tag = "2.0.0"
-let checksum = "ef0d0cc46421f8644f455b62537f4e4db2c97bdca5820641219a1836f3782878"
+let tag = "2.0.0-beta.1"
+let checksum = "f9b34f91a2dee4bf265640a793c445668c416f22019cbe7d8b9e0b31c838ab71"
 let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/Sparkle-for-Swift-Package-Manager.zip"
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 // Version is technically not required here, SPM doesn't check
 let version = "2.0.0"
 // Tag is required to point towards the right asset. SPM requires the tag to follow semantic versioning to be able to resolve it.
-let tag = "2.0.0-beta.1"
-let checksum = "f9b34f91a2dee4bf265640a793c445668c416f22019cbe7d8b9e0b31c838ab71"
+let tag = "2.0.0"
+let checksum = "ef0d0cc46421f8644f455b62537f4e4db2c97bdca5820641219a1836f3782878"
 let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/Sparkle-for-Swift-Package-Manager.zip"
 
 let package = Package(

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/generate_appcast.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/generate_appcast.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -5,6 +5,9 @@
 
 import Foundation
 
+// CDATA text must contain less characters than this threshold
+let CDATA_HTML_FRAGMENT_THRESHOLD = 1000
+
 class DeltaUpdate {
     let fromVersion: String
     let archivePath: URL
@@ -164,7 +167,7 @@ class ArchiveItem: CustomStringConvertible {
 
     private func getReleaseNotesAsHTMLFragment(_ path: URL) -> String?  {
         if let html = try? String(contentsOf: path) {
-            if html.utf8.count < 1000 &&
+            if html.utf8.count < CDATA_HTML_FRAGMENT_THRESHOLD &&
                 !html.localizedCaseInsensitiveContains("<!DOCTYPE") &&
                 !html.localizedCaseInsensitiveContains("<body") {
                 return html

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -47,18 +47,23 @@ func loadPrivateKeys(_ privateDSAKey: SecKey?, _ privateEdString: String?) -> Pr
 }
 
 struct GenerateAppcast: ParsableCommand {
-    static var programName: String = CommandLine.arguments.first ?? "./generate-appcast"
+    static let programName = "generate_appcast"
+    static let programNamePath: String = CommandLine.arguments.first ?? "./\(programName)"
+    static let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0].appendingPathComponent("Sparkle_generate_appcast")
     
-    @Option(name: .customShort("s"), help: ArgumentHelp("The private EdDSA string (128 characters).", valueName: "private-EdDSA-key"))
+    static let DEFAULT_MAX_NEW_VERSIONS_IN_FEED = 5
+    static let DEFAULT_MAXIMUM_DELTAS = 5
+    
+    @Option(name: .customShort("s"), help: ArgumentHelp("The private EdDSA string (128 characters). If not specified, the private EdDSA key will be read from the Keychain instead.", valueName: "private-EdDSA-key"))
     var privateEdString : String?
     
-    @Option(name: .customShort("f"), help: ArgumentHelp("Path to the private DSA key file.", valueName: "private-dsa-key-file"), transform: { URL(fileURLWithPath: $0) })
+    @Option(name: .customShort("f"), help: ArgumentHelp("Path to the private DSA key file. Only use this option for transitioning to EdDSA from older updates.", valueName: "private-dsa-key-file"), transform: { URL(fileURLWithPath: $0) })
     var privateDSAKeyURL: URL?
     
-    @Option(name: .customShort("n"), help: ArgumentHelp("The name of the private DSA key. This option must be used together with `-k`.", valueName: "dsa-key-name"))
+    @Option(name: .customShort("n"), help: ArgumentHelp("The name of the private DSA key. This option must be used together with `-k`. Only use this option for transitioning to EdDSA from older updates.", valueName: "dsa-key-name"))
     var privateDSAKeyName: String?
     
-    @Option(name: .customShort("k"), help: ArgumentHelp("The path to the keychain to look up the private DSA key. This option must be used together with `-n`.", valueName: "keychain-for-dsa"), transform: { URL(fileURLWithPath: $0) })
+    @Option(name: .customShort("k"), help: ArgumentHelp("The path to the keychain to look up the private DSA key. This option must be used together with `-n`. Only use this option for transitioning to EdDSA from older updates.", valueName: "keychain-for-dsa"), transform: { URL(fileURLWithPath: $0) })
     var keychainURL: URL?
     
     @Option(name: .customLong("download-url-prefix"), help: ArgumentHelp("A URL that will be used as prefix for the URL from where updates will be downloaded.", valueName: "url"), transform: { URL(string: $0) })
@@ -67,11 +72,41 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .customLong("release-notes-url-prefix"), help: ArgumentHelp("A URL that will be used as prefix for constructing URLs for release notes.", valueName: "url"), transform: { URL(string: $0) })
     var releaseNotesURLPrefix : URL?
     
+    @Option(name: .long, help: ArgumentHelp("A URL to the application's website which Sparkle may use for directing users to if they cannot download a new update from within the application. This will be used for new generated update items. By default, no product link is used.", valueName: "link"))
+    var link: String?
+    
+    @Option(name: .long, help: ArgumentHelp("An optional comma delimited list of application versions (specified by CFBundleVersion) to generate new update items for. By default, new update items are inferred from the available archives and are only generated if they are in the latest \(DEFAULT_MAX_NEW_VERSIONS_IN_FEED) updates in the appcast.", valueName: "versions"), transform: { Set($0.components(separatedBy: ",")) })
+    var versions: Set<String>?
+    
+    @Option(name: .long, help: ArgumentHelp("The maximum number of delta items to create for the latest update for each minimum required operating system.", valueName: "maximum-deltas"))
+    var maximumDeltas: Int = DEFAULT_MAXIMUM_DELTAS
+    
+    @Option(name: .long, help: ArgumentHelp("The Sparkle channel name that will be used for generating new updates. By default, no channel is used. Old applications need to be using Sparkle 2 to use this feature.", valueName: "channel-name"))
+    var channel: String?
+    
+    @Option(name: .long, help: ArgumentHelp("The last major or minimum autoupdate sparkle:version that will be used for generating new updates. By default, no last major version is used.", valueName: "major-version"))
+    var majorVersion: String?
+    
+    @Option(name: .long, help: ArgumentHelp("The phased rollout interval in seconds that will be used for generating new updates. By default, no phased rollout interval is used.", valueName: "phased-rollout-interval"), transform: { Int($0) })
+    var phasedRolloutInterval: Int?
+    
+    @Option(name: .long, help: ArgumentHelp("The last critical update sparkle:version that will be used for generating new updates. An empty string argument will treat this update as critical coming from any application version. By default, no last critical update version is used. Old applications need to be using Sparkle 2 to use this feature.", valueName: "critical-update-version"))
+    var criticalUpdateVersion: String?
+    
+    @Option(name: .long, help: ArgumentHelp("A comma delimited list of application sparkle:version's that will see newly generated updates as being informational only. An empty string argument will treat this update as informational coming from any application version. By default, updates are not informational only. --link must also be provided. Old applications need to be using Sparkle 2 to use this feature.", valueName: "informational-update-versions"), transform: { $0.components(separatedBy: ",").filter({$0.count > 0}) })
+    var informationalUpdateVersions: [String]?
+    
     @Option(name: .customShort("o"), help: ArgumentHelp("Path to filename for the generated appcast (allowed when only one will be created).", valueName: "output-path"), transform: { URL(fileURLWithPath: $0) })
     var outputPathURL: URL?
     
     @Argument(help: "The path to the directory containing the update archives and delta files.", transform: { URL(fileURLWithPath: $0, isDirectory: true) })
     var archivesSourceDir: URL
+    
+    // New update items are only generated if they are in the latest maxNewVersionsInFeed updates in the appcast
+    // If the `versions` to generate is specified however, this counter has no effect.
+    // Keep this option hidden from the user for now
+    @Option(name: .long, help: .hidden)
+    var maxNewVersionsInFeed: Int = DEFAULT_MAX_NEW_VERSIONS_IN_FEED
     
     @Flag(help: .hidden)
     var verbose: Bool = false
@@ -80,11 +115,34 @@ struct GenerateAppcast: ParsableCommand {
         abstract: "Generate appcast from a directory of Sparkle update archives.",
         discussion: """
         Appcast files and deltas will be written to the archives directory.
-        Note that pkg-based updates are not supported.
         
+        If an appcast file is already present in the archives directory, that file will be re-used and updated with new entries.
+        Old entries in the appcast are kept intact. Otherwise, a new appcast file will be generated and written.
+        
+        .html files that have the same filename as an archive (except for the file extension) will be used for release notes for that item.
+        If the contents of these files are short (< \(CDATA_HTML_FRAGMENT_THRESHOLD) characters) and do not include a DOCTYPE or body tags, they will be treated as embedded CDATA release notes.
+        
+        For new update entries, Sparkle infers the minimum system OS requirement based on your update's LSMinimumSystemVersion provided
+        by your application's Info.plist. If none is found, \(programName) defaults to Sparkle's own minimum system requirement (macOS 10.11).
+        
+        An example of an archives directory may look like:
+            ./my-app-release-zipfiles/
+                MyApp 1.0.zip
+                MyApp 1.0.html
+                MyApp 1.1.zip
+                MyApp 1.1.html
+                appcast.xml
+                
         EXAMPLES:
-            \(programName) ./my-app-release-zipfiles/
-            \(programName) -o appcast-name.xml ./my-app-release-zipfiles/
+            \(programNamePath) ./my-app-release-zipfiles/
+            \(programNamePath) -o appcast-name.xml ./my-app-release-zipfiles/
+        
+        For more advanced options that can be used for publishing updates, see https://sparkle-project.org/documentation/publishing/ for further documentation.
+        
+        Extracted archives are cached in \((cacheDirectory.path as NSString).abbreviatingWithTildeInPath) to avoid re-computation in subsequent runs.
+        If archives that were processed are modified later, the caches may need to be cleared otherwise \(programName) assumes the archives do not change.
+        
+        Note that \(programName) does not support package-based (.pkg) updates.
         """)
     
     func validate() throws {
@@ -95,6 +153,16 @@ struct GenerateAppcast: ParsableCommand {
         // Both keychain/dsa key name options, and private dsa key file options cannot coexist
         guard (keychainURL == nil) || (privateDSAKeyURL == nil) else {
             throw ValidationError("-f <private-dsa-key-file> cannot be provided if -n <dsa-key-name> and -k <keychain> is provided")
+        }
+        
+        if let versions = versions {
+            guard versions.count > 0 else {
+                throw ValidationError("--versions must specify at least one application version.")
+            }
+        }
+        
+        guard (informationalUpdateVersions == nil) || (link != nil) else {
+            throw ValidationError("--link must be specified if --informational-update-versions is specified.")
         }
     }
     
@@ -122,7 +190,7 @@ struct GenerateAppcast: ParsableCommand {
         let keys = loadPrivateKeys(privateDSAKey, privateEdString)
         
         do {
-            let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, keys: keys, verbose: verbose)
+            let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, cacheDirectory: GenerateAppcast.cacheDirectory, keys: keys, versions: versions, maximumDeltas: maximumDeltas, verbose: verbose)
             
             // If a URL prefix was provided, set on the archive items
             if downloadURLPrefix != nil || releaseNotesURLPrefix != nil {
@@ -153,11 +221,14 @@ struct GenerateAppcast: ParsableCommand {
                                                                 relativeTo: archivesSourceDir)
 
                 // Write the appcast
-                try writeAppcast(appcastDestPath: appcastDestPath, updates: updates)
+                let (numNewUpdates, numExistingUpdates) = try writeAppcast(appcastDestPath: appcastDestPath, updates: updates, newVersions: versions, maxNewVersionsInFeed: maxNewVersionsInFeed, link: link, newChannel: channel, majorVersion: majorVersion, phasedRolloutInterval: phasedRolloutInterval, criticalUpdateVersion: criticalUpdateVersion, informationalUpdateVersions: informationalUpdateVersions)
 
                 // Inform the user, pluralizing "update" if necessary
-                let updateString = (updates.count == 1) ? "update" : "updates"
-                print("Wrote \(updates.count) \(updateString) to: \(appcastDestPath.path)")
+                let pluralizeUpdates = { $0 == 1 ? "update" : "updates" }
+                let newUpdatesString = pluralizeUpdates(numNewUpdates)
+                let existingUpdatesString = pluralizeUpdates(numExistingUpdates)
+                
+                print("Wrote \(numNewUpdates) new \(newUpdatesString) and updated \(numExistingUpdates) existing \(existingUpdatesString)")
             }
         } catch {
             print("Error generating appcast from directory", archivesSourceDir.path, "\n", error)


### PR DESCRIPTION
Add generate_appcast options for appcast selection features
    
  We can now supply for new update items:
  * Link
  * Channel name
  * Last major version / minimum autoupdate version
  * Phased rollout interval
  * Last critical update version
  * Originating informational update versions
    
We can also specify the maximum number of delta items to generate.
    
Lastly we can specify which versions to create new items for now. This allows applying flags for only specific versions, or for exceptional cases allows adding old versions that do not meet the most recent updates threshold (`maxNewVersionsInFeed`) -- think for updates for a prior OS or for a prior major version.

We do not override the minimum system version element on already existing items now, if the element already exists. Apps don't strictly need to specify LSMinimumSystemVersion and this allows users specifying it themselves in the feed.
    
The help page for generate_appcast was expanded with how the archive directory looks like, how release notes work, that old entries are kept in tact, and how extracted archives are cached..

We now write out the number of new updates written and the number of existing items updated, to make the generated result be less confusing.

Bug fixes:
* The scheme now builds for Debug so I can properly debug generate_appcast from within Xcode (distribution builds are still in Release)
* Newly generated items were appended at the end of the appcast and not necessarily inserted in the correct order (on top). As a workaround when we process existing items, we remove them, and re-add them.
* Fixed an off-by-one error for maximum number of delta files we can generate.

Fixes #1903

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other - generate_appcast

Tested generation of all new flags on my app archive directory, tested combinations of new and already existing items being written out. Tested subsequent runs of generate_appcast, maximum delta flag, ordering of generated versions, reviewed documentation.

macOS version tested: 11.5.1 (20G80)

--

I thought about "propagating" this information from older items to newer items and bucketing items (based on channel, min autoupdate version, min os version) at one point, but I think this approach of specifying parameters and what versions to create for new generated items is much simpler and more useful. 

I left out maximumSystemVersion because I think that's a not desirable edge case to have.
