### PR TITLE
Fix to prevent Sparkle manipulating the host app's high level WebView defaults

### DIFF
--- a/Sparkle/SULegacyWebView.m
+++ b/Sparkle/SULegacyWebView.m
@@ -30,8 +30,9 @@
     self = [super init];
     if (self != nil) {
         _webView = [[WebView alloc] initWithFrame:NSZeroRect];
-        
-        WebPreferences *preferences = _webView.preferences;
+
+        WebPreferences *preferences = [[WebPreferences alloc] initWithIdentifier:@"sparkle-project.org.legacy-web-view"];
+        preferences.autosaves = NO;
         preferences.javaScriptEnabled = javaScriptEnabled;
         preferences.javaEnabled = NO;
         preferences.plugInsEnabled = NO;


### PR DESCRIPTION
This patch prevents Sparkle from manipulating the default WebView preferences, which at least on Monterey beta returns a preferences instance with nil identifier and with autosaves set to YES. This has the unfortunate effect of causing Sparkle, when it uses SULegacyWebView, to pollute the host app's user defaults with high level WebKit defaults for user style sheet, font sizes, etc. Specifying a unique identifier as well as turning autosaves off should both ensure Sparkle doesn't impose app-wide defaults on the host app, and also avoid littering the host app's preference file with identifier-prefixed defaults.

- [x ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x ] My own app

macOS version tested: 12.0 (21A5522h) 
