### PR TITLE
Use entitlements check to determine whether to use legacy WebView

### DIFF
--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (getter=isRunningOnReadOnlyVolume, readonly) BOOL runningOnReadOnlyVolume;
 @property (getter=isRunningTranslocated, readonly) BOOL runningTranslocated;
 @property (readonly, nonatomic, copy, nullable) NSString *publicDSAKeyFileKey;
+@property (readonly) BOOL requiresLegacyWebView;
 
 - (nullable id)objectForInfoDictionaryKey:(NSString *)key;
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -314,15 +314,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         int defaultFontSize = (int)[NSFont systemFontSize];
         
         BOOL javaScriptEnabled = [self.host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
-        
-        // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
-        // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
-        // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
-        // In this case, fall back to legacy WebKit view.
-        // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
-        BOOL useWKWebView = !SPUXPCServiceExists(@DOWNLOADER_BUNDLE_ID);
-        
-        if (useWKWebView) {
+
+        if ([self.host requiresLegacyWebView] == NO) {
             self.webView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
         } else {
             self.webView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];


### PR DESCRIPTION
Hi again! I know you mentioned the unlikelihood of a host app having the Downloader XPC and not needing to use the legacy WebView, but since I got down the path of implementing a solution that checks more specifically for the problem scenario, I thought I'd share it in case you are interested.

This PR factors out the logic for determining whether to use a legacy WebView or not, so that it may be determined by the SUHost object. Default implementation bases the determination on the presence of entitlements on the host app specifying it is sandboxed but does not have networking client capabilities.

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x ] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes the edge case scenario where a host app wants to include the Downloader XPC but doesn't want to have to use the legacy WebView.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] My own app

I have confirmed the code works as expected in these scenarios:

- Host app has no entitlements
- Host app is sandboxed and has the networking entitlement set to YES
- Host app is sandboxed and has the networking entitlement set to NO
- Host app is sandboxed and has no networking entitlement

macOS version tested: 12.0 (21A5522h)
