### PR TITLE
Preserve the `Entitlements` directory in podspec

### DIFF
--- a/Sparkle.podspec
+++ b/Sparkle.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.source   = { :http => "https://github.com/sparkle-project/Sparkle/releases/download/#{s.version}/Sparkle-#{s.version}.tar.xz" }
   s.source_files = 'Sparkle.framework/Versions/B/Headers/*.h'
 
-  s.preserve_paths = ['bin/*', 'Symbols']
+  s.preserve_paths = ['bin/*', 'Entitlements', 'Symbols']
   s.public_header_files = 'Sparkle.framework/Versions/B/Headers/*.h'
   s.vendored_frameworks  = 'Sparkle.framework'
   s.xcconfig            = {


### PR DESCRIPTION
In order to code sign Sparkle when installing via a Pod, the `Entitlements` directory needs to be available.

(Insert summary of your pull request here)

Fixes #2062

## Misc Checklist:

- [ ] ~~My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)~~
- [ ] ~~My change requires changes to generate_appcast, generate_keys, or sign_update~~

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: 12.1
