### PR TITLE
Improve pipe usage when unarchiving files

### DIFF
--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -221,11 +221,20 @@
             task.standardOutput = [NSPipe pipe];
             task.standardError = [NSPipe pipe];
             
-            @try {
-                [task launch];
-            } @catch (NSException *exception) {
-                SULog(SULogLevelError, @"Failed to unmount %@", mountPoint);
-                SULog(SULogLevelError, @"Exception: %@", exception);
+            
+            if (@available(macOS 10.13, *)) {
+                NSError *launchCleanupError = nil;
+                if (![task launchAndReturnError:&launchCleanupError]) {
+                    SULog(SULogLevelError, @"Failed to unmount %@", mountPoint);
+                    SULog(SULogLevelError, @"Error: %@", launchCleanupError);
+                }
+            } else {
+                @try {
+                    [task launch];
+                } @catch (NSException *exception) {
+                    SULog(SULogLevelError, @"Failed to unmount %@", mountPoint);
+                    SULog(SULogLevelError, @"Exception: %@", exception);
+                }
             }
         } else {
             SULog(SULogLevelError, @"Can't mount DMG %@", self.archivePath);

--- a/Autoupdate/SUGuidedPackageInstaller.m
+++ b/Autoupdate/SUGuidedPackageInstaller.m
@@ -53,8 +53,8 @@
     task.arguments = @[@"-pkg", self.packagePath, @"-target", @"/"];
     // Set the $HOME and $USER variables so pre/post install scripts reference the correct user environment
     task.environment = @{@"HOME": self.homeDirectory, @"USER": self.userName};
-    task.standardError = [NSPipe pipe];
-    task.standardOutput = [NSPipe pipe];
+    task.standardError = nil;
+    task.standardOutput = nil;
     
     BOOL success = YES;
     @try {

--- a/Autoupdate/SUGuidedPackageInstaller.m
+++ b/Autoupdate/SUGuidedPackageInstaller.m
@@ -56,23 +56,43 @@
     task.standardError = nil;
     task.standardOutput = nil;
     
-    BOOL success = YES;
-    @try {
-        [task launch];
-        [task waitUntilExit];
-        if (task.terminationStatus != EXIT_SUCCESS) {
-            success = NO;
+    if (@available(macOS 10.13, *)) {
+        NSError *launchError = nil;
+        if (![task launchAndReturnError:&launchError]) {
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Guided package installer returned non-zero exit status (%d)", task.terminationStatus] }];
+                NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey: @"Guided package installer failed to launch" }];
+                
+                if (launchError != nil) {
+                    userInfo[NSUnderlyingErrorKey] = launchError;
+                }
+                
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:userInfo];
             }
+            return NO;
         }
-    } @catch (NSException *) {
-        success = NO;
-        if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Guided package installer task threw an exception"] }];
+    } else {
+        @try {
+            [task launch];
+        } @catch (NSException *) {
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: @"Guided package installer task threw an exception" }];
+            }
+            
+            return NO;
         }
     }
-    return success;
+    
+    [task waitUntilExit];
+    
+    if (task.terminationStatus != EXIT_SUCCESS) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Guided package installer returned non-zero exit status (%d)", task.terminationStatus] }];
+        }
+        
+        return NO;
+    }
+    
+    return YES;
 }
 
 - (void)performCleanup

--- a/Tests/SUInstallerTest.m
+++ b/Tests/SUInstallerTest.m
@@ -37,8 +37,8 @@
 {
     uid_t uid = getuid();
 
-    if (uid) {
-        NSLog(@"Test must be run as root: sudo xctest -XCTest SUInstallerTest 'Sparkle Unit Tests.xctest'");
+    if (uid != 0) {
+        NSLog(@"Test must be run as root: sudo xcodebuild -project Sparkle.xcodeproj -scheme Sparkle '-only-testing:Sparkle Unit Tests/SUInstallerTest/testInstallIfRoot' test");
         return;
     }
 


### PR DESCRIPTION
Fix dmg unarchiving blocked pipe bug where readDataToEndOfFile supposedly can hang in rare cases (re: #2023)

Don't set pipes for guided package installer task.

Use newer NSData / NSFileHandle APIs too that populate an NSError

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Likely later I will get to this..
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested unit tests and both legacy (inverted-@available)/newer paths

Tested updating an application using a dmg and using a pkg with sparkle-cli.

I could not create any fake sample that exposes the bug this fixes.

macOS version tested: 12.0.1 (21A559)

