### PR TITLE
Revert monotonic timer

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -280,6 +280,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
 /**
  Appropriately schedules or cancels the update checking timer according to the preferences for time interval and automatic checks.
 
+ If you change the `updateCheckInterval` or `automaticallyChecksForUpdates` properties, the update cycle will be reset automatically after a short delay.
+ The update cycle is also started automatically after the updater is started. In all these cases, this method should not be called directly.
+ 
  This call does not change the date of the next check, but only the internal timer.
  */
 - (void)resetUpdateCycle;

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -279,13 +279,11 @@ SU_EXPORT @interface SPUUpdater : NSObject
 
 /**
  Appropriately schedules or cancels the update checking timer according to the preferences for time interval and automatic checks.
- 
- If you change the `updateCheckInterval` or `automaticallyChecksForUpdates` properties, the update cycle will be reset automatically after a short delay.
- The update cycle is also started automatically after the updater is started. In these cases, this method should not be called directly.
 
  This call does not change the date of the next check, but only the internal timer.
  */
 - (void)resetUpdateCycle;
+
 
 /**
  The system profile information that is sent when checking for updates.

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -62,7 +62,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @property (nonatomic) BOOL showingPermissionRequest;
 
 @property (nonatomic, copy) NSDate *updateLastCheckedDate;
-@property (nonatomic) NSTimeInterval lastMonotonicUpdateCheckTime;
 
 @property (nonatomic) BOOL loggedATSWarning;
 @property (nonatomic) BOOL loggedNoSecureKeyWarning;
@@ -88,7 +87,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize canCheckForUpdates = _canCheckForUpdates;
 @synthesize showingPermissionRequest = _showingPermissionRequest;
 @synthesize updateLastCheckedDate = _updateLastCheckedDate;
-@synthesize lastMonotonicUpdateCheckTime = _lastMonotonicUpdateCheckTime;
 @synthesize loggedATSWarning = _loggedATSWarning;
 @synthesize loggedNoSecureKeyWarning = _loggedNoSecureKeyWarning;
 
@@ -404,7 +402,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         // We start the update checks and register as observer for changes after the prompt finishes
     } else {
         // We check if the user's said they want updates, or they haven't said anything, and the default is set to checking.
-        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentDate:YES];
+        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:YES];
     }
 }
 
@@ -424,27 +422,17 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     return [self updateLastCheckedDate];
 }
 
-- (NSTimeInterval)currentMonotonicTimeInterval
-{
-    // This is monotonic system time while the system is not asleep
-    return [[NSProcessInfo processInfo] systemUptime];
-}
-
 - (void)updateLastUpdateCheckDate
 {
     [self willChangeValueForKey:NSStringFromSelector(@selector((lastUpdateCheckDate)))];
-    
     // We use an intermediate property for last update check date due to https://github.com/sparkle-project/Sparkle/pull/1135
     [self setUpdateLastCheckedDate:[NSDate date]];
     [self.host setObject:[self updateLastCheckedDate] forUserDefaultsKey:SULastCheckTimeKey];
-    
-    self.lastMonotonicUpdateCheckTime = [self currentMonotonicTimeInterval];
-    
     [self didChangeValueForKey:NSStringFromSelector(@selector((lastUpdateCheckDate)))];
 }
 
 // Note this method is never called when sessionInProgress is YES
-- (void)scheduleNextUpdateCheckFiringImmediately:(BOOL)firingImmediately usingCurrentDate:(BOOL)usingCurrentDate
+- (void)scheduleNextUpdateCheckFiringImmediately:(BOOL)firingImmediately usingCurrentTime:(BOOL)usingCurrentTime
 {
     [self.updaterTimer invalidate];
     
@@ -491,74 +479,34 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             // This callback is asynchronous, so the timer may be set. Invalidate to make sure it isn't.
             [self.updaterTimer invalidate];
             
-            NSTimeInterval dateIntervalSinceCheck;
-            NSTimeInterval minimumMonotonicEnforcedDelay;
-            if (usingCurrentDate) {
+            NSTimeInterval intervalSinceCheck;
+            if (usingCurrentTime) {
                 // How long has it been since last we checked for an update?
                 NSDate *lastCheckDate = [self lastUpdateCheckDate];
                 if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
-                NSTimeInterval wallTimeInterval = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
-                if (wallTimeInterval < 0) {
+                intervalSinceCheck = [[NSDate date] timeIntervalSinceDate:lastCheckDate];
+                if (intervalSinceCheck < 0) {
                     // Last update check date is in the future and bogus, so reset it to current date
                     [self updateLastUpdateCheckDate];
                     
-                    // And assume a full update interval is needed
-                    dateIntervalSinceCheck = 0;
-                    minimumMonotonicEnforcedDelay = SUMinimumMonotonicUpdateCheckInterval;
-                } else {
-                    // Check the monotonic clock for an enforced minimum delay
-                    NSTimeInterval lastMonotonicUpdateCheckTime = self.lastMonotonicUpdateCheckTime;
-                    if (lastMonotonicUpdateCheckTime <= 0) {
-                        // When the updater is first started, the last monotonic time may not have been updated yet.
-                        // In this case there is no enforced minimum delay.
-                        minimumMonotonicEnforcedDelay = 0;
-                    } else {
-                        // Compute an enforced minimum delay based on elapsed monotonic time
-                        // The elapsed monotonic time is more stable than wall time interval and does not include the
-                        // amount of time while the system is asleep
-                        NSTimeInterval currentMonotonicTime = [self currentMonotonicTimeInterval];
-                        NSTimeInterval elapsedMonotonicTime = (currentMonotonicTime - lastMonotonicUpdateCheckTime);
-
-                        if (elapsedMonotonicTime < SUMinimumMonotonicUpdateCheckInterval) {
-                            minimumMonotonicEnforcedDelay = (SUMinimumMonotonicUpdateCheckInterval - elapsedMonotonicTime);
-                        } else {
-                            minimumMonotonicEnforcedDelay = 0;
-                        }
-                    }
-                    
-                    dateIntervalSinceCheck = wallTimeInterval;
+                    intervalSinceCheck = 0;
                 }
             } else {
-                // Without using the current date, we assume a full update interval is needed
-                dateIntervalSinceCheck = 0;
-                minimumMonotonicEnforcedDelay = SUMinimumMonotonicUpdateCheckInterval;
-            }
-            
-            if (updateCheckInterval < SUMinimumUpdateCheckInterval) {
-                updateCheckInterval = SUMinimumUpdateCheckInterval;
+                intervalSinceCheck = 0;
             }
             
             // Now we want to figure out how long until we check again.
-            NSTimeInterval wallDelayUntilCheck;
-            if (dateIntervalSinceCheck < updateCheckInterval) {
-                // It hasn't been long enough.
-                wallDelayUntilCheck = (updateCheckInterval - dateIntervalSinceCheck);
+            if (updateCheckInterval < SUMinimumUpdateCheckInterval)
+                updateCheckInterval = SUMinimumUpdateCheckInterval;
+            if (intervalSinceCheck < updateCheckInterval) {
+                NSTimeInterval delayUntilCheck = (updateCheckInterval - intervalSinceCheck); // It hasn't been long enough.
+                if ([self.delegate respondsToSelector:@selector(updater:willScheduleUpdateCheckAfterDelay:)]) {
+                    [self.delegate updater:self willScheduleUpdateCheckAfterDelay:delayUntilCheck];
+                }
+                [self.updaterTimer startAndFireAfterDelay:delayUntilCheck];
             } else {
-                wallDelayUntilCheck = 0;
-            }
-            
-            // Now compute delay with enforced minimum delay requirement
-            // The minimum delay (based on monotonic clock) is an extra layer of defense to prevent too frequent update checks
-            // in case the wall clock is not working properly (eg from too many system wake events, system date changes, NTP..)
-            NSTimeInterval finalDelayUntilCheck = MAX(wallDelayUntilCheck, minimumMonotonicEnforcedDelay);
-            if (finalDelayUntilCheck <= 0) {
                 // We're overdue! Run one now.
                 [self checkForUpdatesInBackground];
-            } else {
-                if ([self.delegate respondsToSelector:@selector(updater:willScheduleUpdateCheckAfterDelay:)]) {
-                    [self.delegate updater:self willScheduleUpdateCheckAfterDelay:finalDelayUntilCheck];
-                }
-                [self.updaterTimer startTimerWithWallTimeDelay:wallDelayUntilCheck monotonicTimeDelay:minimumMonotonicEnforcedDelay];
             }
         });
     }
@@ -740,7 +688,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 // Ensure the delegate doesn't start a new session when being notified of the previous one ending
                 if (!strongSelf.sessionInProgress) {
                     if (shouldScheduleNextUpdateCheck) {
-                        [strongSelf scheduleNextUpdateCheckFiringImmediately:NO usingCurrentDate:NO];
+                        [strongSelf scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:NO];
                     } else {
                         SULog(SULogLevelDefault, @"Disabling scheduled updates..");
                     }
@@ -791,7 +739,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             
             // Ensure the delegate doesn't start a new session when being notified of the previous one ending
             if (!strongSelf.sessionInProgress) {
-                [strongSelf scheduleNextUpdateCheckFiringImmediately:shouldShowUpdateImmediately usingCurrentDate:NO];
+                [strongSelf scheduleNextUpdateCheckFiringImmediately:shouldShowUpdateImmediately usingCurrentTime:NO];
             }
         }
     }];
@@ -836,7 +784,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (!self.sessionInProgress) {
         [self cancelNextUpdateCycle];
-        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentDate:YES];
+        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:YES];
     }
 }
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -402,7 +402,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         // We start the update checks and register as observer for changes after the prompt finishes
     } else {
         // We check if the user's said they want updates, or they haven't said anything, and the default is set to checking.
-        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:YES];
+        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentDate:YES];
     }
 }
 
@@ -432,7 +432,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 }
 
 // Note this method is never called when sessionInProgress is YES
-- (void)scheduleNextUpdateCheckFiringImmediately:(BOOL)firingImmediately usingCurrentTime:(BOOL)usingCurrentTime
+- (void)scheduleNextUpdateCheckFiringImmediately:(BOOL)firingImmediately usingCurrentDate:(BOOL)usingCurrentDate
 {
     [self.updaterTimer invalidate];
     
@@ -480,7 +480,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             [self.updaterTimer invalidate];
             
             NSTimeInterval intervalSinceCheck;
-            if (usingCurrentTime) {
+            if (usingCurrentDate) {
                 // How long has it been since last we checked for an update?
                 NSDate *lastCheckDate = [self lastUpdateCheckDate];
                 if (!lastCheckDate) { lastCheckDate = [NSDate distantPast]; }
@@ -688,7 +688,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 // Ensure the delegate doesn't start a new session when being notified of the previous one ending
                 if (!strongSelf.sessionInProgress) {
                     if (shouldScheduleNextUpdateCheck) {
-                        [strongSelf scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:NO];
+                        [strongSelf scheduleNextUpdateCheckFiringImmediately:NO usingCurrentDate:NO];
                     } else {
                         SULog(SULogLevelDefault, @"Disabling scheduled updates..");
                     }
@@ -739,7 +739,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             
             // Ensure the delegate doesn't start a new session when being notified of the previous one ending
             if (!strongSelf.sessionInProgress) {
-                [strongSelf scheduleNextUpdateCheckFiringImmediately:shouldShowUpdateImmediately usingCurrentTime:NO];
+                [strongSelf scheduleNextUpdateCheckFiringImmediately:shouldShowUpdateImmediately usingCurrentDate:NO];
             }
         }
     }];
@@ -784,7 +784,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (!self.sessionInProgress) {
         [self cancelNextUpdateCycle];
-        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentTime:YES];
+        [self scheduleNextUpdateCheckFiringImmediately:NO usingCurrentDate:YES];
     }
 }
 

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -366,7 +366,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  
  Automatic update checks need to be enabled for this to trigger.
  
- @param delay The delay in seconds until the next scheduled update will occur. This is an approximation and may vary due to system state.
+ @param delay The delay in seconds until the next scheduled update will occur.
  
  @param updater The updater instance.
  */

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -366,7 +366,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  
  Automatic update checks need to be enabled for this to trigger.
  
- @param delay The delay in seconds until the next scheduled update will occur.
+ @param delay The delay in seconds until the next scheduled update will occur. This is an approximation and may vary due to system state.
  
  @param updater The updater instance.
  */

--- a/Sparkle/SPUUpdaterTimer.h
+++ b/Sparkle/SPUUpdaterTimer.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDelegate:(id<SPUUpdaterTimerDelegate>)delegate;
 
-- (void)startTimerWithWallTimeDelay:(NSTimeInterval)wallDelayUntilCheck monotonicTimeDelay:(NSTimeInterval)minimumEnforcedDelay;
+- (void)startAndFireAfterDelay:(NSTimeInterval)delay;
 
 - (void)invalidate;
 

--- a/Sparkle/SPUUpdaterTimer.m
+++ b/Sparkle/SPUUpdaterTimer.m
@@ -15,16 +15,14 @@
 @interface SPUUpdaterTimer ()
 
 @property (nonatomic, readonly, weak) id<SPUUpdaterTimerDelegate> delegate;
-@property (nonatomic) dispatch_source_t wallTimeSource;
-@property (nonatomic) dispatch_source_t monotonicTimeSource;
+@property (nonatomic) dispatch_source_t source;
 
 @end
 
 @implementation SPUUpdaterTimer
 
 @synthesize delegate = _delegate;
-@synthesize wallTimeSource = _wallTimeSource;
-@synthesize monotonicTimeSource = _monotonicTimeSource;
+@synthesize source = _source;
 
 - (instancetype)initWithDelegate:(id<SPUUpdaterTimerDelegate>)delegate
 {
@@ -35,76 +33,28 @@
     return self;
 }
 
-- (void)startTimerWithWallTimeDelay:(NSTimeInterval)wallTimeDelay monotonicTimeDelay:(NSTimeInterval)monotonicTimeDelay
+- (void)startAndFireAfterDelay:(NSTimeInterval)delay
 {
+    self.source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+    
+    // We use the wall time instead of cpu time for our dispatch timer
+    // So eg if the computer sleeps we want to include that time spent in our timer
+    dispatch_time_t timeToFire = dispatch_walltime(NULL, (int64_t)(delay * NSEC_PER_SEC));
+    dispatch_source_set_timer(self.source, timeToFire, DISPATCH_TIME_FOREVER, SULeewayUpdateCheckInterval * NSEC_PER_SEC);
+    
     __weak __typeof__(self) weakSelf = self;
-    // When timersFired reaches 2, both wall/monotonic timers have been fired, and the delegate is ready to receive the notification
-    __block uint8_t timersFired = 0;
+    dispatch_source_set_event_handler(self.source, ^{
+        [weakSelf.delegate updaterTimerDidFire];
+    });
     
-    if (wallTimeDelay <= 0) {
-        timersFired++;
-        self.wallTimeSource = nil;
-    } else {
-        // We use the wall time instead of cpu time for a large date interval
-        // So eg if the computer sleeps we want to include that time spent in our timer
-        self.wallTimeSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
-        
-        dispatch_time_t wallTime = dispatch_walltime(NULL, (int64_t)(wallTimeDelay * NSEC_PER_SEC));
-        dispatch_source_set_timer(self.wallTimeSource, wallTime, DISPATCH_TIME_FOREVER, SULeewayWallUpdateCheckInterval * NSEC_PER_SEC);
-        
-        dispatch_source_set_event_handler(self.wallTimeSource, ^{
-            timersFired++;
-            if (timersFired > 1) {
-                [weakSelf.delegate updaterTimerDidFire];
-            }
-        });
-    }
-    
-    if (monotonicTimeDelay <= 0) {
-        timersFired++;
-        self.monotonicTimeSource = nil;
-    } else {
-        // We also use monotonic time to enforce a minimum delay interval
-        // This ensures we don't fire the wall clock based timer too frequently if the real clock changes
-        self.monotonicTimeSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
-        
-        dispatch_time_t monotonicTime = dispatch_time(DISPATCH_TIME_NOW , (int64_t)(monotonicTimeDelay * NSEC_PER_SEC));
-        dispatch_source_set_timer(self.monotonicTimeSource, monotonicTime, DISPATCH_TIME_FOREVER, SULeewayMonotonicUpdateCheckInterval * NSEC_PER_SEC);
-        
-        dispatch_source_set_event_handler(self.monotonicTimeSource, ^{
-            timersFired++;
-            if (timersFired > 1) {
-                [weakSelf.delegate updaterTimerDidFire];
-            }
-        });
-    }
-    
-    // Have both timers already ran? (this should be unlikely)
-    if (timersFired > 1) {
-        [self.delegate updaterTimerDidFire];
-    } else {
-        // Resume available timers
-        
-        if (self.wallTimeSource != nil) {
-            dispatch_resume(self.wallTimeSource);
-        }
-        
-        if (self.monotonicTimeSource != nil) {
-            dispatch_resume(self.monotonicTimeSource);
-        }
-    }
+    dispatch_resume(self.source);
 }
 
 - (void)invalidate
 {
-    if (self.wallTimeSource != nil) {
-        dispatch_source_cancel(self.wallTimeSource);
-        self.wallTimeSource = nil;
-    }
-    
-    if (self.monotonicTimeSource != nil) {
-        dispatch_source_cancel(self.monotonicTimeSource);
-        self.monotonicTimeSource = nil;
+    if (self.source != nil) {
+        dispatch_source_cancel(self.source);
+        self.source = nil;
     }
 }
 

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -19,9 +19,7 @@
 extern const NSTimeInterval SUDefaultUpdatePermissionPromptInterval;
 extern const NSTimeInterval SUMinimumUpdateCheckInterval;
 extern const NSTimeInterval SUDefaultUpdateCheckInterval;
-extern const NSTimeInterval SUMinimumMonotonicUpdateCheckInterval;
-extern const uint64_t SULeewayWallUpdateCheckInterval;
-extern const uint64_t SULeewayMonotonicUpdateCheckInterval;
+extern const uint64_t SULeewayUpdateCheckInterval;
 extern const NSTimeInterval SUImpatientUpdateCheckInterval;
 
 extern NSString *const SUBundleIdentifier;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -18,11 +18,8 @@
 // Define some minimum intervals to avoid DoS-like checking attacks
 const NSTimeInterval SUMinimumUpdateCheckInterval = DEBUG ? 60 : (60 * 60);
 const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);
-const NSTimeInterval SUMinimumMonotonicUpdateCheckInterval = DEBUG ? 30 : (60 * 5);
-
 // The amount of time the system can defer our update check (for improved performance)
-const uint64_t SULeewayWallUpdateCheckInterval = DEBUG ? 1 : 60;
-const uint64_t SULeewayMonotonicUpdateCheckInterval = DEBUG ? 1 : 5;
+const uint64_t SULeewayUpdateCheckInterval = DEBUG ? 1 : 15;
 
 // If the update has already been automatically downloaded, we normally don't want to bug the user about the update
 // However if the user has gone a very long time without quitting an application, we will bug them


### PR DESCRIPTION
Now that I know that recent rapid polling of appcasts has been caused from third-party forked updaters, and not a problem in Sparkle itself, I want to revert the monotonic timer changes I did in #2002. Nothing should technically be wrong with these changes but I don't want to maintain the extra code and don't have a strong justification to now.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

Miscellaneous revert.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested scheduled timer in test app works as expected when launching app and subsequent cycles work.

macOS version tested: 12.0.1 (21A559)
