### PR TITLE
fix: some iframes can use about:srcdoc, which spawns popups (follow-up to #1586)

### DIFF
--- a/Sparkle/SUWebViewCommon.m
+++ b/Sparkle/SUWebViewCommon.m
@@ -11,7 +11,7 @@
 BOOL SUWebViewIsSafeURL(NSURL *url, BOOL *isAboutBlankURL)
 {
     NSString *scheme = url.scheme;
-    BOOL isAboutBlank = [url.absoluteString isEqualToString:@"about:blank"];
+    BOOL isAboutBlank = [@[@"about:blank", @"about:srcdoc"] containsObject:url.absoluteString];
     BOOL whitelistedSafe = isAboutBlank || [@[@"http", @"https", @"macappstore", @"macappstores", @"itms-apps", @"itms-appss"] containsObject:scheme];
     
     *isAboutBlankURL = isAboutBlank;


### PR DESCRIPTION
Hi,

This is follow-up to https://github.com/sparkle-project/Sparkle/pull/1586

It turns out some iframes use `about:srcdoc` instead of `about:blank`, and this creates the same issue as in the original PR.

This PR is a one-liner, so I hope you forgive if I didn't fill the template

Thank you!