### PR TITLE
Add hidden option to generate_appcast to set max CDATA threshold

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -5,9 +5,6 @@
 
 import Foundation
 
-// CDATA text must contain less characters than this threshold
-let CDATA_HTML_FRAGMENT_THRESHOLD = 1000
-
 class DeltaUpdate {
     let fromVersion: String
     let archivePath: URL
@@ -184,9 +181,9 @@ class ArchiveItem: CustomStringConvertible {
         return releaseNotes
     }
 
-    private func getReleaseNotesAsHTMLFragment(_ path: URL) -> String?  {
+    private func getReleaseNotesAsHTMLFragment(_ path: URL, _ maxCDATAThreshold: Int) -> String?  {
         if let html = try? String(contentsOf: path) {
-            if html.utf8.count < CDATA_HTML_FRAGMENT_THRESHOLD &&
+            if html.utf8.count <= maxCDATAThreshold &&
                 !html.localizedCaseInsensitiveContains("<!DOCTYPE") &&
                 !html.localizedCaseInsensitiveContains("<body") {
                 return html
@@ -194,20 +191,20 @@ class ArchiveItem: CustomStringConvertible {
         }
         return nil
     }
-
-    var releaseNotesHTML: String? {
+    
+    func releaseNotesHTML(maxCDATAThreshold: Int) -> String? {
         if let path = self.releaseNotesPath {
-            return self.getReleaseNotesAsHTMLFragment(path)
+            return self.getReleaseNotesAsHTMLFragment(path, maxCDATAThreshold)
         }
         return nil
     }
-
-    var releaseNotesURL: URL? {
+    
+    func releaseNotesURL(maxCDATAThreshold: Int) -> URL? {
         guard let path = self.releaseNotesPath else {
             return nil
         }
         // The file is already used as inline description
-        if self.getReleaseNotesAsHTMLFragment(path) != nil {
+        if self.getReleaseNotesAsHTMLFragment(path, maxCDATAThreshold) != nil {
             return nil
         }
         return self.releaseNoteURL(for: path.lastPathComponent)

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -49,7 +49,7 @@ func extractVersion(parent: XMLNode) -> String? {
     return nil
 }
 
-func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem], newVersions: Set<String>?, maxNewVersionsInFeed: Int, fullReleaseNotesLink: String?, link: String?, newChannel: String?, majorVersion: String?, phasedRolloutInterval: Int?, criticalUpdateVersion: String?, informationalUpdateVersions: [String]?) throws -> (numNewUpdates: Int, numExistingUpdates: Int) {
+func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem], newVersions: Set<String>?, maxNewVersionsInFeed: Int, fullReleaseNotesLink: String?, maxCDATAThreshold: Int, link: String?, newChannel: String?, majorVersion: String?, phasedRolloutInterval: Int?, criticalUpdateVersion: String?, informationalUpdateVersions: [String]?) throws -> (numNewUpdates: Int, numExistingUpdates: Int) {
     let appBaseName = updates[0].appPath.deletingPathExtension().lastPathComponent
 
     let sparkleNS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
@@ -232,7 +232,7 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem], newVersions: Set
         }
         shortVersionElement?.setChildren([text(update.shortVersion)])
 
-        if let html = update.releaseNotesHTML {
+        if let html = update.releaseNotesHTML(maxCDATAThreshold: maxCDATAThreshold) {
             let descElement = findOrCreateElement(name: "description", parent: item)
             let cdata = XMLNode(kind: .text, options: .nodeIsCDATA)
             cdata.stringValue = html
@@ -260,7 +260,7 @@ func writeAppcast(appcastDestPath: URL, updates: [ArchiveItem], newVersions: Set
             .contains(where: { $0.name == SUXMLLanguage }) }
         let relElement = results?.first
         
-        if let url = update.releaseNotesURL {
+        if let url = update.releaseNotesURL(maxCDATAThreshold: maxCDATAThreshold) {
             // The update includes a valid release notes URL
             if let existingReleaseNotesElement = relElement {
                 // The existing item includes a release notes element. Update it.

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -46,6 +46,8 @@ func loadPrivateKeys(_ privateDSAKey: SecKey?, _ privateEdString: String?) -> Pr
     return PrivateKeys(privateDSAKey: privateDSAKey, privateEdKey: privateEdKey, publicEdKey: publicEdKey)
 }
 
+let DEFAULT_MAX_CDATA_THRESHOLD = 1000
+
 struct GenerateAppcast: ParsableCommand {
     static let programName = "generate_appcast"
     static let programNamePath: String = CommandLine.arguments.first ?? "./\(programName)"
@@ -120,6 +122,10 @@ struct GenerateAppcast: ParsableCommand {
     @Flag(help: .hidden)
     var verbose: Bool = false
     
+    // CDATA text must contain <= this number of characters
+    @Option(name: .customLong("max-cdata-threshold"), help: .hidden)
+    var maxCDATAThreshold: Int = DEFAULT_MAX_CDATA_THRESHOLD
+    
     static var configuration = CommandConfiguration(
         abstract: "Generate appcast from a directory of Sparkle update archives.",
         discussion: """
@@ -129,7 +135,7 @@ struct GenerateAppcast: ParsableCommand {
         Old entries in the appcast are kept intact. Otherwise, a new appcast file will be generated and written.
         
         .html files that have the same filename as an archive (except for the file extension) will be used for release notes for that item.
-        If the contents of these files are short (< \(CDATA_HTML_FRAGMENT_THRESHOLD) characters) and do not include a DOCTYPE or body tags, they will be treated as embedded CDATA release notes.
+        If the contents of these files are short (< \(DEFAULT_MAX_CDATA_THRESHOLD) characters) and do not include a DOCTYPE or body tags, they will be treated as embedded CDATA release notes.
         
         For new update entries, Sparkle infers the minimum system OS requirement based on your update's LSMinimumSystemVersion provided
         by your application's Info.plist. If none is found, \(programName) defaults to Sparkle's own minimum system requirement (macOS 10.11).
@@ -239,7 +245,7 @@ struct GenerateAppcast: ParsableCommand {
                                                                 relativeTo: archivesSourceDir)
 
                 // Write the appcast
-                let (numNewUpdates, numExistingUpdates) = try writeAppcast(appcastDestPath: appcastDestPath, updates: updates, newVersions: versions, maxNewVersionsInFeed: maxNewVersionsInFeed, fullReleaseNotesLink: fullReleaseNotesURL, link: link, newChannel: channel, majorVersion: majorVersion, phasedRolloutInterval: phasedRolloutInterval, criticalUpdateVersion: criticalUpdateVersion, informationalUpdateVersions: informationalUpdateVersions)
+                let (numNewUpdates, numExistingUpdates) = try writeAppcast(appcastDestPath: appcastDestPath, updates: updates, newVersions: versions, maxNewVersionsInFeed: maxNewVersionsInFeed, fullReleaseNotesLink: fullReleaseNotesURL, maxCDATAThreshold: maxCDATAThreshold, link: link, newChannel: channel, majorVersion: majorVersion, phasedRolloutInterval: phasedRolloutInterval, criticalUpdateVersion: criticalUpdateVersion, informationalUpdateVersions: informationalUpdateVersions)
 
                 // Inform the user, pluralizing "update" if necessary
                 let pluralizeUpdates = { $0 == 1 ? "update" : "updates" }


### PR DESCRIPTION
`--max-cdata-threshold` is a hidden option that might unblock people in certain cases.

Related: #2039 

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast with and without setting threshold and outputs what I'd expect (no inline release notes for large HTML fragment without setting the option, and does inline them when setting the option to something very large).

macOS version tested: 12.1 (21C52)
