### PR TITLE
Verify applying delta patch in generate_appcast

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -35,6 +35,7 @@ class DeltaUpdate {
         let fileManager = FileManager.default
         
         let tempApplyToPath = to.appPath.deletingLastPathComponent().appendingPathComponent(".temp_" + to.appPath.lastPathComponent)
+        let _ = try? fileManager.removeItem(at: tempApplyToPath)
         
         var applyDiffError: NSError?
         if !applyBinaryDelta(from.appPath.path, tempApplyToPath.path, archivePath.path, false, { _ in

--- a/generate_appcast/Bridging-Header.h
+++ b/generate_appcast/Bridging-Header.h
@@ -6,6 +6,7 @@
 #import "SUUnarchiver.h"
 #import "SUBinaryDeltaUnarchiver.h"
 #import "SUBinaryDeltaCreate.h"
+#import "SUBinaryDeltaApply.h"
 #import "SUBinaryDeltaCommon.h"
 #import "SUSignatures.h"
 #import "SPUInstallationType.h"


### PR DESCRIPTION
When we create new delta patches we should verify they can actually apply successfully.

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested patches can be created successfully in generate_appcast and they fail if I introduce a bug in apply code.

macOS version tested: 12.1 (21C52)
