### PR TITLE
Simplify tracking of file permissions for deltas

### DIFF
--- a/Autoupdate/SPUDeltaArchive.m
+++ b/Autoupdate/SPUDeltaArchive.m
@@ -56,18 +56,17 @@ id<SPUDeltaArchiveProtocol> SPUDeltaArchiveReadPatchAndHeader(NSString *patchFil
 @synthesize clonedRelativePath = _clonedRelativePath;
 @synthesize sourcePath = _sourcePath;
 @synthesize commands = _commands;
-@synthesize permissions = _permissions;
 @synthesize xarContext = _xarContext;
-@synthesize extractMode = _extractMode;
+@synthesize mode = _mode;
 @synthesize codedDataLength = _codedDataLength;
 
-- (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands permissions:(uint16_t)permissions
+- (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands mode:(uint16_t)mode
 {
     self = [super init];
     if (self != nil) {
         _relativeFilePath = [relativeFilePath copy];
         _commands = commands;
-        _permissions = permissions;
+        _mode = mode;
     }
     return self;
 }

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(uint8_t, SPUDeltaItemCommands) {
 // Represents an item we read or write to in our delta archive
 @interface SPUDeltaArchiveItem : NSObject
 
-- (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands permissions:(uint16_t)permissions;
+- (instancetype)initWithRelativeFilePath:(NSString *)relativeFilePath commands:(SPUDeltaItemCommands)commands mode:(uint16_t)mode;
 
 // The relative file path of the item, eg /Contents/MacOS/Foo
 @property (nonatomic, readonly) NSString *relativeFilePath;
@@ -53,14 +53,12 @@ typedef NS_ENUM(uint8_t, SPUDeltaItemCommands) {
 @property (nonatomic, nullable) NSString *sourcePath;
 // The commands that describe the actions to take for this item.
 @property (nonatomic, readonly) SPUDeltaItemCommands commands;
-// Provided change in permissions for the SPUDeltaItemCommandModifyPermissions command
-@property (nonatomic, readonly) uint16_t permissions;
+// Provided change in permissions for item or tracking file mode for the item
+@property (nonatomic) uint16_t mode;
 
 // Private properties
 // xar_file context for Xar delta archiver
 @property (nonatomic, nullable) const void *xarContext;
-// Tracking mode type of item (regular file, symlink) when encoding items.
-@property (nonatomic) uint16_t extractMode;
 // Tracking length of item's data in data section, when encoding items and when extracting items
 @property (nonatomic) uint64_t codedDataLength;
 

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -280,7 +280,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     NSString *relativeFilePath = item.relativeFilePath;
     NSString *filePath = item.itemFilePath;
     SPUDeltaItemCommands commands = item.commands;
-    uint16_t permissions = item.permissions;
+    uint16_t mode = item.mode;
     
     xar_file_t newFile = _xarAddFile(self.fileTable, self.x, relativeFilePath, filePath);
     if (newFile == NULL) {
@@ -301,7 +301,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     }
     
     if ((commands & SPUDeltaItemCommandModifyPermissions) != 0) {
-        xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [NSString stringWithFormat:@"%u", permissions].UTF8String);
+        xar_prop_set(newFile, MODIFY_PERMISSIONS_KEY, [NSString stringWithFormat:@"%u", mode].UTF8String);
     }
 }
 
@@ -362,16 +362,16 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
             }
         }
         
-        uint16_t permissions = 0;
+        uint16_t mode = 0;
         {
             const char *value = NULL;
             if (xar_prop_get(file, MODIFY_PERMISSIONS_KEY, &value) == 0) {
                 commands |= SPUDeltaItemCommandModifyPermissions;
-                permissions = (uint16_t)[@(value) intValue];
+                mode = (uint16_t)[@(value) intValue];
             }
         }
         
-        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands permissions:permissions];
+        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands mode:mode];
         item.xarContext = file;
         
         itemHandler(item, &exitedEarly);

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -345,7 +345,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
         }
 
         if ((commands & SPUDeltaItemCommandModifyPermissions) != 0) {
-            mode_t mode = (mode_t)item.permissions;
+            mode_t mode = (mode_t)item.mode;
             if (!modifyPermissions(destinationFilePath, mode)) {
                 if (verbose) {
                     fprintf(stderr, "\n");
@@ -358,7 +358,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *destination, NSString *patchFi
             }
 
             if (verbose) {
-                fprintf(stderr, "\n👮  %s %s (0%o)", VERBOSE_MODIFIED, [relativePath fileSystemRepresentation], mode);
+                fprintf(stderr, "\n👮  %s %s (0%o)", VERBOSE_MODIFIED, [relativePath fileSystemRepresentation], mode & PERMISSION_FLAGS);
             }
         }
     }];

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -735,7 +735,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         id value = [newTreeState valueForKey:key];
 
         if ([(NSObject *)value isEqual:[NSNull null]]) {
-            [archive addItem:[[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:SPUDeltaItemCommandDelete permissions:0]];
+            [archive addItem:[[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:SPUDeltaItemCommandDelete mode:0]];
 
             if (verbose) {
                 fprintf(stderr, "\n❌  %s %s", VERBOSE_REMOVED, [key fileSystemRepresentation]);
@@ -748,7 +748,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         if (shouldSkipDeltaCompression(originalInfo, newInfo)) {
             if (shouldSkipExtracting(originalInfo, newInfo)) {
                 if (shouldChangePermissions(originalInfo, newInfo)) {
-                    [archive addItem:[[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:SPUDeltaItemCommandModifyPermissions permissions:[(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]]];
+                    [archive addItem:[[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:SPUDeltaItemCommandModifyPermissions mode:[(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]]];
 
                     if (verbose) {
                         fprintf(stderr, "\n👮  %s %s (0%o -> 0%o)", VERBOSE_MODIFIED, [key fileSystemRepresentation], [(NSNumber *)originalInfo[INFO_PERMISSIONS_KEY] unsignedShortValue], [(NSNumber *)newInfo[INFO_PERMISSIONS_KEY] unsignedShortValue]);
@@ -773,7 +773,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                             commands |= SPUDeltaItemCommandModifyPermissions;
                         }
                         
-                        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:(clonePermissionsChanged ? newPermissions.unsignedShortValue : 0)];
+                        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands mode:(clonePermissionsChanged ? newPermissions.unsignedShortValue : 0)];
                         // Physical path for clones points to the old file
                         item.itemFilePath = [source stringByAppendingPathComponent:clonedRelativePath];
                         item.sourcePath = item.itemFilePath;
@@ -794,7 +794,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                         commands |= SPUDeltaItemCommandDelete;
                     }
                     
-                    SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands permissions:0];
+                    SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:key commands:commands mode:0];
                     item.itemFilePath = path;
                     item.sourcePath = path;
                     
@@ -843,7 +843,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             }
         }
         
-        NSNumber *permissions = operation.permissions;
+        NSNumber *mode = operation.permissions;
         NSString *relativePath = operation.relativePath;
         
         SPUDeltaItemCommands commands = SPUDeltaItemCommandBinaryDiff;
@@ -854,7 +854,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             commands |= SPUDeltaItemCommandClone;
         }
         
-        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands permissions:permissions.unsignedShortValue];
+        SPUDeltaArchiveItem *item = [[SPUDeltaArchiveItem alloc] initWithRelativeFilePath:relativePath commands:commands mode:mode.unsignedShortValue];
         item.itemFilePath = resultPath;
         item.sourcePath = operation._fromPath;
         item.clonedRelativePath = clonedRelativePath;


### PR DESCRIPTION
Also fixes minor issue where change in permissions wasn't printed in correct format when applying a patch in verbose mode.

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested creating/applying a patch with permission changes.

macOS version tested: 12.1 (21C52)
