### PR TITLE
Improve API header docs

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -11,6 +11,7 @@
 #import "SPULocalCacheDirectory.h"
 #import "SPUURLRequest.h"
 #import "SPUDownloadData.h"
+#import "SPUDownloadDataPrivate.h"
 #import "SUErrors.h"
 
 

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -939,6 +939,7 @@
 		7218EC362623F31C008FECF3 /* org.sparkle-project.InstallerConnection.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "org.sparkle-project.InstallerConnection.entitlements"; sourceTree = "<group>"; };
 		7218EC372623F32E008FECF3 /* org.sparkle-project.InstallerStatus.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "org.sparkle-project.InstallerStatus.entitlements"; sourceTree = "<group>"; };
 		7218EC4B2623F51C008FECF3 /* codesign_xpc_service.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = codesign_xpc_service.py; sourceTree = "<group>"; };
+		721AB11626C777D900D34A86 /* SPUDownloadDataPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUDownloadDataPrivate.h; sourceTree = "<group>"; };
 		721BC2061D17A532002BC71E /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		721BC2081D17A553002BC71E /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		721BC20A1D17A5AD002BC71E /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
@@ -1780,6 +1781,7 @@
 			isa = PBXGroup;
 			children = (
 				72F9EC421D5E9ED8004AC8B6 /* SPUDownloadData.h */,
+				721AB11626C777D900D34A86 /* SPUDownloadDataPrivate.h */,
 				72F9EC431D5E9ED8004AC8B6 /* SPUDownloadData.m */,
 				7214B8851D45AD9A00CB5CED /* SPUInstallationType.h */,
 				7293A1AC1CEE933800B957A7 /* SPUURLRequest.h */,

--- a/Sparkle.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Sparkle.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Sparkle.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Sparkle/SPUDownloadData.h
+++ b/Sparkle/SPUDownloadData.h
@@ -32,8 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 SU_EXPORT @interface SPUDownloadData : NSObject <NSSecureCoding>
 
-- (instancetype)initWithData:(NSData *)data URL:(NSURL *)URL textEncodingName:(NSString * _Nullable)textEncodingName MIMEType:(NSString * _Nullable)MIMEType;
-
 /**
  * The raw data that was downloaded.
  */

--- a/Sparkle/SPUDownloadDataPrivate.h
+++ b/Sparkle/SPUDownloadDataPrivate.h
@@ -1,0 +1,19 @@
+//
+//  SPUDownloadDataPrivate.h
+//  SPUDownloadDataPrivate
+//
+//  Created by Mayur Pawashe on 8/13/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPUDownloadData (Private)
+
+- (instancetype)initWithData:(NSData *)data URL:(NSURL *)URL textEncodingName:(NSString * _Nullable)textEncodingName MIMEType:(NSString * _Nullable)MIMEType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -12,7 +12,7 @@
 #import "SPUXPCServiceInfo.h"
 #import "SPUUpdaterDelegate.h"
 #import "SUAppcastItem.h"
-#import "SULog.h"
+#import "SUAppcastItem+Private.h"
 #import "SULocalizations.h"
 #import "SUErrors.h"
 #import "SUHost.h"

--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -30,7 +30,7 @@ SU_EXPORT @interface SPUStandardUserDriver : NSObject <SPUUserDriver>
  Initializes a Sparkle's standard user driver for user update interactions
  
  @param hostBundle The target bundle of the host that is being updated.
- @param delegate The delegate to this user driver. Pass nil if you don't want to provide one.
+ @param delegate The optional delegate to this user driver.
  */
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle delegate:(nullable id<SPUStandardUserDriverDelegate>)delegate;
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -225,7 +225,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  The user agent used when checking for updates.
  
  By default the user agent string returned is in the format:
- $(BundleDisplayName)/$(BundleDisplayVersion)/$(SparkleDisplayVersion)
+ $(BundleDisplayName)/$(BundleDisplayVersion) Sparkle/$(SparkleDisplayVersion)
  
  BundleDisplayVersion is derived from the application Info.plist's CFBundleShortVersionString.
  

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -861,14 +861,16 @@ static NSString *escapeURLComponent(NSString *str) {
     NSArray *systemProfile = [SUSystemProfiler systemProfileArrayForHost:self.host];
     if ([self.delegate respondsToSelector:@selector(allowedSystemProfileKeysForUpdater:)]) {
         NSArray * allowedKeys = [self.delegate allowedSystemProfileKeysForUpdater:self];
-        NSMutableArray *filteredProfile = [NSMutableArray array];
-        for (NSDictionary *profileElement in systemProfile) {
-            NSString *key = [profileElement objectForKey:@"key"];
-            if (key && [allowedKeys containsObject:key]) {
-                [filteredProfile addObject:profileElement];
+        if (allowedKeys != nil) {
+            NSMutableArray *filteredProfile = [NSMutableArray array];
+            for (NSDictionary *profileElement in systemProfile) {
+                NSString *key = [profileElement objectForKey:@"key"];
+                if (key && [allowedKeys containsObject:key]) {
+                    [filteredProfile addObject:profileElement];
+                }
             }
+            systemProfile = [filteredProfile copy];
         }
-        systemProfile = [filteredProfile copy];
     }
     return systemProfile;
 }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -491,8 +491,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             }
             
             BOOL preventsInstallerInteraction;
-            if ([strongSelf.delegate respondsToSelector:@selector(updaterShouldAllowInstallerInteraction:userInitiated:)]) {
-                preventsInstallerInteraction = ![strongSelf.delegate updaterShouldAllowInstallerInteraction:strongSelf userInitiated:NO];
+            if ([strongSelf.delegate respondsToSelector:@selector(updater:shouldAllowInstallerInteractionForUpdateCheck:)]) {
+                preventsInstallerInteraction = ![strongSelf.delegate updater:strongSelf shouldAllowInstallerInteractionForUpdateCheck:SPUUpdateCheckBackgroundScheduled];
             } else {
                 preventsInstallerInteraction = NO;
             }
@@ -538,8 +538,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             SPUUpdater *strongSelf = weakSelf;
             if (strongSelf != nil) {
                 BOOL preventsInstallerInteraction;
-                if ([strongSelf.delegate respondsToSelector:@selector(updaterShouldAllowInstallerInteraction:userInitiated:)]) {
-                    preventsInstallerInteraction = ![strongSelf.delegate updaterShouldAllowInstallerInteraction:strongSelf userInitiated:YES];
+                if ([strongSelf.delegate respondsToSelector:@selector(updater:shouldAllowInstallerInteractionForUpdateCheck:)]) {
+                    preventsInstallerInteraction = ![strongSelf.delegate updater:strongSelf shouldAllowInstallerInteractionForUpdateCheck:SPUUpdateCheckUserInitiated];
                 } else {
                     preventsInstallerInteraction = NO;
                 }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -403,8 +403,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     [self.updaterTimer invalidate];
     
     if (![self automaticallyChecksForUpdates]) {
-        if ([self.delegate respondsToSelector:@selector(updaterWillNotScheduleUpdate:)]) {
-            [self.delegate updaterWillNotScheduleUpdate:self];
+        if ([self.delegate respondsToSelector:@selector(updaterWillNotScheduleUpdateCheck:)]) {
+            [self.delegate updaterWillNotScheduleUpdateCheck:self];
         }
         return;
     }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -403,8 +403,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     [self.updaterTimer invalidate];
     
     if (![self automaticallyChecksForUpdates]) {
-        if ([self.delegate respondsToSelector:@selector(updaterWillIdleSchedulingUpdates:)]) {
-            [self.delegate updaterWillIdleSchedulingUpdates:self];
+        if ([self.delegate respondsToSelector:@selector(updaterWillNotScheduleUpdate:)]) {
+            [self.delegate updaterWillNotScheduleUpdate:self];
         }
         return;
     }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -491,8 +491,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             }
             
             BOOL preventsInstallerInteraction;
-            if ([strongSelf.delegate respondsToSelector:@selector(updater:shouldAllowInstallerInteractionForUpdateCheck:)]) {
-                preventsInstallerInteraction = ![strongSelf.delegate updater:strongSelf shouldAllowInstallerInteractionForUpdateCheck:SPUUpdateCheckBackgroundScheduled];
+            if ([strongSelf.delegate respondsToSelector:@selector(updaterShouldAllowInstallerInteraction:userInitiated:)]) {
+                preventsInstallerInteraction = ![strongSelf.delegate updaterShouldAllowInstallerInteraction:strongSelf userInitiated:NO];
             } else {
                 preventsInstallerInteraction = NO;
             }
@@ -538,8 +538,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             SPUUpdater *strongSelf = weakSelf;
             if (strongSelf != nil) {
                 BOOL preventsInstallerInteraction;
-                if ([strongSelf.delegate respondsToSelector:@selector(updater:shouldAllowInstallerInteractionForUpdateCheck:)]) {
-                    preventsInstallerInteraction = ![strongSelf.delegate updater:strongSelf shouldAllowInstallerInteractionForUpdateCheck:SPUUpdateCheckUserInitiated];
+                if ([strongSelf.delegate respondsToSelector:@selector(updaterShouldAllowInstallerInteraction:userInitiated:)]) {
+                    preventsInstallerInteraction = ![strongSelf.delegate updaterShouldAllowInstallerInteraction:strongSelf userInitiated:YES];
                 } else {
                     preventsInstallerInteraction = NO;
                 }

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -57,12 +57,6 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 //	SPUUpdater Delegate:
 // -----------------------------------------------------------------------------
 
-typedef NS_ENUM(NSInteger, SPUUpdateCheck)
-{
-    SPUUpdateCheckUserInitiated = 0,
-    SPUUpdateCheckBackgroundScheduled = 1
-};
-
 /**
  Provides delegation methods to control the behavior of an `SPUUpdater` object.
  */
@@ -384,9 +378,10 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  Note this has no effect if the update has already been downloaded in the background silently and ready to be resumed.
  
  @param updater The updater instance.
- @param updateCheck The type of update check being performed.
+ @param userInitiated Flag that indicates if the update check is initiated by the user.
+ @return @c YES if installer interaction is allowed (the default), @c NO if installer interaction is not allowed.
  */
-- (BOOL)updater:(SPUUpdater *)updater shouldAllowInstallerInteractionForUpdateCheck:(SPUUpdateCheck)updateCheck;
+- (BOOL)updaterShouldAllowInstallerInteraction:(SPUUpdater *)updater userInitiated:(BOOL)userInitiated;
 
 /**
  Returns the decryption password (if any) which is used to extract the update archive DMG.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -367,7 +367,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  @param updater The updater instance.
  */
-- (void)updaterWillIdleSchedulingUpdates:(SPUUpdater *)updater;
+- (void)updaterWillNotScheduleUpdate:(SPUUpdater *)updater;
 
 /**
  Returns whether or not the updater should allow interaction from the installer

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 };
 
 /**
- Provides methods to control the behavior of an `SPUUpdater` object.
+ Provides delegation methods to control the behavior of an `SPUUpdater` object.
  */
 @protocol SPUUpdaterDelegate <NSObject>
 @optional
@@ -405,7 +405,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  Also if the updater is given responsibility and the update item is marked critical, the new update will be presented to the user immediately after.
  
- Even if the `immediateInstallHandler` is not invoked, the installer will attempt to install the update on termination.
+ Even if the @p immediateInstallHandler is not invoked, the installer will attempt to install the update on termination.
  
  @param updater The updater instance.
  @param item The appcast item corresponding to the update that is proposed to be installed.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -70,99 +70,31 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 @optional
 
 /**
- Called when a background update will be scheduled after a delay.
- 
- Automatic update checks need to be enabled for this to trigger.
- 
- @param delay The delay in seconds until the next scheduled update will occur.
- 
- @param updater The updater instance.
- */
-- (void)updater:(SPUUpdater *)updater willScheduleUpdateCheckAfterDelay:(NSTimeInterval)delay;
-
-/**
- Called when no updates will be scheduled in the future.
- 
- This may later change if automatic update checks become enabled.
- 
- @param updater The updater instance.
- */
-- (void)updaterWillIdleSchedulingUpdates:(SPUUpdater *)updater;
-
-/**
  Returns whether to allow Sparkle to pop up.
  
  For example, this may be used to prevent Sparkle from interrupting a setup assistant.
  Alternatively, you may want to consider starting the updater after eg: the setup assistant finishes
  
  @param updater The updater instance.
+ @return @c YES if the updater may check for updates otherwise @c NO
  */
 - (BOOL)updaterMayCheckForUpdates:(SPUUpdater *)updater;
-
-/**
- Returns additional parameters to append to the appcast URL's query string.
- 
- This is potentially based on whether or not Sparkle will also be sending along the system profile.
- 
- @param updater The updater instance.
- @param sendingProfile Whether the system profile will also be sent.
- 
- @return An array of dictionaries with keys: "key", "value", "displayKey", "displayValue", the latter two being specifically for display to the user.
- */
-- (NSArray<NSDictionary<NSString *, NSString *> *> *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
-
-/**
- Returns a list of system profile keys to be appended to the appcast URL's query string.
-
- If this is unimplemented then all keys will be included.
-
- @param updater The updater instance.
-
- @return An array of system profile keys to include in the appcast URL's query string. Elements must be one of the SUSystemProfiler*Key constants
- */
-- (NSArray<NSString *> *)allowedSystemProfileKeysForUpdater:(SPUUpdater *)updater;
-
-/**
- Returns a custom appcast URL.
- 
- Override this to dynamically specify the feed URL.
- 
- @param updater The updater instance.
- */
-- (nullable NSString *)feedURLStringForUpdater:(SPUUpdater *)updater;
-
-/**
- Returns whether Sparkle should prompt the user about automatic update checks.
- 
- Use this to override the default behavior.
- 
- @param updater The updater instance.
- */
-- (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SPUUpdater *)updater;
-
-/**
- Called after Sparkle has downloaded the appcast from the remote server.
- 
- Implement this if you want to do some special handling with the appcast once it finishes loading.
- 
- @param updater The updater instance.
- @param appcast The appcast that was downloaded from the remote server.
- */
-- (void)updater:(SPUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast;
 
 /**
  Returns the set of Sparkle channels the updater is allowed to find new updates from.
  
  An appcast item can specify a channel the update is posted to. Without specifying a channel, the appcast item is posted to the default channel.
  For instance:
+ ```
  <item>
     <sparkle:version>2.0 Beta 1</sparkle:version>
     <sparkle:channel>beta</sparkle:channel>
  </item>
+ ```
  
- This example posts an update to the 'beta' channel, so only updaters that are allowed to use the 'beta' channel can find this update.
+ This example posts an update to the @c beta channel, so only updaters that are allowed to use the @c beta channel can find this update.
  
- If the <sparkle:channel> is not present, the update item is posted to the default channel and can be found by any updater.
+ If the @c <sparkle:channel> element is not present, the update item is posted to the default channel and can be found by any updater.
  
  You can pick any name you'd like for the channel. The valid characters for channel names are letters, numbers, dashes, underscores, and periods.
  
@@ -175,37 +107,61 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)updater;
 
 /**
- Returns the item in the appcast corresponding to the update that should be installed.
+ Returns a custom appcast URL.
  
- Please consider using or migrating to other supported features before adopting this method.
- Specifically:
- If you want to filter out certain tagged updates (like beta updates), consider -[SPUUpdaterDelegate allowedChannelsForUpdater:] instead.
- If you want to treat certain updates as informational-only, consider supplying <sparkle:informationalUpdate> with a set of affected versions users are updating from.
+ Override this to dynamically specify the feed URL.
  
- If you're using special logic or extensions in your appcast,
- implement this to use your own logic for finding a valid update, if any,
- in the given appcast.
- 
- Do not base your logic by filtering out items with a minimum or maximum OS version or minimum autoupdate version,
- because Sparkle already has logic for determining whether or not those items should be filtered out.
- Also do not return a non-top level item from the appcast such as a delta item. Delta items will be ignored.
- Sparkle picks the delta item from your selection if the appropriate one is available.
- 
- This method will not be invoked with an appcast that has zero items. Pick the best item from the appcast.
- If an item is available that has the same version as the application or bundle to update,
- do not pick an item that is worse than that version.
- 
- This method may be called multiple times for different selections and filters. This method should be efficient.
- 
- @param appcast The appcast that was downloaded from the remote server.
  @param updater The updater instance.
- @return The best valid appcast item. Return `SUAppcastItem.emptyAppcastItem` if no appcast item is valid. Return @c nil if you don't want to be delegated this task and
-         want to let Sparkle handle picking the best valid update.
+ @return An appcast feed URL to check for new updates in. Return @c nil for the default behavior and if you don't want to be delegated this task.
  */
-- (nullable SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;
+- (nullable NSString *)feedURLStringForUpdater:(SPUUpdater *)updater;
 
 /**
- Called when a valid update is found by the update driver.
+ Returns additional parameters to append to the appcast URL's query string.
+ 
+ This is potentially based on whether or not Sparkle will also be sending along the system profile.
+ 
+ @param updater The updater instance.
+ @param sendingProfile Whether the system profile will also be sent.
+ 
+ @return An array of dictionaries with keys: `key`, `value`, `displayKey`, `displayValue`, the latter two being specifically for display to the user.
+ */
+- (NSArray<NSDictionary<NSString *, NSString *> *> *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
+
+
+/**
+ Returns whether Sparkle should prompt the user about automatic update checks.
+ 
+ Use this to override the default behavior.
+ 
+ @param updater The updater instance.
+ @return @c YES if the updater should prompt for permission to check for updates, otherwise @c NO
+ */
+- (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SPUUpdater *)updater;
+
+/**
+ Returns a list of system profile keys to be appended to the appcast URL's query string.
+
+ If this is not implemented then all keys will be included.
+
+ @param updater The updater instance.
+
+ @return An array of system profile keys to include in the appcast URL's query string. Elements must be one of the `SUSystemProfiler*Key` constants. Return @c nil for the default behavior and if you don't want to be delegated this task.
+ */
+- (nullable NSArray<NSString *> *)allowedSystemProfileKeysForUpdater:(SPUUpdater *)updater;
+
+/**
+ Called after Sparkle has downloaded the appcast from the remote server.
+ 
+ Implement this if you want to do some special handling with the appcast once it finishes loading.
+ 
+ @param updater The updater instance.
+ @param appcast The appcast that was downloaded from the remote server.
+ */
+- (void)updater:(SPUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast;
+
+/**
+ Called when a new valid update is found by the update driver.
  
  @param updater The updater instance.
  @param item The appcast item corresponding to the update that is proposed to be installed.
@@ -213,25 +169,60 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (void)updater:(SPUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)item;
 
 /**
- Called when a valid update is not found.
+ Called when a valid new update is not found.
+ 
+ There are various reasons a new update is unavailable and can't be installed.
+ 
+ The userInfo dictionary on the error is populated with three keys:
+ - `SPULatestAppcastItemFoundKey`: if available, this may provide the latest `SUAppcastItem` that was found. This will be @c nil if it's unavailable.
+ - `SPUNoUpdateFoundReasonKey`: This will provide the `SPUNoUpdateFoundReason`.
+ For example the reason could be because the latest version in the feed requires a newer OS version or could be because the user is already on the latest version.
+ - `SPUNoUpdateFoundUserInitiatedKey`: A boolean that indicates if a new update was not found when the user intitiated an update check manually.
  
  @param updater The updater instance.
  @param error An error containing information on why a new valid update was not found
-    There are various reasons a new update is unavailable and can't be installed.
-    The userInfo dictionary on the error is also populated with three keys:
-    SPULatestAppcastItemFoundKey: if available, this may provide the latest SUAppcastItem that was found. This will be nil if it's unavailable.
-    SPUNoUpdateFoundReasonKey: This will provide the SUNoUpdateFoundReason.
-    For example the reason could be because the latest version in the feed requires a newer OS version or could be because the user is already on the latest version.
-    SPUNoUpdateFoundUserInitiatedKey: A boolean that indicates if a new update was not found when the user intitiated an update check manually.
  */
 - (void)updaterDidNotFindUpdate:(SPUUpdater *)updater error:(NSError *)error;
 
 /**
- Called when a valid update is not found.
+ Called when a valid new update is not found.
+ 
+ If more information is needed on why an update was not found, use `-[SPUUpdaterDelegate updaterDidNotFindUpdate:error:]` instead.
  
  @param updater The updater instance.
  */
 - (void)updaterDidNotFindUpdate:(SPUUpdater *)updater;
+
+/**
+ Returns the item in the appcast corresponding to the update that should be installed.
+ 
+ Please consider using or migrating to other supported features before adopting this method.
+ Specifically:
+ - If you want to filter out certain tagged updates (like beta updates), consider `-[SPUUpdaterDelegate allowedChannelsForUpdater:]` instead.
+ - If you want to treat certain updates as informational-only, consider supplying @c <sparkle:informationalUpdate> with a set of affected versions users are updating from.
+ 
+ If you're using special logic or extensions in your appcast, implement this to use your own logic for finding a valid update, if any, in the given appcast.
+ 
+ Do not base your logic by filtering out items with a minimum or maximum OS version or minimum autoupdate version
+ because Sparkle already has logic for determining whether or not those items should be filtered out.
+ 
+ Also do not return a non-top level item from the appcast such as a delta item. Delta items will be ignored.
+ Sparkle picks the delta item from your selection if the appropriate one is available.
+ 
+ This method will not be invoked with an appcast that has zero items. Pick the best item from the appcast.
+ If an item is available that has the same version as the application or bundle to update, do not pick an item that is worse than that version.
+ 
+ This method may be called multiple times for different selections and filters. This method should be efficient.
+ 
+ Return `+[SUAppcastItem emptyAppcastItem]` if no appcast item is valid.
+ 
+ Return @c nil if you don't want to be delegated this task and want to let Sparkle handle picking the best valid update.
+ 
+ @param appcast The appcast that was downloaded from the remote server.
+ @param updater The updater instance.
+ @return The best valid appcast item.
+ */
+- (nullable SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;
 
 /**
  Called when an update is skipped by the user.
@@ -244,11 +235,11 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 /**
  Returns whether the release notes (if available) should be downloaded after an update is found and shown.
  
- This is specifically for the releaseNotesLink element in the appcast.
+ This is specifically for the @c <releaseNotesLink> element in the appcast item.
  
  @param updater The updater instance.
  
- @return @c YES to download and show the release notes if available, otherwise @c NO. The default behavior is YES.
+ @return @c YES to download and show the release notes if available, otherwise @c NO. The default behavior is @c YES.
  */
 - (BOOL)updaterShouldDownloadReleaseNotes:(SPUUpdater *)updater;
 
@@ -328,11 +319,11 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 /**
  Returns whether the application should be relaunched at all.
  
- Some apps \b cannot be relaunched under certain circumstances.
+ Some apps @b cannot be relaunched under certain circumstances.
  This method can be used to explicitly prevent a relaunch.
  
  @param updater The updater instance.
- @return YES if the updater should be relaunched, otherwise NO if it shouldn't.
+ @return @c YES if the updater should be relaunched, otherwise @c NO if it shouldn't.
  */
 - (BOOL)updaterShouldRelaunchApplication:(SPUUpdater *)updater;
 
@@ -354,9 +345,29 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  even if you provide a custom comparator here.
  
  @param updater The updater instance.
- @return The custom version comparator or nil if you don't want to be delegated this task.
+ @return The custom version comparator or @c nil if you don't want to be delegated this task.
  */
 - (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater;
+
+/**
+ Called when a background update will be scheduled after a delay.
+ 
+ Automatic update checks need to be enabled for this to trigger.
+ 
+ @param delay The delay in seconds until the next scheduled update will occur.
+ 
+ @param updater The updater instance.
+ */
+- (void)updater:(SPUUpdater *)updater willScheduleUpdateCheckAfterDelay:(NSTimeInterval)delay;
+
+/**
+ Called when no updates will be scheduled in the future.
+ 
+ This may later change if automatic update checks become enabled.
+ 
+ @param updater The updater instance.
+ */
+- (void)updaterWillIdleSchedulingUpdates:(SPUUpdater *)updater;
 
 /**
  Returns whether or not the updater should allow interaction from the installer
@@ -380,24 +391,26 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 /**
  Returns the decryption password (if any) which is used to extract the update archive DMG.
  
- Return nil if no password should be used.
+ Return @c nil if no password should be used.
  
  @param updater The updater instance.
- @return The password used for decrypting the archive, or nil if no password should be used.
+ @return The password used for decrypting the archive, or @c nil if no password should be used.
  */
 - (nullable NSString *)decryptionPasswordForUpdater:(SPUUpdater *)updater;
 
 /**
  Called when an update is scheduled to be silently installed on quit after downloading the update automatically.
  
+ If the updater is given responsibility, it can later remind the user an update is available if they have not terminated the application for a long time.
+ 
+ Also if the updater is given responsibility and the update item is marked critical, the new update will be presented to the user immediately after.
+ 
+ Even if the `immediateInstallHandler` is not invoked, the installer will attempt to install the update on termination.
+ 
  @param updater The updater instance.
  @param item The appcast item corresponding to the update that is proposed to be installed.
  @param immediateInstallHandler The install handler to immediately install the update. No UI interaction will be shown and the application will be relaunched after installation.
- @return YES if the delegate will handle installing the update or NO if the updater should be given responsibility.
- 
- If the updater is given responsibility, it can later remind the user an update is available if they have not terminated the application for a long time.
- Also if the updater is given responsibility and the update item is marked critical, the new update will be presented to the user immediately after.
- Even if the immediateInstallHandler is not invoked, the installer will attempt to install the update on termination.
+ @return @c YES if the delegate will handle installing the update or @c NO if the updater should be given responsibility.
  */
 - (BOOL)updater:(SPUUpdater *)updater willInstallUpdateOnQuit:(SUAppcastItem *)item immediateInstallationBlock:(void (^)(void))immediateInstallHandler;
 

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -361,13 +361,13 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (void)updater:(SPUUpdater *)updater willScheduleUpdateCheckAfterDelay:(NSTimeInterval)delay;
 
 /**
- Called when no updates will be scheduled in the future.
+ Called when no update checks will be scheduled in the future.
  
  This may later change if automatic update checks become enabled.
  
  @param updater The updater instance.
  */
-- (void)updaterWillNotScheduleUpdate:(SPUUpdater *)updater;
+- (void)updaterWillNotScheduleUpdateCheck:(SPUUpdater *)updater;
 
 /**
  Returns whether or not the updater should allow interaction from the installer

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -140,9 +140,9 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
 - (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SPUUpdater *)updater;
 
 /**
- Returns a list of system profile keys to be appended to the appcast URL's query string.
+ Returns an allowed list of system profile keys to be appended to the appcast URL's query string.
 
- If this is not implemented then all keys will be included.
+ By default all keys will be included. This method allows overriding which keys should only be allowed.
 
  @param updater The updater instance.
 

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -199,7 +199,7 @@ typedef NS_ENUM(NSInteger, SPUUpdateCheck)
  
  @param appcast The appcast that was downloaded from the remote server.
  @param updater The updater instance.
- @return The best valid appcast item. Return SUAppcastItem.emptyAppcastItem if no appcast item is valid. Return nil if you don't want to be delegated this task and
+ @return The best valid appcast item. Return `SUAppcastItem.emptyAppcastItem` if no appcast item is valid. Return @c nil if you don't want to be delegated this task and
          want to let Sparkle handle picking the best valid update.
  */
 - (nullable SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast forUpdater:(SPUUpdater *)updater;

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -57,6 +57,12 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 //	SPUUpdater Delegate:
 // -----------------------------------------------------------------------------
 
+typedef NS_ENUM(NSInteger, SPUUpdateCheck)
+{
+    SPUUpdateCheckUserInitiated = 0,
+    SPUUpdateCheckBackgroundScheduled = 1
+};
+
 /**
  Provides delegation methods to control the behavior of an `SPUUpdater` object.
  */
@@ -378,10 +384,9 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  Note this has no effect if the update has already been downloaded in the background silently and ready to be resumed.
  
  @param updater The updater instance.
- @param userInitiated Flag that indicates if the update check is initiated by the user.
- @return @c YES if installer interaction is allowed (the default), @c NO if installer interaction is not allowed.
+ @param updateCheck The type of update check being performed.
  */
-- (BOOL)updaterShouldAllowInstallerInteraction:(SPUUpdater *)updater userInitiated:(BOOL)userInitiated;
+- (BOOL)updater:(SPUUpdater *)updater shouldAllowInstallerInteractionForUpdateCheck:(SPUUpdateCheck)updateCheck;
 
 /**
  Returns the decryption password (if any) which is used to extract the update archive DMG.

--- a/Sparkle/SPUUserUpdateState.h
+++ b/Sparkle/SPUUserUpdateState.h
@@ -22,23 +22,59 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ A choice made by the user when prompted with a new update.
+ */
 typedef NS_ENUM(NSInteger, SPUUserUpdateChoice) {
+    /**
+     Dismisses the update and skips being notified of it in the future.
+     */
     SPUUserUpdateChoiceSkip,
+    /**
+     Downloads (if needed) and installs the update.
+     */
     SPUUserUpdateChoiceInstall,
+    /**
+     Dismisses the update until Sparkle reminds the user of it at a later time.
+     */
     SPUUserUpdateChoiceDismiss,
 };
 
+/**
+ Describes the current stage an update is undergoing.
+ */
 typedef NS_ENUM(NSInteger, SPUUserUpdateStage) {
+    /**
+     The update has not been downloaded.
+     */
     SPUUserUpdateStageNotDownloaded,
+    /**
+     The update has already been downloaded but not begun installing.
+     */
     SPUUserUpdateStageDownloaded,
+    /**
+     The update has already been downloaded and began installing in the background.
+     */
     SPUUserUpdateStageInstalling
 };
 
+/**
+ This represents the user's current update state.
+ */
 SU_EXPORT @interface SPUUserUpdateState : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
+/**
+ The current update stage.
+ 
+ This stage indicates if data has been already downloaded or not, or if an update is currently being installed.
+ */
 @property (nonatomic, readonly) SPUUserUpdateStage stage;
+
+/**
+ Indicates whether or not the update check was initiated by the user.
+ */
 @property (nonatomic, readonly) BOOL userInitiated;
 
 @end

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUAppcastItem;
 
 /**
- The appcast representing a collection of `SUAppcastItem` update items in the feed.
+ The appcast representing a collection of `SUAppcastItem` items in the feed.
  */
 SU_EXPORT @interface SUAppcast : NSObject
 
@@ -33,7 +33,7 @@ SU_EXPORT @interface SUAppcast : NSObject
 /**
  The collection of update items.
  
- These update items are in the same order as specified in the appcast XML feed and are thus not sorted by version.
+ These `SUAppcastItem` items are in the same order as specified in the appcast XML feed and are thus not sorted by version.
  */
 @property (readonly, copy) NSArray<SUAppcastItem *> *items;
 

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -22,10 +22,19 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SUAppcastItem;
+
+/**
+ The appcast representing a collection of updates in the appcast feed.
+ */
 SU_EXPORT @interface SUAppcast : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
+/**
+ The collection of update items.
+ 
+ These update items are in the same order as specified in the appcast XML feed and are thus not sorted by version.
+ */
 @property (readonly, copy) NSArray<SUAppcastItem *> *items;
 
 @end

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUAppcastItem;
 
 /**
- The appcast representing a collection of updates in the appcast feed.
+ The appcast representing a collection of `SUAppcastItem` update items in the feed.
  */
 SU_EXPORT @interface SUAppcast : NSObject
 

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUAppcastItem;
 SU_EXPORT @interface SUAppcast : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @property (readonly, copy) NSArray<SUAppcastItem *> *items;
 
 @end

--- a/Sparkle/SUAppcastItem+Private.h
+++ b/Sparkle/SUAppcastItem+Private.h
@@ -33,6 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dict relativeToURL:(NSURL * _Nullable)appcastURL stateResolver:(SPUAppcastItemStateResolver *)stateResolver failureReason:(NSString * _Nullable __autoreleasing *_Nullable)error;
 
+/**
+ The DSA and EdDSA signatures along with their statuses.
+ */
+@property (readonly, nullable) SUSignatures *signatures;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The appcast item describing an update in the application's appcast feed.
 
- An appcast item represents a single update item in your `SUAppcast`  contained within the <item> element.
+ An appcast item represents a single update item in the `SUAppcast`  contained within the @c <item> element.
  
  Every appcast item must have a `versionString`, and either a `fileURL` or an `infoURL`.
  All the remaining properties describing an update to the application are optional.
@@ -49,20 +49,22 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 /**
  The version of the update item.
  
+ Sparkle uses this property to compare update items and determine the best available update item in the `SUAppcast`.
+ 
  This corresponds to the application update's @c CFBundleVersion
  
- Sparkle also uses this property to determine the sorting order of appcast items in the `SUAppcast`.
- 
- This is extracted from the <sparkle:version> element, or the sparkle:version attribute from the <enclosure> element.
+ This is extracted from the @c <sparkle:version> element, or the @c sparkle:version attribute from the @c <enclosure> element.
  */
 @property (copy, readonly) NSString *versionString;
 
 /**
  The human-readable display version of the update item if provided.
  
+ This is the version string shown to the user when they are notified of a new update.
+ 
  This corresponds to the application update's @c CFBundleShortVersionString
  
- This is extracted from the <sparkle:shortVersionString> element,  or the sparkle:version attribute from the <enclosure> element.
+ This is extracted from the @c <sparkle:shortVersionString> element,  or the @c sparkle:shortVersionString attribute from the @c <enclosure> element.
  */
 @property (copy, readonly, nullable) NSString *displayVersionString;
 
@@ -70,23 +72,23 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  The file URL to the update item if provided.
  
  This download contains the actual update Sparkle will attempt to install.
- In cases a download cannot be provided, an `infoURL` must be provided instead.
+ In cases where a download cannot be provided, an `infoURL` must be provided instead.
  
  A file URL should have an accompanying `contentLength` provided.
  
- This is extracted from the @c url attribute in the <enclosure> element.
+ This is extracted from the @c url attribute in the @c <enclosure> element.
  */
 @property (readonly, nullable) NSURL *fileURL;
 
 /**
  The content length of the download in bytes.
  
- This property is used as a fallback when the download server doesn't report the content length of the download.
+ This property is used as a fallback when the server doesn't report the content length of the download.
  In that case, it is used to report progress of the downloading update to the user.
  
  A warning is outputted if this property is not equal the server's expected content length (if provided).
  
- This is extracted from the @c length attribute in the <enclosure> element.
+ This is extracted from the @c length attribute in the @c <enclosure> element.
  It should be specified if a `fileURL` is provided.
  */
 @property (nonatomic, readonly) uint64_t contentLength;
@@ -99,23 +101,25 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  
  The informational link will be used if `informationOnlyUpdate` is @c YES
  
- This is extracted from the <link> element.
+ This is extracted from the @c <link> element.
  */
 @property (readonly, nullable) NSURL *infoURL;
 
 /**
- Indicates whether or not the update item is informational.
+ Indicates whether or not the update item is only informational and has no download.
  
  If `infoURL` is not present, this is @c NO
+ 
  If `fileURL` is not present, this is @c YES
- Otherwise this is determined based on the contents extracted from the <sparkle:informationalUpdate> element.
+ 
+ Otherwise this is determined based on the contents extracted from the @c <sparkle:informationalUpdate> element.
  */
 @property (getter=isInformationOnlyUpdate, readonly) BOOL informationOnlyUpdate;
 
 /**
  The title of the appcast item if provided.
  
- This is extracted from the <title> element.
+ This is extracted from the @c <title> element.
  */
 @property (copy, readonly, nullable) NSString *title;
 
@@ -123,51 +127,52 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  The date string of the appcast item if provided.
  
  The `date` property is constructed from this property and expects this string to comply with the following date format:
- E, dd MMM yyyy HH:mm:ss Z
+ `E, dd MMM yyyy HH:mm:ss Z`
  
- This is extracted from the <pubDate> element.
+ This is extracted from the @c <pubDate> element.
  */
 @property (copy, readonly, nullable) NSString *dateString;
 
 /**
- The date constructed from the `dateString` property, if provided, using an en_US locale.
+ The date constructed from the `dateString` property if provided.
  
  Sparkle by itself only uses this property for phased group rollouts specified via `phasedRolloutInterval`, but clients may query this property too.
+ 
+ This date is constructed using the  @c en_US locale.
  */
 @property (copy, readonly, nullable) NSDate *date;
 
 /**
  The release notes URL of the appcast item if provided.
  
- This link points to an HTML file that Sparkle downloads and renders to the user for showing them a new or old update item's changes.
+ This external link points to an HTML file that Sparkle downloads and renders to show the user a new or old update item's changelog.
  
  An alternative to using an external release notes link is providing an embedded `itemDescription`.
  
- This is extracted from the <sparkle:releaseNotesLink> element.
+ This is extracted from the @c <sparkle:releaseNotesLink> element.
  */
 @property (readonly, nullable) NSURL *releaseNotesURL;
 
 /**
  The description of the appcast item if provided.
  
- A description may be provided for inline/embedded release notes of new updates using <![CDATA[...]]>
+ A description may be provided for inline/embedded release notes for new updates using @c <![CDATA[...]]>
  This is an alternative to providing a `releaseNotesURL`.
  
- This is extracted from the <description> element.
+ This is extracted from the @c <description> element.
  */
 @property (copy, readonly, nullable) NSString *itemDescription;
 
 /**
- The required minimum system operating version string this update meets if provided.
+ The required minimum system operating version string for this update if provided.
  
  This version string should contain three period-separated components.
  
- Example:
- 10.12.0
+ Example: @c 10.12.0
  
  Use `minimumOperatingSystemVersionIsOK` property to test if the current running system passes this requirement.
  
- This is extracted from the <sparkle:minimumSystemVersion> element.
+ This is extracted from the @c <sparkle:minimumSystemVersion> element.
  */
 @property (copy, readonly, nullable) NSString *minimumSystemVersion;
 
@@ -177,18 +182,17 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 @property (nonatomic, readonly) BOOL minimumOperatingSystemVersionIsOK;
 
 /**
- The required maximum system operating version string this update meets if provided.
+ The required maximum system operating version string for this update if provided.
  
  A maximum system operating version requirement should only be made in unusual scenarios.
  
  This version string should contain three period-separated components.
  
- Example:
- 10.13.0
+ Example: @c 10.13.0
  
- Use `maximumOperatingSystemVersionIsOK`property  to test if the current running system passes this requirement.
+ Use `maximumOperatingSystemVersionIsOK` property  to test if the current running system passes this requirement.
  
- This is extracted from the <sparkle:maximumSystemVersion> element.
+ This is extracted from the @c <sparkle:maximumSystemVersion> element.
  */
 @property (copy, readonly, nullable) NSString *maximumSystemVersion;
 
@@ -200,10 +204,10 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 /**
  The channel the update item is on if provided.
  
- An update item may specify a custom channel name (such as "beta") that can only be found by updaters that filter for that channel.
+ An update item may specify a custom channel name (such as @c beta) that can only be found by updaters that filter for that channel.
  If no channel is provided, the update item is assumed to be on the default channel.
  
- This is extracted from the <sparkle:channel> element.
+ This is extracted from the @c <sparkle:channel> element.
  Old applications must be using Sparkle 2 or later to interpret the channel element and to ignore unmatched channels.
  */
 @property (nonatomic, readonly, nullable) NSString *channel;
@@ -212,15 +216,19 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  The installation type of the update at `fileURL`
  
  This may be:
- @c application - indicates this is a regular application update.
- @c package - indicates this is a guided package installer update.
- @c interactive-package - indicates this is an interactive package installer update (deprecated; use "package" instead)
+ - @c application - indicates this is a regular application update.
+ - @c package - indicates this is a guided package installer update.
+ - @c interactive-package - indicates this is an interactive package installer update (deprecated; use "package" instead)
  
- This is extracted from the @c sparkle:installationType attribute in the <enclosure> element.
+ This is extracted from the @c sparkle:installationType attribute in the @c <enclosure> element.
+ 
  If no installation type is provided in the enclosure, the installation type is inferred from the `fileURL` file extension instead.
- If the file extension is pkg or mpkg, the installation type is @c package otherwise it is @c application
- Hence, the installation type in the enclosure element only needs to be specified for package based updates distributed inside of a zip or other archive format.
- Old applications must be using Sparkle 1.26 or later to support downloading bare package updates that are not additionally archived inside of a zip or other archive format.
+ 
+ If the file extension is @c pkg or @c mpkg, the installation type is @c package otherwise it is @c application
+ 
+ Hence, the installation type in the enclosure element only needs to be specified for package based updates distributed inside of a @c zip or other archive format.
+ 
+ Old applications must be using Sparkle 1.26 or later to support downloading bare package updates (`pkg` or `mpkg`) that are not additionally archived inside of a @c zip or other archive format.
  */
 @property (nonatomic, copy, readonly) NSString *installationType;
 
@@ -228,19 +236,24 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  The phased rollout interval of the update item in seconds if provided.
  
  This is the interval between when different groups of users are notified of a new update.
- For this property to be used by Sparkle, the published `date` on the update item must be present as well.
- After each interval after the update item's `date`, a new group of users become eligible for being notified of a new update.
  
- This is extracted from the <sparkle:phasedRolloutInterval> element.
+ For this property to be used by Sparkle, the published `date` on the update item must be present as well.
+ 
+ After each interval after the update item's `date`, a new group of users become eligible for being notified of the new update.
+ 
+ This is extracted from the @c <sparkle:phasedRolloutInterval> element.
+ 
  Old applications must be using Sparkle 1.25 or later to support phased rollout intervals, otherwise they may assume updates are immediately available.
  */
 @property (copy, readonly, nullable) NSNumber* phasedRolloutInterval;
 
 /**
- The required minimum bundle version string this update meets for automatically downloading and installing updates if provided.
+ The minimum bundle version string this update requires for automatically downloading and installing updates if provided.
  
  If an application's bundle version meets this version requirement, it can install the new update item in the background automatically.
+ 
  Otherwise if the requirement is not met, the user is always  prompted to install the update. In this case, the update is assumed to be a `majorUpgrade`.
+ 
  If the update is a `majorUpgrade` and the update is skipped by the user, other future update alerts with the same `minimumAutoupdateVersion` will also be skipped.
  
  This version string corresponds to the application's @c CFBundleVersion
@@ -257,10 +270,11 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 /**
  Indicates whether or not the update item is critical.
  
- Critical updates are shown to the user more promptly. Sparkle's standard user interface does not allow them to be skipped.
+ Critical updates are shown to the user more promptly. Sparkle's standard user interface also does not allow them to be skipped.
  
- This is determined and extracted from a top-level <sparkle:criticalUpdate> element or a sparkle:criticalUpdate element inside of a sparkle:tags element.
- Old applications must be using Sparkle 2 or later to support the top-level <sparkle:criticalUpdate> element.
+ This is determined and extracted from a top-level @c <sparkle:criticalUpdate> element or a @c sparkle:criticalUpdate element inside of a @c sparkle:tags element.
+ 
+ Old applications must be using Sparkle 2 or later to support the top-level @c <sparkle:criticalUpdate> element.
  */
 @property (getter=isCriticalUpdate, readonly) BOOL criticalUpdate;
 
@@ -269,13 +283,14 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  
  If this property is not provided, then the supported operating system is assumed to be macOS.
  
- Known potential values for this string are "macos" and "windows"
+ Known potential values for this string are @c macos and @c windows
+ 
  Sparkle on Mac ignores update items that are for other operating systems.
  This is only useful for sharing appcasts between Sparkle on Mac and Sparkle on other operating systems.
  
  Use `macOsUpdate` property to test if this update item is for macOS.
  
- This is extracted from the @c sparkle:os attribute in the <enclosure> element.
+ This is extracted from the @c sparkle:os attribute in the @c <enclosure> element.
  */
 @property (copy, readonly, nullable) NSString *osString;
 
@@ -291,12 +306,12 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  
  Sparkle uses these to download and apply a smaller update based on the version the user is updating from.
  
- The key is based on the sparkle:version of the update.
+ The key is based on the @c sparkle:version of the update.
  The value is an update item that will have `deltaUpdate` be @c YES
  
  Clients typically should not need to examine the contents of the delta updates.
  
- This is extracted from the sparkle:deltas element.
+ This is extracted from the @c <sparkle:deltas> element.
  */
 @property (copy, readonly, nullable) NSDictionary<NSString *, SUAppcastItem *> *deltaUpdates;
 

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -37,6 +37,8 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
 
 @interface SUAppcastItem ()
 
+@property (readonly, nullable) SUSignatures *signatures;
+
 // Auxillary appcast item state that needs to be evaluated based on the host state
 // This may be nil if the client creates an SUAppcastItem with a deprecated initializer
 // In that case we will need to fallback to safe behavior

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -388,14 +388,14 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
 
         // Need an info URL or an enclosure URL. Former to show "More Info"
         //	page, latter to download & install:
-        if (!enclosure && !theInfoURL) {
+        if (!enclosure && !_infoURL) {
             if (error) {
                 *error = @"No enclosure in feed item";
             }
             return nil;
         }
         
-        if (theInfoURL != nil) {
+        if (_infoURL != nil) {
             // If enclosure doesn't exist, the update must be an informational update
             // Otherwise check presence of informational update element
             _informationalUpdateVersions = (enclosure != nil) ? [dict objectForKey:SUAppcastElementInformationalUpdate] : [NSSet set];
@@ -405,7 +405,7 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
         }
 
         NSString *enclosureURLString = [enclosure objectForKey:SURSSAttributeURL];
-        if (!enclosureURLString && !theInfoURL) {
+        if (!enclosureURLString && !_infoURL) {
             if (error) {
                 *error = @"Feed item's enclosure lacks URL";
             }

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -78,11 +78,29 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUIncorrectAPIUsageError = 5000
 };
 
+/**
+ The reason why a new update is not available.
+ */
 typedef NS_ENUM(OSStatus, SPUNoUpdateFoundReason) {
+    /**
+     A new update is unavailable for an unknown reason.
+     */
     SPUNoUpdateFoundReasonUnknown,
+    /**
+     A new update is unavailable because the user is on the latest known version in the appcast feed.
+     */
     SPUNoUpdateFoundReasonOnLatestVersion,
+    /**
+     A new update is unavailable because the user is on a version newer than the latest known version in the appcast feed.
+     */
     SPUNoUpdateFoundReasonOnNewerThanLatestVersion,
+    /**
+     A new update is unavailable because the user's operating system version is too old for the update.
+     */
     SPUNoUpdateFoundReasonSystemIsTooOld,
+    /**
+     A new update is unavailable because the user's operating system version is too new for the update.
+     */
     SPUNoUpdateFoundReasonSystemIsTooNew
 };
 

--- a/Sparkle/SUStandardVersionComparator.h
+++ b/Sparkle/SUStandardVersionComparator.h
@@ -47,18 +47,23 @@ SU_EXPORT @interface SUStandardVersionComparator : NSObject <SUVersionComparison
 - (instancetype)init;
 
 /**
-    Returns a singleton instance of the comparator.
-
-    It is usually preferred to alloc/init new a comparator instead.
+    A singleton instance of the comparator.
  */
-+ (SUStandardVersionComparator *)defaultComparator;
+@property (nonatomic, class, readonly) SUStandardVersionComparator *defaultComparator;
 
 /**
-    Compares version strings through textual analysis.
-
-    See the implementation for more details.
+    Compares two version strings through textual analysis.
+ 
+    These version strings should be in the format of x, x.y, or x.y.z where each component is a number.
+    For example, valid version strings include "1.5.3", "500", or "4000.1"
+    These versions that are compared correspond to the @c CFBundleVersion values of the updates.
+ 
+    @param versionA The first version string to compare.
+    @param versionB The second version string to compare.
+    @return A comparison result between @c versionA and @c versionB
 */
 - (NSComparisonResult)compareVersion:(NSString *)versionA toVersion:(NSString *)versionB;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -17,7 +17,7 @@ class SUAppcastTest: XCTestCase {
         do {
             let testData = try Data(contentsOf: testURL)
             
-            let versionComparator = SUStandardVersionComparator.default()
+            let versionComparator = SUStandardVersionComparator.default
             let hostVersion = "1.0"
             let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
             
@@ -86,7 +86,7 @@ class SUAppcastTest: XCTestCase {
         do {
             let testData = try Data(contentsOf: testURL)
             
-            let versionComparator = SUStandardVersionComparator.default()
+            let versionComparator = SUStandardVersionComparator.default
             let hostVersion = "1.0"
             let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
             
@@ -144,7 +144,7 @@ class SUAppcastTest: XCTestCase {
         do {
             let testData = try Data(contentsOf: testURL)
             
-            let versionComparator = SUStandardVersionComparator.default()
+            let versionComparator = SUStandardVersionComparator.default
             
             // If critical update version is 1.5 and host version is 1.0, update should be marked critical
             do {
@@ -184,7 +184,7 @@ class SUAppcastTest: XCTestCase {
         do {
             let testData = try Data(contentsOf: testURL)
             
-            let versionComparator = SUStandardVersionComparator.default()
+            let versionComparator = SUStandardVersionComparator.default
             
             // Test informational updates from version 1.0
             do {
@@ -200,7 +200,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // Test delta updates inheriting informational only updates
                 do {
-                    let deltaUpdate = appcast.items[2].deltaUpdates!["2.0"] as! SUAppcastItem
+                    let deltaUpdate = appcast.items[2].deltaUpdates!["2.0"]!
                     XCTAssertTrue(deltaUpdate.isInformationOnlyUpdate)
                 }
             }
@@ -612,7 +612,7 @@ class SUAppcastTest: XCTestCase {
         do {
             let testFileData = try Data(contentsOf: testFileUrl)
             
-            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default(), standardVersionComparator: SUStandardVersionComparator.default())
+            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default, standardVersionComparator: SUStandardVersionComparator.default)
             
             let appcast = try SUAppcast(xmlData: testFileData, relativeTo: testFileUrl, stateResolver: stateResolver)
             let items = appcast.items
@@ -628,7 +628,7 @@ class SUAppcastTest: XCTestCase {
         let testData = NSData(contentsOfFile: testFile)!
 
         do {
-            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default(), standardVersionComparator: SUStandardVersionComparator.default())
+            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default, standardVersionComparator: SUStandardVersionComparator.default)
             
             let appcast = try SUAppcast(xmlData: testData as Data, relativeTo: nil, stateResolver: stateResolver)
             let items = appcast.items
@@ -652,7 +652,7 @@ class SUAppcastTest: XCTestCase {
         do {
             let baseURL = URL(string: "https://fake.sparkle-project.org/updates/index.xml")!
             
-            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default(), standardVersionComparator: SUStandardVersionComparator.default())
+            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default, standardVersionComparator: SUStandardVersionComparator.default)
             
             let appcast = try SUAppcast(xmlData: testData as Data, relativeTo: baseURL, stateResolver: stateResolver)
             let items = appcast.items

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -71,7 +71,7 @@
     exit(EXIT_SUCCESS);
 }
 
-- (void)updaterWillNotScheduleUpdate:(SPUUpdater *)__unused updater __attribute__((noreturn))
+- (void)updaterWillNotScheduleUpdateCheck:(SPUUpdater *)__unused updater __attribute__((noreturn))
 {
     if (self.verbose) {
         fprintf(stderr, "Automatic update checks are disabled. Exiting.\n");

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -71,7 +71,7 @@
     exit(EXIT_SUCCESS);
 }
 
-- (void)updaterWillIdleSchedulingUpdates:(SPUUpdater *)__unused updater __attribute__((noreturn))
+- (void)updaterWillNotScheduleUpdate:(SPUUpdater *)__unused updater __attribute__((noreturn))
 {
     if (self.verbose) {
         fprintf(stderr, "Automatic update checks are disabled. Exiting.\n");

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -81,9 +81,13 @@
 
 // If the installation is interactive, we can show an authorization prompt for requesting additional privileges,
 // along with allowing the installer to show UI when installing
-- (BOOL)updaterShouldAllowInstallerInteraction:(SPUUpdater *)__unused updater userInitiated:(BOOL)__unused userInitiated
+- (BOOL)updater:(SPUUpdater *)__unused updater shouldAllowInstallerInteractionForUpdateCheck:(SPUUpdateCheck)updateCheck
 {
-    return self.interactive;
+    switch (updateCheck) {
+        case SPUUpdateCheckUserInitiated:
+        case SPUUpdateCheckBackgroundScheduled:
+            return self.interactive;
+    }
 }
 
 - (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)__unused updater

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -81,13 +81,9 @@
 
 // If the installation is interactive, we can show an authorization prompt for requesting additional privileges,
 // along with allowing the installer to show UI when installing
-- (BOOL)updater:(SPUUpdater *)__unused updater shouldAllowInstallerInteractionForUpdateCheck:(SPUUpdateCheck)updateCheck
+- (BOOL)updaterShouldAllowInstallerInteraction:(SPUUpdater *)__unused updater userInitiated:(BOOL)__unused userInitiated
 {
-    switch (updateCheck) {
-        case SPUUpdateCheckUserInitiated:
-        case SPUUpdateCheckBackgroundScheduled:
-            return self.interactive;
-    }
+    return self.interactive;
 }
 
 - (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)__unused updater


### PR DESCRIPTION
Improve API header docs (part 2). Still need to make a read me but the important header docs are mostly up to date now.

Also:
- Renamed fairly new `-updaterWillIdleSchedulingUpdates:` to `-updaterWillNotScheduleUpdateCheck:`
- Allow `-allowedSystemProfileKeysForUpdater:` to return nil for default behavior

Still I need to make a suitable read me markdown file for the API docs page.

Related: #1910

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) / documentation-fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app works, tested sparkle-cli on test app with automatic update checks disabled.

macOS version tested: 11.5.2 (20G95)
