### PR TITLE
Don't use current date unless necessary when scheduling next update (1.x)

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -309,6 +309,9 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
         intervalSinceCheck = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
         if (intervalSinceCheck < 0) {
+            // Last update check date is in the future and bogus, so reset it to current date
+            [self updateLastUpdateCheckDate];
+            
             intervalSinceCheck = 0;
         }
     } else {


### PR DESCRIPTION
Don't use current date unless necessary when scheduling next update

Related: #1986

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

* Scheduled timer works correctly after update cycle finishes
* Scheduled timer works correctly when launching the app (both when there's leftover time, and when the leftover time has been exceeded)
* Scheduled timer works correctly when toggling automatic update checks from OFF to ON (both when there's leftover time, and when the leftover time has been exceeded)
* Timer fires right away on launch when there's an absence of SULastCheckTime in user defaults
* Tested when last update check date is set in the future (now it will reset the last update check date, before it would have created a large interval once and then converge after the update cycle finishes)

macOS version tested: 11.6.1 (20G224)
