### PR TITLE
Fix not being able to show resumed update in utmost focus

### DIFF
--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -72,6 +72,13 @@
     [self.uiDriver resumeUpdate:resumableUpdate];
 }
 
+- (void)uiDriverDidShowUpdate
+{
+    // When a new update check has not been initiated and an update has been resumed,
+    // update the driver to indicate we are showing an update to the user
+    self.showingUpdate = YES;
+}
+
 - (void)basicDriverIsRequestingAbortUpdateWithError:(nullable NSError *)error
 {
     [self abortUpdateWithError:error];


### PR DESCRIPTION
This fixes a minor bug where canCheckForUpdates returned NO on a user initiated update check that shows an update that was already downloaded / begun installing. Now that it returns YES, the update can be shown in utmost focus by the user again.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested automatic downloading of updates in Test App, and initiated an update check myself from menu bar, then went to the settings window, and verified I could still Check for Updates in menubar and it would bring the update window to frontmost/active window.

macOS version tested: 11.5.2 (20G95)
