### PR TITLE
Fix volume detection being wrong in rare cases

### DIFF
--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -86,24 +86,36 @@
     // The system periodically cleans up files by looking at the mod & access times, so we have to make sure they're up to date
     // They could be potentially be preserved when archiving an application, but also an update could just be sitting on the system for a long time
     // before being installed
-    if (![fileManager updateAccessTimeOfItemAtRootURL:newURL error:error]) {
+    NSError *accessTimeError = nil;
+    if (![fileManager updateAccessTimeOfItemAtRootURL:newURL error:&accessTimeError]) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to recursively update new application's modification time before moving into temporary directory" }];
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey: @"Failed to recursively update new application's modification time before moving into temporary directory" }];
+            
+            if (accessTimeError != nil) {
+                userInfo[NSUnderlyingErrorKey] = accessTimeError;
+            }
+            
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
         }
         
         return NO;
     }
     
-    // Create a temporary directory for our new app that resides on our destination's volume
-    NSString *preferredName = [installationURL.lastPathComponent.stringByDeletingPathExtension stringByAppendingString:@" (Incomplete Update)"];
-    NSURL *installationDirectory = installationURL.URLByDeletingLastPathComponent;
-    NSURL *tempNewDirectoryURL = [fileManager makeTemporaryDirectoryWithPreferredName:preferredName appropriateForDirectoryURL:installationDirectory error:error];
-    
-    if (tempNewDirectoryURL == nil) {
+    NSURL *oldURL = [NSURL fileURLWithPath:host.bundlePath];
+    if (oldURL == nil) {
+        // this really shouldn't happen but just in case
+        SULog(SULogLevelError, @"Failed to construct URL from bundle path: %@", host.bundlePath);
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to make new temporary directory" }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to perform installation because a path could not be constructed for the old installation" }];
         }
-        
+        return NO;
+    }
+    
+    // Create a temporary directory for our new app that resides on our destination's volume
+    // We use oldURL here instead of installationURL because in the case of normalization, installationURL may not exist
+    // And we don't want to use either of the URL's parent directories because the parent directory could be on a different volume
+    NSURL *tempNewDirectoryURL = [fileManager makeTemporaryDirectoryAppropriateForDirectoryURL:oldURL error:error];
+    if (tempNewDirectoryURL == nil) {
         return NO;
     }
     
@@ -116,9 +128,16 @@
     // Move the new app to our temporary directory
     NSString *newURLLastPathComponent = newURL.lastPathComponent;
     NSURL *newTempURL = [tempNewDirectoryURL URLByAppendingPathComponent:newURLLastPathComponent];
-    if (![fileManager moveItemAtURL:newURL toURL:newTempURL error:error]) {
+    NSError *newTempMoveError = nil;
+    if (![fileManager moveItemAtURL:newURL toURL:newTempURL error:&newTempMoveError]) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move the new app from %@ to its temp directory at %@", newURL.path, newTempURL.path] }];
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move the new app from %@ to its temp directory at %@", newURL.path, newTempURL.path] }];
+            
+            if (newTempMoveError != nil) {
+                userInfo[NSUnderlyingErrorKey] = newTempMoveError;
+            }
+            
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
         }
         return NO;
     }
@@ -136,16 +155,6 @@
 
     if (progress) {
         progress(4/10.0);
-    }
-
-    NSURL *oldURL = [NSURL fileURLWithPath:host.bundlePath];
-    if (oldURL == nil) {
-        // this really shouldn't happen but just in case
-        SULog(SULogLevelError, @"Failed to construct URL from bundle path: %@", host.bundlePath);
-        if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to perform installation because a path could not be constructed for the old installation" }];
-        }
-        return NO;
     }
     
     // Try to preserve Finder Tags
@@ -180,40 +189,32 @@
         progress(6/10.0);
     }
     
-    // First try replacing the application atomically
-    NSError *replaceError = nil;
-    BOOL replacedApp;
+    // First try swapping the application atomically
+    NSError *swapError = nil;
+    BOOL swappedApp;
     if (@available(macOS 10.13, *)) {
         // If the app is normalized and the installation path differs, go through the old swap path
         if (SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME && ![oldURL.path isEqual:installationURL.path]) {
-            replacedApp = NO;
+            swappedApp = NO;
         } else {
-            // Note: in my experience, a clone of the app may still be left at newTempURL
-            // This is OK though because we will be cleaning up the temporary directory later in -performCleanup:
-            replacedApp = [fileManager replaceItemAtURL:installationURL withItemAtURL:newTempURL error:&replaceError];
+            // We will be cleaning up the temporary directory later in -performCleanup:
+            // We don't want to clean it up now because it can take some time
+            swappedApp = [fileManager swapItemAtURL:installationURL withItemAtURL:newTempURL error:&swapError];
         }
     } else {
-        replacedApp = NO;
+        swappedApp = NO;
     }
     
-    if (!replacedApp) {
+    if (!swappedApp) {
         // Otherwise swap out the old and new applications using the legacy path
         
-        if (replaceError != nil) {
-            SULog(SULogLevelDefault, @"Invoking fallback from failing to replace original item with error: %@", replaceError);
+        if (swapError != nil) {
+            SULog(SULogLevelDefault, @"Invoking fallback from failing to replace original item with error: %@", swapError);
         }
-        
-        // Decide on a destination name we should use for the older app when we move it around the file system
-        NSString *oldDestinationName = oldURL.lastPathComponent.stringByDeletingPathExtension;
-        NSString *oldDestinationNameWithPathExtension = oldURL.lastPathComponent;
 
         // Create a temporary directory for our old app that resides on its volume
-        NSURL *oldDirectoryURL = oldURL.URLByDeletingLastPathComponent;
-        NSURL *tempOldDirectoryURL = (oldDirectoryURL != nil) ? [fileManager makeTemporaryDirectoryWithPreferredName:oldDestinationName appropriateForDirectoryURL:oldDirectoryURL error:error] : nil;
+        NSURL *tempOldDirectoryURL = [fileManager makeTemporaryDirectoryAppropriateForDirectoryURL:oldURL error:error];
         if (tempOldDirectoryURL == nil) {
-            if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to create temporary directory for old app at %@", oldURL.path] }];
-            }
             return NO;
         }
         
@@ -223,11 +224,28 @@
             progress(7/10.0);
         }
         
-        // Move the old app to the temporary directory
-        NSURL *oldTempURL = [tempOldDirectoryURL URLByAppendingPathComponent:oldDestinationNameWithPathExtension];
-        if (![fileManager moveItemAtURL:oldURL toURL:oldTempURL error:error]) {
+        NSString *oldURLFilename = oldURL.lastPathComponent;
+        if (oldURLFilename == nil) {
+            // this really shouldn't happen..
+            SULog(SULogLevelError, @"Failed to retrieve last path component from old URL: %@", oldURL.path);
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move the old app at %@ to a temporary location at %@", oldURL.path, oldTempURL.path] }];
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Failed to perform installation because the last path component of the old installation URL could not be constructed." }];
+            }
+            return NO;
+        }
+        
+        // Move the old app to the temporary directory
+        NSURL *oldTempURL = [tempOldDirectoryURL URLByAppendingPathComponent:oldURLFilename];
+        NSError *oldMoveError = nil;
+        if (![fileManager moveItemAtURL:oldURL toURL:oldTempURL error:&oldMoveError]) {
+            if (error != NULL) {
+                NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move the old app at %@ to a temporary location at %@", oldURL.path, oldTempURL.path] }];
+                
+                if (oldMoveError != nil) {
+                    userInfo[NSUnderlyingErrorKey] = oldMoveError;
+                }
+                
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
             }
             return NO;
         }
@@ -237,9 +255,16 @@
         }
 
         // Move the new app to its final destination
-        if (![fileManager moveItemAtURL:newTempURL toURL:installationURL error:error]) {
+        NSError *installMoveError = nil;
+        if (![fileManager moveItemAtURL:newTempURL toURL:installationURL error:&installMoveError]) {
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move new app at %@ to final destination %@", newTempURL.path, installationURL.path] }];
+                NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to move new app at %@ to final destination %@", newTempURL.path, installationURL.path] }];
+                
+                if (installMoveError != nil) {
+                    userInfo[NSUnderlyingErrorKey] = installMoveError;
+                }
+                
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
             }
             
             // Attempt to restore our old app back the way it was on failure

--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -111,6 +111,10 @@
         return NO;
     }
     
+    if (progress) {
+        progress(2/10.0);
+    }
+    
     // Create a temporary directory for our new app that resides on our destination's volume
     // We use oldURL here instead of installationURL because in the case of normalization, installationURL may not exist
     // And we don't want to use either of the URL's parent directories because the parent directory could be on a different volume
@@ -122,7 +126,7 @@
     self.temporaryNewDirectory = tempNewDirectoryURL;
 
     if (progress) {
-        progress(2/10.0);
+        progress(3/10.0);
     }
 
     // Move the new app to our temporary directory
@@ -143,7 +147,7 @@
     }
 
     if (progress) {
-        progress(3/10.0);
+        progress(4/10.0);
     }
 
     // Release our new app from quarantine
@@ -154,7 +158,7 @@
     }
 
     if (progress) {
-        progress(4/10.0);
+        progress(5/10.0);
     }
     
     // Try to preserve Finder Tags
@@ -162,6 +166,10 @@
     BOOL retrievedResourceTags = [oldURL getResourceValue:&resourceTags forKey:NSURLTagNamesKey error:NULL];
     if (retrievedResourceTags && resourceTags.count > 0) {
         [newTempURL setResourceValue:resourceTags forKey:NSURLTagNamesKey error:NULL];
+    }
+    
+    if (progress) {
+        progress(6/10.0);
     }
     
     // We must leave moving the app to its destination as the final step in installing it, so that
@@ -175,7 +183,7 @@
     }
 
     if (progress) {
-        progress(5/10.0);
+        progress(7/10.0);
     }
 
     NSError *touchError = nil;
@@ -186,7 +194,7 @@
     }
 
     if (progress) {
-        progress(6/10.0);
+        progress(8/10.0);
     }
     
     // First try swapping the application atomically
@@ -221,7 +229,7 @@
         self.temporaryOldDirectory = tempOldDirectoryURL;
 
         if (progress) {
-            progress(7/10.0);
+            progress(9/10.0);
         }
         
         NSString *oldURLFilename = oldURL.lastPathComponent;
@@ -251,7 +259,7 @@
         }
 
         if (progress) {
-            progress(8/10.0);
+            progress(9.5/10.0);
         }
 
         // Move the new app to its final destination
@@ -271,10 +279,6 @@
             [fileManager moveItemAtURL:oldTempURL toURL:oldURL error:NULL];
             
             return NO;
-        }
-        
-        if (progress) {
-            progress(9/10.0);
         }
     }
 

--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -340,7 +340,7 @@ BOOL SPUSystemNeedsAuthorizationAccessForBundlePath(NSString *bundlePath)
         NSString *tempFilename = @"permission_test" ;
         
         SUFileManager *suFileManager = [[SUFileManager alloc] init];
-        NSURL *tempDirectoryURL = [suFileManager makeTemporaryDirectoryWithPreferredName:tempFilename appropriateForDirectoryURL:[NSURL fileURLWithPath:NSTemporaryDirectory()] error:NULL];
+        NSURL *tempDirectoryURL = [suFileManager makeTemporaryDirectoryAppropriateForDirectoryURL:[NSURL fileURLWithPath:NSTemporaryDirectory()] error:NULL];
         
         if (tempDirectoryURL == nil) {
             // I don't imagine this ever happening but in case it does, requesting authorization may be the better option

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -27,7 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Creates a temporary directory on the same volume as a provided URL
- * @param preferredName A name that may be used when creating the temporary directory. Note that in the uncothirdStageErrormmon case this name is used, the temporary directory will be created inside the directory pointed by appropriateURL
  * @param appropriateURL A URL to a directory that resides on the volume that the temporary directory will be created on. In the uncommon case, the temporary directory may be created inside this directory.
  * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
  * @return A URL pointing to the newly created temporary directory, or nil with a populated error object if an error occurs.

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  * When moving an item from a source to a destination, it is desirable to create a temporary intermediate destination on the same volume as the destination to ensure
  * that the item will be moved, and not copied, from the intermediate point to the final destination. This ensures file atomicity.
  */
-- (NSURL * _Nullable)makeTemporaryDirectoryWithPreferredName:(NSString *)preferredName appropriateForDirectoryURL:(NSURL *)appropriateURL error:(NSError * __autoreleasing *)error;
+- (NSURL * _Nullable)makeTemporaryDirectoryAppropriateForDirectoryURL:(NSURL *)appropriateURL error:(NSError * __autoreleasing *)error;
 
 /**
  * Creates a directory at the target URL
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)moveItemAtURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL error:(NSError **)error;
 
 /**
- * Replaces an original item with a new item atomically.
+ * Swaps an original item with a new item atomically.
  * @param originalItemURL A URL pointing to the original item to replace. The item at this URL must exist.
  * @param newItemURL A URL pointing to the new item that will replace the original item.
  * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Otherwise on failure you may need to re-try using move operations. This operation will fail on non-apfs volumes or volumes that don't support rename swapping.
  * Both originalItemURL and newItemURL must exist.
  */
-- (BOOL)replaceItemAtURL:(NSURL *)originalItemURL withItemAtURL:(NSURL *)newItemURL error:(NSError **)error __OSX_AVAILABLE(10.13);
+- (BOOL)swapItemAtURL:(NSURL *)originalItemURL withItemAtURL:(NSURL *)newItemURL error:(NSError **)error __OSX_AVAILABLE(10.13);
 
 /**
  * Copies an item from a source to a destination

--- a/Sparkle/SUFileManager.m
+++ b/Sparkle/SUFileManager.m
@@ -311,7 +311,7 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
     return [_fileManager moveItemAtURL:sourceURL toURL:destinationURL error:error];
 }
 
-- (BOOL)replaceItemAtURL:(NSURL *)originalItemURL withItemAtURL:(NSURL *)newItemURL error:(NSError * __autoreleasing *)error __OSX_AVAILABLE(10.13)
+- (BOOL)swapItemAtURL:(NSURL *)originalItemURL withItemAtURL:(NSURL *)newItemURL error:(NSError * __autoreleasing *)error __OSX_AVAILABLE(10.13)
 {
     char originalPath[PATH_MAX] = {0};
     if (![originalItemURL.path getFileSystemRepresentation:originalPath maxLength:sizeof(originalPath)]) {
@@ -641,25 +641,9 @@ static BOOL SUMakeRefFromURL(NSURL *url, FSRef *ref, NSError **error) {
     return YES;
 }
 
-- (NSURL *)makeTemporaryDirectoryWithPreferredName:(NSString *)preferredName appropriateForDirectoryURL:(NSURL *)directoryURL error:(NSError * __autoreleasing *)error
+- (NSURL *)makeTemporaryDirectoryAppropriateForDirectoryURL:(NSURL *)directoryURL error:(NSError * __autoreleasing *)error
 {
-    NSError *tempError = nil;
-    NSURL *tempURL = [_fileManager URLForDirectory:NSItemReplacementDirectory inDomain:NSUserDomainMask appropriateForURL:directoryURL create:YES error:&tempError];
-
-    if (tempURL != nil) {
-        return tempURL;
-    }
-
-    // It is pretty unlikely in my testing we will get here, but just in case we do, we should create a directory inside
-    // the directory pointed by directoryURL, using the preferredName
-
-    NSURL *desiredURL = [directoryURL URLByAppendingPathComponent:preferredName];
-    NSUInteger tagIndex = 1;
-    while ([self _itemExistsAtURL:desiredURL] && tagIndex <= 9999) {
-        desiredURL = [directoryURL URLByAppendingPathComponent:[preferredName stringByAppendingFormat:@" (%lu)", (unsigned long)++tagIndex]];
-    }
-
-    return [self makeDirectoryAtURL:desiredURL error:error] ? desiredURL : nil;
+    return [_fileManager URLForDirectory:NSItemReplacementDirectory inDomain:NSUserDomainMask appropriateForURL:directoryURL create:YES error:error];
 }
 
 - (BOOL)removeItemAtURL:(NSURL *)url error:(NSError * __autoreleasing *)error

--- a/Tests/SUCodeSigningVerifierTest.m
+++ b/Tests/SUCodeSigningVerifierTest.m
@@ -53,7 +53,7 @@
     SUFileManager *fileManager = [[SUFileManager alloc] init];
     
     NSError *tempError = nil;
-    NSURL *tempDir = [fileManager makeTemporaryDirectoryWithPreferredName:unitTestBundleIdentifier appropriateForDirectoryURL:[NSURL fileURLWithPath:zippedAppURL] error:&tempError];
+    NSURL *tempDir = [fileManager makeTemporaryDirectoryAppropriateForDirectoryURL:[NSURL fileURLWithPath:zippedAppURL] error:&tempError];
 
     if (tempDir == nil) {
         XCTFail(@"Failed to create temporary directory with error: %@", tempError);

--- a/Tests/SUFileManagerTest.swift
+++ b/Tests/SUFileManagerTest.swift
@@ -13,8 +13,8 @@ class SUFileManagerTest: XCTestCase
     func makeTempFiles(_ testBlock: (SUFileManager, URL, URL, URL, URL, URL, URL) -> Void)
     {
         let fileManager = SUFileManager()
-
-        let tempDirectoryURL = try! fileManager.makeTemporaryDirectory(withPreferredName: "Sparkle Unit Test Data", appropriateForDirectoryURL: URL(fileURLWithPath: NSHomeDirectory()))
+        
+        let tempDirectoryURL = try! fileManager.makeTemporaryDirectoryAppropriate(forDirectoryURL: URL(fileURLWithPath: NSHomeDirectory()))
 
         defer {
             try! fileManager.removeItem(at: tempDirectoryURL)

--- a/Tests/SUSpotlightImporterTest.swift
+++ b/Tests/SUSpotlightImporterTest.swift
@@ -13,7 +13,7 @@ class SUSpotlightImporterTest: XCTestCase
     func testUpdatingSpotlightBundles()
     {
         let fileManager = SUFileManager()
-        let tempDirectoryURL = try! fileManager.makeTemporaryDirectory(withPreferredName: "Sparkle Unit Test Data", appropriateForDirectoryURL: URL(fileURLWithPath: NSHomeDirectory()))
+        let tempDirectoryURL = try! fileManager.makeTemporaryDirectoryAppropriate(forDirectoryURL: URL(fileURLWithPath: NSHomeDirectory()))
 
         let bundleDirectory = tempDirectoryURL.appendingPathComponent("bundle.app")
         try! fileManager.makeDirectory(at: bundleDirectory)


### PR DESCRIPTION
Fix volume detection being wrong in rare cases when the parent directory of the app is on a different volume (eg an app being installed in root directory of SMB mount). This should be rare and even if it occurs often not fatal.

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested temp directory used is correct across SMB mount and USB HFS+ drive, as well as normal apfs system.

macOS version tested:
12.0.1 (21A559)
10.12 VM