### PR TITLE
Fix silly bug in PR #1782.

### DIFF
--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -55,13 +55,13 @@ if [ "$ACTION" = "" ] ; then
     cp -R "$CONFIGURATION_BUILD_DIR/staging/bin" "$CONFIGURATION_BUILD_DIR/staging-spm"
 
     cd "$CONFIGURATION_BUILD_DIR/staging"
-    
+
     if [ -x "$(command -v xz)" ]; then
         XZ_EXISTS=1
     else
         XZ_EXISTS=0
     fi
-    
+
     rm -rf "/tmp/sparkle-extract"
     mkdir -p "/tmp/sparkle-extract"
 
@@ -88,7 +88,7 @@ if [ "$ACTION" = "" ] ; then
 
     rm -rf "/tmp/sparkle-extract"
     rm -rf "$CONFIGURATION_BUILD_DIR/staging"
-    
+
     # Generate zip containing the xcframework for SPM
     rm -rf "/tmp/sparkle-spm-extract"
     mkdir -p "/tmp/sparkle-spm-extract"
@@ -100,7 +100,7 @@ if [ "$ACTION" = "" ] ; then
     # This guards against our archives being corrupt / created incorrectly
     ditto -x -k "../Sparkle-for-Swift-Package-Manager.zip" "/tmp/sparkle-spm-extract"
     verify_code_signatures "/tmp/sparkle-spm-extract"
-    
+
     rm -rf "/tmp/sparkle-spm-extract"
     rm -rf "$CONFIGURATION_BUILD_DIR/staging-spm"
 
@@ -138,10 +138,10 @@ if [ "$ACTION" = "" ] ; then
     else
         echo "warning: Xcode version $XCODE_VERSION_ACTUAL does not support computing checksums for Swift Packages. Please update the Package manifest manually."
     fi
-    
-    if [ "$XZ_EXISTS" -eq 1 ] ; then
+
+    if [ "$XZ_EXISTS" -ne 1 ] ; then
         echo "WARNING: xz compression is used for official releases but bz2 is being used instead because xz tool is not installed on your system."
     fi
-        
+
     rm -rf "$CONFIGURATION_BUILD_DIR/staging-spm"
 fi


### PR DESCRIPTION
`make release` ends up with a note saying `xz` isn't installed even when it is and has been used without falling back to `bz2`.

Same fix applies to 2.x branch also. Requesting the person merging this PR to fix that too. Not creating a separate PR for that.

Fixes #1782

## Checklist:

- [ ] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [x] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested `build release` with `xz` installed. Didn't test without `xz` installed but it should trivially work. Requesting the person merging this PR to verify by eyeballing the change and/or by testing without `xz` installed.

macOS version tested: 10.15.7
