### PR TITLE
Add verify and account options for signing updates

### DIFF
--- a/sign_update/main.swift
+++ b/sign_update/main.swift
@@ -10,19 +10,19 @@ import Foundation
 import Security
 import ArgumentParser
 
-func findKeysInKeychain() throws -> (Data, Data) {
+func findKeysInKeychain(account: String) throws -> (Data, Data) {
     var item: CFTypeRef?
     let res = SecItemCopyMatching([
         kSecClass as String: kSecClassGenericPassword,
         kSecAttrService as String: "https://sparkle-project.org",
-        kSecAttrAccount as String: "ed25519",
+        kSecAttrAccount as String: account,
         kSecAttrProtocol as String: kSecAttrProtocolSSH,
         kSecReturnData as String: kCFBooleanTrue!,
         ] as CFDictionary, &item)
     if res == errSecSuccess, let encoded = item as? Data, let keys = Data(base64Encoded: encoded) {
         return (keys[0..<64], keys[64..<(64+32)])
     } else if res == errSecItemNotFound {
-        print("ERROR! Signing key not found. Please run generate_keys tool first or provide key with -f <private_key_file> or -s <private_key> parameter.")
+        print("ERROR! Signing key not found for account \(account). Please run generate_keys tool first or provide key with -f <private_key_file> or -s <private_key> parameter.")
     } else if res == errSecAuthFailed {
         print("ERROR! Access denied. Can't get keys from the keychain.")
         print("Go to Keychain Access.app, lock the login keychain, then unlock it again.")
@@ -70,8 +70,11 @@ func edSignature(data: Data, publicEdKey: Data, privateEdKey: Data) -> String {
 }
 
 struct SignUpdate: ParsableCommand {
-    @Argument(help: "The update archive, delta update, or package (pkg) to sign.")
-    var updatePath: String
+    @Option(help: ArgumentHelp("The account name in your keychain associated with your private EdDSA (ed25519) key to use for signing the update."))
+    var account: String = "ed25519"
+    
+    @Flag(help: ArgumentHelp("Verify that the update is signed correctly. If this is set, a second argument <verify-signature> denoting the signature must be passed after the <update-path>.", valueName: "verify"))
+    var verify: Bool = false
     
     @Option(name: .customShort("s"), help: ArgumentHelp("The private EdDSA (ed25519) key.", valueName: "private-key"))
     var privateKey: String?
@@ -79,13 +82,23 @@ struct SignUpdate: ParsableCommand {
     @Option(name: .customShort("f"), help: ArgumentHelp("Path to the file containing the private EdDSA (ed25519) key.", valueName: "private-key-file"))
     var privateKeyFile: String?
     
+    @Argument(help: "The update archive, delta update, or package (pkg) to sign or verify.")
+    var updatePath: String
+    
+    @Argument(help: "The signature to verify when --verify is passed.")
+    var verifySignature: String?
+    
     static var configuration: CommandConfiguration = CommandConfiguration(
-        abstract: "Sign an update using your private EdDSA (ed25519) key.",
+        abstract: "Sign or verify an update using your private EdDSA (ed25519) key.",
         discussion: "The private EdDSA key is automatically read from the Keychain if no <private-key> or <private-key-file> is specified.\n\nThis tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure.")
     
     func validate() throws {
         guard privateKey == nil || privateKeyFile == nil else {
             throw ValidationError("Both -s <private-key> and -f <private-key-file> options cannot be provided.")
+        }
+        
+        guard !verify || verifySignature != nil else {
+            throw ValidationError("<verify-signature> must be passed as a second argument after <update-path> if --verify is passed.")
         }
     }
     
@@ -97,12 +110,40 @@ struct SignUpdate: ParsableCommand {
         } else if let privateKeyFile = privateKeyFile {
             (priv, pub) = try findKeys(inFile: privateKeyFile)
         } else {
-            (priv, pub) = try findKeysInKeychain()
+            (priv, pub) = try findKeysInKeychain(account: account)
         }
     
         let data = try Data.init(contentsOf: URL.init(fileURLWithPath: updatePath), options: .mappedIfSafe)
-        let sig = edSignature(data: data, publicEdKey: pub, privateEdKey: priv)
-        print("sparkle:edSignature=\"\(sig)\" length=\"\(data.count)\"")
+        if verify {
+            // Verify the signature
+            guard let verifySignature = verifySignature else {
+                print("Error: failed to unwrap verifySignature, which is unexpected")
+                throw ExitCode.failure
+            }
+            
+            guard let signatureData = Data(base64Encoded: verifySignature, options: .ignoreUnknownCharacters) else {
+                print("Error: failed to decode base64 signature: \(verifySignature)")
+                throw ExitCode.failure
+            }
+            
+            let signatureBytes = Array(signatureData)
+            guard signatureBytes.count == 64 else {
+                print("Error: signature passed in has an invalid byte count.")
+                throw ExitCode.failure
+            }
+            
+            let dataBytes = Array(data)
+            let publicKeyBytes = Array(pub)
+            
+            if ed25519_verify(signatureBytes, dataBytes, data.count, publicKeyBytes) == 0 {
+                print("Error: failed to pass signing verification.")
+                throw ExitCode.failure
+            }
+        } else {
+            // Sign the update
+            let sig = edSignature(data: data, publicEdKey: pub, privateEdKey: priv)
+            print("sparkle:edSignature=\"\(sig)\" length=\"\(data.count)\"")
+        }
     }
 }
 

--- a/sign_update/main.swift
+++ b/sign_update/main.swift
@@ -89,8 +89,8 @@ struct SignUpdate: ParsableCommand {
     var verifySignature: String?
     
     static var configuration: CommandConfiguration = CommandConfiguration(
-        abstract: "Sign or verify an update using your private EdDSA (ed25519) key.",
-        discussion: "The private EdDSA key is automatically read from the Keychain if no <private-key> or <private-key-file> is specified.\n\nThis tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure.")
+        abstract: "Sign or verify an update using your EdDSA (ed25519) keys.",
+        discussion: "The EdDSA keys are automatically read from the Keychain if no <private-key> or <private-key-file> is specified.\n\nWhen signing, this tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure.")
     
     func validate() throws {
         guard privateKey == nil || privateKeyFile == nil else {


### PR DESCRIPTION
Accounts are intended to be used for when working on products that belong to different organizations. This way multiple keys related to Sparkle can be stored in the keychain.

We also add a --verify option to sign_update which allows verifying that updates are signed correctly.

Fixes #1969, #896

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested that keys can be generated and signed under a new account name (differing from default ed25519 one). Tested that generate_appcast can use different accounts and verified the results with sign_update --verify. Tested sign_update --verify on several update files, using different accounts, truncating the base64 provided signature (results in an error), or using a different signature (results in failing to pass verification).

macOS version tested: 12.1 (21C52)
