### PR TITLE
Whitelist about:srcdoc as a safe web URL (1.x)

### DIFF
--- a/Sparkle/SUWebViewCommon.m
+++ b/Sparkle/SUWebViewCommon.m
@@ -11,7 +11,7 @@
 BOOL SUWebViewIsSafeURL(NSURL *url, BOOL *isAboutBlankURL)
 {
     NSString *scheme = url.scheme;
-    BOOL isAboutBlank = [url.absoluteString isEqualToString:@"about:blank"];
+    BOOL isAboutBlank = [url.absoluteString isEqualToString:@"about:blank"] || [url.absoluteString isEqualToString:@"about:srcdoc"];
     BOOL whitelistedSafe = isAboutBlank || [@[@"http", @"https", @"macappstore", @"macappstores", @"itms-apps", @"itms-appss"] containsObject:scheme];
     
     *isAboutBlankURL = isAboutBlank;


### PR DESCRIPTION
Backport of #2006 to 1.x

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested with JS snippet in #2006. Tested with legacy web view and WKWebView implementation. Without these changes, the content wouldn't load.

macOS version tested: 12.0.1 (21A559)
