### PR TITLE
Warn and validate against irregular permissions for delta patches

### DIFF
--- a/Autoupdate/SPUSparkleDeltaArchive.m
+++ b/Autoupdate/SPUSparkleDeltaArchive.m
@@ -1042,7 +1042,14 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
                     break;
                 }
                 
-                extractMode = sourceFileInfo.st_mode;
+                // For symbolic links we always default to 0755 when adding new items
+                // Symbolic link permissions can get more easily lost when moving to other (linux) filesystems,
+                // so we only support the macOS default
+                if (S_ISLNK(sourceFileInfo.st_mode)) {
+                    extractMode = (sourceFileInfo.st_mode & ~PERMISSION_FLAGS) | VALID_SYMBOLIC_LINK_PERMISSIONS;
+                } else {
+                    extractMode = sourceFileInfo.st_mode;
+                }
                 
                 uint16_t encodedMode;
                 if ((commands & SPUDeltaItemCommandModifyPermissions) != 0) {

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -14,6 +14,7 @@
 #include <fts.h>
 
 #define PERMISSION_FLAGS (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID | S_ISVTX)
+#define VALID_SYMBOLIC_LINK_PERMISSIONS 0755
 
 #define APPLE_CODE_SIGN_XATTR_CODE_DIRECTORY_KEY "com.apple.cs.CodeDirectory"
 #define APPLE_CODE_SIGN_XATTR_CODE_REQUIREMENTS_KEY "com.apple.cs.CodeRequirements"

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -569,13 +569,13 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             uint16_t permissions = (ent->fts_statp->st_mode & PERMISSION_FLAGS);
             if (ent->fts_info == FTS_SL) {
                 if (permissions != VALID_SYMBOLIC_LINK_PERMISSIONS) {
-                    fprintf(stderr, "\nWarning: file permissions %o of symbolic link '%s' won't be preserved in the delta update (only permissions with mode 0755 are supported for symbolic links).", permissions, ent->fts_path);
+                    fprintf(stderr, "\nWarning: file permissions 0%o of symbolic link '%s' won't be preserved in the delta update (only permissions with mode 0755 are supported for symbolic links).", permissions, ent->fts_path);
                     
                     warningsCount++;
                 }
             } else if (permissions != 0755 && permissions != 0644) {
                 // This could indicate something is wrong inside of the bundle so it's worth warning the user about
-                fprintf(stderr, "\nWarning: detected irregular file permissions %o for '%s'", permissions, ent->fts_path);
+                fprintf(stderr, "\nWarning: detected irregular file permissions 0%o for '%s'", permissions, ent->fts_path);
                 
                 warningsCount++;
             }


### PR DESCRIPTION
For symbolic links we only apply regular (0755) permissions, due to linux file systems not preserving symlink permissions.

On other occasions we warn about encountering irregular permissions that aren't 0755 or 0644.

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Added unit tests and tested running BinaryDelta on directory trees with irregular permissions.

macOS version tested: 12.1 (21C52)
