### PR TITLE
Clarify signing error better

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -125,6 +125,8 @@
 
 "The update is improperly signed." = "The update is improperly signed.";
 
+"The update is improperly signed. Please try again later or contact the app developer." = "The update is improperly signed. Please try again later or contact the app developer.";
+
 "Update Error!" = "Update Error!";
 
 "Updating %@" = "Updating %@";

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -125,7 +125,7 @@
 
 "The update is improperly signed." = "The update is improperly signed.";
 
-"The update is improperly signed. Please try again later or contact the app developer." = "The update is improperly signed. Please try again later or contact the app developer.";
+"The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "The update is improperly signed and could not be validated. Please try again later or contact the app developer.";
 
 "Update Error!" = "Update Error!";
 

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -106,7 +106,7 @@
         NSError *underlyingError = currentInstallerError.userInfo[NSUnderlyingErrorKey];
         if (underlyingError != nil && underlyingError.code == SUValidationError) {
             NSDictionary *userInfo = @{
-                NSLocalizedDescriptionKey: SULocalizedString(@"The update is improperly signed. Please try again later or contact the app developer.", nil),
+                NSLocalizedDescriptionKey: SULocalizedString(@"The update is improperly signed and could not be validated. Please try again later or contact the app developer.", nil),
                 NSUnderlyingErrorKey: (NSError * _Nonnull)currentInstallerError
             };
             

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -97,6 +97,43 @@
     return self;
 }
 
+- (void)_reportInstallerError:(nullable NSError *)currentInstallerError genericErrorCode:(NSInteger)genericErrorCode genericUserInfo:(NSDictionary *)genericUserInfo
+{
+    // First see if there is a good custom error we can show
+    // We only check for signing validation errors currently
+    NSError *customError;
+    if (currentInstallerError != nil) {
+        NSError *underlyingError = currentInstallerError.userInfo[NSUnderlyingErrorKey];
+        if (underlyingError != nil && underlyingError.code == SUValidationError) {
+            NSDictionary *userInfo = @{
+                NSLocalizedDescriptionKey: SULocalizedString(@"The update is improperly signed. Please try again later or contact the app developer.", nil),
+                NSUnderlyingErrorKey: (NSError * _Nonnull)currentInstallerError
+            };
+            
+            customError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
+        } else {
+            customError = nil;
+        }
+    } else {
+        customError = nil;
+    }
+    
+    // Otherwise if there's no custom error, then use a generic installer error to show
+    // and keep the underlying error around for logging
+    NSError *installerError;
+    if (customError != nil) {
+        installerError = customError;
+    } else {
+        NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:genericUserInfo];
+        if (currentInstallerError != nil) {
+            userInfo[NSUnderlyingErrorKey] = currentInstallerError;
+        }
+        installerError = [NSError errorWithDomain:SUSparkleErrorDomain code:genericErrorCode userInfo:userInfo];
+    }
+    
+    [self.delegate installerIsRequestingAbortInstallWithError:installerError];
+}
+
 - (void)setUpConnection
 {
     if (self.installerConnection != nil) {
@@ -117,40 +154,12 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             SPUInstallerDriver *strongSelf = weakSelf;
             if (strongSelf.installerConnection != nil && !strongSelf.aborted) {
-                // First see if there is a good custom error we can show
-                // We only check for signing validation errors currently
-                NSError *customError;
-                NSError *priorInstallerError = strongSelf.installerError;
-                if (priorInstallerError != nil) {
-                    NSError *underlyingError = priorInstallerError.userInfo[NSUnderlyingErrorKey];
-                    
-                    if (underlyingError != nil && underlyingError.code == SUValidationError) {
-                        NSDictionary *userInfo = @{
-                            NSLocalizedDescriptionKey: SULocalizedString(@"The update is improperly signed. Please try again later or contact the app developer.", nil)
-                        };
-                        
-                        customError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
-                    } else {
-                        customError = nil;
-                    }
-                } else {
-                    customError = nil;
-                }
+                NSDictionary *genericUserInfo = @{
+                    NSLocalizedDescriptionKey: SULocalizedString(@"An error occurred while running the updater. Please try again later.", nil),
+                    NSLocalizedFailureReasonErrorKey:@"The remote port connection was invalidated from the updater. For additional details, please check Console logs for "@SPARKLE_RELAUNCH_TOOL_NAME". If your application is sandboxed, please also ensure Installer Connection & Status entitlements are correctly set up: https://sparkle-project.org/documentation/sandboxing/"
+                };
                 
-                // If there's no custom error then use a generic installer error to show
-                NSError *installerError;
-                if (customError != nil) {
-                    installerError = customError;
-                } else {
-                    NSDictionary *userInfo = @{
-                        NSLocalizedDescriptionKey: SULocalizedString(@"An error occurred while running the updater. Please try again later.", nil),
-                        NSLocalizedFailureReasonErrorKey:@"The remote port connection was invalidated from the updater. For additional details, please check Console logs for "@SPARKLE_RELAUNCH_TOOL_NAME". If your application is sandboxed, please also ensure Installer Connection & Status entitlements are correctly set up: https://sparkle-project.org/documentation/sandboxing/"
-                    };
-                    
-                    installerError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
-                }
-                
-                [strongSelf.delegate installerIsRequestingAbortInstallWithError:installerError];
+                [strongSelf _reportInstallerError:strongSelf.installerError genericErrorCode:SUInstallationError genericUserInfo:genericUserInfo];
             }
         });
     }];
@@ -260,14 +269,10 @@
             [self.delegate installerDidFailToApplyDeltaUpdate];
         } else {
             // Don't have to store current stage because we're going to abort
-            NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey:SULocalizedString(@"An error occurred while extracting the archive. Please try again later.", nil) }];
+            NSDictionary *genericUserInfo = @{ NSLocalizedDescriptionKey:SULocalizedString(@"An error occurred while extracting the archive. Please try again later.", nil) };
             
             NSError *unarchivedError = (NSError *)SPUUnarchiveRootObjectSecurely(data, [NSError class]);
-            if (unarchivedError != nil) {
-                userInfo[NSUnderlyingErrorKey] = unarchivedError;
-            }
-            
-            [self.delegate installerIsRequestingAbortInstallWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:userInfo]];
+            [self _reportInstallerError:unarchivedError genericErrorCode:SUUnarchivingError genericUserInfo:genericUserInfo];
         }
     } else if (identifier == SPUValidationStarted) {
         self.currentStage = identifier;


### PR DESCRIPTION
Clarify when a signing error occurs better, rather than treat it as a "generic" installer failure.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested error shows when:
- fails due to signing before extraction (when pre-validation is required)
- fails due to signing after extraction

And when other generic error paths are triggered, a generic install or unarchiving error is shown instead. Logs still contain underlying errors.

macOS version tested: 12.0.1 (21A559)
