### PR TITLE
Fix issues with standard updater controller initialization

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -37,20 +37,17 @@ NS_ASSUME_NONNULL_BEGIN
  If you need more control over what bundle you want to update, or you want to provide a custom user interface (via `SPUUserDriver`), please use `SPUUpdater` directly instead.
   */
 SU_EXPORT @interface SPUStandardUpdaterController : NSObject
-
-/**
- Interface builder outlet for the updater's delegate.
- 
- This property should only be set using Interface Builder by creating a connection using the outlet.
- */
-@property (nonatomic, weak, nullable) IBOutlet id<SPUUpdaterDelegate> updaterDelegate;
-
-/**
- Interface builder outlet for the user driver's delegate.
- 
- This property should only be set using Interface Builder by creating a connection using the outlet.
- */
-@property (nonatomic, weak, nullable) IBOutlet id<SPUStandardUserDriverDelegate> userDriverDelegate;
+{
+    /**
+     * Interface builder outlet for the updater's delegate.
+     */
+    IBOutlet id<SPUUpdaterDelegate> updaterDelegate;
+    
+    /**
+     * Interface builder outlet for the user driver's delegate.
+     */
+    IBOutlet id<SPUStandardUserDriverDelegate> userDriverDelegate;
+}
 
 /**
  Accessible property for the updater. Some properties on the updater can be binded via KVO

--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -41,12 +41,12 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
     /**
      * Interface builder outlet for the updater's delegate.
      */
-    IBOutlet id<SPUUpdaterDelegate> updaterDelegate;
+    IBOutlet __weak id<SPUUpdaterDelegate> updaterDelegate;
     
     /**
      * Interface builder outlet for the user driver's delegate.
      */
-    IBOutlet id<SPUStandardUserDriverDelegate> userDriverDelegate;
+    IBOutlet __weak id<SPUStandardUserDriverDelegate> userDriverDelegate;
 }
 
 /**

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -28,8 +28,6 @@
 
 @synthesize updater = _updater;
 @synthesize userDriver = _userDriver;
-@synthesize updaterDelegate = _updaterDelegate;
-@synthesize userDriverDelegate = _userDriverDelegate;
 
 - (void)awakeFromNib
 {
@@ -45,22 +43,25 @@
 - (void)_initUpdater
 {
     NSBundle *hostBundle = [NSBundle mainBundle];
-    SPUStandardUserDriver *userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:self.userDriverDelegate];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+    SPUStandardUserDriver *userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:self->userDriverDelegate];
     
-    self.updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self.updaterDelegate];
+    self.updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self->updaterDelegate];
     self.userDriver = userDriver;
+#pragma clang diagnostic pop
 }
 
-- (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate
+- (instancetype)initWithUpdaterDelegate:(nullable id<SPUUpdaterDelegate>)theUpdaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)theUserDriverDelegate
 {
-    return [self initWithStartingUpdater:YES updaterDelegate:updaterDelegate userDriverDelegate:userDriverDelegate];
+    return [self initWithStartingUpdater:YES updaterDelegate:theUpdaterDelegate userDriverDelegate:theUserDriverDelegate];
 }
 
-- (instancetype)initWithStartingUpdater:(BOOL)startUpdater updaterDelegate:(nullable id<SPUUpdaterDelegate>)updaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)userDriverDelegate
+- (instancetype)initWithStartingUpdater:(BOOL)startUpdater updaterDelegate:(nullable id<SPUUpdaterDelegate>)theUpdaterDelegate userDriverDelegate:(nullable id<SPUStandardUserDriverDelegate>)theUserDriverDelegate
 {
     if ((self = [super init])) {
-        _updaterDelegate = updaterDelegate;
-        _userDriverDelegate = userDriverDelegate;
+        self->updaterDelegate = theUpdaterDelegate;
+        self->userDriverDelegate = theUserDriverDelegate;
 
         [self _initUpdater];
         
@@ -71,21 +72,27 @@
     return self;
 }
 
-- (void)setUpdaterDelegate:(id<SPUUpdaterDelegate>)updaterDelegate
+- (void)setUpdaterDelegate:(id<SPUUpdaterDelegate>)newUpdaterDelegate
 {
     if (self.updater != nil) {
-        NSLog(@"Error: %@ - cannot set updater delegate %@ after the updater has been initialized. If you are instantiating %@ programmatically, please pass the updater delegate in its initializer. If you are instantiating %@ in a nib, please set the updater delegate by connecting its outlet.", NSStringFromSelector(_cmd), updaterDelegate, [self className], [self className]);
+        NSLog(@"Error: %@ - cannot set updater delegate %@ after the updater has been initialized. If you are instantiating %@ programmatically, please pass the updater delegate in its initializer. If you are instantiating %@ in a nib, please set the updater delegate by connecting its outlet.", NSStringFromSelector(_cmd), newUpdaterDelegate, [self className], [self className]);
     } else {
-        _updaterDelegate = updaterDelegate;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+        self->updaterDelegate = newUpdaterDelegate;
+#pragma clang diagnostic pop
     }
 }
 
-- (void)setUserDriverDelegate:(id<SPUStandardUserDriverDelegate>)userDriverDelegate
+- (void)setUserDriverDelegate:(id<SPUStandardUserDriverDelegate>)newUserDriverDelegate
 {
     if (self.updater != nil) {
-        NSLog(@"Error: %@ - cannot set user driver delegate %@ after the updater has been initialized. If you are instantiating %@ programmatically, please pass the user driver delegate in its initializer. If you are instantiating %@ in a nib, please set the user driver delegate by connecting its outlet.", NSStringFromSelector(_cmd), userDriverDelegate, [self className], [self className]);
+        NSLog(@"Error: %@ - cannot set user driver delegate %@ after the updater has been initialized. If you are instantiating %@ programmatically, please pass the user driver delegate in its initializer. If you are instantiating %@ in a nib, please set the user driver delegate by connecting its outlet.", NSStringFromSelector(_cmd), newUserDriverDelegate, [self className], [self className]);
     } else {
-        _userDriverDelegate = userDriverDelegate;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
+        self->userDriverDelegate = newUserDriverDelegate;
+#pragma clang diagnostic pop
     }
 }
 

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -17,6 +17,10 @@
 #import "SULocalizations.h"
 #import <AppKit/AppKit.h>
 
+// We use public instance variables instead of properties for the updater / user driver delegates
+// because we want them to be connectable outlets from Interface Builder, but we do not want their setters to be invoked
+// programmatically.
+
 @interface SPUStandardUpdaterController () <NSMenuItemValidation>
 
 @property (nonatomic) SPUUpdater *updater;
@@ -70,30 +74,6 @@
         }
     }
     return self;
-}
-
-- (void)setUpdaterDelegate:(id<SPUUpdaterDelegate>)newUpdaterDelegate
-{
-    if (self.updater != nil) {
-        NSLog(@"Error: %@ - cannot set updater delegate %@ after the updater has been initialized. If you are instantiating %@ programmatically, please pass the updater delegate in its initializer. If you are instantiating %@ in a nib, please set the updater delegate by connecting its outlet.", NSStringFromSelector(_cmd), newUpdaterDelegate, [self className], [self className]);
-    } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-        self->updaterDelegate = newUpdaterDelegate;
-#pragma clang diagnostic pop
-    }
-}
-
-- (void)setUserDriverDelegate:(id<SPUStandardUserDriverDelegate>)newUserDriverDelegate
-{
-    if (self.updater != nil) {
-        NSLog(@"Error: %@ - cannot set user driver delegate %@ after the updater has been initialized. If you are instantiating %@ programmatically, please pass the user driver delegate in its initializer. If you are instantiating %@ in a nib, please set the user driver delegate by connecting its outlet.", NSStringFromSelector(_cmd), newUserDriverDelegate, [self className], [self className]);
-    } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-        self->userDriverDelegate = newUserDriverDelegate;
-#pragma clang diagnostic pop
-    }
 }
 
 - (void)startUpdater


### PR DESCRIPTION
* Fix updater SPUStandardUpdaterController delegate / user driver delegate not being set when hooked up via IBOutlets in Interface Builder - we need to defer initialization of updater until awakeFromNib, after the outlets are set
* Disallow setting updater / user driver delegates programmatically after updater controller has been initialized by turning the outlets into instance variables

Related: #1957

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

* Tested creating a SPUStandardUpdaterController programmatically (in Swift) and setting updater / user driver delegates in initializer - confirmed they fire.
* Tested creating a SPUStandardUpdaterController in a nib (in Swift project) and setting updater / user driver delegate outlets in IB - confirmed delegate methods fire.
* Tested when outlets are connected in a nib from an older version of Sparkle, they are still connected using this newer build of Sparkle.

macOS version tested: 11.5.2 (20G95)
