### PR TITLE
Support relative links for fullReleaseNotesLink and enforce http(s)

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		7293A1AF1CEE933800B957A7 /* SPUURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293A1AD1CEE933800B957A7 /* SPUURLRequest.m */; };
 		7293A1B11CEE9B9F00B957A7 /* SPUURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293A1AD1CEE933800B957A7 /* SPUURLRequest.m */; };
 		729924941DF4A45000DBCDF5 /* SUUpdateValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 729924931DF4A45000DBCDF5 /* SUUpdateValidator.m */; };
+		729F7EAC27366353004592DC /* test-links.xml in Resources */ = {isa = PBXBuildFile; fileRef = 729F7EAB27366353004592DC /* test-links.xml */; };
 		72A1C2631CD6849C004CD282 /* SUUpdatePermissionPrompt.h in Headers */ = {isa = PBXBuildFile; fileRef = 612DCBAD0D488BC60015DBEA /* SUUpdatePermissionPrompt.h */; };
 		72A450531C69A68900D67EEA /* SUUpdatePermissionResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A450511C69A68900D67EEA /* SUUpdatePermissionResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72A450541C69A68900D67EEA /* SUUpdatePermissionResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 72A450521C69A68900D67EEA /* SUUpdatePermissionResponse.m */; };
@@ -1227,6 +1228,7 @@
 		729BB3D11D503826007C4276 /* org.sparkle-project.Downloader.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = "org.sparkle-project.Downloader.entitlements"; path = "Downloader/org.sparkle-project.Downloader.entitlements"; sourceTree = SOURCE_ROOT; };
 		729F10FD1C65A9B500DFCCC5 /* ConfigUITest.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigUITest.xcconfig; sourceTree = "<group>"; };
 		729F10FE1C65A9B500DFCCC5 /* ConfigUITestCoverage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigUITestCoverage.xcconfig; sourceTree = "<group>"; };
+		729F7EAB27366353004592DC /* test-links.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "test-links.xml"; sourceTree = "<group>"; };
 		72A450511C69A68900D67EEA /* SUUpdatePermissionResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUUpdatePermissionResponse.h; sourceTree = "<group>"; };
 		72A450521C69A68900D67EEA /* SUUpdatePermissionResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUUpdatePermissionResponse.m; sourceTree = "<group>"; };
 		72A4A23F1BB6567D00E7820D /* SUFileManagerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUFileManagerTest.swift; sourceTree = "<group>"; };
@@ -1709,6 +1711,7 @@
 				5F1510A11C96E591006E1629 /* testnamespaces.xml */,
 				FA30773C24CBC295007BA37D /* testlocalizedreleasenotesappcast.xml */,
 				5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */,
+				729F7EAB27366353004592DC /* test-links.xml */,
 				5A5DD40324958AFF0045EB3E /* SUUpdateValidatorTest */,
 			);
 			path = Resources;
@@ -2973,6 +2976,7 @@
 				722545B626805FF80036465C /* testappcast_info_updates.xml in Resources */,
 				7202DC9A269ABD3500737EC4 /* testappcast_phasedRollout.xml in Resources */,
 				5F1510A21C96E591006E1629 /* testnamespaces.xml in Resources */,
+				729F7EAC27366353004592DC /* test-links.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -8,6 +8,7 @@
         <title>Version 2.0</title>
         <sparkle:version>2.0</sparkle:version>
         <link>https://sparkle-project.org</link>
+        <sparkle:fullReleaseNotesLink>releasenotes.html</sparkle:fullReleaseNotesLink>
         <description>
           <![CDATA[
             <ul>

--- a/Tests/Resources/test-links.xml
+++ b/Tests/Resources/test-links.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 3.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <sparkle:releaseNotesLink>https://sparkle-project.org/notes/relnote-3.0.txt</sparkle:releaseNotesLink>
+        <sparkle:fullReleaseNotesLink>https://sparkle-project.org/fullnotes.txt</sparkle:fullReleaseNotesLink>
+        <link>https://sparkle-project.org</link>
+        <enclosure url="https://sparkle-project.org/release-3.0.zip" sparkle:version="3.0" length="1346234" />
+    </item>
+    <item>
+        <title>Version 2.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <sparkle:releaseNotesLink>http://sparkle-project.org/notes/relnote-2.0.txt</sparkle:releaseNotesLink>
+        <sparkle:fullReleaseNotesLink>http://sparkle-project.org/fullnotes.txt</sparkle:fullReleaseNotesLink>
+        <link>http://sparkle-project.org</link>
+        <enclosure url="http://sparkle-project.org/release-2.0.zip" sparkle:version="2.0" length="1346234" />
+    </item>
+    <item>
+        <title>Version 1.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <sparkle:releaseNotesLink>file://sparkle-project.org/notes/relnote-1.0.txt</sparkle:releaseNotesLink>
+        <sparkle:fullReleaseNotesLink>file://sparkle-project.org/fullnotes.txt</sparkle:fullReleaseNotesLink>
+        <link>file://sparkle-project.org</link>
+        <enclosure url="file://sparkle-project.org/release-1.0.zip" sparkle:version="1.0" length="1346234" />
+    </item>
+  </channel>
+</rss>

--- a/Tests/Resources/test-relative-urls.xml
+++ b/Tests/Resources/test-relative-urls.xml
@@ -15,5 +15,21 @@
         <sparkle:version>2.0</sparkle:version>
         <link>/info/info-2.0.txt</link>
     </item>
+    <item>
+        <title>Version 1.0</title>
+        <description>desc</description>
+        <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+        <sparkle:version>1.0</sparkle:version>
+        <sparkle:fullReleaseNotesLink>notes/fullnotes.txt</sparkle:fullReleaseNotesLink>
+        <enclosure url="release-1.0.zip" sparkle:version="1.0" length="1346234" />
+    </item>
+    <item>
+        <title>Version 0.9</title>
+        <description>desc</description>
+        <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+        <sparkle:version>0.9</sparkle:version>
+        <sparkle:fullReleaseNotesLink>https://sparkle-project.org/releasenotes.html</sparkle:fullReleaseNotesLink>
+        <enclosure url="release-0.9.zip" sparkle:version="0.9" length="1346234" />
+    </item>
   </channel>
 </rss>


### PR DESCRIPTION
Support relative links for fullReleaseNotesLink and enforce http(s). Add unit tests to test all types of links are extracted or are bad and not extracted.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 12.0.1 (21A559)
