### PR TITLE
Add heuristics for binary delta when files move to other directories

### DIFF
--- a/Autoupdate/SPUDeltaArchive.m
+++ b/Autoupdate/SPUDeltaArchive.m
@@ -52,7 +52,7 @@ id<SPUDeltaArchiveProtocol> SPUDeltaArchiveReadPatchAndHeader(NSString *patchFil
 @implementation SPUDeltaArchiveItem
 
 @synthesize relativeFilePath = _relativeFilePath;
-@synthesize physicalFilePath = _physicalFilePath;
+@synthesize itemFilePath = _itemFilePath;
 @synthesize clonedRelativePath = _clonedRelativePath;
 @synthesize sourcePath = _sourcePath;
 @synthesize commands = _commands;

--- a/Autoupdate/SPUDeltaArchive.m
+++ b/Autoupdate/SPUDeltaArchive.m
@@ -57,7 +57,7 @@ id<SPUDeltaArchiveProtocol> SPUDeltaArchiveReadPatchAndHeader(NSString *patchFil
 @synthesize sourcePath = _sourcePath;
 @synthesize commands = _commands;
 @synthesize permissions = _permissions;
-@synthesize context = _context;
+@synthesize xarContext = _xarContext;
 @synthesize extractMode = _extractMode;
 @synthesize codedDataLength = _codedDataLength;
 

--- a/Autoupdate/SPUDeltaArchive.m
+++ b/Autoupdate/SPUDeltaArchive.m
@@ -54,10 +54,11 @@ id<SPUDeltaArchiveProtocol> SPUDeltaArchiveReadPatchAndHeader(NSString *patchFil
 @synthesize relativeFilePath = _relativeFilePath;
 @synthesize physicalFilePath = _physicalFilePath;
 @synthesize clonedRelativePath = _clonedRelativePath;
+@synthesize sourcePath = _sourcePath;
 @synthesize commands = _commands;
 @synthesize permissions = _permissions;
 @synthesize context = _context;
-@synthesize originalMode = _originalMode;
+@synthesize extractMode = _extractMode;
 @synthesize codedDataLength = _codedDataLength;
 
 - (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands permissions:(uint16_t)permissions

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -45,12 +45,13 @@ typedef NS_ENUM(uint8_t, SPUDeltaItemCommands) {
 @property (nonatomic, readonly) NSString *relativeFilePath;
 @property (nonatomic, nullable) NSString *physicalFilePath;
 @property (nonatomic, nullable) NSString *clonedRelativePath;
+@property (nonatomic, nullable) NSString *sourcePath;
 @property (nonatomic, readonly) SPUDeltaItemCommands commands;
 @property (nonatomic, readonly) uint16_t permissions;
 
 // Private properties
 @property (nonatomic, nullable) const void *context;
-@property (nonatomic) uint16_t originalMode;
+@property (nonatomic) uint16_t extractMode;
 @property (nonatomic) uint64_t codedDataLength;
 
 @end

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -42,16 +42,26 @@ typedef NS_ENUM(uint8_t, SPUDeltaItemCommands) {
 
 - (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands permissions:(uint16_t)permissions;
 
+// The relative file path of the item, eg /Contents/MacOS/Foo
 @property (nonatomic, readonly) NSString *relativeFilePath;
+// For extraction, the path where the item will be extracted. For creation, the path to the item to add to the archive.
 @property (nonatomic, nullable) NSString *itemFilePath;
+// The relative file path of the originating item for clones. This may be null.
+// For example, if /Contents/Resources/hello/foo.txt moves to /Contents/Resources/hello2/foo.txt, the former is the relative path
 @property (nonatomic, nullable) NSString *clonedRelativePath;
+// The source path of the item to extract file metadata from such as file size.
 @property (nonatomic, nullable) NSString *sourcePath;
+// The commands that describe the actions to take for this item.
 @property (nonatomic, readonly) SPUDeltaItemCommands commands;
+// Provided change in permissions for the SPUDeltaItemCommandModifyPermissions command
 @property (nonatomic, readonly) uint16_t permissions;
 
 // Private properties
-@property (nonatomic, nullable) const void *context;
+// xar_file context for Xar delta archiver
+@property (nonatomic, nullable) const void *xarContext;
+// Tracking mode type of item (regular file, symlink) when encoding items.
 @property (nonatomic) uint16_t extractMode;
+// Tracking length of item's data in data section, when encoding items and when extracting items
 @property (nonatomic) uint64_t codedDataLength;
 
 @end

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(uint8_t, SPUDeltaItemCommands) {
 - (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands permissions:(uint16_t)permissions;
 
 @property (nonatomic, readonly) NSString *relativeFilePath;
-@property (nonatomic, nullable) NSString *physicalFilePath;
+@property (nonatomic, nullable) NSString *itemFilePath;
 @property (nonatomic, nullable) NSString *clonedRelativePath;
 @property (nonatomic, nullable) NSString *sourcePath;
 @property (nonatomic, readonly) SPUDeltaItemCommands commands;

--- a/Autoupdate/SPUSparkleDeltaArchive.m
+++ b/Autoupdate/SPUSparkleDeltaArchive.m
@@ -534,8 +534,8 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
 
 - (BOOL)extractItem:(SPUDeltaArchiveItem *)item
 {
-    NSString *physicalFilePath = item.physicalFilePath;
-    assert(physicalFilePath != nil);
+    NSString *itemFilePath = item.itemFilePath;
+    assert(itemFilePath != nil);
     
     SPUDeltaItemCommands commands = item.commands;
     assert((commands & SPUDeltaItemCommandExtract) != 0 || (commands & SPUDeltaItemCommandBinaryDiff) != 0);
@@ -552,15 +552,15 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
         if ((commands & SPUDeltaItemCommandBinaryDiff) != 0 || S_ISREG(mode)) {
             // Regular files
             
-            char physicalFilePathString[PATH_MAX + 1] = {0};
-            if (![physicalFilePath getFileSystemRepresentation:physicalFilePathString maxLength:sizeof(physicalFilePathString) - 1]) {
-                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path to extract cannot be decoded and expressed as a file system representation: %@", physicalFilePath] }];
+            char itemFilePathString[PATH_MAX + 1] = {0};
+            if (![itemFilePath getFileSystemRepresentation:itemFilePathString maxLength:sizeof(itemFilePathString) - 1]) {
+                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path to extract cannot be decoded and expressed as a file system representation: %@", itemFilePath] }];
                 return NO;
             }
             
-            FILE *outputFile = fopen(physicalFilePathString, "wb");
+            FILE *outputFile = fopen(itemFilePathString, "wb");
             if (outputFile == NULL) {
-                self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to fopen() %@", physicalFilePath] }];
+                self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to fopen() %@", itemFilePath] }];
                 return NO;
             }
             
@@ -592,8 +592,8 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
                 return NO;
             }
             
-            if ((commands & SPUDeltaItemCommandExtract) != 0 && chmod(physicalFilePathString, mode) != 0) {
-                self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to chmod() mode %d on %@", mode, physicalFilePath] }];
+            if ((commands & SPUDeltaItemCommandExtract) != 0 && chmod(itemFilePathString, mode) != 0) {
+                self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to chmod() mode %d on %@", mode, itemFilePath] }];
                 return NO;
             }
         } else {
@@ -619,30 +619,30 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
             NSString *destinationPath = [fileManager stringWithFileSystemRepresentation:buffer length:decodedLength];
             
             if (destinationPath == nil) {
-                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination path for link %@ cannot be created in a file system representation: %@",physicalFilePath, destinationPath] }];
+                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Destination path for link %@ cannot be created in a file system representation: %@",itemFilePath, destinationPath] }];
                 return NO;
             }
             
             NSError *createLinkError = nil;
-            if (![fileManager createSymbolicLinkAtPath:physicalFilePath withDestinationPath:destinationPath error:&createLinkError]) {
+            if (![fileManager createSymbolicLinkAtPath:itemFilePath withDestinationPath:destinationPath error:&createLinkError]) {
                 self.error = createLinkError;
                 return NO;
             }
             
-            char physicalFilePathString[PATH_MAX + 1] = {0};
-            if (![physicalFilePath getFileSystemRepresentation:physicalFilePathString maxLength:sizeof(physicalFilePathString) - 1]) {
-                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path to extract cannot be decoded and expressed as a file system representation: %@", physicalFilePath] }];
+            char itemFilePathString[PATH_MAX + 1] = {0};
+            if (![itemFilePath getFileSystemRepresentation:itemFilePathString maxLength:sizeof(itemFilePathString) - 1]) {
+                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path to extract cannot be decoded and expressed as a file system representation: %@", itemFilePath] }];
                 return NO;
             }
             
             // We shouldn't fail if setting permissions on symlinks fail
             // Apple filesystems have file permissions for symbolic links but other linux file systems don't
             // So this may have no effect on some file systems over the network
-            lchmod(physicalFilePathString, mode);
+            lchmod(itemFilePathString, mode);
         }
     } else if (S_ISDIR(mode)) {
         NSError *createDirectoryError = nil;
-        if (![fileManager createDirectoryAtPath:physicalFilePath withIntermediateDirectories:NO attributes:@{NSFilePosixPermissions: @(mode)} error:&createDirectoryError]) {
+        if (![fileManager createDirectoryAtPath:itemFilePath withIntermediateDirectories:NO attributes:@{NSFilePosixPermissions: @(mode)} error:&createDirectoryError]) {
             self.error = createDirectoryError;
             return NO;
         }
@@ -1000,18 +1000,18 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
             }
             
             if ((commands & SPUDeltaItemCommandBinaryDiff) != 0) {
-                NSString *physicalPath = item.physicalFilePath;
-                assert(physicalPath != nil);
+                NSString *itemPath = item.itemFilePath;
+                assert(itemPath != nil);
                 
-                char physicalFilePathString[PATH_MAX + 1] = {0};
-                if (![physicalPath getFileSystemRepresentation:physicalFilePathString maxLength:sizeof(physicalFilePathString) - 1]) {
-                    self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path cannot be decoded and expressed as a file system representation while encoding cloned binary diff item: %@", physicalPath] }];
+                char itemFilePathString[PATH_MAX + 1] = {0};
+                if (![itemPath getFileSystemRepresentation:itemFilePathString maxLength:sizeof(itemFilePathString) - 1]) {
+                    self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path cannot be decoded and expressed as a file system representation while encoding cloned binary diff item: %@", itemPath] }];
                     break;
                 }
                 
                 struct stat fileInfo = {0};
-                if (lstat(physicalFilePathString, &fileInfo) != 0) {
-                    self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to lstat() on %@", physicalPath] }];
+                if (lstat(itemFilePathString, &fileInfo) != 0) {
+                    self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to lstat() on %@", itemPath] }];
                     break;
                 }
                 
@@ -1061,30 +1061,30 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
             // Store data length
             // Length doesn't matter for directory names (we already track the name in the relative path)
             
-            NSString *physicalPath = item.physicalFilePath;
-            assert(physicalPath != nil);
+            NSString *itemPath = item.itemFilePath;
+            assert(itemPath != nil);
             
-            char physicalFilePathString[PATH_MAX + 1] = {0};
-            if (![physicalPath getFileSystemRepresentation:physicalFilePathString maxLength:sizeof(physicalFilePathString) - 1]) {
-                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path cannot be decoded and expressed as a file system representation while encoding items: %@", physicalPath] }];
+            char itemFilePathString[PATH_MAX + 1] = {0};
+            if (![itemPath getFileSystemRepresentation:itemFilePathString maxLength:sizeof(itemFilePathString) - 1]) {
+                self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path cannot be decoded and expressed as a file system representation while encoding items: %@", itemPath] }];
                 break;
             }
             
-            struct stat physicalFileInfo = {0};
-            if (lstat(physicalFilePathString, &physicalFileInfo) != 0) {
-                self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to lstat() on %@", physicalPath] }];
+            struct stat itemFileInfo = {0};
+            if (lstat(itemFilePathString, &itemFileInfo) != 0) {
+                self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to lstat() on %@", itemPath] }];
                 break;
             }
             
             if ((commands & SPUDeltaItemCommandBinaryDiff) != 0 || S_ISREG(extractMode)) {
-                uint64_t dataLength = (uint64_t)physicalFileInfo.st_size;
+                uint64_t dataLength = (uint64_t)itemFileInfo.st_size;
                 if (![self _writeBuffer:&dataLength length:sizeof(dataLength)]) {
                     break;
                 }
                 
                 item.codedDataLength = dataLength;
             } else if (S_ISLNK(extractMode)) {
-                off_t fileSize = physicalFileInfo.st_size;
+                off_t fileSize = itemFileInfo.st_size;
                 if (fileSize > UINT16_MAX) {
                     self.error = [NSError errorWithDomain:SPARKLE_DELTA_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_ARCHIVE_ERROR_CODE_LINK_TOO_LONG userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path has a destination that is too long: %llu bytes", fileSize] }];
                     break;
@@ -1121,8 +1121,8 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
     for (SPUDeltaArchiveItem *item in writableItems) {
         SPUDeltaItemCommands commands = item.commands;
         if ((commands & SPUDeltaItemCommandExtract) != 0 || (commands & SPUDeltaItemCommandBinaryDiff) != 0) {
-            NSString *physicalPath = item.physicalFilePath;
-            assert(physicalPath != nil);
+            NSString *itemPath = item.itemFilePath;
+            assert(itemPath != nil);
             
             mode_t extractMode = item.extractMode;
             if ((commands & SPUDeltaItemCommandBinaryDiff) != 0 || S_ISREG(extractMode)) {
@@ -1130,15 +1130,15 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
                 
                 uint64_t totalItemSize = item.codedDataLength;
                 if (totalItemSize > 0) {
-                    char physicalFilePathString[PATH_MAX + 1] = {0};
-                    if (![physicalPath getFileSystemRepresentation:physicalFilePathString maxLength:sizeof(physicalFilePathString) - 1]) {
-                        self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path to finish encoding cannot be decoded and expressed as a file system representation: %@", physicalPath] }];
+                    char itemFilePathString[PATH_MAX + 1] = {0};
+                    if (![itemPath getFileSystemRepresentation:itemFilePathString maxLength:sizeof(itemFilePathString) - 1]) {
+                        self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Path to finish encoding cannot be decoded and expressed as a file system representation: %@", itemPath] }];
                         break;
                     }
                     
-                    FILE *inputFile = fopen(physicalFilePathString, "rb");
+                    FILE *inputFile = fopen(itemFilePathString, "rb");
                     if (inputFile == NULL) {
-                        self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to open file for reading while encoding items: %@", physicalPath] }];
+                        self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to open file for reading while encoding items: %@", itemPath] }];
                         break;
                     }
                     
@@ -1165,16 +1165,16 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
                     }
                 }
             } else if (S_ISLNK(extractMode)) {
-                char physicalFilePathString[PATH_MAX + 1] = {0};
-                if (![physicalPath getFileSystemRepresentation:physicalFilePathString maxLength:sizeof(physicalFilePathString) - 1]) {
-                    self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path to finish encoding cannot be decoded and expressed as a file system representation: %@", physicalPath] }];
+                char itemFilePathString[PATH_MAX + 1] = {0};
+                if (![itemPath getFileSystemRepresentation:itemFilePathString maxLength:sizeof(itemFilePathString) - 1]) {
+                    self.error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadInvalidFileNameError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path to finish encoding cannot be decoded and expressed as a file system representation: %@", itemPath] }];
                     break;
                 }
                 
                 char linkDestination[PATH_MAX + 1] = {0};
-                ssize_t linkDestinationLength = readlink(physicalFilePathString, linkDestination, PATH_MAX);
+                ssize_t linkDestinationLength = readlink(itemFilePathString, linkDestination, PATH_MAX);
                 if (linkDestinationLength < 0) {
-                    self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to readlink() file at %@", physicalPath] }];
+                    self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to readlink() file at %@", itemPath] }];
                     break;
                 }
                 

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -278,7 +278,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     }
     
     NSString *relativeFilePath = item.relativeFilePath;
-    NSString *filePath = item.physicalFilePath;
+    NSString *filePath = item.itemFilePath;
     SPUDeltaItemCommands commands = item.commands;
     uint16_t permissions = item.permissions;
     
@@ -389,12 +389,12 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
         return NO;
     }
     
-    assert(item.physicalFilePath != nil);
+    assert(item.itemFilePath != nil);
     assert(item.context != NULL);
     
     xar_file_t file = item.context;
-    if (xar_extract_tofile(self.x, file, item.physicalFilePath.fileSystemRepresentation) != 0) {
-        self.error = [NSError errorWithDomain:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_CODE_EXTRACT_FAILURE userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to extract xar file entry to %@", item.physicalFilePath] }];
+    if (xar_extract_tofile(self.x, file, item.itemFilePath.fileSystemRepresentation) != 0) {
+        self.error = [NSError errorWithDomain:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_CODE_EXTRACT_FAILURE userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to extract xar file entry to %@", item.itemFilePath] }];
         return NO;
     }
     

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -372,7 +372,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
         }
         
         SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands permissions:permissions];
-        item.context = file;
+        item.xarContext = file;
         
         itemHandler(item, &exitedEarly);
         if (exitedEarly) {
@@ -390,9 +390,9 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     }
     
     assert(item.itemFilePath != nil);
-    assert(item.context != NULL);
+    assert(item.xarContext != NULL);
     
-    xar_file_t file = item.context;
+    xar_file_t file = item.xarContext;
     if (xar_extract_tofile(self.x, file, item.itemFilePath.fileSystemRepresentation) != 0) {
         self.error = [NSError errorWithDomain:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_CODE_EXTRACT_FAILURE userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to extract xar file entry to %@", item.itemFilePath] }];
         return NO;

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -237,7 +237,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
             }
         } else if ((commands & SPUDeltaItemCommandBinaryDiff) != 0) {
             NSString *tempDiffFile = temporaryFilename(@"apply-binary-delta");
-            item.physicalFilePath = tempDiffFile;
+            item.itemFilePath = tempDiffFile;
             
             if (![archive extractItem:item]) {
                 if (verbose) {
@@ -318,7 +318,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
                 }
             }
         } else if ((commands & SPUDeltaItemCommandExtract) != 0) { // extract and permission modifications don't coexist
-            item.physicalFilePath = destinationFilePath;
+            item.itemFilePath = destinationFilePath;
             if (![archive extractItem:item]) {
                 if (verbose) {
                     fprintf(stderr, "\n");

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -748,23 +748,21 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 BOOL clonedBinaryDiff = NO;
                 NSString *clonedRelativePath = MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion3) ? cloneableRelativePath(afterFileKeyToHashDictionary, beforeHashToFileKeyDictionary, frameworkVersionsSubstitutes, fileSubstitutes, originalTreeState, newInfo, key, &changedPermissionsFromClone, &clonedBinaryDiff) : nil;
                 if (clonedRelativePath != nil) {
-                    SPUDeltaItemCommands commands = SPUDeltaItemCommandClone;
-                    if (shouldDeleteThenExtract(originalInfo, newInfo, majorVersion)) {
-                        commands |= SPUDeltaItemCommandDelete;
-                    }
-                    if (changedPermissionsFromClone != nil) {
-                        commands |= SPUDeltaItemCommandModifyPermissions;
-                    }
-                    
                     if (clonedBinaryDiff) {
-                        commands |= SPUDeltaItemCommandBinaryDiff;
-                        
                         NSDictionary *cloneInfo = originalTreeState[clonedRelativePath];
                         
                         CreateBinaryDeltaOperation *operation = [[CreateBinaryDeltaOperation alloc] initWithRelativePath:key clonedRelativePath:clonedRelativePath oldTree:source newTree:destination oldPermissions:cloneInfo[INFO_PERMISSIONS_KEY] newPermissions:changedPermissionsFromClone];
                         [deltaQueue addOperation:operation];
                         [deltaOperations addObject:operation];
                     } else {
+                        SPUDeltaItemCommands commands = SPUDeltaItemCommandClone;
+                        if (shouldDeleteThenExtract(originalInfo, newInfo, majorVersion)) {
+                            commands |= SPUDeltaItemCommandDelete;
+                        }
+                        if (changedPermissionsFromClone != nil) {
+                            commands |= SPUDeltaItemCommandModifyPermissions;
+                        }
+                        
                         SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:changedPermissionsFromClone.unsignedShortValue];
                         // Physical path for clones points to the old file
                         item.physicalFilePath = [source stringByAppendingPathComponent:clonedRelativePath];

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -30,29 +30,37 @@ extern int bsdiff(int argc, const char **argv);
 
 @interface CreateBinaryDeltaOperation : NSOperation
 @property (copy) NSString *relativePath;
+@property (copy) NSString *clonedRelativePath;
 @property (strong) NSString *resultPath;
 @property (strong) NSNumber *oldPermissions;
 @property (strong) NSNumber *permissions;
 @property (strong) NSString *_fromPath;
 @property (strong) NSString *_toPath;
-- (id)initWithRelativePath:(NSString *)relativePath oldTree:(NSString *)oldTree newTree:(NSString *)newTree oldPermissions:(NSNumber *)oldPermissions newPermissions:(NSNumber *)permissions;
+- (id)initWithRelativePath:(NSString *)relativePath clonedRelativePath:(NSString *)clonedRelativePath oldTree:(NSString *)oldTree newTree:(NSString *)newTree oldPermissions:(NSNumber *)oldPermissions newPermissions:(NSNumber *)permissions;
 @end
 
 @implementation CreateBinaryDeltaOperation
 @synthesize relativePath = _relativePath;
+@synthesize clonedRelativePath = _clonedRelativePath;
 @synthesize resultPath = _resultPath;
 @synthesize oldPermissions = _oldPermissions;
 @synthesize permissions = _permissions;
 @synthesize _fromPath = _fromPath;
 @synthesize _toPath = _toPath;
 
-- (id)initWithRelativePath:(NSString *)relativePath oldTree:(NSString *)oldTree newTree:(NSString *)newTree oldPermissions:(NSNumber *)oldPermissions newPermissions:(NSNumber *)permissions
+- (id)initWithRelativePath:(NSString *)relativePath clonedRelativePath:(NSString *)clonedRelativePath oldTree:(NSString *)oldTree newTree:(NSString *)newTree oldPermissions:(NSNumber *)oldPermissions newPermissions:(NSNumber *)permissions
 {
     if ((self = [super init])) {
         self.relativePath = relativePath;
+        self.clonedRelativePath = clonedRelativePath;
         self.oldPermissions = oldPermissions;
         self.permissions = permissions;
-        self._fromPath = [oldTree stringByAppendingPathComponent:relativePath];
+        
+        if (clonedRelativePath == nil) {
+            self._fromPath = [oldTree stringByAppendingPathComponent:relativePath];
+        } else {
+            self._fromPath = [oldTree stringByAppendingPathComponent:clonedRelativePath];
+        }
         self._toPath = [newTree stringByAppendingPathComponent:relativePath];
     }
     return self;
@@ -168,17 +176,16 @@ static BOOL shouldSkipDeltaCompression(NSDictionary *originalInfo, NSDictionary 
 
     unsigned short originalInfoType = [(NSNumber *)originalInfo[INFO_TYPE_KEY] unsignedShortValue];
     unsigned short newInfoType = [(NSNumber *)newInfo[INFO_TYPE_KEY] unsignedShortValue];
-    if (originalInfoType != newInfoType) {
-        // File types are different
+    if (originalInfoType != newInfoType || originalInfoType != FTS_F) {
+        // File types are different or they're not regular files
         return YES;
     }
 
     NSString *originalPath = originalInfo[INFO_PATH_KEY];
     NSString *newPath = newInfo[INFO_PATH_KEY];
 
-    // Skip delta if both entries are directories, or if the files/symlinks are equal in content
-    if (originalInfoType == FTS_D || [[NSFileManager defaultManager] contentsEqualAtPath:originalPath andPath:newPath]) {
-        // this is possible if just the permissions have changed but contents have not
+    // Skip delta if the files are equal in content
+    if ([[NSFileManager defaultManager] contentsEqualAtPath:originalPath andPath:newPath]) {
         return YES;
     }
 
@@ -251,48 +258,127 @@ static BOOL shouldChangePermissions(NSDictionary *originalInfo, NSDictionary *ne
 }
 
 #define MIN_SIZE_FOR_CLONE 4096
-static NSString *cloneableRelativePath(NSDictionary<NSString *, NSData *> *afterFileKeyToHashDictionary, NSDictionary<NSData *, NSArray<NSString *> *> *beforeHashToFileKeyDictionary, NSDictionary *originalTreeState, NSDictionary *newInfo, NSString *key, NSNumber * __autoreleasing *outPermissions)
+#define MIN_SIZE_FOR_CLONE_DIFF (4096 * 4)
+static NSString *cloneableRelativePath(NSDictionary<NSString *, NSData *> *afterFileKeyToHashDictionary, NSDictionary<NSData *, NSArray<NSString *> *> *beforeHashToFileKeyDictionary, NSDictionary<NSString *, NSString *> *frameworkVersionsSubstitutes, NSDictionary<NSString *, NSString *> *fileSubstitutes, NSDictionary *originalTreeState, NSDictionary *newInfo, NSString *key, NSNumber * __autoreleasing *outChangedPermissions, BOOL *clonedBinaryDiff)
 {
-    if (afterFileKeyToHashDictionary == nil) {
-        return nil;
-    }
-    
     // Avoid clones for small files. Small files can compress very well, sometimes better than tracking clones.
     if ([(NSNumber *)newInfo[INFO_SIZE_KEY] unsignedLongLongValue] <= MIN_SIZE_FOR_CLONE) {
         return nil;
     }
     
-    NSData *keyHash = afterFileKeyToHashDictionary[key];
-    if (keyHash == nil) {
+    if ([(NSNumber *)newInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_F) {
         return nil;
     }
     
-    for (NSString *oldRelativePath in beforeHashToFileKeyDictionary[keyHash]) {
-        NSDictionary *oldCloneInfo = originalTreeState[oldRelativePath];
+    {
+        NSData *keyHash = afterFileKeyToHashDictionary[key];
+        if (keyHash != nil) {
+            // Check for identical clones first
+            for (NSString *oldRelativePath in beforeHashToFileKeyDictionary[keyHash]) {
+                NSDictionary *oldCloneInfo = originalTreeState[oldRelativePath];
+                if (oldCloneInfo == nil) {
+                    continue;
+                }
+                
+                if ([(NSNumber *)oldCloneInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_F) {
+                    continue;
+                }
+                
+                NSString *clonePath = oldCloneInfo[INFO_PATH_KEY];
+                NSString *newPath = newInfo[INFO_PATH_KEY];
+                
+                if (![[NSFileManager defaultManager] contentsEqualAtPath:clonePath andPath:newPath]) {
+                    continue;
+                }
+                
+                NSNumber *newPermissions = newInfo[INFO_PERMISSIONS_KEY];
+                if ([(NSNumber *)oldCloneInfo[INFO_PERMISSIONS_KEY] unsignedShortValue] != [newPermissions unsignedShortValue]) {
+                    if (outChangedPermissions != NULL) {
+                        *outChangedPermissions = newPermissions;
+                    }
+                }
+                
+                if (clonedBinaryDiff != NULL) {
+                    *clonedBinaryDiff = NO;
+                }
+                
+                return oldRelativePath;
+            }
+        }
+    }
+    
+    // For non-identical files where we do a binary diff, make sure file size matches a more strict file size test
+    if ([(NSNumber *)newInfo[INFO_SIZE_KEY] unsignedLongLongValue] <= MIN_SIZE_FOR_CLONE_DIFF) {
+        return nil;
+    }
+    
+    // Look out for any .framework/Versions/{A -> B} changes
+    for (NSString *frameworkVersionPrefix in frameworkVersionsSubstitutes) {
+        if (![key hasPrefix:frameworkVersionPrefix]) {
+            continue;
+        }
+        
+        NSString *cloneFrameworkSubstitutePrefix = frameworkVersionsSubstitutes[frameworkVersionPrefix];
+        if (cloneFrameworkSubstitutePrefix == nil) {
+            continue;
+        }
+        
+        NSString *cloneRelativeKey = [key stringByReplacingCharactersInRange:NSMakeRange(0, frameworkVersionPrefix.length) withString:cloneFrameworkSubstitutePrefix];
+        
+        NSDictionary *oldCloneInfo = originalTreeState[cloneRelativeKey];
         if (oldCloneInfo == nil) {
-            continue;
-        }
-        
-        if ([(NSNumber *)oldCloneInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_F || [(NSNumber *)newInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_F) {
-            continue;
-        }
-        
-        NSString *clonePath = oldCloneInfo[INFO_PATH_KEY];
-        NSString *newPath = newInfo[INFO_PATH_KEY];
-        
-        if (![[NSFileManager defaultManager] contentsEqualAtPath:clonePath andPath:newPath]) {
             continue;
         }
         
         NSNumber *newPermissions = newInfo[INFO_PERMISSIONS_KEY];
         if ([(NSNumber *)oldCloneInfo[INFO_PERMISSIONS_KEY] unsignedShortValue] != [newPermissions unsignedShortValue]) {
-            if (outPermissions != NULL) {
-                *outPermissions = newPermissions;
+            if (outChangedPermissions != NULL) {
+                *outChangedPermissions = newPermissions;
             }
         }
         
-        return oldRelativePath;
+        if (clonedBinaryDiff != NULL) {
+            *clonedBinaryDiff = YES;
+        }
+        
+        return cloneRelativeKey;
     }
+    
+    // Look out for any changes that involve the same named file moving to another directory
+    do {
+        NSString *cloneRelativeKey = fileSubstitutes[key.lastPathComponent];
+        if (cloneRelativeKey == nil) {
+            break;
+        }
+        
+        NSDictionary *oldCloneInfo = originalTreeState[cloneRelativeKey];
+        if (oldCloneInfo == nil) {
+            break;
+        }
+        
+        uint64_t cloneSize = [(NSNumber *)oldCloneInfo[INFO_SIZE_KEY] unsignedLongValue];
+        uint64_t newSize = [(NSNumber *)newInfo[INFO_SIZE_KEY] unsignedLongValue];
+        uint64_t minSize = MIN(cloneSize, newSize);
+        uint64_t maxSize = MAX(cloneSize, newSize);
+        
+        // Ensure file is at least 60% the same size
+        if (minSize == 0 || maxSize == 0 || (double)minSize / (double)maxSize < 0.60) {
+            break;
+        }
+        
+        NSNumber *newPermissions = newInfo[INFO_PERMISSIONS_KEY];
+        if ([(NSNumber *)oldCloneInfo[INFO_PERMISSIONS_KEY] unsignedShortValue] != [newPermissions unsignedShortValue]) {
+            if (outChangedPermissions != NULL) {
+                *outChangedPermissions = newPermissions;
+            }
+        }
+        
+        if (clonedBinaryDiff != NULL) {
+            *clonedBinaryDiff = YES;
+        }
+        
+        return cloneRelativeKey;
+    } while (NO);
     
     return nil;
 }
@@ -539,6 +625,99 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
 
       return originalTreeState[key1] ? NSOrderedAscending : NSOrderedDescending;
     }];
+    
+    // Using a couple of heursitics we track if files have been moved to other locations within the app bundle
+    NSMutableDictionary<NSString *, NSString *> *frameworkVersionsSubstitutes = [NSMutableDictionary dictionary];
+    NSMutableDictionary<NSString *, NSString *> *fileSubstitutes = [NSMutableDictionary dictionary];
+    if (MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion3)) {
+        // Heuristic #1: track if an old framework version was removed and a new framework version was added
+        // Keep track of these prefixes in a dictionary
+        // Eg: /Contents/Frameworks/Foo.framework/Versions/B/ (new) -> /Contents/Frameworks/Foo.framework/Versions/A/ (old)
+        
+        NSMutableDictionary<NSString *, NSString *> *oldFrameworkVersions = [NSMutableDictionary dictionary];
+        for (NSString *key in keys) {
+            id value = [newTreeState valueForKey:key];
+            if (![(NSObject *)value isEqual:[NSNull null]]) {
+                continue;
+            }
+            
+            NSDictionary *originalInfo = originalTreeState[key];
+            if ([(NSNumber *)originalInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_D) {
+                continue;
+            }
+            
+            NSString *keyWithoutLastPathComponent = key.stringByDeletingLastPathComponent;
+            
+            if (![keyWithoutLastPathComponent.lastPathComponent isEqualToString:@"Versions"]) {
+                continue;
+            }
+            
+            NSString *keyWithoutLastLastPathComponent = keyWithoutLastPathComponent.stringByDeletingLastPathComponent;
+            
+            if (![keyWithoutLastLastPathComponent.pathExtension isEqualToString:@"framework"]) {
+                continue;
+            }
+            
+            oldFrameworkVersions[keyWithoutLastLastPathComponent] = key;
+        }
+        
+        for (NSString *key in keys) {
+            id value = [newTreeState valueForKey:key];
+            if ([(NSObject *)value isEqual:[NSNull null]] || originalTreeState[key] != nil) {
+                continue;
+            }
+            
+            NSDictionary *newInfo = value;
+            if ([(NSNumber *)newInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_D) {
+                continue;
+            }
+            
+            NSString *keyWithoutLastPathComponent = key.stringByDeletingLastPathComponent;
+            
+            if (![keyWithoutLastPathComponent.lastPathComponent isEqualToString:@"Versions"]) {
+                continue;
+            }
+            
+            NSString *keyWithoutLastLastPathComponent = keyWithoutLastPathComponent.stringByDeletingLastPathComponent;
+            
+            if (![keyWithoutLastLastPathComponent.pathExtension isEqualToString:@"framework"]) {
+                continue;
+            }
+            
+            NSString *oldFrameworkVersionKey = oldFrameworkVersions[keyWithoutLastLastPathComponent];
+            if (oldFrameworkVersionKey == nil) {
+                continue;
+            }
+            
+            frameworkVersionsSubstitutes[[key stringByAppendingString:@"/"]] = [oldFrameworkVersionKey stringByAppendingString:@"/"];
+        }
+        
+        // Heuristic #2: Keep a table of removed filenames, collapsing them by the largest file per unique name
+        // This sees if a file has just been moved to another location
+        for (NSString *key in keys) {
+            id value = [newTreeState valueForKey:key];
+            if (![(NSObject *)value isEqual:[NSNull null]]) {
+                continue;
+            }
+            
+            NSDictionary *keyInfo = originalTreeState[key];
+            if ([(NSNumber *)keyInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_F) {
+                continue;
+            }
+            
+            NSString *lastPathComponent = key.lastPathComponent;
+            
+            NSString *existingKey = fileSubstitutes[lastPathComponent];
+            if (existingKey == nil) {
+                fileSubstitutes[lastPathComponent] = key;
+            } else {
+                NSDictionary *existingKeyInfo = originalTreeState[existingKey];
+                if ([(NSNumber *)keyInfo[INFO_SIZE_KEY] unsignedLongValue] > [(NSNumber *)existingKeyInfo[INFO_SIZE_KEY] unsignedLongValue]) {
+                    fileSubstitutes[lastPathComponent] = key;
+                }
+            }
+        }
+    }
 
     for (NSString *key in keys) {
         id value = [newTreeState valueForKey:key];
@@ -565,32 +744,46 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 }
             } else {
                 // Check if the new file can be cloned from an old existing one located at a different path
-                NSNumber *newPermissionsFromClone = nil;
-                NSString *clonedRelativePath = cloneableRelativePath(afterFileKeyToHashDictionary, beforeHashToFileKeyDictionary, originalTreeState, newInfo, key, &newPermissionsFromClone);
+                NSNumber *changedPermissionsFromClone = nil;
+                BOOL clonedBinaryDiff = NO;
+                NSString *clonedRelativePath = MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion3) ? cloneableRelativePath(afterFileKeyToHashDictionary, beforeHashToFileKeyDictionary, frameworkVersionsSubstitutes, fileSubstitutes, originalTreeState, newInfo, key, &changedPermissionsFromClone, &clonedBinaryDiff) : nil;
                 if (clonedRelativePath != nil) {
                     SPUDeltaItemCommands commands = SPUDeltaItemCommandClone;
                     if (shouldDeleteThenExtract(originalInfo, newInfo, majorVersion)) {
                         commands |= SPUDeltaItemCommandDelete;
                     }
-                    if (newPermissionsFromClone != nil) {
+                    if (changedPermissionsFromClone != nil) {
                         commands |= SPUDeltaItemCommandModifyPermissions;
                     }
                     
-                    SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:newPermissionsFromClone.unsignedShortValue];
-                    // Physical path for clones points to the old file
-                    item.physicalFilePath = [source stringByAppendingPathComponent:clonedRelativePath];
-                    item.clonedRelativePath = clonedRelativePath;
-                    
-                    [archive addItem:item];
-                    
-                    if (verbose) {
-                        fprintf(stderr, "\n✂️   %s %s -> %s", VERBOSE_CLONED, [clonedRelativePath fileSystemRepresentation], [key fileSystemRepresentation]);
+                    if (clonedBinaryDiff) {
+                        commands |= SPUDeltaItemCommandBinaryDiff;
+                        
+                        NSDictionary *cloneInfo = originalTreeState[clonedRelativePath];
+                        
+                        CreateBinaryDeltaOperation *operation = [[CreateBinaryDeltaOperation alloc] initWithRelativePath:key clonedRelativePath:clonedRelativePath oldTree:source newTree:destination oldPermissions:cloneInfo[INFO_PERMISSIONS_KEY] newPermissions:changedPermissionsFromClone];
+                        [deltaQueue addOperation:operation];
+                        [deltaOperations addObject:operation];
+                    } else {
+                        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:changedPermissionsFromClone.unsignedShortValue];
+                        // Physical path for clones points to the old file
+                        item.physicalFilePath = [source stringByAppendingPathComponent:clonedRelativePath];
+                        item.clonedRelativePath = clonedRelativePath;
+                        
+                        [archive addItem:item];
+                        
+                        if (verbose) {
+                            fprintf(stderr, "\n✂️   %s %s -> %s", VERBOSE_CLONED, [clonedRelativePath fileSystemRepresentation], [key fileSystemRepresentation]);
+                        }
                     }
                 } else {
                     // Otherwise add a new file
                     NSString *path = [destination stringByAppendingPathComponent:key];
                     
-                    SPUDeltaItemCommands commands = shouldDeleteThenExtract(originalInfo, newInfo, majorVersion) ? (SPUDeltaItemCommandDelete | SPUDeltaItemCommandExtract) : SPUDeltaItemCommandExtract;
+                    SPUDeltaItemCommands commands = SPUDeltaItemCommandExtract;
+                    if (shouldDeleteThenExtract(originalInfo, newInfo, majorVersion)) {
+                        commands |= SPUDeltaItemCommandDelete;
+                    }
                     
                     SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:0];
                     item.physicalFilePath = path;
@@ -611,7 +804,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                 shouldChangePermissions(originalInfo, newInfo) ?
                 newInfo[INFO_PERMISSIONS_KEY] :
                 nil;
-            CreateBinaryDeltaOperation *operation = [[CreateBinaryDeltaOperation alloc] initWithRelativePath:key oldTree:source newTree:destination oldPermissions:originalInfo[INFO_PERMISSIONS_KEY] newPermissions:permissions];
+            CreateBinaryDeltaOperation *operation = [[CreateBinaryDeltaOperation alloc] initWithRelativePath:key clonedRelativePath:nil oldTree:source newTree:destination oldPermissions:originalInfo[INFO_PERMISSIONS_KEY] newPermissions:permissions];
             [deltaQueue addOperation:operation];
             [deltaOperations addObject:operation];
         }
@@ -633,17 +826,29 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             break;
         }
 
+        NSString *clonedRelativePath = [operation clonedRelativePath];
         if (verbose) {
-            fprintf(stderr, "\n🔨  %s %s", VERBOSE_DIFFED, [[operation relativePath] fileSystemRepresentation]);
+            if (clonedRelativePath == nil) {
+                fprintf(stderr, "\n🔨  %s %s", VERBOSE_DIFFED, [[operation relativePath] fileSystemRepresentation]);
+            } else {
+                fprintf(stderr, "\n🔨  %s %s -> %s", VERBOSE_DIFFED, [clonedRelativePath fileSystemRepresentation], [[operation relativePath] fileSystemRepresentation]);
+            }
         }
         
         NSNumber *permissions = operation.permissions;
         NSString *relativePath = operation.relativePath;
         
-        SPUDeltaItemCommands commands = (permissions != nil) ? (SPUDeltaItemCommandBinaryDiff | SPUDeltaItemCommandModifyPermissions) : SPUDeltaItemCommandBinaryDiff;
+        SPUDeltaItemCommands commands = SPUDeltaItemCommandBinaryDiff;
+        if (permissions != nil) {
+            commands |= SPUDeltaItemCommandModifyPermissions;
+        }
+        if (clonedRelativePath != nil) {
+            commands |= SPUDeltaItemCommandClone;
+        }
         
         SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands permissions:permissions.unsignedShortValue];
         item.physicalFilePath = resultPath;
+        item.clonedRelativePath = clonedRelativePath;
         
         [archive addItem:item];
 

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -775,8 +775,8 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                         
                         SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:(clonePermissionsChanged ? newPermissions.unsignedShortValue : 0)];
                         // Physical path for clones points to the old file
-                        item.physicalFilePath = [source stringByAppendingPathComponent:clonedRelativePath];
-                        item.sourcePath = item.physicalFilePath;
+                        item.itemFilePath = [source stringByAppendingPathComponent:clonedRelativePath];
+                        item.sourcePath = item.itemFilePath;
                         item.clonedRelativePath = clonedRelativePath;
                         
                         [archive addItem:item];
@@ -795,7 +795,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                     }
                     
                     SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:0];
-                    item.physicalFilePath = path;
+                    item.itemFilePath = path;
                     item.sourcePath = path;
                     
                     [archive addItem:item];
@@ -855,7 +855,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         }
         
         SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands permissions:permissions.unsignedShortValue];
-        item.physicalFilePath = resultPath;
+        item.itemFilePath = resultPath;
         item.sourcePath = operation._fromPath;
         item.clonedRelativePath = clonedRelativePath;
         


### PR DESCRIPTION
We have one heuristic for when a .framework version changes, and another for when a file with the same name moves to another location.

To support this, we added a clone + binary diff command.

Fixes #979 in the most common cases

To test this, pass `--version=3` to `BinaryDelta create`

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io) (eventually I will get to this)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Added / better exercised unit tests, and manually tested BinaryDelta with my own apps, Vivaldi, Docker. Ensured patch size was reduced while not trying to detect too much (causing size / patch time to overblow)

macOS version tested: 12.1 (21C52)
