### PR TITLE
Updates Version History French string translation.

### DIFF
--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -91,3 +91,5 @@
 "Learn More..." = "En savoir plus…";
 
 "The update is improperly signed." = "La signature numérique de la mise à jour est incorrecte";
+
+"Version History" = "Historique des versions";


### PR DESCRIPTION
Adds French string translation of Version History button. Translation provided by native French speaking user of our application.

Fixes #1971 

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Ran `make release` and dropped the Sparkle.framework and org.sparkle-project.InstallerLauncher into our application, then ran it with Language set to French and confirmed it displayed the translation on the Version History button.

macOS version tested: 11.6
