### PR TITLE
Fix check to only validate XPC display versions in Debug

### DIFF
--- a/Sparkle/SPUXPCServiceInfo.m
+++ b/Sparkle/SPUXPCServiceInfo.m
@@ -26,7 +26,7 @@ BOOL SPUXPCValidateServiceIfBundleExists(NSString *bundleName, NSBundle *sparkle
         return YES;
     }
 
-#if !DEBUG
+#if DEBUG
         // Post install scripts for appending git hash info to CFBundleShortVersionString are too unreliable to verify for debug/development
         // Fortunately debug builds of Sparkle are not usable in a production environment
     (void)sparkleBundle; // Mark parameter as used


### PR DESCRIPTION
Fix check to only validate XPC display versions in Debug

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested that incremental Debug builds of Test App continued to work and not get in a slightly out of sync state.

macOS version tested: 12.0 Beta (21A5506j)
