### PR TITLE
Isolate xar usage in its own archive type for delta patches

### DIFF
--- a/Autoupdate/SPUDeltaArchive.h
+++ b/Autoupdate/SPUDeltaArchive.h
@@ -1,0 +1,18 @@
+//
+//  SPUDeltaArchive.h
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 12/29/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol SPUDeltaArchiveProtocol;
+
+NS_ASSUME_NONNULL_BEGIN
+
+id<SPUDeltaArchiveProtocol> _Nullable SPUDeltaArchiveForReading(NSString *patchFile);
+id<SPUDeltaArchiveProtocol> _Nullable SPUDeltaArchiveForWriting(NSString *patchFile);
+
+NS_ASSUME_NONNULL_END

--- a/Autoupdate/SPUDeltaArchive.m
+++ b/Autoupdate/SPUDeltaArchive.m
@@ -1,0 +1,24 @@
+//
+//  SPUDeltaArchive.m
+//  Sparkle
+//
+//  Created by Mayur Pawashe on 12/29/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import "SPUDeltaArchive.h"
+#import "SPUDeltaArchiveProtocol.h"
+#import "SPUXarDeltaArchive.h"
+
+
+#include "AppKitPrevention.h"
+
+id<SPUDeltaArchiveProtocol> _Nullable SPUDeltaArchiveForReading(NSString *patchFile)
+{
+    return [[SPUXarDeltaArchive alloc] initWithPatchFileForReading:patchFile];
+}
+
+id<SPUDeltaArchiveProtocol> _Nullable SPUDeltaArchiveForWriting(NSString *patchFile)
+{
+    return [[SPUXarDeltaArchive alloc] initWithPatchFileForWriting:patchFile];
+}

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -1,0 +1,32 @@
+//
+//  SPUDeltaArchiveProtocol.h
+//  Autoupdate
+//
+//  Created by Mayur Pawashe on 12/28/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
+    SPUDeltaFileAttributesDelete = (1u << 0),
+    SPUDeltaFileAttributesExtract = (1u << 1),
+    SPUDeltaFileAttributesModifyPermissions = (1u << 2),
+    SPUDeltaFileAttributesBinaryDiff = (1u << 3),
+};
+
+@protocol SPUDeltaArchiveProtocol <NSObject>
+
++ (BOOL)getMajorDeltaVersion:(uint16_t *)outMajorDiffVersion minorDeltaVersion:(uint16_t *)outMinorDiffVersion fromPatchFile:(NSString *)patchFile;
+
+- (void)setMajorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(NSString *)beforeTreeHash afterTreeHash:(NSString *)afterTreeHash;
+
+- (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(nullable NSNumber *)permissions;
+
+- (void)close;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -10,6 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Attributes for an item we extract/write to the archive
 typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
     SPUDeltaFileAttributesDelete = (1u << 0),
     SPUDeltaFileAttributesExtract = (1u << 1),
@@ -17,25 +18,34 @@ typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
     SPUDeltaFileAttributesBinaryDiff = (1u << 3),
 };
 
+// A protocol for reading and writing binary delta patches
 @protocol SPUDeltaArchiveProtocol <NSObject>
 
 @property (nonatomic, readonly, class) BOOL maySupportSafeExtraction;
 
+// Closes file for reading/writing, called in -dealloc if it's not called manually
 - (void)close;
 
 // For reading
 
+// Retrieves metadata for the archive including major/minor version and expected bundle hashes
 - (void)getMajorDeltaVersion:(nullable uint16_t *)outMajorDiffVersion minorDeltaVersion:(nullable uint16_t *)outMinorDiffVersion beforeTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outBeforeTreeHash afterTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outAfterTreeHash;
 
+// Enumerate through items in the patch file and read the path, attributes, permissions (if permission attribute is available), and way to stop enumeration
 - (BOOL)enumerateItems:(void (^)(const void *item, NSString *relativePath, SPUDeltaFileAttributes attributes, uint16_t permissions, BOOL *stop))itemHandler;
 
+// Extract a file item from the patch file to a destination file
 - (BOOL)extractItem:(const void *)item destination:(NSString *)destinationPath;
 
 // For writing
 
+// Set metadata for archive including major/minor version and expected bundle hashes
 - (void)setMajorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(NSString *)beforeTreeHash afterTreeHash:(NSString *)afterTreeHash;
 
-- (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(nullable NSNumber *)permissions;
+// Add item to patch file
+// File path must be provided if there is a extract or binary delta attribute
+// Permissions are used only if there is a modify permissions attribute
+- (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(uint16_t)permissions;
 
 @end
 

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -19,13 +19,25 @@ typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
 
 @protocol SPUDeltaArchiveProtocol <NSObject>
 
+- (void)close;
+
+// For reading
+
+@property (nonatomic, readonly, class) BOOL supportsSafeExtraction;
+
 + (BOOL)getMajorDeltaVersion:(uint16_t *)outMajorDiffVersion minorDeltaVersion:(uint16_t *)outMinorDiffVersion fromPatchFile:(NSString *)patchFile;
+
+- (void)getMajorDeltaVersion:(nullable uint16_t *)outMajorDiffVersion minorDeltaVersion:(nullable uint16_t *)outMinorDiffVersion beforeTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outBeforeTreeHash afterTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outAfterTreeHash;
+
+- (BOOL)enumerateItems:(void (^)(const void *item, NSString *relativePath, SPUDeltaFileAttributes attributes, uint16_t permissions, BOOL *stop))itemHandler;
+
+- (BOOL)extractItem:(const void *)item destination:(NSString *)destinationPath;
+
+// For writing
 
 - (void)setMajorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(NSString *)beforeTreeHash afterTreeHash:(NSString *)afterTreeHash;
 
 - (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(nullable NSNumber *)permissions;
-
-- (void)close;
 
 @end
 

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
 
 // For reading
 
-@property (nonatomic, readonly, class) BOOL supportsSafeExtraction;
+@property (nonatomic, readonly, class) BOOL maySupportSafeExtraction;
 
 - (void)getMajorDeltaVersion:(nullable uint16_t *)outMajorDiffVersion minorDeltaVersion:(nullable uint16_t *)outMinorDiffVersion beforeTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outBeforeTreeHash afterTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outAfterTreeHash;
 

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -19,11 +19,11 @@ typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
 
 @protocol SPUDeltaArchiveProtocol <NSObject>
 
+@property (nonatomic, readonly, class) BOOL maySupportSafeExtraction;
+
 - (void)close;
 
 // For reading
-
-@property (nonatomic, readonly, class) BOOL maySupportSafeExtraction;
 
 - (void)getMajorDeltaVersion:(nullable uint16_t *)outMajorDiffVersion minorDeltaVersion:(nullable uint16_t *)outMinorDiffVersion beforeTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outBeforeTreeHash afterTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outAfterTreeHash;
 

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -25,8 +25,6 @@ typedef NS_ENUM(uint8_t, SPUDeltaFileAttributes) {
 
 @property (nonatomic, readonly, class) BOOL supportsSafeExtraction;
 
-+ (BOOL)getMajorDeltaVersion:(uint16_t *)outMajorDiffVersion minorDeltaVersion:(uint16_t *)outMinorDiffVersion fromPatchFile:(NSString *)patchFile;
-
 - (void)getMajorDeltaVersion:(nullable uint16_t *)outMajorDiffVersion minorDeltaVersion:(nullable uint16_t *)outMinorDiffVersion beforeTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outBeforeTreeHash afterTreeHash:(NSString * _Nullable __autoreleasing * _Nullable)outAfterTreeHash;
 
 - (BOOL)enumerateItems:(void (^)(const void *item, NSString *relativePath, SPUDeltaFileAttributes attributes, uint16_t permissions, BOOL *stop))itemHandler;

--- a/Autoupdate/SPUXarDeltaArchive.h
+++ b/Autoupdate/SPUXarDeltaArchive.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SPUXarDeltaArchive : NSObject <SPUDeltaArchiveProtocol>
 
 - (nullable instancetype)initWithPatchFileForWriting:(NSString *)patchFile;
+- (nullable instancetype)initWithPatchFileForReading:(NSString *)patchFile;
 
 @end
 

--- a/Autoupdate/SPUXarDeltaArchive.h
+++ b/Autoupdate/SPUXarDeltaArchive.h
@@ -1,0 +1,21 @@
+//
+//  SPUXarDeltaArchive.h
+//  Autoupdate
+//
+//  Created by Mayur Pawashe on 12/28/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "SPUDeltaArchiveProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SPUXarDeltaArchive : NSObject <SPUDeltaArchiveProtocol>
+
+- (nullable instancetype)initWithPatchFileForWriting:(NSString *)patchFile;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -49,18 +49,6 @@ extern char *xar_get_safe_path(xar_file_t f) __attribute__((weak_import));
 @synthesize x = _x;
 @synthesize fileTable = _fileTable;
 
-+ (BOOL)getMajorDeltaVersion:(uint16_t *)outMajorDiffVersion minorDeltaVersion:(uint16_t *)outMinorDiffVersion fromPatchFile:(NSString *)patchFile
-{
-    SPUXarDeltaArchive *archive = [[SPUXarDeltaArchive alloc] initWithPatchFileForReading:patchFile];
-    if (archive == nil) {
-        return NO;
-    }
-    
-    [archive getMajorDeltaVersion:outMajorDiffVersion minorDeltaVersion:outMinorDiffVersion beforeTreeHash:NULL afterTreeHash:NULL];
-    
-    return YES;
-}
-
 - (nullable instancetype)initWithPatchFileForWriting:(NSString *)patchFile
 {
     self = [super init];

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -1,0 +1,182 @@
+//
+//  SPUXarDeltaArchive.m
+//  Autoupdate
+//
+//  Created by Mayur Pawashe on 12/28/21.
+//  Copyright © 2021 Sparkle Project. All rights reserved.
+//
+
+#import "SPUXarDeltaArchive.h"
+#include <xar/xar.h>
+#include "SUBinaryDeltaCommon.h"
+
+#include "AppKitPrevention.h"
+
+@interface SPUXarDeltaArchive ()
+
+@property (nonatomic) xar_t x;
+@property (nonatomic, readonly) NSMutableDictionary<NSString *, NSValue *> *fileTable;
+
+@end
+
+@implementation SPUXarDeltaArchive
+
+@synthesize x = _x;
+@synthesize fileTable = _fileTable;
+
++ (BOOL)getMajorDeltaVersion:(uint16_t *)outMajorDiffVersion minorDeltaVersion:(uint16_t *)outMinorDiffVersion fromPatchFile:(NSString *)patchFile
+{
+    xar_t x = xar_open([patchFile fileSystemRepresentation], READ);
+    if (x == NULL) {
+        return NO;
+    }
+
+    uint16_t majorDiffVersion = FIRST_DELTA_DIFF_MAJOR_VERSION;
+    uint16_t minorDiffVersion = 0;
+
+    xar_subdoc_t subdoc;
+    for (subdoc = xar_subdoc_first(x); subdoc; subdoc = xar_subdoc_next(subdoc)) {
+        if (strcmp(xar_subdoc_name(subdoc), BINARY_DELTA_ATTRIBUTES_KEY) == 0) {
+            {
+                // available in version 2.0 or later
+                const char *value = NULL;
+                xar_subdoc_prop_get(subdoc, MAJOR_DIFF_VERSION_KEY, &value);
+                if (value != NULL) {
+                    majorDiffVersion = (uint16_t)[@(value) intValue];
+                }
+            }
+
+            {
+                // available in version 2.0 or later
+                const char *value = NULL;
+                xar_subdoc_prop_get(subdoc, MINOR_DIFF_VERSION_KEY, &value);
+                if (value != NULL) {
+                    minorDiffVersion = (uint16_t)[@(value) intValue];
+                }
+            }
+        }
+    }
+    
+    if (outMajorDiffVersion != NULL) {
+        *outMajorDiffVersion = majorDiffVersion;
+    }
+    
+    if (outMinorDiffVersion != NULL) {
+        *outMinorDiffVersion = minorDiffVersion;
+    }
+    
+    xar_close(x);
+    return YES;
+}
+
+- (nullable instancetype)initWithPatchFileForWriting:(NSString *)patchFile
+{
+    self = [super init];
+    if (self != nil) {
+        _x = xar_open(patchFile.fileSystemRepresentation, WRITE);
+        if (_x == NULL) {
+            return nil;
+        }
+        
+        _fileTable = [NSMutableDictionary dictionary];
+        xar_opt_set(_x, XAR_OPT_COMPRESSION, "bzip2");
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [self close];
+}
+
+- (void)close
+{
+    if (self.x != NULL) {
+        xar_close(self.x);
+        self.x = NULL;
+    }
+}
+
+- (void)setMajorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(NSString *)beforeTreeHash afterTreeHash:(NSString *)afterTreeHash
+{
+    xar_subdoc_t attributes = xar_subdoc_new(self.x, BINARY_DELTA_ATTRIBUTES_KEY);
+    
+    xar_subdoc_prop_set(attributes, MAJOR_DIFF_VERSION_KEY, [[NSString stringWithFormat:@"%u", majorVersion] UTF8String]);
+    xar_subdoc_prop_set(attributes, MINOR_DIFF_VERSION_KEY, [[NSString stringWithFormat:@"%u", minorVersion] UTF8String]);
+    
+    xar_subdoc_prop_set(attributes, BEFORE_TREE_SHA1_KEY, [beforeTreeHash UTF8String]);
+    xar_subdoc_prop_set(attributes, AFTER_TREE_SHA1_KEY, [afterTreeHash UTF8String]);
+}
+
+static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTable, xar_t x, NSString *relativePath, NSString *filePath)
+{
+    NSArray<NSString *> *rootRelativePathComponents = relativePath.pathComponents;
+    // Relative path must at least have starting "/" component and one more path component
+    if (rootRelativePathComponents.count < 2) {
+        return NULL;
+    }
+    
+    NSArray<NSString *> *relativePathComponents = [rootRelativePathComponents subarrayWithRange:NSMakeRange(1, rootRelativePathComponents.count - 1)];
+    
+    NSUInteger relativePathComponentsCount = relativePathComponents.count;
+    
+    // Build parent files as needed until we get to our final file we want to add
+    // So if we get "Contents/Resources/foo.txt", we will first add "Contents" parent,
+    // then "Resources" parent, then "foo.txt" as the final entry we want to add
+    // We store every file we add into a fileTable for easy referencing
+    // Note if a diff has Contents/Resources/foo/ and Contents/Resources/foo/bar.txt,
+    // due to sorting order we will add the foo directory first and won't end up with
+    // mis-ordering bugs
+    xar_file_t lastParent = NULL;
+    for (NSUInteger componentIndex = 0; componentIndex < relativePathComponentsCount; componentIndex++) {
+        NSArray<NSString *> *subpathComponents = [relativePathComponents subarrayWithRange:NSMakeRange(0, componentIndex + 1)];
+        NSString *subpathKey = [subpathComponents componentsJoinedByString:@"/"];
+        
+        xar_file_t cachedFile = [fileTable[subpathKey] pointerValue];
+        if (cachedFile != NULL) {
+            lastParent = cachedFile;
+        } else {
+            xar_file_t newParent;
+            
+            BOOL atLastIndex = (componentIndex == relativePathComponentsCount - 1);
+            
+            NSString *lastPathComponent = subpathComponents.lastObject;
+            if (atLastIndex && filePath != nil) {
+                newParent = xar_add_frompath(x, lastParent, lastPathComponent.fileSystemRepresentation, filePath.fileSystemRepresentation);
+            } else {
+                newParent = xar_add_frombuffer(x, lastParent, lastPathComponent.fileSystemRepresentation, "", 1);
+            }
+            
+            lastParent = newParent;
+            fileTable[subpathKey] = [NSValue valueWithPointer:newParent];
+        }
+    }
+    return lastParent;
+}
+
+- (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(nullable NSNumber *)permissions
+{
+    xar_file_t newFile = _xarAddFile(self.fileTable, self.x, relativeFilePath, filePath);
+    assert(newFile != NULL);
+    
+    if ((attributes & SPUDeltaFileAttributesDelete) != 0) {
+        xar_prop_set(newFile, DELETE_KEY, "true");
+    }
+    
+    if ((attributes & SPUDeltaFileAttributesExtract) != 0) {
+        xar_prop_set(newFile, EXTRACT_KEY, "true");
+    }
+    
+    if ((attributes & SPUDeltaFileAttributesBinaryDiff) != 0) {
+        xar_prop_set(newFile, BINARY_DELTA_KEY, "true");
+    }
+    
+    if ((attributes & SPUDeltaFileAttributesModifyPermissions) != 0) {
+        assert(permissions != nil);
+        if (permissions != nil) {
+            xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [NSString stringWithFormat:@"%u", permissions.unsignedShortValue].UTF8String);
+        }
+    }
+}
+
+@end

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -261,13 +261,19 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     for (xar_file_t file = xar_file_first(self.x, iter); file; file = xar_file_next(iter)) {
         char *pathCString;
 #if HAS_XAR_GET_SAFE_PATH
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
         if (xar_get_safe_path != NULL) {
             pathCString = xar_get_safe_path(file);
         }
+#pragma clang diagnostic pop
         else
 #endif
         {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             pathCString = xar_get_path(file);
+#pragma clang diagnostic pop
         }
         
         if (pathCString == NULL) {

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -89,7 +89,8 @@ extern char *xar_get_safe_path(xar_file_t f) __attribute__((weak_import));
     }
 }
 
-+ (BOOL)supportsSafeExtraction
+// This indicates if safe extraction is available at compile time (SDK), but not if it's available at runtime.
++ (BOOL)maySupportSafeExtraction
 {
     return HAS_XAR_GET_SAFE_PATH;
 }

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -218,7 +218,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     return lastParent;
 }
 
-- (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(nullable NSNumber *)permissions
+- (void)addRelativeFilePath:(NSString *)relativeFilePath realFilePath:(nullable NSString *)filePath attributes:(SPUDeltaFileAttributes)attributes permissions:(uint16_t)permissions
 {
     xar_file_t newFile = _xarAddFile(self.fileTable, self.x, relativeFilePath, filePath);
     assert(newFile != NULL);
@@ -236,10 +236,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     }
     
     if ((attributes & SPUDeltaFileAttributesModifyPermissions) != 0) {
-        assert(permissions != nil);
-        if (permissions != nil) {
-            xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [NSString stringWithFormat:@"%u", permissions.unsignedShortValue].UTF8String);
-        }
+        xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [NSString stringWithFormat:@"%u", permissions].UTF8String);
     }
 }
 

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -8,8 +8,9 @@
 
 #import "SUBinaryDeltaApply.h"
 #import "SUBinaryDeltaCommon.h"
-#import "SPUXarDeltaArchive.h"
-#include <CommonCrypto/CommonDigest.h>
+#import "SPUDeltaArchiveProtocol.h"
+#import "SPUDeltaArchive.h"
+#import <CommonCrypto/CommonDigest.h>
 #import <Foundation/Foundation.h>
 #include "bspatch.h"
 #include <stdio.h>
@@ -18,7 +19,7 @@
 
 #include "AppKitPrevention.h"
 
-static BOOL applyBinaryDeltaToFile(SPUXarDeltaArchive *archive, const void *item, NSString *sourceFilePath, NSString *destinationFilePath)
+static BOOL applyBinaryDeltaToFile(id<SPUDeltaArchiveProtocol> archive, const void *item, NSString *sourceFilePath, NSString *destinationFilePath)
 {
     NSString *patchFile = temporaryFilename(@"apply-binary-delta");
     if (![archive extractItem:item destination:patchFile]) {
@@ -33,7 +34,7 @@ static BOOL applyBinaryDeltaToFile(SPUXarDeltaArchive *archive, const void *item
 
 BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, BOOL verbose, void (^progressCallback)(double progress), NSError *__autoreleasing *error)
 {
-    id<SPUDeltaArchiveProtocol> archive = [[SPUXarDeltaArchive alloc] initWithPatchFileForReading:patchFile];
+    id<SPUDeltaArchiveProtocol> archive = SPUDeltaArchiveForReading(patchFile);
     if (archive == nil) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to open %@. Giving up.", patchFile] }];

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -74,7 +74,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
     
     // Reject patches that did not generate valid hierarchical xar container paths
     // These will not succeed to patch using recent versions of BinaryDelta
-    if ([[archive class] supportsSafeExtraction] && majorDiffVersion == SUBinaryDeltaMajorVersion2 && minorDiffVersion < 3) {
+    if ([[archive class] maySupportSafeExtraction] && majorDiffVersion == SUBinaryDeltaMajorVersion2 && minorDiffVersion < 3) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadCorruptFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"This patch version (%u.%u) is too old and potentially unsafe to apply. Please re-generate the patch using the latest version of BinaryDelta or generate_appcast. New version %u.%u patches will still be compatible with older versions of Sparkle.", majorDiffVersion, minorDiffVersion, majorDiffVersion, latestMinorVersionForMajorVersion(majorDiffVersion)] }];
         }

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -295,7 +295,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
             removedFile = YES;
         }
 
-        if (!xar_prop_get(file, BINARY_DELTA_KEY, &value)) {
+        if (xar_prop_get(file, BINARY_DELTA_KEY, &value) == 0) {
             if (!applyBinaryDeltaToFile(x, file, sourceFilePath, destinationFilePath)) {
                 xar_close(x);
                 

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -32,11 +32,6 @@
 #define BINARY_DELTA_KEY "binary-delta"
 #define MODIFY_PERMISSIONS_KEY "mod-permissions"
 
-// Properties no longer used in new patches
-#define DELETE_THEN_EXTRACT_OLD_KEY "delete-then-extract"
-#define BEFORE_TREE_SHA1_OLD_KEY "before-sha1"
-#define AFTER_TREE_SHA1_OLD_KEY "after-sha1"
-
 #define VERBOSE_DELETED "Deleted" // file is deleted from the file system when applying a patch
 #define VERBOSE_REMOVED "Removed" // file is set to be removed when creating a patch
 #define VERBOSE_ADDED "Added" // file is added to the patch or file system
@@ -53,11 +48,13 @@
 
 typedef NS_ENUM(uint16_t, SUBinaryDeltaMajorVersion)
 {
+    // Note: support for creating or applying version 1 deltas have been removed
     SUBinaryDeltaMajorVersion1 = 1,
     SUBinaryDeltaMajorVersion2 = 2
 };
 
 #define FIRST_DELTA_DIFF_MAJOR_VERSION SUBinaryDeltaMajorVersion1
+#define FIRST_SUPPORTED_DELTA_MAJOR_VERSION SUBinaryDeltaMajorVersion2
 #define LATEST_DELTA_DIFF_MAJOR_VERSION SUBinaryDeltaMajorVersion2
 
 extern int compareFiles(const FTSENT **a, const FTSENT **b);

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -67,5 +67,5 @@ extern NSString *pathRelativeToDirectory(NSString *directory, NSString *path);
 NSString *temporaryFilename(NSString *base);
 NSString *temporaryDirectory(NSString *base);
 NSString *stringWithFileSystemRepresentation(const char*);
-int latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion);
+uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion);
 #endif

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -22,16 +22,6 @@
 #define APPLE_CODE_SIGN_XATTR_CODE_REQUIREMENTS_KEY "com.apple.cs.CodeRequirements"
 #define APPLE_CODE_SIGN_XATTR_CODE_SIGNATURE_KEY "com.apple.cs.CodeSignature"
 
-#define BINARY_DELTA_ATTRIBUTES_KEY "binary-delta-attributes"
-#define MAJOR_DIFF_VERSION_KEY "major-version"
-#define MINOR_DIFF_VERSION_KEY "minor-version"
-#define BEFORE_TREE_SHA1_KEY "before-tree-sha1"
-#define AFTER_TREE_SHA1_KEY "after-tree-sha1"
-#define DELETE_KEY "delete"
-#define EXTRACT_KEY "extract"
-#define BINARY_DELTA_KEY "binary-delta"
-#define MODIFY_PERMISSIONS_KEY "mod-permissions"
-
 #define VERBOSE_DELETED "Deleted" // file is deleted from the file system when applying a patch
 #define VERBOSE_REMOVED "Removed" // file is set to be removed when creating a patch
 #define VERBOSE_ADDED "Added" // file is added to the patch or file system

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -16,7 +16,6 @@
 #include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <xar/xar.h>
 
 #include "AppKitPrevention.h"
 
@@ -39,7 +38,7 @@ NSString *stringWithFileSystemRepresentation(const char *input)
     return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:input length:strlen(input)];
 }
 
-int latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion)
+uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion)
 {
     switch (majorVersion) {
         case SUBinaryDeltaMajorVersion1:
@@ -137,7 +136,7 @@ static BOOL _hashOfFileContents(unsigned char *hash, FTSENT *ent)
     return YES;
 }
 
-NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
+NSString *hashOfTreeWithVersion(NSString *path, uint16_t __unused majorVersion)
 {
     char pathBuffer[PATH_MAX] = { 0 };
     if (![path getFileSystemRepresentation:pathBuffer maxLength:sizeof(pathBuffer)]) {

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -162,10 +162,6 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
         if (ent->fts_info != FTS_F && ent->fts_info != FTS_SL && ent->fts_info != FTS_D)
             continue;
 
-        if (ent->fts_info == FTS_D && !MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2)) {
-            continue;
-        }
-
         NSString *relativePath = pathRelativeToDirectory(normalizedPath, stringWithFileSystemRepresentation(ent->fts_path));
         if (relativePath.length == 0)
             continue;
@@ -179,19 +175,17 @@ NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion)
         const char *relativePathBytes = [relativePath fileSystemRepresentation];
         CC_SHA1_Update(&hashContext, relativePathBytes, (CC_LONG)strlen(relativePathBytes));
 
-        if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2)) {
-            uint16_t mode = ent->fts_statp->st_mode;
-            // permission of symlinks is irrelevant and can't be changed.
-            // hardcoding a value helps avoid differences between filesystems.
-            if (ent->fts_info == FTS_SL) {
-                mode = 0755;
-            }
-            uint16_t type = ent->fts_info;
-            uint16_t permissions = mode & PERMISSION_FLAGS;
-
-            CC_SHA1_Update(&hashContext, &type, sizeof(type));
-            CC_SHA1_Update(&hashContext, &permissions, sizeof(permissions));
+        uint16_t mode = ent->fts_statp->st_mode;
+        // permission of symlinks is irrelevant and can't be changed.
+        // hardcoding a value helps avoid differences between filesystems.
+        if (ent->fts_info == FTS_SL) {
+            mode = 0755;
         }
+        uint16_t type = ent->fts_info;
+        uint16_t permissions = mode & PERMISSION_FLAGS;
+
+        CC_SHA1_Update(&hashContext, &type, sizeof(type));
+        CC_SHA1_Update(&hashContext, &permissions, sizeof(permissions));
     }
     fts_close(fts);
 

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -501,7 +501,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         id value = [newTreeState valueForKey:key];
 
         if ([(NSObject *)value isEqual:[NSNull null]]) {
-            [archive addRelativeFilePath:key realFilePath:nil attributes:SPUDeltaFileAttributesDelete permissions:nil];
+            [archive addRelativeFilePath:key realFilePath:nil attributes:SPUDeltaFileAttributesDelete permissions:0];
 
             if (verbose) {
                 fprintf(stderr, "\n❌  %s %s", VERBOSE_REMOVED, [key fileSystemRepresentation]);
@@ -514,7 +514,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         if (shouldSkipDeltaCompression(originalInfo, newInfo)) {
             if (shouldSkipExtracting(originalInfo, newInfo)) {
                 if (shouldChangePermissions(originalInfo, newInfo)) {
-                    [archive addRelativeFilePath:key realFilePath:nil attributes:SPUDeltaFileAttributesModifyPermissions permissions:(NSNumber *)newInfo[INFO_PERMISSIONS_KEY]];
+                    [archive addRelativeFilePath:key realFilePath:nil attributes:SPUDeltaFileAttributesModifyPermissions permissions:[(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]];
 
                     if (verbose) {
                         fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, [key fileSystemRepresentation], [(NSNumber *)originalInfo[INFO_PERMISSIONS_KEY] unsignedShortValue], [(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]);
@@ -525,7 +525,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 
                 SPUDeltaFileAttributes attributes = shouldDeleteThenExtract(originalInfo, newInfo) ? (SPUDeltaFileAttributesDelete | SPUDeltaFileAttributesExtract) : SPUDeltaFileAttributesExtract;
                 
-                [archive addRelativeFilePath:key realFilePath:path attributes:attributes permissions:nil];
+                [archive addRelativeFilePath:key realFilePath:path attributes:attributes permissions:0];
 
                 if (verbose) {
                     if (originalInfo) {
@@ -569,7 +569,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         
         SPUDeltaFileAttributes attributes = (permissions != nil) ? (SPUDeltaFileAttributesBinaryDiff | SPUDeltaFileAttributesModifyPermissions) : SPUDeltaFileAttributesBinaryDiff;
         
-        [archive addRelativeFilePath:relativePath realFilePath:resultPath attributes:attributes permissions:permissions];
+        [archive addRelativeFilePath:relativePath realFilePath:resultPath attributes:attributes permissions:permissions.unsignedShortValue];
         
         unlink(resultPath.fileSystemRepresentation);
 

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -530,12 +530,8 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
     xar_subdoc_prop_set(attributes, MAJOR_DIFF_VERSION_KEY, [[NSString stringWithFormat:@"%u", majorVersion] UTF8String]);
     xar_subdoc_prop_set(attributes, MINOR_DIFF_VERSION_KEY, [[NSString stringWithFormat:@"%u", minorVersion] UTF8String]);
 
-    // Version 1 patches don't have a major or minor version field, so we need to differentiate between the hash keys
-    const char *beforeHashKey = MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2) ? BEFORE_TREE_SHA1_KEY : BEFORE_TREE_SHA1_OLD_KEY;
-    const char *afterHashKey = MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2) ? AFTER_TREE_SHA1_KEY : AFTER_TREE_SHA1_OLD_KEY;
-
-    xar_subdoc_prop_set(attributes, beforeHashKey, [beforeHash UTF8String]);
-    xar_subdoc_prop_set(attributes, afterHashKey, [afterHash UTF8String]);
+    xar_subdoc_prop_set(attributes, BEFORE_TREE_SHA1_KEY, [beforeHash UTF8String]);
+    xar_subdoc_prop_set(attributes, AFTER_TREE_SHA1_KEY, [afterHash UTF8String]);
 
     NSOperationQueue *deltaQueue = [[NSOperationQueue alloc] init];
     NSMutableArray *deltaOperations = [NSMutableArray array];
@@ -570,7 +566,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         NSDictionary *originalInfo = originalTreeState[key];
         NSDictionary *newInfo = newTreeState[key];
         if (shouldSkipDeltaCompression(originalInfo, newInfo)) {
-            if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2) && shouldSkipExtracting(originalInfo, newInfo)) {
+            if (shouldSkipExtracting(originalInfo, newInfo)) {
                 if (shouldChangePermissions(originalInfo, newInfo)) {
                     xar_file_t newFile = _xarAddFile(fileTable, x, key, NULL);
                     assert(newFile);
@@ -586,16 +582,10 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 assert(newFile);
 
                 if (shouldDeleteThenExtract(originalInfo, newInfo)) {
-                    if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2)) {
-                        xar_prop_set(newFile, DELETE_KEY, "true");
-                    } else {
-                        xar_prop_set(newFile, DELETE_THEN_EXTRACT_OLD_KEY, "true");
-                    }
+                    xar_prop_set(newFile, DELETE_KEY, "true");
                 }
-
-                if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2)) {
-                    xar_prop_set(newFile, EXTRACT_KEY, "true");
-                }
+                
+                xar_prop_set(newFile, EXTRACT_KEY, "true");
 
                 if (verbose) {
                     if (originalInfo) {
@@ -607,7 +597,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             }
         } else {
             NSNumber *permissions =
-                (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion2) && shouldChangePermissions(originalInfo, newInfo)) ?
+                shouldChangePermissions(originalInfo, newInfo) ?
                 newInfo[INFO_PERMISSIONS_KEY] :
                 nil;
             CreateBinaryDeltaOperation *operation = [[CreateBinaryDeltaOperation alloc] initWithRelativePath:key oldTree:source newTree:destination oldPermissions:originalInfo[INFO_PERMISSIONS_KEY] newPermissions:permissions];

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -21,7 +21,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sys/xattr.h>
-#include <xar/xar.h>
 
 
 #include "AppKitPrevention.h"

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -9,6 +9,7 @@
 #import "SUBinaryDeltaCreate.h"
 #import <Foundation/Foundation.h>
 #include "SUBinaryDeltaCommon.h"
+#import "SPUXarDeltaArchive.h"
 #import <CommonCrypto/CommonDigest.h>
 #include <fcntl.h>
 #include <fts.h>
@@ -20,6 +21,7 @@
 #include <unistd.h>
 #include <sys/xattr.h>
 #include <xar/xar.h>
+
 
 #include "AppKitPrevention.h"
 
@@ -248,52 +250,6 @@ static BOOL shouldChangePermissions(NSDictionary *originalInfo, NSDictionary *ne
     return YES;
 }
 
-static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTable, xar_t x, NSString *relativePath, NSString *filePath)
-{
-    NSArray<NSString *> *rootRelativePathComponents = relativePath.pathComponents;
-    // Relative path must at least have starting "/" component and one more path component
-    if (rootRelativePathComponents.count < 2) {
-        return NULL;
-    }
-    
-    NSArray<NSString *> *relativePathComponents = [rootRelativePathComponents subarrayWithRange:NSMakeRange(1, rootRelativePathComponents.count - 1)];
-    
-    NSUInteger relativePathComponentsCount = relativePathComponents.count;
-    
-    // Build parent files as needed until we get to our final file we want to add
-    // So if we get "Contents/Resources/foo.txt", we will first add "Contents" parent,
-    // then "Resources" parent, then "foo.txt" as the final entry we want to add
-    // We store every file we add into a fileTable for easy referencing
-    // Note if a diff has Contents/Resources/foo/ and Contents/Resources/foo/bar.txt,
-    // due to sorting order we will add the foo directory first and won't end up with
-    // mis-ordering bugs
-    xar_file_t lastParent = NULL;
-    for (NSUInteger componentIndex = 0; componentIndex < relativePathComponentsCount; componentIndex++) {
-        NSArray<NSString *> *subpathComponents = [relativePathComponents subarrayWithRange:NSMakeRange(0, componentIndex + 1)];
-        NSString *subpathKey = [subpathComponents componentsJoinedByString:@"/"];
-        
-        xar_file_t cachedFile = [fileTable[subpathKey] pointerValue];
-        if (cachedFile != NULL) {
-            lastParent = cachedFile;
-        } else {
-            xar_file_t newParent;
-            
-            BOOL atLastIndex = (componentIndex == relativePathComponentsCount - 1);
-            
-            NSString *lastPathComponent = subpathComponents.lastObject;
-            if (atLastIndex && filePath != nil) {
-                newParent = xar_add_frompath(x, lastParent, lastPathComponent.fileSystemRepresentation, filePath.fileSystemRepresentation);
-            } else {
-                newParent = xar_add_frombuffer(x, lastParent, lastPathComponent.fileSystemRepresentation, "", 1);
-            }
-            
-            lastParent = newParent;
-            fileTable[subpathKey] = [NSValue valueWithPointer:newParent];
-        }
-    }
-    return lastParent;
-}
-
 BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchFile, SUBinaryDeltaMajorVersion majorVersion, BOOL verbose, NSError *__autoreleasing *error)
 {
     assert(source);
@@ -301,7 +257,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
     assert(patchFile);
     assert(majorVersion >= FIRST_DELTA_DIFF_MAJOR_VERSION && majorVersion <= LATEST_DELTA_DIFF_MAJOR_VERSION);
 
-    int minorVersion = latestMinorVersionForMajorVersion(majorVersion);
+    uint16_t minorVersion = latestMinorVersionForMajorVersion(majorVersion);
 
     NSMutableDictionary *originalTreeState = [NSMutableDictionary dictionary];
 
@@ -512,8 +468,9 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
     if (verbose) {
         fprintf(stderr, "\nWriting to temporary file %s...", [temporaryFile fileSystemRepresentation]);
     }
-    xar_t x = xar_open([temporaryFile fileSystemRepresentation], WRITE);
-    if (!x) {
+    
+    id<SPUDeltaArchiveProtocol> archive = [[SPUXarDeltaArchive alloc] initWithPatchFileForWriting:temporaryFile];
+    if (archive == nil) {
         if (verbose) {
             fprintf(stderr, "\n");
         }
@@ -522,16 +479,8 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         }
         return NO;
     }
-
-    xar_opt_set(x, XAR_OPT_COMPRESSION, "bzip2");
-
-    xar_subdoc_t attributes = xar_subdoc_new(x, BINARY_DELTA_ATTRIBUTES_KEY);
-
-    xar_subdoc_prop_set(attributes, MAJOR_DIFF_VERSION_KEY, [[NSString stringWithFormat:@"%u", majorVersion] UTF8String]);
-    xar_subdoc_prop_set(attributes, MINOR_DIFF_VERSION_KEY, [[NSString stringWithFormat:@"%u", minorVersion] UTF8String]);
-
-    xar_subdoc_prop_set(attributes, BEFORE_TREE_SHA1_KEY, [beforeHash UTF8String]);
-    xar_subdoc_prop_set(attributes, AFTER_TREE_SHA1_KEY, [afterHash UTF8String]);
+    
+    [archive setMajorVersion:majorVersion minorVersion:minorVersion beforeTreeHash:beforeHash afterTreeHash:afterHash];
 
     NSOperationQueue *deltaQueue = [[NSOperationQueue alloc] init];
     NSMutableArray *deltaOperations = [NSMutableArray array];
@@ -546,16 +495,12 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
       return originalTreeState[key1] ? NSOrderedAscending : NSOrderedDescending;
     }];
-    
-    NSMutableDictionary<NSString *, NSValue *> *fileTable = [NSMutableDictionary dictionary];
-    
+
     for (NSString *key in keys) {
         id value = [newTreeState valueForKey:key];
 
         if ([(NSObject *)value isEqual:[NSNull null]]) {
-            xar_file_t newFile = _xarAddFile(fileTable, x, key, NULL);
-            assert(newFile);
-            xar_prop_set(newFile, DELETE_KEY, "true");
+            [archive addRelativeFilePath:key realFilePath:nil attributes:SPUDeltaFileAttributesDelete permissions:nil];
 
             if (verbose) {
                 fprintf(stderr, "\n❌  %s %s", VERBOSE_REMOVED, [key fileSystemRepresentation]);
@@ -568,9 +513,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         if (shouldSkipDeltaCompression(originalInfo, newInfo)) {
             if (shouldSkipExtracting(originalInfo, newInfo)) {
                 if (shouldChangePermissions(originalInfo, newInfo)) {
-                    xar_file_t newFile = _xarAddFile(fileTable, x, key, NULL);
-                    assert(newFile);
-                    xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [[NSString stringWithFormat:@"%u", [(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]] UTF8String]);
+                    [archive addRelativeFilePath:key realFilePath:nil attributes:SPUDeltaFileAttributesModifyPermissions permissions:(NSNumber *)newInfo[INFO_PERMISSIONS_KEY]];
 
                     if (verbose) {
                         fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, [key fileSystemRepresentation], [(NSNumber *)originalInfo[INFO_PERMISSIONS_KEY] unsignedShortValue], [(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]);
@@ -578,14 +521,10 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 }
             } else {
                 NSString *path = [destination stringByAppendingPathComponent:key];
-                xar_file_t newFile = _xarAddFile(fileTable, x, key, path);
-                assert(newFile);
-
-                if (shouldDeleteThenExtract(originalInfo, newInfo)) {
-                    xar_prop_set(newFile, DELETE_KEY, "true");
-                }
                 
-                xar_prop_set(newFile, EXTRACT_KEY, "true");
+                SPUDeltaFileAttributes attributes = shouldDeleteThenExtract(originalInfo, newInfo) ? (SPUDeltaFileAttributesDelete | SPUDeltaFileAttributesExtract) : SPUDeltaFileAttributesExtract;
+                
+                [archive addRelativeFilePath:key realFilePath:path attributes:attributes permissions:nil];
 
                 if (verbose) {
                     if (originalInfo) {
@@ -610,7 +549,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
     for (CreateBinaryDeltaOperation *operation in deltaOperations) {
         NSString *resultPath = [operation resultPath];
-        if (!resultPath) {
+        if (resultPath == nil) {
             if (verbose) {
                 fprintf(stderr, "\n");
             }
@@ -623,22 +562,24 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         if (verbose) {
             fprintf(stderr, "\n🔨  %s %s", VERBOSE_DIFFED, [[operation relativePath] fileSystemRepresentation]);
         }
+        
+        NSNumber *permissions = operation.permissions;
+        NSString *relativePath = operation.relativePath;
+        
+        SPUDeltaFileAttributes attributes = (permissions != nil) ? (SPUDeltaFileAttributesBinaryDiff | SPUDeltaFileAttributesModifyPermissions) : SPUDeltaFileAttributesBinaryDiff;
+        
+        [archive addRelativeFilePath:relativePath realFilePath:resultPath attributes:attributes permissions:permissions];
+        
+        unlink(resultPath.fileSystemRepresentation);
 
-        xar_file_t newFile = _xarAddFile(fileTable, x, [operation relativePath], resultPath);
-        assert(newFile);
-        xar_prop_set(newFile, BINARY_DELTA_KEY, "true");
-        unlink([resultPath fileSystemRepresentation]);
-
-        if (operation.permissions) {
-            xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [[NSString stringWithFormat:@"%u", [operation.permissions unsignedShortValue]] UTF8String]);
-
+        if (permissions != nil) {
             if (verbose) {
-                fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, [[operation relativePath] fileSystemRepresentation], operation.oldPermissions.unsignedShortValue, operation.permissions.unsignedShortValue);
+                fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, relativePath.fileSystemRepresentation, operation.oldPermissions.unsignedShortValue, operation.permissions.unsignedShortValue);
             }
         }
     }
 
-    xar_close(x);
+    [archive close];
 
     NSFileManager *filemgr;
     filemgr = [NSFileManager defaultManager];

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -9,7 +9,8 @@
 #import "SUBinaryDeltaCreate.h"
 #import <Foundation/Foundation.h>
 #include "SUBinaryDeltaCommon.h"
-#import "SPUXarDeltaArchive.h"
+#import "SPUDeltaArchiveProtocol.h"
+#import "SPUDeltaArchive.h"
 #import <CommonCrypto/CommonDigest.h>
 #include <fcntl.h>
 #include <fts.h>
@@ -469,7 +470,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         fprintf(stderr, "\nWriting to temporary file %s...", [temporaryFile fileSystemRepresentation]);
     }
     
-    id<SPUDeltaArchiveProtocol> archive = [[SPUXarDeltaArchive alloc] initWithPatchFileForWriting:temporaryFile];
+    id<SPUDeltaArchiveProtocol> archive = SPUDeltaArchiveForWriting(temporaryFile);
     if (archive == nil) {
         if (verbose) {
             fprintf(stderr, "\n");

--- a/Autoupdate/SUBinaryDeltaTool.m
+++ b/Autoupdate/SUBinaryDeltaTool.m
@@ -191,9 +191,15 @@ static BOOL runVersionCommand(NSString *programName, NSArray *args)
         uint16_t majorDiffVersion = 0;
         uint16_t minorDiffVersion = 0;
         
-        BOOL retrievedInfo = [SPUXarDeltaArchive getMajorDeltaVersion:&majorDiffVersion minorDeltaVersion:&minorDiffVersion fromPatchFile:patchFile];
+        SPUXarDeltaArchive *archive = [[SPUXarDeltaArchive alloc] initWithPatchFileForReading:patchFile];
+        if (archive == nil) {
+            fprintf(stderr, "Unable to open patch %s\n", [patchFile fileSystemRepresentation]);
+            return NO;
+        }
         
-        if (!retrievedInfo) {
+        [archive getMajorDeltaVersion:&majorDiffVersion minorDeltaVersion:&minorDiffVersion beforeTreeHash:NULL afterTreeHash:NULL];
+        
+        if (majorDiffVersion < FIRST_DELTA_DIFF_MAJOR_VERSION) {
             fprintf(stderr, "Unable to retrieve version information from patch %s\n", [patchFile fileSystemRepresentation]);
             return NO;
         }

--- a/Autoupdate/SUBinaryDeltaTool.m
+++ b/Autoupdate/SUBinaryDeltaTool.m
@@ -6,10 +6,11 @@
 //  Copyright 2009 Mark Rowe. All rights reserved.
 //
 
-#include "SUBinaryDeltaApply.h"
-#include "SUBinaryDeltaCreate.h"
-#include "SPUXarDeltaArchive.h"
-#include <Foundation/Foundation.h>
+#import "SUBinaryDeltaApply.h"
+#import "SUBinaryDeltaCreate.h"
+#import "SPUDeltaArchive.h"
+#import "SPUDeltaArchiveProtocol.h"
+#import <Foundation/Foundation.h>
 
 #define VERBOSE_FLAG @"--verbose"
 #define VERSION_FLAG @"--version"
@@ -191,7 +192,7 @@ static BOOL runVersionCommand(NSString *programName, NSArray *args)
         uint16_t majorDiffVersion = 0;
         uint16_t minorDiffVersion = 0;
         
-        SPUXarDeltaArchive *archive = [[SPUXarDeltaArchive alloc] initWithPatchFileForReading:patchFile];
+        id<SPUDeltaArchiveProtocol> archive = SPUDeltaArchiveForReading(patchFile);
         if (archive == nil) {
             fprintf(stderr, "Unable to open patch %s\n", [patchFile fileSystemRepresentation]);
             return NO;

--- a/Autoupdate/SUBinaryDeltaTool.m
+++ b/Autoupdate/SUBinaryDeltaTool.m
@@ -80,6 +80,11 @@ static BOOL runCreateCommand(NSString *programName, NSArray<NSString *> *args)
         fprintf(stderr, "Version provided (%u) is not valid\n", patchVersion);
         return NO;
     }
+    
+    if (patchVersion < FIRST_SUPPORTED_DELTA_MAJOR_VERSION) {
+        fprintf(stderr, "Creating version %u patches is no longer supported.\n", patchVersion);
+        return NO;
+    }
 
     if (patchVersion > LATEST_DELTA_DIFF_MAJOR_VERSION) {
         fprintf(stderr, "This program is too old to create a version %u patch, or the version number provided is invalid\n", patchVersion);

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -221,6 +221,11 @@
 		725EE480277BF13B00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
 		725EE482277BF44A00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
 		725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
+		725EE486277D375F00D820CE /* SPUDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE485277D375F00D820CE /* SPUDeltaArchive.m */; };
+		725EE487277D376000D820CE /* SPUDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE485277D375F00D820CE /* SPUDeltaArchive.m */; };
+		725EE488277D398100D820CE /* SPUDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE485277D375F00D820CE /* SPUDeltaArchive.m */; };
+		725EE489277D39B400D820CE /* SPUDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE485277D375F00D820CE /* SPUDeltaArchive.m */; };
+		725EE48A277D39B400D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
 		725F97771C8A62F500265BE4 /* SUAdHocCodeSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 725F97751C8A62F500265BE4 /* SUAdHocCodeSigning.m */; };
 		725F97781C8A65AC00265BE4 /* SUAdHocCodeSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 725F97751C8A62F500265BE4 /* SUAdHocCodeSigning.m */; };
 		725F97841C8AA90000265BE4 /* SUPopUpTitlebarUserDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 725F97831C8AA90000265BE4 /* SUPopUpTitlebarUserDriver.m */; };
@@ -1138,6 +1143,8 @@
 		725EE47E277BF13A00D820CE /* SPUXarDeltaArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUXarDeltaArchive.h; path = Autoupdate/SPUXarDeltaArchive.h; sourceTree = SOURCE_ROOT; };
 		725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPUXarDeltaArchive.m; path = Autoupdate/SPUXarDeltaArchive.m; sourceTree = SOURCE_ROOT; };
 		725EE481277BF17A00D820CE /* SPUDeltaArchiveProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUDeltaArchiveProtocol.h; path = Autoupdate/SPUDeltaArchiveProtocol.h; sourceTree = SOURCE_ROOT; };
+		725EE484277D375F00D820CE /* SPUDeltaArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUDeltaArchive.h; path = Autoupdate/SPUDeltaArchive.h; sourceTree = SOURCE_ROOT; };
+		725EE485277D375F00D820CE /* SPUDeltaArchive.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPUDeltaArchive.m; path = Autoupdate/SPUDeltaArchive.m; sourceTree = SOURCE_ROOT; };
 		725F97741C8A62F500265BE4 /* SUAdHocCodeSigning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUAdHocCodeSigning.h; sourceTree = "<group>"; };
 		725F97751C8A62F500265BE4 /* SUAdHocCodeSigning.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUAdHocCodeSigning.m; sourceTree = "<group>"; };
 		725F97821C8AA90000265BE4 /* SUPopUpTitlebarUserDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUPopUpTitlebarUserDriver.h; sourceTree = "<group>"; };
@@ -1767,6 +1774,8 @@
 				7267E5721D3D895B00D1BF90 /* SUBinaryDeltaCreate.h */,
 				7267E5731D3D895B00D1BF90 /* SUBinaryDeltaCreate.m */,
 				725EE481277BF17A00D820CE /* SPUDeltaArchiveProtocol.h */,
+				725EE484277D375F00D820CE /* SPUDeltaArchive.h */,
+				725EE485277D375F00D820CE /* SPUDeltaArchive.m */,
 				725EE47E277BF13A00D820CE /* SPUXarDeltaArchive.h */,
 				725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */,
 				7267E5741D3D895B00D1BF90 /* SUBinaryDeltaTool.m */,
@@ -3165,6 +3174,7 @@
 			files = (
 				725EE482277BF44A00D820CE /* SPUXarDeltaArchive.m in Sources */,
 				7267E5761D3D895B00D1BF90 /* SUBinaryDeltaApply.m in Sources */,
+				725EE487277D376000D820CE /* SPUDeltaArchive.m in Sources */,
 				7267E5781D3D895B00D1BF90 /* SUBinaryDeltaCommon.m in Sources */,
 				7267E57A1D3D895B00D1BF90 /* SUBinaryDeltaCreate.m in Sources */,
 				7267E57C1D3D895B00D1BF90 /* SUBinaryDeltaTool.m in Sources */,
@@ -3178,6 +3188,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				725EE488277D398100D820CE /* SPUDeltaArchive.m in Sources */,
 				725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */,
 				7269E4982648D3460088C213 /* SPUSkippedUpdate.m in Sources */,
 				721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
@@ -3229,6 +3240,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				725EE489277D39B400D820CE /* SPUDeltaArchive.m in Sources */,
+				725EE48A277D39B400D820CE /* SPUXarDeltaArchive.m in Sources */,
 				721D5B1B25C692BB00D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				72464F7C1E2097F600FB341C /* SUOperatingSystem.m in Sources */,
 				7205C44C1E1304CE00E370AE /* Appcast.swift in Sources */,
@@ -3371,6 +3384,7 @@
 				7267E5CD1D3D8C7200D1BF90 /* SPUSecureCoding.m in Sources */,
 				7267E5CB1D3D8C6400D1BF90 /* SUAppcastItem.m in Sources */,
 				7267E5751D3D895B00D1BF90 /* SUBinaryDeltaApply.m in Sources */,
+				725EE486277D375F00D820CE /* SPUDeltaArchive.m in Sources */,
 				7267E5771D3D895B00D1BF90 /* SUBinaryDeltaCommon.m in Sources */,
 				7267E5791D3D895B00D1BF90 /* SUBinaryDeltaCreate.m in Sources */,
 				7267E57F1D3D896700D1BF90 /* SUBinaryDeltaUnarchiver.m in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -218,6 +218,9 @@
 		725CB9571C7120410064365A /* SPUUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 725CB9561C7120410064365A /* SPUUserDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		725CB95A1C7121830064365A /* SPUStandardUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 725CB9581C7121830064365A /* SPUStandardUserDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		725CB95B1C7121830064365A /* SPUStandardUserDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 725CB9591C7121830064365A /* SPUStandardUserDriver.m */; };
+		725EE480277BF13B00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
+		725EE482277BF44A00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
+		725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
 		725F97771C8A62F500265BE4 /* SUAdHocCodeSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 725F97751C8A62F500265BE4 /* SUAdHocCodeSigning.m */; };
 		725F97781C8A65AC00265BE4 /* SUAdHocCodeSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 725F97751C8A62F500265BE4 /* SUAdHocCodeSigning.m */; };
 		725F97841C8AA90000265BE4 /* SUPopUpTitlebarUserDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 725F97831C8AA90000265BE4 /* SUPopUpTitlebarUserDriver.m */; };
@@ -1132,6 +1135,9 @@
 		725CB9581C7121830064365A /* SPUStandardUserDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUStandardUserDriver.h; sourceTree = "<group>"; };
 		725CB9591C7121830064365A /* SPUStandardUserDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUStandardUserDriver.m; sourceTree = "<group>"; };
 		725DED72263D10C400E7FA8F /* SUAppcast+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SUAppcast+Private.h"; sourceTree = "<group>"; };
+		725EE47E277BF13A00D820CE /* SPUXarDeltaArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUXarDeltaArchive.h; path = Autoupdate/SPUXarDeltaArchive.h; sourceTree = SOURCE_ROOT; };
+		725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPUXarDeltaArchive.m; path = Autoupdate/SPUXarDeltaArchive.m; sourceTree = SOURCE_ROOT; };
+		725EE481277BF17A00D820CE /* SPUDeltaArchiveProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUDeltaArchiveProtocol.h; path = Autoupdate/SPUDeltaArchiveProtocol.h; sourceTree = SOURCE_ROOT; };
 		725F97741C8A62F500265BE4 /* SUAdHocCodeSigning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUAdHocCodeSigning.h; sourceTree = "<group>"; };
 		725F97751C8A62F500265BE4 /* SUAdHocCodeSigning.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUAdHocCodeSigning.m; sourceTree = "<group>"; };
 		725F97821C8AA90000265BE4 /* SUPopUpTitlebarUserDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUPopUpTitlebarUserDriver.h; sourceTree = "<group>"; };
@@ -1760,6 +1766,9 @@
 				7267E5711D3D895B00D1BF90 /* SUBinaryDeltaCommon.m */,
 				7267E5721D3D895B00D1BF90 /* SUBinaryDeltaCreate.h */,
 				7267E5731D3D895B00D1BF90 /* SUBinaryDeltaCreate.m */,
+				725EE481277BF17A00D820CE /* SPUDeltaArchiveProtocol.h */,
+				725EE47E277BF13A00D820CE /* SPUXarDeltaArchive.h */,
+				725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */,
 				7267E5741D3D895B00D1BF90 /* SUBinaryDeltaTool.m */,
 				7267E57D1D3D896700D1BF90 /* SUBinaryDeltaUnarchiver.h */,
 				7267E57E1D3D896700D1BF90 /* SUBinaryDeltaUnarchiver.m */,
@@ -3154,6 +3163,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				725EE482277BF44A00D820CE /* SPUXarDeltaArchive.m in Sources */,
 				7267E5761D3D895B00D1BF90 /* SUBinaryDeltaApply.m in Sources */,
 				7267E5781D3D895B00D1BF90 /* SUBinaryDeltaCommon.m in Sources */,
 				7267E57A1D3D895B00D1BF90 /* SUBinaryDeltaCreate.m in Sources */,
@@ -3168,6 +3178,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */,
 				7269E4982648D3460088C213 /* SPUSkippedUpdate.m in Sources */,
 				721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				725F97771C8A62F500265BE4 /* SUAdHocCodeSigning.m in Sources */,
@@ -3346,6 +3357,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				725EE480277BF13B00D820CE /* SPUXarDeltaArchive.m in Sources */,
 				72EF30C42675CFA1008CE987 /* SPUAppcastItemState.m in Sources */,
 				72EF30C52675CFA1008CE987 /* SPUAppcastItemStateResolver.m in Sources */,
 				72464F701E1F31E000FB341C /* SUOperatingSystem.m in Sources */,

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -356,19 +356,9 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 }
 
 // Make sure old version patches still work for simple cases
-- (void)testRegularFileAddedWithAzureVersion
+- (void)testRegularFileAddedWithVersion1Delta
 {
-    XCTAssertTrue([self createAndApplyPatchUsingVersion:SUBinaryDeltaMajorVersion1 beforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
-        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
-        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
-        NSString *destinationFile2 = [destinationDirectory stringByAppendingPathComponent:@"B"];
-        
-        XCTAssertTrue([[NSData data] writeToFile:sourceFile atomically:YES]);
-        XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:destinationFile atomically:YES]);
-        XCTAssertTrue([[NSData dataWithBytes:"lol" length:3] writeToFile:destinationFile2 atomically:YES]);
-        
-        XCTAssertFalse([self testDirectoryHashEqualityWithSource:sourceDirectory destination:destinationDirectory]);
-    } afterDiffHandler:nil]);
+    XCTAssertFalse([self createAndApplyPatchUsingVersion:SUBinaryDeltaMajorVersion1 beforeDiffHandler:nil afterDiffHandler:nil]);
 }
 
 - (void)testDirectoryAdded


### PR DESCRIPTION
Isolate xar usage in its own archive type for delta patches. This abstraction will make it easier to adopt a new archive format.

We also drop support for version 1 patches which nobody should be using for many years now (pre Sparkle 1.10, year ~2015).

## Checklist:

- [x] My change is being tested and reviewed against the Sparkle 2.x branch. New changes must be developed on the 2.x development branch first.
- [ ] My change is being backported to master branch (Sparkle 1.x). Please create a separate pull request for 1.x, should it be backported. Note 1.x is feature frozen and is only taking bug fixes, localization updates, and critical OS adoption enhancements.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change is or requires a documentation or localization update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

All unit tests pass. Tested running BinaryDelta and creating/applying new patches manually.

macOS version tested: 12.1 (21C52)
