### PR TITLE
Fix unsteady progress when installing updates

### DIFF
--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -191,13 +191,13 @@
             NSString *fromPath = [mountPoint stringByAppendingPathComponent:item];
             NSString *toPath = [[self.archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:item];
             
-            // We skip any files in the DMG which are not readable.
+            itemsCopied += 1.0;
+            [notifier notifyProgress:0.5 + itemsCopied/(totalItems*2.0)];
+            
+            // We skip any files in the DMG which are not readable but include the item in the progress
             if (![manager isReadableFileAtPath:fromPath]) {
                 continue;
             }
-            
-            itemsCopied += 1.0;
-            [notifier notifyProgress:0.5 + itemsCopied/(totalItems*2.0)];
 
             SULog(SULogLevelDefault, @"copyItemAtPath:%@ toPath:%@", fromPath, toPath);
 

--- a/Sparkle/SPUCoreBasedUpdateDriver.h
+++ b/Sparkle/SPUCoreBasedUpdateDriver.h
@@ -38,11 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)coreDriverDidStartExtractingUpdate;
 
-- (void)installerDidStartInstalling;
+- (void)installerDidStartInstallingWithApplicationTerminated:(BOOL)applicationTerminated;
 
 - (void)installerDidExtractUpdateWithProgress:(double)progress;
-
-- (void)installerIsSendingAppTerminationSignal;
 
 - (void)installerDidFinishInstallationAndRelaunched:(BOOL)relaunched acknowledgement:(void(^)(void))acknowledgement;
 

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -261,10 +261,10 @@
     [self.delegate coreDriverIsRequestingAbortUpdateWithError:error];
 }
 
-- (void)installerDidStartInstalling
+- (void)installerDidStartInstallingWithApplicationTerminated:(BOOL)applicationTerminated
 {
-    if ([self.delegate respondsToSelector:@selector(installerDidStartInstalling)]) {
-        [self.delegate installerDidStartInstalling];
+    if ([self.delegate respondsToSelector:@selector(installerDidStartInstallingWithApplicationTerminated:)]) {
+        [self.delegate installerDidStartInstallingWithApplicationTerminated:applicationTerminated];
     }
 }
 
@@ -321,14 +321,6 @@
         [self.delegate installerDidFinishInstallationAndRelaunched:relaunched acknowledgement:acknowledgement];
     } else {
         acknowledgement();
-    }
-}
-
-- (void)installerIsSendingAppTerminationSignal
-{
-    // If they don't respond or do anything, we'll just install after the user terminates the app anyway
-    if ([self.delegate respondsToSelector:@selector(installerIsSendingAppTerminationSignal)]) {
-        [self.delegate installerIsSendingAppTerminationSignal];
     }
 }
 

--- a/Sparkle/SPUInstallerDriver.h
+++ b/Sparkle/SPUInstallerDriver.h
@@ -15,11 +15,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SPUInstallerDriverDelegate <NSObject>
 
-- (void)installerDidStartInstalling;
+- (void)installerDidStartInstallingWithApplicationTerminated:(BOOL)applicationTerminated;
 - (void)installerDidStartExtracting;
 - (void)installerDidExtractUpdateWithProgress:(double)progress;
 - (void)installerDidFinishPreparationAndWillInstallImmediately:(BOOL)willInstallImmediately silently:(BOOL)willInstallSilently;
-- (void)installerIsSendingAppTerminationSignal;
 - (void)installerWillFinishInstallationAndRelaunch:(BOOL)relaunch;
 - (void)installerDidFinishInstallationAndRelaunched:(BOOL)relaunch acknowledgement:(void(^)(void))acknowledgement;
 

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -43,7 +43,6 @@
 @property (nonatomic, readonly) NSBundle *applicationBundle;
 @property (nonatomic, weak, readonly) id<SPUInstallerDriverDelegate> delegate;
 @property (nonatomic) SPUInstallerMessageType currentStage;
-@property (nonatomic) BOOL startedInstalling;
 
 @property (nonatomic) id<SUInstallerConnectionProtocol> installerConnection;
 
@@ -70,7 +69,6 @@
 @synthesize applicationBundle = _applicationBundle;
 @synthesize delegate = _delegate;
 @synthesize currentStage = _currentStage;
-@synthesize startedInstalling = _startedInstalling;
 @synthesize installerConnection = _installerConnection;
 @synthesize extractionAttempts = _extractionAttempts;
 @synthesize postponedOnce = _postponedOnce;
@@ -278,9 +276,6 @@
         self.currentStage = identifier;
     } else if (identifier == SPUInstallationStartedStage1) {
         self.currentStage = identifier;
-        [self.delegate installerDidStartInstalling];
-        self.startedInstalling = YES;
-        
     } else if (identifier == SPUInstallationFinishedStage1) {
         self.currentStage = identifier;
         
@@ -308,18 +303,14 @@
     } else if (identifier == SPUInstallationFinishedStage2) {
         self.currentStage = identifier;
         
-        if (!self.startedInstalling) {
-            // It's possible we can start from resuming to stage 2 rather than doing stage 1 again, so we should notify to start installing if we haven't done so already
-            self.startedInstalling = YES;
-            [self.delegate installerDidStartInstalling];
-        }
-        
         BOOL hasTargetTerminated = NO;
         if (data.length >= sizeof(uint8_t)) {
             hasTargetTerminated = (BOOL)*((const uint8_t *)data.bytes);
         }
         
         [self.delegate installerWillFinishInstallationAndRelaunch:self.relaunch];
+        
+        [self.delegate installerDidStartInstalling];
         
         if (!hasTargetTerminated) {
             [self.delegate installerIsSendingAppTerminationSignal];

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -310,11 +310,7 @@
         
         [self.delegate installerWillFinishInstallationAndRelaunch:self.relaunch];
         
-        [self.delegate installerDidStartInstalling];
-        
-        if (!hasTargetTerminated) {
-            [self.delegate installerIsSendingAppTerminationSignal];
-        }
+        [self.delegate installerDidStartInstallingWithApplicationTerminated:hasTargetTerminated];
     } else if (identifier == SPUInstallationFinishedStage3) {
         self.currentStage = identifier;
         

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -464,12 +464,20 @@
     [self.statusController setProgressValue:progress];
 }
 
-- (void)showInstallingUpdate
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated
 {
     assert(NSThread.isMainThread);
     
-    [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
-    [self.statusController setButtonEnabled:NO];
+    if (applicationTerminated) {
+        [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
+        [self.statusController setButtonEnabled:NO];
+    } else {
+        // The "quit" event can always be canceled or delayed by the application we're updating
+        // So we can't easily predict how long the installation will take or if it won't happen right away
+        // We close our status window because we don't want it persisting for too long and have it obscure other windows
+        [self.statusController close];
+        self.statusController = nil;
+    }
 }
 
 - (void)showUpdateInstalledAndRelaunched:(BOOL)relaunched acknowledgement:(void (^)(void))acknowledgement
@@ -512,17 +520,6 @@
 }
 
 #pragma mark Aborting Everything
-
-- (void)showSendingTerminationSignal
-{
-    assert(NSThread.isMainThread);
-    
-    // The "quit" event can always be canceled or delayed by the application we're updating
-    // So we can't easily predict how long the installation will take or if it won't happen right away
-    // We close our status window because we don't want it persisting for too long and have it obscure other windows
-    [self.statusController close];
-    self.statusController = nil;
-}
 
 - (void)dismissUpdateInstallation
 {

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -42,6 +42,9 @@
 @property (nonatomic) SUStatusController *statusController;
 @property (nonatomic) SUUpdatePermissionPrompt *permissionPrompt;
 
+@property (nonatomic) uint64_t expectedContentLength;
+@property (nonatomic) uint64_t bytesDownloaded;
+
 @end
 
 @implementation SPUStandardUserDriver
@@ -56,6 +59,8 @@
 @synthesize activeUpdateAlert = _activeUpdateAlert;
 @synthesize statusController = _statusController;
 @synthesize permissionPrompt = _permissionPrompt;
+@synthesize expectedContentLength = _expectedContentLength;
+@synthesize bytesDownloaded = _bytesDownloaded;
 
 #pragma mark Birth
 
@@ -366,8 +371,12 @@
     self.cancellation = cancellation;
     
     [self createAndShowStatusController];
-    [self.statusController beginActionWithTitle:SULocalizedString(@"Downloading update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
+    
+    [self.statusController beginActionWithTitle:SULocalizedString(@"Downloading update...", @"Take care not to overflow the status window.") maxProgressValue:1.0 statusText:nil];
+    [self.statusController setProgressValue:0.0];
     [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelDownload:) isDefault:NO];
+    
+    self.bytesDownloaded = 0;
 }
 
 - (void)cancelDownload:(id)__unused sender
@@ -382,7 +391,10 @@
 {
     assert(NSThread.isMainThread);
     
-    [self.statusController setMaxProgressValue:expectedContentLength];
+    self.expectedContentLength = expectedContentLength;
+    if (expectedContentLength == 0) {
+        [self.statusController setMaxProgressValue:0.0];
+    }
 }
 
 - (NSString *)localizedStringFromByteCount:(long long)value
@@ -419,18 +431,17 @@
 {
     assert(NSThread.isMainThread);
     
-    double newProgressValue = [self.statusController progressValue] + (double)length;
+    self.bytesDownloaded += length;
     
-    // In case our expected content length was incorrect
-    if (newProgressValue > [self.statusController maxProgressValue]) {
-        [self.statusController setMaxProgressValue:newProgressValue];
+    if (self.expectedContentLength > 0.0) {
+        double newProgressValue = (double)self.bytesDownloaded / (double)self.expectedContentLength;
+        
+        [self.statusController setProgressValue:MIN(newProgressValue, 1.0)];
+        
+        [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ of %@", nil), [self localizedStringFromByteCount:(long long)self.bytesDownloaded], [self localizedStringFromByteCount:(long long)MAX(self.bytesDownloaded, self.expectedContentLength)]]];
+    } else {
+        [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ downloaded", nil), [self localizedStringFromByteCount:(long long)self.bytesDownloaded]]];
     }
-    
-    [self.statusController setProgressValue:newProgressValue];
-    if ([self.statusController maxProgressValue] > 0.0)
-        [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ of %@", nil), [self localizedStringFromByteCount:(long long)self.statusController.progressValue], [self localizedStringFromByteCount:(long long)self.statusController.maxProgressValue]]];
-    else
-        [self.statusController setStatusText:[NSString stringWithFormat:SULocalizedString(@"%@ downloaded", nil), [self localizedStringFromByteCount:(long long)self.statusController.progressValue]]];
 }
 
 - (void)showDownloadDidStartExtractingUpdate
@@ -440,7 +451,8 @@
     self.cancellation = nil;
     
     [self createAndShowStatusController];
-    [self.statusController beginActionWithTitle:SULocalizedString(@"Extracting update...", @"Take care not to overflow the status window.") maxProgressValue:0.0 statusText:nil];
+    [self.statusController beginActionWithTitle:SULocalizedString(@"Extracting update...", @"Take care not to overflow the status window.") maxProgressValue:1.0 statusText:nil];
+    [self.statusController setProgressValue:0.0];
     [self.statusController setButtonTitle:SULocalizedString(@"Cancel", nil) target:nil action:nil isDefault:NO];
     [self.statusController setButtonEnabled:NO];
 }
@@ -449,9 +461,6 @@
 {
     assert(NSThread.isMainThread);
     
-    if ([self.statusController maxProgressValue] == 0.0) {
-        [self.statusController setMaxProgressValue:1];
-    }
     [self.statusController setProgressValue:progress];
 }
 

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -310,9 +310,24 @@
     [self.userDriver showDownloadDidStartExtractingUpdate];
 }
 
-- (void)installerDidStartInstalling
+- (void)installerDidStartInstallingWithApplicationTerminated:(BOOL)applicationTerminated
 {
-    [self.userDriver showInstallingUpdate];
+    if ([self.userDriver respondsToSelector:@selector(showInstallingUpdateWithApplicationTerminated:)]) {
+        [self.userDriver showInstallingUpdateWithApplicationTerminated:applicationTerminated];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if ([self.userDriver respondsToSelector:@selector(showInstallingUpdate)]) {
+            [self.userDriver showInstallingUpdate];
+        }
+        
+        if (!applicationTerminated) {
+            if ([self.userDriver respondsToSelector:@selector(showSendingTerminationSignal)]) {
+                [self.userDriver showSendingTerminationSignal];
+            }
+        }
+#pragma clang diagnostic pop
+    }
 }
 
 - (void)installerDidExtractUpdateWithProgress:(double)progress
@@ -329,11 +344,6 @@
             });
         }];
     }
-}
-
-- (void)installerIsSendingAppTerminationSignal
-{
-    [self.userDriver showSendingTerminationSignal];
 }
 
 - (void)installerDidFinishInstallationAndRelaunched:(BOOL)relaunched acknowledgement:(void(^)(void))acknowledgement

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -198,15 +198,6 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)showExtractionReceivedProgress:(double)progress;
 
 /**
- * Show the user that the update is installing
- *
- * Let the user know that the update is currently installing. Sparkle uses this to show an indeterminate progress bar.
- *
- * Before this point, `-showExtractionReceivedProgress:` may be called.
- */
-- (void)showInstallingUpdate;
-
-/**
  * Show the user that the update is ready to install & relaunch
  *
  * Let the user know that the update is ready to install and relaunch, and ask them whether they want to proceed.
@@ -218,11 +209,20 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  *
  * A reply of `SPUUserUpdateChoiceSkip` cancels the current update that has begun installing and dismisses the update. In this circumstance, the update is canceled but this update version is not skipped in the future.
  *
- * Before this point, `-showInstallingUpdate` will be called.
+ * Before this point, `-showExtractionReceivedProgress:` or  `-showUpdateFoundWithAppcastItem:state:reply:` may be called.
  *
  * @param reply The reply which indicates if the update should be installed, dismissed, or skipped. See above discussion for more details.
  */
 - (void)showReadyToInstallAndRelaunch:(void (^)(SPUUserUpdateChoice))reply;
+
+/**
+ * Show the user that the update is installing
+ *
+ * Let the user know that the update is currently installing. Sparkle uses this to show an indeterminate progress bar.
+ *
+ * Before this point, `-showReadyToInstallAndRelaunch:` or  `-showUpdateFoundWithAppcastItem:state:reply:` will be called.
+ */
+- (void)showInstallingUpdate;
 
 /**
  * Show or dismiss progress while a termination signal is being sent to the application from Sparkle's installer
@@ -232,6 +232,8 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  *
  * It is up to the implementor whether or not to decide to continue showing installation progress
  * or dismissing UI that won't remain obscuring other parts of the user interface.
+ *
+ * Before this point, `-showInstallingUpdate` will be called.
  *
  * This will not be invoked if the application that is being updated is already terminated.
  */

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -218,26 +218,16 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 /**
  * Show the user that the update is installing
  *
- * Let the user know that the update is currently installing. Sparkle uses this to show an indeterminate progress bar.
+ * Let the user know that the update is currently installing.
  *
  * Before this point, `-showReadyToInstallAndRelaunch:` or  `-showUpdateFoundWithAppcastItem:state:reply:` will be called.
+ *
+ * @param applicationTerminated Indicates if the application has been terminated already.
+ * If the application hasn't been terminated, a quit event is sent to the running application before installing the update.
+ * If the application or user delays or cancels termination, there may be an indefinite period of time before the application fully quits.
+ * It is up to the implementor whether or not to decide to continue showing installation progress in this case.
  */
-- (void)showInstallingUpdate;
-
-/**
- * Show or dismiss progress while a termination signal is being sent to the application from Sparkle's installer
- *
- * Terminating and relaunching the application (if requested to be relaunched) may happen quickly,
- * or it may take some time to perform the final installation, or the termination signal can be canceled or delayed by the application or user.
- *
- * It is up to the implementor whether or not to decide to continue showing installation progress
- * or dismissing UI that won't remain obscuring other parts of the user interface.
- *
- * Before this point, `-showInstallingUpdate` will be called.
- *
- * This will not be invoked if the application that is being updated is already terminated.
- */
-- (void)showSendingTerminationSignal;
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated;
 
 /**
  * Show the user that the update installation finished
@@ -248,7 +238,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * the updater's lifetime is tied to the application it is updating. This implementation must not try to reference
  * the old bundle prior to the installation, which will no longer be around.
  *
- * Before this point, `-showSendingTerminationSignal` or `-showReadyToInstallAndRelaunch:` may be called.
+ * Before this point, `-showInstallingUpdateWithApplicationTerminated:` will be called.
  *
  * @param relaunched Indicates if the update was relaunched.
  * @param acknowledgement Acknowledge to the updater that the finished installation was shown.
@@ -286,7 +276,11 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 
 - (void)showUpdateInstallationDidFinishWithAcknowledgement:(void (^)(void))acknowledgement __deprecated_msg("Implement -showUpdateInstalledAndRelaunched:acknowledgement: instead");
 
-- (void)dismissUserInitiatedUpdateCheck __deprecated_msg("Transition to new UI appropriately when a new update is shown, when no update is found, or when an update error occurs.");;
+- (void)dismissUserInitiatedUpdateCheck __deprecated_msg("Transition to new UI appropriately when a new update is shown, when no update is found, or when an update error occurs.");
+
+- (void)showInstallingUpdate __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated: instead.");
+
+- (void)showSendingTerminationSignal __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated: instead.");
 
 @end
 

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -251,15 +251,14 @@
     [self addUpdateButtonWithTitle:[NSString stringWithFormat:@"Extracting (%d%%)…", (int)(progress * 100)]];
 }
 
-- (void)showInstallingUpdate
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated
 {
-    [self addUpdateButtonWithTitle:@"Installing…"];
-}
-
-- (void)showSendingTerminationSignal
-{
-    // In case our termination request fails or is delayed
-    [self removeUpdateButton];
+    if (applicationTerminated) {
+        [self addUpdateButtonWithTitle:@"Installing…"];
+    } else {
+        // In case our termination request fails or is delayed
+        [self removeUpdateButton];
+    }
 }
 
 - (void)showUpdateInstalledAndRelaunched:(BOOL)__unused relaunched acknowledgement:(void (^)(void))acknowledgement

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -217,7 +217,7 @@
     }
 }
 
-- (void)showInstallingUpdate
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)__unused applicationTerminated
 {
     if (self.verbose) {
         fprintf(stderr, "Installing Update...\n");
@@ -235,11 +235,6 @@
 
 - (void)dismissUpdateInstallation
 {
-}
-
-- (void)showSendingTerminationSignal
-{
-    // We are already showing that the update is installing, so there is no need to do anything here
 }
 
 @end


### PR DESCRIPTION
We move showing installing the update after showing that the update is ready to install. We also fix progress status in dmg unarchiver not reaching 100% in some cases.

We deprecate a couple of user driver methods and replace/combine them with a method that shows installing the update and lets the driver know if the target is terminated.

Fixes #2068

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested sparkle-cli installing another app that is running or already terminated, tested an app updating itself.

macOS version tested: 12.1 (21C52)
