### PR TITLE
Use NSPanel for Sparkle windows to allow untitled windows form Dock

### DIFF
--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -20,7 +20,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window identifier="SUUpdateAlert" title="Software Update" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)">
+        <window identifier="SUUpdateAlert" title="Software Update" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SUUpdateAlert" animationBehavior="default" id="5" userLabel="Update Alert (release notes)" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>

--- a/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
@@ -23,7 +23,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Profile Info">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Profile Info" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/Sparkle/SUStatus.xib
+++ b/Sparkle/SUStatus.xib
@@ -16,7 +16,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window identifier="SUStatus" title="Set in Code" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window">
+        <window identifier="SUStatus" title="Set in Code" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="200" y="222" width="400" height="107"/>

--- a/UITests/SUTestApplicationTest.swift
+++ b/UITests/SUTestApplicationTest.swift
@@ -47,12 +47,12 @@ class SUTestApplicationTest: XCTestCase
             menuBarsQuery.menuBarItems["Sparkle Test App"].click()
         }
 
-        app.windows["SUUpdateAlert"].buttons["Install Update"].click()
+        app.dialogs["SUUpdateAlert"].buttons["Install Update"].click()
         
         // Give some time for the update to finish downloading / extracting
         sleep(30)
         
-        app.windows["SUStatus"].buttons["Install and Relaunch"].click()
+        app.dialogs["SUStatus"].buttons["Install and Relaunch"].click()
 
         // Wait for the new updated app to finish launching so we can test if it's the frontmost app
         sleep(10)


### PR DESCRIPTION
## Background

It takes time to download updates and users tend to continue using an app while it's downloading updates.

Document based apps often override `-[NSApplicationDelegate applicationShouldOpenUntitledFile:]`` & `-[NSApplicationDelegate applicationOpenUntitledFile:]` to allow opening new document when the Dock icon being clicked when no window exists.

An interesting behavior that I discover is that while Sparkle has its window on screen (e.g. downloading updates), AppKit no longer calls `-[NSApplicationDelegate applicationOpenUntitledFile:]`. This behavior especially bothers users for apps such as [iTerm2](https://iterm2.com/), since closing an unneeded pseudo terminal and reopen a new one from Dock is an extremely frequent interaction. Users have to right-click or control-click the Dock icon to achieve the desired behavior.

This PR uses NSPanel (rather than `NSWindow`) for Sparkle windows  to allow untitled windows form Dock.

## Deeper Dive

Here is a typical call stack that AppKit handles opening untitled file:

<img width="1194" alt="Screenshot 2021-11-07 上午2 09 25" src="https://user-images.githubusercontent.com/8158163/140619574-5e6200a7-2272-4183-838e-b3b08c3973f0.png">

Disassembling AppKit binary (12.0.1, 21A559) and looking for symbol `-[NSApplication(NSAppleEventHandling) _handleAEReopen:] signifies AppKit prevents `-[NSApplication _doOpenUntitled]` call when `-[NSApplication _appHasOpenNSWindow]` is `YES`:

<img width="1459" alt="Screenshot 2021-11-07 上午2 14 57" src="https://user-images.githubusercontent.com/8158163/140619752-cb0c9b8b-e42e-4a12-9db8-001501d331c4.png">

For its implementation (notice the third argument differs):

<img width="1459" alt="Screenshot 2021-11-07 上午2 22 16" src="https://user-images.githubusercontent.com/8158163/140619955-d2ecf03b-2a88-4bf3-a2fd-159aa668bfe1.png">

<img width="1459" alt="Screenshot 2021-11-07 上午2 22 25" src="https://user-images.githubusercontent.com/8158163/140619961-2806b4ba-dcc7-4264-a16d-3733ea9cce11.png">

`-[NSApplication _appHasOpenNSWindow]` has a dedicated check that excludes `NSPanel` class:

<img width="1660" alt="Screenshot 2021-11-07 上午2 26 18" src="https://user-images.githubusercontent.com/8158163/140620453-f9460ef3-e1b4-4477-8bde-98f9c13cf216.png">

and here comes this PR.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)
  - [x] [CotEditor](https://github.com/coteditor/CotEditor)

1. Make sure target app implements `-[NSApplicationDelegate applicationShouldOpenUntitledFile:]`
2. Close all windows except any Sparkle windows, click the Dock icon.
3. `-[NSApplicationDelegate applicationShouldOpenUntitledFile:]` should be called.

macOS version tested: All latest major versions from 10.11-12.0 have been tested with the Test App. A version of [CotEditor](https://github.com/coteditor/CotEditor) using the branch version of Sparkle has been tested on all latest major versions from 10.15-12.0