### PR TITLE
Don't use current date unless necessary when scheduling next update (2.x)

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -482,6 +482,9 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
                 intervalSinceCheck = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
                 if (intervalSinceCheck < 0) {
+                    // Last update check date is in the future and bogus, so reset it to current date
+                    [self updateLastUpdateCheckDate];
+                    
                     intervalSinceCheck = 0;
                 }
             } else {

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -398,7 +398,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         // We start the update checks and register as observer for changes after the prompt finishes
     } else {
         // We check if the user's said they want updates, or they haven't said anything, and the default is set to checking.
-        [self scheduleNextUpdateCheckFiringImmediately:NO];
+        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:YES];
     }
 }
 
@@ -428,7 +428,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 }
 
 // Note this method is never called when sessionInProgress is YES
-- (void)scheduleNextUpdateCheckFiringImmediately:(BOOL)firingImmediately
+- (void)scheduleNextUpdateCheckFiringImmediately:(BOOL)firingImmediately usingCurrentTime:(BOOL)usingCurrentTime
 {
     [self.updaterTimer invalidate];
     
@@ -475,10 +475,18 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             // This callback is asynchronous, so the timer may be set. Invalidate to make sure it isn't.
             [self.updaterTimer invalidate];
             
-            // How long has it been since last we checked for an update?
-            NSDate *lastCheckDate = [self lastUpdateCheckDate];
-            if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
-            NSTimeInterval intervalSinceCheck = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
+            NSTimeInterval intervalSinceCheck;
+            if (usingCurrentTime) {
+                // How long has it been since last we checked for an update?
+                NSDate *lastCheckDate = [self lastUpdateCheckDate];
+                if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
+                intervalSinceCheck = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
+                if (intervalSinceCheck < 0) {
+                    intervalSinceCheck = 0;
+                }
+            } else {
+                intervalSinceCheck = 0;
+            }
             
             // Now we want to figure out how long until we check again.
             if (updateCheckInterval < SUMinimumUpdateCheckInterval)
@@ -673,7 +681,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 // Ensure the delegate doesn't start a new session when being notified of the previous one ending
                 if (!strongSelf.sessionInProgress) {
                     if (shouldScheduleNextUpdateCheck) {
-                        [strongSelf scheduleNextUpdateCheckFiringImmediately:NO];
+                        [strongSelf scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:NO];
                     } else {
                         SULog(SULogLevelDefault, @"Disabling scheduled updates..");
                     }
@@ -724,7 +732,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             
             // Ensure the delegate doesn't start a new session when being notified of the previous one ending
             if (!strongSelf.sessionInProgress) {
-                [strongSelf scheduleNextUpdateCheckFiringImmediately:shouldShowUpdateImmediately];
+                [strongSelf scheduleNextUpdateCheckFiringImmediately:shouldShowUpdateImmediately usingCurrentTime:NO];
             }
         }
     }];
@@ -769,7 +777,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (!self.sessionInProgress) {
         [self cancelNextUpdateCycle];
-        [self scheduleNextUpdateCheckFiringImmediately:NO];
+        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:YES];
     }
 }
 


### PR DESCRIPTION
Don't use current date unless necessary when scheduling next update

Related: #1986

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested:
* Scheduled timer works correctly after update cycle finishes
* Scheduled timer works correctly when launching the app (both when there's leftover time, and when the leftover time has been exceeded)
* Scheduled timer works correctly when toggling automatic update checks from OFF to ON (both when there's leftover time, and when the leftover time has been exceeded)
* Timer fires right away on launch when there's an absence of SULastCheckTime in user defaults
* Tested when last update check date is set in the future (now it will reset the last update check date, before it would have created a large interval once and then converge after the update cycle finishes)

macOS version tested: 11.6.1 (20G224)
