### PR TITLE
Version History opens full release notes (changelog) if informed

### DIFF
--- a/Resources/SampleAppcast.xml
+++ b/Resources/SampleAppcast.xml
@@ -11,6 +11,9 @@
             <sparkle:releaseNotesLink>
                 https://you.com/app/2.0.html
             </sparkle:releaseNotesLink>
+            <sparkle:fullReleaseNotesLink>
+                https://you.com/app/changelog.php
+            </sparkle:fullReleaseNotesLink>
             <pubDate>Wed, 09 Jan 2006 19:20:11 +0000</pubDate>
             <enclosure url="https://you.com/app/Your%20Great%20App%202.0.zip" length="1623481" type="application/octet-stream" sparkle:edSignature="WVyVJpOx+a5+vNWJVY79TRjFKveNk+VhGJf2iti4CZtJsJewIUGvh/1AKKEAFbH1qUwx+vro1ECuzOsMmumoBA==" />
             <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>
@@ -23,6 +26,9 @@
             <sparkle:releaseNotesLink>
                 https://you.com/app/1.5.html
             </sparkle:releaseNotesLink>
+            <sparkle:fullReleaseNotesLink>
+                https://you.com/app/changelog.php?up-to=1.5
+            </sparkle:fullReleaseNotesLink>
             <pubDate>Wed, 01 Jan 2006 12:20:11 +0000</pubDate>
             <enclosure url="https://you.com/app/Your%20Great%20App%201.5.zip" length="1472893" type="application/octet-stream" sparkle:edSignature="pNFd7KbcQSu+Mq7UYrbQXTPq82luht2ACXm/r2utp1u/Uv/5hWqctdT2jwQgMejW7DRoeV/hVr6J4VdZYdwWDw==" />
             <sparkle:minimumSystemVersion>10.11</sparkle:minimumSystemVersion>
@@ -35,6 +41,9 @@
             <sparkle:releaseNotesLink>
                 https://you.com/app/1.4.html
             </sparkle:releaseNotesLink>
+            <sparkle:fullReleaseNotesLink>
+                https://you.com/app/changelog.php?up-to=1.4
+            </sparkle:fullReleaseNotesLink>
             <sparkle:version>241</sparkle:version>
             <sparkle:shortVersionString>1.4</sparkle:shortVersionString>
             <pubDate>Wed, 25 Dec 2005 12:20:11 +0000</pubDate>

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -286,8 +286,15 @@
                     secondaryAction = ^{
                         [delegate standardUserDriverShowVersionHistoryForAppcastItem:latestAppcastItem];
                     };
+                } else if (latestAppcastItem.fullReleaseNotesURL != nil) {
+                    // Open the full release notes URL if informed
+                    [alert addButtonWithTitle:localizedButtonTitle];
+                    
+                    secondaryAction = ^{
+                        [[NSWorkspace sharedWorkspace] openURL:(NSURL * _Nonnull)latestAppcastItem.fullReleaseNotesURL];
+                    };
                 } else if (latestAppcastItem.releaseNotesURL != nil) {
-                    // Fall back to opening the release notes URL (or forthcoming full version history link attr!)
+                    // Fall back to opening the release notes URL
                     [alert addButtonWithTitle:localizedButtonTitle];
                     
                     secondaryAction = ^{

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -164,6 +164,18 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 @property (copy, readonly, nullable) NSString *itemDescription;
 
 /**
+ The full release notes URL of the appcast item if provided.
+ 
+ This external link will open when `Version History` button is clicked. The link should point to the product's changelog.
+ 
+ The delegate `standardUserDriverShowVersionHistoryForAppcastItem` will be used instead if implemented.
+ If none is set `releaseNotesURL` will be used.
+ 
+ This is extracted from the @c <sparkle:fullReleaseNotesLink> element.
+ */
+@property (readonly, nullable) NSURL *fullReleaseNotesURL;
+
+/**
  The required minimum system operating version string for this update if provided.
  
  This version string should contain three period-separated components.

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -29,6 +29,7 @@ static NSString *SUAppcastItemDescriptionKey = @"itemDescription";
 static NSString *SUAppcastItemMaximumSystemVersionKey = @"maximumSystemVersion";
 static NSString *SUAppcastItemMinimumSystemVersionKey = @"minimumSystemVersion";
 static NSString *SUAppcastItemReleaseNotesURLKey = @"releaseNotesURL";
+static NSString *SUAppcastItemFullReleaseNotesURLKey = @"fullReleaseNotesURL";
 static NSString *SUAppcastItemTitleKey = @"title";
 static NSString *SUAppcastItemVersionStringKey = @"versionString";
 static NSString *SUAppcastItemPropertiesKey = @"propertiesDictionary";
@@ -65,6 +66,7 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
 @synthesize maximumSystemVersion = _maximumSystemVersion;
 @synthesize minimumSystemVersion = _minimumSystemVersion;
 @synthesize releaseNotesURL = _releaseNotesURL;
+@synthesize fullReleaseNotesURL = _fullReleaseNotesURL;
 @synthesize title = _title;
 @synthesize versionString = _versionString;
 @synthesize osString = _osString;
@@ -114,6 +116,7 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
         _minimumSystemVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastItemMinimumSystemVersionKey] copy];
         _minimumAutoupdateVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastElementMinimumAutoupdateVersion] copy];
         _releaseNotesURL = [decoder decodeObjectOfClass:[NSURL class] forKey:SUAppcastItemReleaseNotesURLKey];
+        _fullReleaseNotesURL = [decoder decodeObjectOfClass:[NSURL class] forKey:SUAppcastItemFullReleaseNotesURLKey];
         _title = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastItemTitleKey] copy];
         
         NSString *versionString =  [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastItemVersionStringKey] copy];
@@ -186,6 +189,10 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
     
     if (self.releaseNotesURL != nil) {
         [encoder encodeObject:self.releaseNotesURL forKey:SUAppcastItemReleaseNotesURLKey];
+    }
+    
+    if (self.fullReleaseNotesURL != nil) {
+        [encoder encodeObject:self.fullReleaseNotesURL forKey:SUAppcastItemFullReleaseNotesURLKey];
     }
     
     if (self.title != nil) {
@@ -542,6 +549,19 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
             _releaseNotesURL = [NSURL URLWithString:(NSString * _Nonnull)self.itemDescription];
         } else {
             _releaseNotesURL = nil;
+        }
+        
+        // Get full release notes URL if informed.
+        NSString *fullReleaseNotesString = [dict objectForKey:SUAppcastElementFullReleaseNotesLink];
+        if (fullReleaseNotesString) {
+            NSURL *url = [NSURL URLWithString:fullReleaseNotesString];
+            if ([url isFileURL]) {
+                SULog(SULogLevelError, @"Full release notes with file:// URLs are not supported");
+            } else {
+                _fullReleaseNotesURL = url;
+            }
+        } else {
+            _fullReleaseNotesURL = nil;
         }
 
         NSArray *deltaDictionaries = [dict objectForKey:SUAppcastElementDeltas];

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -89,6 +89,7 @@ extern NSString *const SUAppcastElementMinimumAutoupdateVersion;
 extern NSString *const SUAppcastElementMinimumSystemVersion;
 extern NSString *const SUAppcastElementMaximumSystemVersion;
 extern NSString *const SUAppcastElementReleaseNotesLink;
+extern NSString *const SUAppcastElementFullReleaseNotesLink;
 extern NSString *const SUAppcastElementTags;
 extern NSString *const SUAppcastElementPhasedRolloutInterval;
 extern NSString *const SUAppcastElementInformationalUpdate;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -86,6 +86,7 @@ NSString *const SUAppcastElementMinimumAutoupdateVersion = @"sparkle:minimumAuto
 NSString *const SUAppcastElementMinimumSystemVersion = @"sparkle:minimumSystemVersion";
 NSString *const SUAppcastElementMaximumSystemVersion = @"sparkle:maximumSystemVersion";
 NSString *const SUAppcastElementReleaseNotesLink = @"sparkle:releaseNotesLink";
+NSString *const SUAppcastElementFullReleaseNotesLink = @"sparkle:fullReleaseNotesLink";
 NSString *const SUAppcastElementTags = @"sparkle:tags";
 NSString *const SUAppcastElementPhasedRolloutInterval = @"sparkle:phasedRolloutInterval";
 NSString *const SUAppcastElementInformationalUpdate = @"sparkle:informationalUpdate";


### PR DESCRIPTION
Addition to https://github.com/sparkle-project/Sparkle/pull/1877 & https://github.com/sparkle-project/Sparkle/pull/1989.

If informed in the appcast item, `fullReleaseNotesLink` will be used as the `Version History` (https://github.com/sparkle-project/Sparkle/pull/1877) action instead of `releaseNotesLink`.
It will only be used if the delegate `standardUserDriverShowVersionHistoryForAppcastItem` (https://github.com/sparkle-project/Sparkle/pull/1989) is not implemented.

- Lacks Tests because I'm not sure of the need in this specific case.
- Lacks `generate_appcast` code yet. Since this is a link that will open in the default browser I'm not sure it needs localization. Usually websites already detect the preferred language and show the appropriate content.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

macOS version tested: 11.6.1 (20G224)
