### PR TITLE
Launch test app in English for UI Tests for prevent local test failure.

### DIFF
--- a/UITests/SUTestApplicationTest.swift
+++ b/UITests/SUTestApplicationTest.swift
@@ -26,6 +26,10 @@ class SUTestApplicationTest: XCTestCase
     func testRegularUpdate()
     {
         let app = XCUIApplication()
+        app.launchArguments = [
+            "-AppleLanguages",
+            "(en)"
+        ]
         app.launch()
         
         XCTAssertFalse(app.dialogs["alert"].staticTexts["Update succeeded!"].exists, "Update is already installed; please do a clean build")


### PR DESCRIPTION
Launch test app in English for UI Tests for prevent local test failure when using non-English languages.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Run UI Tests using non-English system language preferences.

macOS version tested: 12.0.1 (21A559)
