### PR TITLE
Prevent potential rapid update checks from sleep/wake events

### DIFF
--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -18,6 +18,7 @@
 
 extern const NSTimeInterval SUMinimumUpdateCheckInterval;
 extern const NSTimeInterval SUDefaultUpdateCheckInterval;
+extern const NSTimeInterval SUMinimumMonotonicUpdateCheckInterval;
 
 extern NSString *const SUBundleIdentifier;
 

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -18,6 +18,7 @@
 // Define some minimum intervals to avoid DoS-like checking attacks
 const NSTimeInterval SUMinimumUpdateCheckInterval = DEBUG ? 60 : (60 * 60);
 const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);
+const NSTimeInterval SUMinimumMonotonicUpdateCheckInterval = DEBUG ? 30 : (60 * 5);
 
 NSString *const SUBundleIdentifier = @SPARKLE_BUNDLE_IDENTIFIER;
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -294,7 +294,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 }
 
 // Note: minimumDelay only matters if usingCurrentTime is YES. minimumDelay is to prevent update checks
-// happening too frequently (in case there's some bug in the system)
+// happening too frequently (in case there's some bug in the system for computing the last update check date / current date)
 - (void)scheduleNextUpdateCheckUsingCurrentTime:(BOOL)usingCurrentTime minimumDelay:(NSTimeInterval)minimumDelay
 {
     if (self.checkTimer)

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -41,11 +41,12 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @property (assign) BOOL shouldRescheduleOnWake;
 @property (strong) NSBundle *sparkleBundle;
 @property (nonatomic) BOOL loggedNoSecureKeyWarning;
+@property (nonatomic) NSTimeInterval lastMonotonicUpdateCheckTime;
 
 - (instancetype)initForBundle:(NSBundle *)bundle;
 - (void)startUpdateCycle;
 - (void)checkForUpdatesWithDriver:(SUUpdateDriver *)updateDriver;
-- (void)scheduleNextUpdateCheckUsingCurrentTime:(BOOL)usingCurrentTime minimumDelay:(NSTimeInterval)minimumDelay;
+- (void)scheduleNextUpdateCheckUsingCurrentDate:(BOOL)usingCurrentDate;
 - (void)registerAsObserver;
 - (void)unregisterAsObserver;
 - (void)updateDriverDidFinish:(NSNotification *)note;
@@ -71,6 +72,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize decryptionPassword;
 @synthesize updateLastCheckedDate;
 @synthesize loggedNoSecureKeyWarning = _loggedNoSecureKeyWarning;
+@synthesize lastMonotonicUpdateCheckTime = _lastMonotonicUpdateCheckTime;
 
 static NSMutableDictionary *sharedUpdaters = nil;
 static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaultsObservationContext";
@@ -255,7 +257,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
         // We start the update checks and register as observer for changes after the prompt finishes
     } else {
         // We check if the user's said they want updates, or they haven't said anything, and the default is set to checking.
-        [self scheduleNextUpdateCheckUsingCurrentTime:YES minimumDelay:0.0];
+        [self scheduleNextUpdateCheckUsingCurrentDate:YES];
     }
 }
 
@@ -271,7 +273,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     {
         self.driver = nil;
         [self updateLastUpdateCheckDate];
-        [self scheduleNextUpdateCheckUsingCurrentTime:NO minimumDelay:0.0];
+        [self scheduleNextUpdateCheckUsingCurrentDate:NO];
     }
 }
 
@@ -285,17 +287,25 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     return [self updateLastCheckedDate];
 }
 
+- (NSTimeInterval)currentMonotonicTimeInterval
+{
+    // This is monotonic system time while the system is not asleep
+    return [[NSProcessInfo processInfo] systemUptime];
+}
+
 - (void)updateLastUpdateCheckDate
 {
     [self willChangeValueForKey:@"lastUpdateCheckDate"];
+    
     [self setUpdateLastCheckedDate:[NSDate date]];
     [self.host setObject:[self updateLastCheckedDate] forUserDefaultsKey:SULastCheckTimeKey];
+    
+    self.lastMonotonicUpdateCheckTime = [self currentMonotonicTimeInterval];
+    
     [self didChangeValueForKey:@"lastUpdateCheckDate"];
 }
 
-// Note: minimumDelay only matters if usingCurrentTime is YES. minimumDelay is to prevent update checks
-// happening too frequently (in case there's some bug in the system for computing the last update check date / current date)
-- (void)scheduleNextUpdateCheckUsingCurrentTime:(BOOL)usingCurrentTime minimumDelay:(NSTimeInterval)minimumDelay
+- (void)scheduleNextUpdateCheckUsingCurrentDate:(BOOL)usingCurrentDate
 {
     if (self.checkTimer)
     {
@@ -305,34 +315,70 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (![self automaticallyChecksForUpdates]) return;
 
     // How long has it been since last we checked for an update?
-    NSTimeInterval intervalSinceCheck;
-    if (usingCurrentTime) {
+    NSTimeInterval dateIntervalSinceCheck;
+    NSTimeInterval minimumEnforcedDelay;
+    if (usingCurrentDate) {
         NSDate *lastCheckDate = [self lastUpdateCheckDate];
         if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
-        intervalSinceCheck = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
-        if (intervalSinceCheck < 0) {
+        NSTimeInterval wallTimeInterval = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
+        if (wallTimeInterval < 0) {
             // Last update check date is in the future and bogus, so reset it to current date
             [self updateLastUpdateCheckDate];
             
-            intervalSinceCheck = 0;
+            // And assume a full update interval is needed
+            dateIntervalSinceCheck = 0;
+            minimumEnforcedDelay = SUMinimumMonotonicUpdateCheckInterval;
+        } else {
+            // Check the monotonic clock for an enforced minimum delay
+            NSTimeInterval lastMonotonicUpdateCheckTime = self.lastMonotonicUpdateCheckTime;
+            if (lastMonotonicUpdateCheckTime <= 0) {
+                // When the updater is first started, the last monotonic time may not have been updated yet.
+                // In this case there is no enforced minimum delay.
+                minimumEnforcedDelay = 0;
+            } else {
+                // Compute an enforced minimum delay based on elapsed monotonic time
+                // The elapsed monotonic time is more stable than wall time interval and does not include the
+                // amount of time while the system is asleep
+                NSTimeInterval currentMonotonicTime = [self currentMonotonicTimeInterval];
+                NSTimeInterval elapsedMonotonicTime = (currentMonotonicTime - lastMonotonicUpdateCheckTime);
+                
+                if (elapsedMonotonicTime < SUMinimumMonotonicUpdateCheckInterval) {
+                    minimumEnforcedDelay = (SUMinimumMonotonicUpdateCheckInterval - elapsedMonotonicTime);
+                } else {
+                    minimumEnforcedDelay = 0;
+                }
+            }
+            
+            dateIntervalSinceCheck = wallTimeInterval;
         }
     } else {
-        intervalSinceCheck = 0;
+        // Without using the current date, we assume a full update interval is needed
+        dateIntervalSinceCheck = 0;
+        minimumEnforcedDelay = SUMinimumMonotonicUpdateCheckInterval;
     }
 
-    // Now we want to figure out how long until we check again.
-    NSTimeInterval delayUntilCheck, updateCheckInterval = [self updateCheckInterval];
-    if (updateCheckInterval < SUMinimumUpdateCheckInterval)
+    NSTimeInterval updateCheckInterval = [self updateCheckInterval];
+    if (updateCheckInterval < SUMinimumUpdateCheckInterval) {
         updateCheckInterval = SUMinimumUpdateCheckInterval;
-    if (intervalSinceCheck < updateCheckInterval)
-        delayUntilCheck = (updateCheckInterval - intervalSinceCheck); // It hasn't been long enough.
-    else
-        delayUntilCheck = 0; // We're overdue! Run one now.
-    
-    if (delayUntilCheck < minimumDelay) {
-        delayUntilCheck = minimumDelay;
     }
-    self.checkTimer = [NSTimer scheduledTimerWithTimeInterval:delayUntilCheck target:self selector:@selector(checkForUpdatesInBackground) userInfo:nil repeats:NO]; // Timer is non-repeating, may have invalidated itself, so we had to retain it.
+    
+    // Now we want to figure out how long until we check again.
+    NSTimeInterval delayUntilCheck;
+    if (dateIntervalSinceCheck < updateCheckInterval) {
+        // It hasn't been long enough.
+        delayUntilCheck = (updateCheckInterval - dateIntervalSinceCheck);
+    } else {
+        // We're overdue!
+        delayUntilCheck = 0;
+    }
+    
+    // Now compute delay with enforced minimum delay requirement
+    // The minimum delay (based on monotonic clock) is an extra layer of defense to prevent too frequent update checks
+    // in case the wall clock is not working properly (eg from too many system wake events, system date changes, NTP..)
+    NSTimeInterval delayUntilCheckWithMinimumEnforcedDelay =
+        (delayUntilCheck < minimumEnforcedDelay) ? minimumEnforcedDelay : delayUntilCheck;
+    
+    self.checkTimer = [NSTimer scheduledTimerWithTimeInterval:delayUntilCheckWithMinimumEnforcedDelay target:self selector:@selector(checkForUpdatesInBackground) userInfo:nil repeats:NO];
 }
 
 - (void)receiveSleepNote
@@ -353,7 +399,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (self.shouldRescheduleOnWake) {
         // Paranoid check: give a minimum delay so sleep/wake events cannot spam update checks
         // Eg: if two wake requests are sent within 15 seconds, only the last request will be processed
-        [self scheduleNextUpdateCheckUsingCurrentTime:YES minimumDelay:60.0];
+        [self scheduleNextUpdateCheckUsingCurrentDate:YES];
     }
 }
 
@@ -407,7 +453,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 
     if( [self.delegate respondsToSelector: @selector(updaterMayCheckForUpdates:)] && ![self.delegate updaterMayCheckForUpdates: self] )
     {
-        [self scheduleNextUpdateCheckUsingCurrentTime:NO minimumDelay:0.0];
+        [self scheduleNextUpdateCheckUsingCurrentDate:NO];
         return;
     }
 
@@ -416,7 +462,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     // If we're not given a driver at all, just schedule the next update check and bail.
     if (!self.driver)
     {
-        [self scheduleNextUpdateCheckUsingCurrentTime:NO minimumDelay:0.0];
+        [self scheduleNextUpdateCheckUsingCurrentDate:NO];
         return;
     }
 
@@ -468,7 +514,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 - (void)resetUpdateCycle
 {
     [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(resetUpdateCycle) object:nil];
-    [self scheduleNextUpdateCheckUsingCurrentTime:YES minimumDelay:0.0];
+    [self scheduleNextUpdateCheckUsingCurrentDate:YES];
 }
 
 - (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyCheckForUpdates

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -353,7 +353,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
     if (self.shouldRescheduleOnWake) {
         // Paranoid check: give a minimum delay so sleep/wake events cannot spam update checks
         // Eg: if two wake requests are sent within 15 seconds, only the last request will be processed
-        [self scheduleNextUpdateCheckUsingCurrentTime:YES minimumDelay:15.0];
+        [self scheduleNextUpdateCheckUsingCurrentTime:YES minimumDelay:60.0];
     }
 }
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -397,8 +397,6 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
 {
     // the reason for rescheduling the update-check timer is that NSTimer does behave as if the time the Mac spends asleep did not exist at all, which can significantly prolong the time between update checks
     if (self.shouldRescheduleOnWake) {
-        // Paranoid check: give a minimum delay so sleep/wake events cannot spam update checks
-        // Eg: if two wake requests are sent within 15 seconds, only the last request will be processed
         [self scheduleNextUpdateCheckUsingCurrentDate:YES];
     }
 }


### PR DESCRIPTION
Prevent potential rapid update checks from sleep/wake events. This is a "paranoid" check.

Related: #1986

I may have to port this to 2.x which means I may have to listen for sleep/wake notifications there (which sucks to begin with), or it could just mean I adjust the dispatch source leeway interval 🤔. (If the suspected problem is too many successive wake notifications, then no need to port. If the suspected issue is system being in bad state after wake, then technically there should be a similar problem after system boots and we aren't really solving anything here)

This is only useful if it's believed that system wake notifications are often successive (or in a bad networking state) AND date checking code is unreliable. 

I am not convinced that this change should be merged yet (and 2.x would need appropriate change IF I believe this is an actual problem, otherwise this won't be merged)

## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested sleep / wake while monotonic time interval has not fully passed yet, but wall time has passed. In that case, leftover delay from monotonic time takes effect.

Tested sleep / wake while monotonic time interval has fully passed, but wall time has not passed. In that case leftover delay from wall time takes effect.

Tested sleep / wake while monotonic time interval has fully passed, and wall time has fully passed. In that case, there's 0 delay.

Tested when app starts updater on launch, no minimum delay from monotonic clock is enforced.

macOS version tested: 12.0.1 (21A559)
