### PR TITLE
Fix version compare not treating '2.1.0' and '2.1' as being equal

### DIFF
--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     kNumberType,
     kStringType,
     kPeriodSeparatorType,
-    kPunctiationSeparatorType,
+    kPunctuationSeparatorType,
     kWhitespaceSeparatorType,
     kDashType,
 };
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     } else if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
         return kWhitespaceSeparatorType;
     } else if ([[NSCharacterSet punctuationCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
-        return kPunctiationSeparatorType;
+        return kPunctuationSeparatorType;
     } else {
         return kStringType;
     }
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
         case kDashType:
             return NO;
         case kPeriodSeparatorType:
-        case kPunctiationSeparatorType:
+        case kPunctuationSeparatorType:
         case kWhitespaceSeparatorType:
             return YES;
     }
@@ -78,11 +78,11 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
         case kDashType:
             return (typeA == typeB);
         case kPeriodSeparatorType:
-        case kPunctiationSeparatorType:
+        case kPunctuationSeparatorType:
         case kWhitespaceSeparatorType: {
             switch (typeB) {
                 case kPeriodSeparatorType:
-                case kPunctiationSeparatorType:
+                case kPunctuationSeparatorType:
                 case kWhitespaceSeparatorType:
                     return YES;
                 case kNumberType:

--- a/Sparkle/SUStandardVersionComparator.m
+++ b/Sparkle/SUStandardVersionComparator.m
@@ -32,34 +32,75 @@
 typedef NS_ENUM(NSInteger, SUCharacterType) {
     kNumberType,
     kStringType,
-    kSeparatorType,
+    kPeriodSeparatorType,
+    kPunctiationSeparatorType,
+    kWhitespaceSeparatorType,
     kDashType,
 };
 
 - (SUCharacterType)typeOfCharacter:(NSString *)character
 {
     if ([character isEqualToString:@"."]) {
-        return kSeparatorType;
+        return kPeriodSeparatorType;
     } else if ([character isEqualToString:@"-"]) {
         return kDashType;
     } else if ([[NSCharacterSet decimalDigitCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
         return kNumberType;
     } else if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
-        return kSeparatorType;
+        return kWhitespaceSeparatorType;
     } else if ([[NSCharacterSet punctuationCharacterSet] characterIsMember:[character characterAtIndex:0]]) {
-        return kSeparatorType;
+        return kPunctiationSeparatorType;
     } else {
         return kStringType;
     }
 }
 
-- (NSArray *)splitVersionString:(NSString *)version
+- (BOOL)isSeparatorType:(SUCharacterType)characterType
+{
+    switch (characterType) {
+        case kNumberType:
+        case kStringType:
+        case kDashType:
+            return NO;
+        case kPeriodSeparatorType:
+        case kPunctiationSeparatorType:
+        case kWhitespaceSeparatorType:
+            return YES;
+    }
+}
+
+// If type A and type B are some sort of separator, consider them to be equal
+- (BOOL)isEqualCharacterTypeClassForTypeA:(SUCharacterType)typeA typeB:(SUCharacterType)typeB
+{
+    switch (typeA) {
+        case kNumberType:
+        case kStringType:
+        case kDashType:
+            return (typeA == typeB);
+        case kPeriodSeparatorType:
+        case kPunctiationSeparatorType:
+        case kWhitespaceSeparatorType: {
+            switch (typeB) {
+                case kPeriodSeparatorType:
+                case kPunctiationSeparatorType:
+                case kWhitespaceSeparatorType:
+                    return YES;
+                case kNumberType:
+                case kStringType:
+                case kDashType:
+                    return NO;
+            }
+        }
+    }
+}
+
+- (NSMutableArray<NSString *> *)splitVersionString:(NSString *)version
 {
     NSString *character;
     NSMutableString *s;
     NSUInteger i, n;
     SUCharacterType oldType, newType;
-    NSMutableArray *parts = [NSMutableArray array];
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
     if ([version length] == 0) {
         // Nothing to do here
         return parts;
@@ -73,7 +114,7 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
         if (newType == kDashType) {
             break;
         }
-        if (oldType != newType || oldType == kSeparatorType) {
+        if (oldType != newType || [self isSeparatorType:oldType]) {
             // We've reached a new segment
             NSString *aPart = [[NSString alloc] initWithString:s];
             [parts addObject:aPart];
@@ -90,10 +131,64 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
     return parts;
 }
 
+// This returns the count of number and period parts at the beginning of the version
+// See -balanceVersionPartsA:partsB below
+- (NSUInteger)countOfNumberAndPeriodStartingParts:(NSArray<NSString *> *)parts
+{
+    NSUInteger count = 0;
+    for (NSString *part in parts) {
+        SUCharacterType characterType = [self typeOfCharacter:part];
+        
+        if (characterType == kNumberType || characterType == kPeriodSeparatorType) {
+            count++;
+        } else {
+            break;
+        }
+    }
+    return count;
+}
+
+// See -balanceVersionPartsA:partsB below
+- (void)addNumberAndPeriodPartsToParts:(NSMutableArray<NSString *> *)toParts toNumberAndPeriodPartsCount:(NSUInteger)toNumberAndPeriodPartsCount fromParts:(NSArray<NSString *> *)fromParts fromNumberAndPeriodPartsCount:(NSUInteger)fromNumberAndPeriodPartsCount
+{
+    NSUInteger partsCountDifference = (fromNumberAndPeriodPartsCount - toNumberAndPeriodPartsCount);
+    
+    for (NSUInteger insertionIndex = toNumberAndPeriodPartsCount; insertionIndex < toNumberAndPeriodPartsCount + partsCountDifference; insertionIndex++) {
+        SUCharacterType typeA = [self typeOfCharacter:fromParts[insertionIndex]];
+        if (typeA == kPeriodSeparatorType) {
+            [toParts insertObject:@"." atIndex:insertionIndex];
+        } else if (typeA == kNumberType) {
+            [toParts insertObject:@"0" atIndex:insertionIndex];
+        } else {
+            // It should not be possible to get here
+            assert(false);
+        }
+    }
+}
+
+// If one version starts with "1.0.0" and the other starts with "1.1" we make sure they're balanced
+// such that the latter version now becomes "1.1.0". This helps ensure that versions like "1.0" and "1.0.0" are equal.
+- (void)balanceVersionPartsA:(NSMutableArray<NSString *> *)partsA partsB:(NSMutableArray<NSString *> *)partsB
+{
+    NSUInteger partANumberAndPeriodPartsCount = [self countOfNumberAndPeriodStartingParts:partsA];
+    NSUInteger partBNumberAndPeriodPartsCount = [self countOfNumberAndPeriodStartingParts:partsB];;
+    
+    if (partANumberAndPeriodPartsCount > partBNumberAndPeriodPartsCount) {
+        [self addNumberAndPeriodPartsToParts:partsB toNumberAndPeriodPartsCount:partBNumberAndPeriodPartsCount fromParts:partsA fromNumberAndPeriodPartsCount:partANumberAndPeriodPartsCount];
+    } else if (partBNumberAndPeriodPartsCount > partANumberAndPeriodPartsCount) {
+        [self addNumberAndPeriodPartsToParts:partsA toNumberAndPeriodPartsCount:partANumberAndPeriodPartsCount fromParts:partsB fromNumberAndPeriodPartsCount:partBNumberAndPeriodPartsCount];
+    }
+}
+
 - (NSComparisonResult)compareVersion:(NSString *)versionA toVersion:(NSString *)versionB
 {
-    NSArray *partsA = [self splitVersionString:versionA];
-    NSArray *partsB = [self splitVersionString:versionB];
+    NSMutableArray<NSString *> *splitPartsA = [self splitVersionString:versionA];
+    NSMutableArray<NSString *> *splitPartsB = [self splitVersionString:versionB];
+    
+    [self balanceVersionPartsA:splitPartsA partsB:splitPartsB];
+    
+    NSArray<NSString *> *partsA = splitPartsA;
+    NSArray<NSString *> *partsB = splitPartsB;
 
     NSString *partA, *partB;
     NSUInteger i, n;
@@ -109,7 +204,7 @@ typedef NS_ENUM(NSInteger, SUCharacterType) {
         typeB = [self typeOfCharacter:partB];
 
         // Compare types
-        if (typeA == typeB) {
+        if ([self isEqualCharacterTypeClassForTypeA:typeA typeB:typeB]) {
             // Same type; we can compare
             if (typeA == kNumberType) {
                 valueA = [partA longLongValue];

--- a/Tests/SUVersionComparisonTest.m
+++ b/Tests/SUVersionComparisonTest.m
@@ -31,6 +31,9 @@
     SUAssertDescending(comparator, @"0.1", @"0.0.1");
     //SUAssertDescending(comparator, @".1", @"0.0.1"); Known bug, but I'm not sure I care.
     SUAssertAscending(comparator, @"0.1", @"0.1.2");
+    
+    SUAssertEqual(comparator, @"1.0", @"1.0.0");
+    SUAssertEqual(comparator, @"1.0.0", @"1.0");
 }
 
 - (void)testCommitSHAs
@@ -40,6 +43,9 @@
     SUAssertAscending(comparator, @"1.5.5-335d3e2", @"1.5.6-b252311");
     SUAssertEqual(comparator, @"1.5.5-335d3e2", @"1.5.5-a655360");
     SUAssertDescending(comparator, @"1.5.6-b252311", @"1.5.5-335d3e2");
+    
+    SUAssertEqual(comparator, @"1.5-335d3e2", @"1.5.0-335d3e2");
+    SUAssertEqual(comparator, @"1.5.0-335d3e2", @"1.5-335d3e2");
 }
 
 - (void)testPrereleases
@@ -59,6 +65,9 @@
     SUAssertAscending(comparator, @"1.0rc", @"1.0");
     SUAssertAscending(comparator, @"1.0b", @"1.0");
     SUAssertAscending(comparator, @"1.0pre1", @"1.0");
+    
+    SUAssertEqual(comparator, @"1.0pre1", @"1.0.0pre1");
+    SUAssertEqual(comparator, @"1.0.0pre1", @"1.0pre1");
 }
 
 - (void)testVersionsWithBuildNumbers
@@ -74,6 +83,13 @@
     SUAssertAscending(comparator, @"1.1.1.1818", @"2.0.0.2430");
     
     SUAssertAscending(comparator, @"3.3 (5847)", @"3.3.1b1 (5902)");
+    
+    SUAssertEqual(comparator, @"3.3 (5847)", @"3.3.0 (5847)");
+    SUAssertEqual(comparator, @"3.3.0 (5847)", @"3.3 (5847)");
+    SUAssertEqual(comparator, @"1.1.1.1818", @"1.1.1.1818.0");
+    SUAssertEqual(comparator, @"1.1.1.1818.0", @"1.1.1.1818");
+    SUAssertEqual(comparator, @"3.3b1 (5902)", @"3.3.0b1 (5902)");
+    SUAssertEqual(comparator, @"3.3.0b1 (5902)", @"3.3b1 (5902)");
 }
 
 - (void)testWordsWithSpaceInFront
@@ -92,6 +108,9 @@
     SUStandardVersionComparator *comparator = [[SUStandardVersionComparator alloc] init];
     
     SUAssertAscending(comparator, @"201210251627", @"201211051041");
+    
+    SUAssertEqual(comparator, @"201210251627.0", @"201210251627");
+    SUAssertEqual(comparator, @"201210251627", @"201210251627.0");
 }
 
 @end


### PR DESCRIPTION
Fixes version comparisons when one version has an additional .0 part and the other doesn't.

Fixes #1210

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Added and wrote unit tests for this.

Tested modified version of test app to ensure equal versions are picked up correctly.

macOS version tested: 12.1 (21C52)
