### PR TITLE
Use px instead of pt when specifying font size

### DIFF
--- a/Sparkle/SUWKWebView.m
+++ b/Sparkle/SUWKWebView.m
@@ -79,7 +79,7 @@ static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
         
         WKUserContentController *userContentController = [[WKUserContentController alloc] init];
         
-        NSString *fontStyleContents = [NSString stringWithFormat:@"body { font-family: %@; font-size: %dpt; }", fontFamily, fontPointSize];
+        NSString *fontStyleContents = [NSString stringWithFormat:@"body { font-family: %@; font-size: %dpx; }", fontFamily, fontPointSize];
         
         NSString *finalStyleContents;
         if (colorStyleContents == nil) {


### PR DESCRIPTION
When applying the system font size to the baseline CSS for the web vi…ew, use px instead of pt to specify the font size. This is consistent with best practices for web content, and alleviates a problem wherein the text in the web view, if not based on a full-fledged release notes HTML document, appears too large.

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] My own app

macOS version tested: 12.0 (21A5522h) 
