### PR TITLE
Fix German localization [1.x]

### DIFF
--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -2,11 +2,11 @@
 
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ wurde geladen und steht zur Installation bereit! Möchtest du %1$@ jetzt durch die neue Version ersetzen und neu starten?";
 
-"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer DMG Datei oder Laufwerk ohne Schreibzugriff gestartet wurde.";
+"%1$@ can't be updated, because it was opened from a read-only or a temporary location." = "%1$@ kann nicht aktualisiert werden, da es aus dem Downloads-Order, oder von einer DMG-Datei oder einem Laufwerk ohne Schreibzugriff gestartet wurde.";
 
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Kopiere %1$@ in den Programmeordner, starte es von dort aus und versuche es erneut zu aktualisieren.";
 
-"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Beenden Sie „%1$@“, bewegen Sie es in den Ordner „Programme“, starten Sie das Programm von dort erneut und versuchen Sie es noch einmal.";
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Beende „%1$@“, bewege es in den Ordner „Programme“, starte das Programm von dort erneut und versuche es noch einmal.";
 
 "%1$@ can’t be updated if it’s running from the location it was downloaded to." = "„%1$@“ kann nicht aktualisiert werden, wenn das Programm von dem Ort ausgeführt wird, an den es heruntergeladen wurde.";
 
@@ -28,7 +28,7 @@
 
 "A new version of %@ is ready to install!" = "Eine neue Version von %@ steht zur Installation bereit!";
 
-"An error occurred in retrieving update information. Please try again later." = "Beim Laden der Updateinformationen trat ein Fehler auf. Bitte versuche es später erneut.";
+"An error occurred in retrieving update information. Please try again later." = "Beim Laden der Updateinformationen ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 
 "An error occurred while downloading the update. Please try again later." = "Beim Laden des Updates ist ein Fehler aufgetreten. Bitte versuche es später erneut.";
 


### PR DESCRIPTION
Fixes a few minor flaws in the German localization:
l. 5: missing Hyphen, wrong agreement
l. 9: formal instead of informal pronouns
l. 31: different tense than the other “An error occurred […]” messages

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first. → #1931 
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

I replaced the .strings file of an app using Sparkle and launched it a) from a write-protected SD card b) with WiFi disabled and checked whether the text displays as intended. I don’t know how to trigger the remaining alert, but since the text is now shorter I do not expect any clipping.

macOS version tested: 11.5.2 (20G95)
