### PR TITLE
Whitelist about:srcdoc as a safe web URL

### DIFF
--- a/Sparkle/SUWebViewCommon.m
+++ b/Sparkle/SUWebViewCommon.m
@@ -16,7 +16,7 @@
 BOOL SUWebViewIsSafeURL(NSURL *url, BOOL *isAboutBlankURL)
 {
     NSString *scheme = url.scheme;
-    BOOL isAboutBlank = [url.absoluteString isEqualToString:@"about:blank"];
+    BOOL isAboutBlank = [url.absoluteString isEqualToString:@"about:blank"] || [url.absoluteString isEqualToString:@"about:srcdoc"];
     BOOL whitelistedSafe = isAboutBlank || [@[@"http", @"https", @"macappstore", @"macappstores", @"itms-apps", @"itms-appss"] containsObject:scheme];
     
     *isAboutBlankURL = isAboutBlank;


### PR DESCRIPTION
The document I tested (after enabling javascript) was:

```xml
<description>
          <![CDATA[
              <p>Hello</p>
              <script>
              var iframe = document.createElement("iframe");
              iframe.srcdoc = `<!DOCTYPE html><p>Hello World!</p>`;
              document.body.appendChild(iframe);
              </script>
          ]]>
</description>
```

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested with JS snippet above. Tested with legacy web view and WKWebView implementation. Without these changes, the content wouldn't load.

macOS version tested: 12.0.1 (21A559)
