### PR TITLE
Make canCheckForUpdates property KVO compliant/observable

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -57,6 +57,10 @@
     [self.coreDriver setCompletionHandler:completionBlock];
 }
 
+- (void)setUpdateShownHandler:(void (^)(void))updateShownHandler
+{
+}
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
 {
     [self.coreDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES requiresSilentInstall:YES];

--- a/Sparkle/SPUProbingUpdateDriver.m
+++ b/Sparkle/SPUProbingUpdateDriver.m
@@ -38,6 +38,10 @@
     [self.basicDriver setCompletionHandler:completionBlock];
 }
 
+- (void)setUpdateShownHandler:(void (^)(void))updateShownHandler
+{
+}
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
 {
     [self.basicDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES];

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -19,6 +19,7 @@
 
 @property (nonatomic, readonly) SPUUIBasedUpdateDriver *uiDriver;
 @property (nonatomic) BOOL showedUpdate;
+@property (nonatomic) void (^updateDidShowHandler)(void);
 
 @end
 
@@ -26,6 +27,7 @@
 
 @synthesize uiDriver = _uiDriver;
 @synthesize showedUpdate = _showedUpdate;
+@synthesize updateDidShowHandler = _updateDidShowHandler;
 
 - (instancetype)initWithHost:(SUHost *)host applicationBundle:(NSBundle *)applicationBundle updater:(id)updater userDriver:(id <SPUUserDriver>)userDriver updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate
 {
@@ -39,6 +41,11 @@
 - (void)setCompletionHandler:(SPUUpdateDriverCompletion)completionBlock
 {
     [self.uiDriver setCompletionHandler:completionBlock];
+}
+
+- (void)setUpdateShownHandler:(void (^)(void))handler
+{
+    self.updateDidShowHandler = handler;
 }
 
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
@@ -59,6 +66,10 @@
 - (void)uiDriverDidShowUpdate
 {
     self.showedUpdate = YES;
+    
+    if (self.updateDidShowHandler != nil) {
+        self.updateDidShowHandler();
+    }
 }
 
 - (BOOL)showingUpdate

--- a/Sparkle/SPUUpdateDriver.h
+++ b/Sparkle/SPUUpdateDriver.h
@@ -21,6 +21,8 @@ typedef void (^SPUUpdateDriverCompletion)(BOOL shouldShowUpdateImmediately, id<S
 
 - (void)setCompletionHandler:(SPUUpdateDriverCompletion)completionBlock;
 
+- (void)setUpdateShownHandler:(void (^)(void))updateShownHandler;
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders;
 
 - (void)resumeInstallingUpdate;

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -144,6 +144,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  This property is suitable to use for menu item validation for seeing if `-checkForUpdates` can be invoked.
  
+ This property is also KVO-compliant.
+ 
  Note this property does not reflect whether or not an update session is in progress. Please see `sessionInProgress` property instead.
  */
 @property (nonatomic, readonly) BOOL canCheckForUpdates;

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -591,6 +591,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)checkForUpdatesWithDriver:(id <SPUUpdateDriver> )d updateCheck:(SPUUpdateCheck)updateCheck installerInProgress:(BOOL)installerInProgress
 {
+    assert(self.driver == nil);
     if (self.driver != nil) {
         return;
     }


### PR DESCRIPTION
Make canCheckForUpdates property KVO compliant/observable.

Also set updater session in progress when probing for update check interval to use.

Fixes #1966

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested user initiated and UI scheduled update checks - menu item is disabled/enabled when appropriate.
Tested update downloaded and installed automatically in background  - menu item is disabled during download, later re-enabled when finished downloading.
Tested update downloaded but not installed automatically (i.e, due to requiring authorization) - menu item is disabled during download, later re-enabled when update prompt comes up

macOS version tested: 11.6 (20G165)
