### PR TITLE
Verify code signing in generate_appcast

### DIFF
--- a/Autoupdate/SUCodeSigningVerifier.h
+++ b/Autoupdate/SUCodeSigningVerifier.h
@@ -12,8 +12,14 @@
 #import <Foundation/Foundation.h>
 
 @interface SUCodeSigningVerifier : NSObject
+
 + (BOOL)codeSignatureAtBundleURL:(NSURL *)oldBundleURL matchesSignatureAtBundleURL:(NSURL *)newBundleURL error:(NSError  **)error;
-+ (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundleURL error:(NSError **)error;
+
++ (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundleURL checkNestedCode:(BOOL)checkNestedCode error:(NSError **)error;
+
+// Same as above except does not check for nested code. This method should be used by the framework.
++ (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundleURL error:(NSError *__autoreleasing *)error;
+
 + (BOOL)bundleAtURLIsCodeSigned:(NSURL *)bundleURL;
 @end
 

--- a/Autoupdate/SUCodeSigningVerifier.m
+++ b/Autoupdate/SUCodeSigningVerifier.m
@@ -128,6 +128,11 @@ finally:
 
 + (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundleURL error:(NSError *__autoreleasing *)error
 {
+    return [self codeSignatureIsValidAtBundleURL:bundleURL checkNestedCode:NO error:error];
+}
+
++ (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)bundleURL checkNestedCode:(BOOL)checkNestedCode error:(NSError *__autoreleasing *)error
+{
     OSStatus result;
     SecStaticCodeRef staticCode = NULL;
     CFErrorRef cfError = NULL;
@@ -143,8 +148,12 @@ finally:
         goto finally;
     }
 
-    // See in -codeSignatureAtBundleURL:matchesSignatureAtBundleURL:error: for why kSecCSCheckNestedCode is not passed
+    // See in -codeSignatureAtBundleURL:matchesSignatureAtBundleURL:error: for why kSecCSCheckNestedCode is not always passed
     SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
+    if (checkNestedCode) {
+        flags |= kSecCSCheckNestedCode;
+    }
+    
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, NULL, &cfError);
     
     if (result != errSecSuccess) {

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		7293A1AE1CEE933800B957A7 /* SPUURLRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7293A1AC1CEE933800B957A7 /* SPUURLRequest.h */; };
 		7293A1AF1CEE933800B957A7 /* SPUURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293A1AD1CEE933800B957A7 /* SPUURLRequest.m */; };
 		7293A1B11CEE9B9F00B957A7 /* SPUURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7293A1AD1CEE933800B957A7 /* SPUURLRequest.m */; };
+		729743AB279D1BD2009910B2 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
 		729924941DF4A45000DBCDF5 /* SUUpdateValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 729924931DF4A45000DBCDF5 /* SUUpdateValidator.m */; };
 		729F7EAC27366353004592DC /* test-links.xml in Resources */ = {isa = PBXBuildFile; fileRef = 729F7EAB27366353004592DC /* test-links.xml */; };
 		729F7EAF273F1840004592DC /* SPUUserAgent+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 729F7EAD273F1840004592DC /* SPUUserAgent+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3290,6 +3291,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				729743AB279D1BD2009910B2 /* SUCodeSigningVerifier.m in Sources */,
 				725EE489277D39B400D820CE /* SPUDeltaArchive.m in Sources */,
 				725EE48A277D39B400D820CE /* SPUXarDeltaArchive.m in Sources */,
 				721D5B1B25C692BB00D23BEA /* SUFlatPackageUnarchiver.m in Sources */,

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -11,10 +11,10 @@ func makeError(code: SUError, _ description: String) -> NSError {
         ])
 }
 
-func makeAppcast(archivesSourceDir: URL, cacheDirectory cacheDir: URL, keys: PrivateKeys, versions: Set<String>?, maximumDeltas: Int, deltaCompressionModeDescription: String, deltaCompressionLevel: UInt8, verbose: Bool) throws -> [String: [ArchiveItem]] {
+func makeAppcast(archivesSourceDir: URL, cacheDirectory cacheDir: URL, keys: PrivateKeys, versions: Set<String>?, maximumDeltas: Int, deltaCompressionModeDescription: String, deltaCompressionLevel: UInt8, disableNestedCodeCheck: Bool, verbose: Bool) throws -> [String: [ArchiveItem]] {
     let comparator = SUStandardVersionComparator()
 
-    let allUpdates = (try unarchiveUpdates(archivesSourceDir: archivesSourceDir, archivesDestDir: cacheDir, verbose: verbose))
+    let allUpdates = (try unarchiveUpdates(archivesSourceDir: archivesSourceDir, archivesDestDir: cacheDir, disableNestedCodeCheck: disableNestedCodeCheck, verbose: verbose))
         .sorted(by: {
             .orderedDescending == comparator.compareVersion($0.version, toVersion: $1.version)
         })

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -73,7 +73,7 @@ class ArchiveItem: CustomStringConvertible {
         self.deltas = []
     }
 
-    convenience init(fromArchive archivePath: URL, unarchivedDir: URL) throws {
+    convenience init(fromArchive archivePath: URL, unarchivedDir: URL, validateBundle: Bool) throws {
         let resourceKeys = [URLResourceKey.typeIdentifierKey]
         let items = try FileManager.default.contentsOfDirectory(at: unarchivedDir, includingPropertiesForKeys: resourceKeys, options: .skipsHiddenFiles)
 
@@ -90,6 +90,12 @@ class ArchiveItem: CustomStringConvertible {
             }
 
             let appPath = bundles[0]
+            
+            // If requested to validate the bundle, ensure it is properly signed
+            if validateBundle && SUCodeSigningVerifier.bundle(atURLIsCodeSigned: appPath) {
+                try SUCodeSigningVerifier.codeSignatureIsValid(atBundleURL: appPath, checkNestedCode: true)
+            }
+            
             guard let infoPlist = NSDictionary(contentsOf: appPath.appendingPathComponent("Contents/Info.plist")) else {
                 throw makeError(code: .unarchivingError, "No plist \(appPath.path)")
             }

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -85,7 +85,7 @@ class ArchiveItem: CustomStringConvertible {
         self.deltas = []
     }
 
-    convenience init(fromArchive archivePath: URL, unarchivedDir: URL, validateBundle: Bool) throws {
+    convenience init(fromArchive archivePath: URL, unarchivedDir: URL, validateBundle: Bool, disableNestedCodeCheck: Bool) throws {
         let resourceKeys = [URLResourceKey.typeIdentifierKey]
         let items = try FileManager.default.contentsOfDirectory(at: unarchivedDir, includingPropertiesForKeys: resourceKeys, options: .skipsHiddenFiles)
 
@@ -105,7 +105,7 @@ class ArchiveItem: CustomStringConvertible {
             
             // If requested to validate the bundle, ensure it is properly signed
             if validateBundle && SUCodeSigningVerifier.bundle(atURLIsCodeSigned: appPath) {
-                try SUCodeSigningVerifier.codeSignatureIsValid(atBundleURL: appPath, checkNestedCode: true)
+                try SUCodeSigningVerifier.codeSignatureIsValid(atBundleURL: appPath, checkNestedCode: !disableNestedCodeCheck)
             }
             
             guard let infoPlist = NSDictionary(contentsOf: appPath.appendingPathComponent("Contents/Info.plist")) else {

--- a/generate_appcast/Bridging-Header.h
+++ b/generate_appcast/Bridging-Header.h
@@ -8,5 +8,6 @@
 #import "SUBinaryDeltaCreate.h"
 #import "SUBinaryDeltaCommon.h"
 #import "SUSignatures.h"
+#import "SUCodeSigningVerifier.h"
 #import "SPUInstallationType.h"
 #import "ed25519.h" // Run `git submodule update --init` if you get an error here

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -71,9 +71,9 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, verbose: Boo
             continue
         }
 
-        let addItem = {
+        let addItem = { (validateBundle: Bool) in
             do {
-                let item = try ArchiveItem(fromArchive: itemPath, unarchivedDir: archiveDestDir)
+                let item = try ArchiveItem(fromArchive: itemPath, unarchivedDir: archiveDestDir, validateBundle: validateBundle)
                 if verbose {
                     print("Found archive", item)
                 }
@@ -81,21 +81,19 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, verbose: Boo
                 unarchived.append(item)
                 objc_sync_exit(unarchived)
             } catch {
-                if verbose {
-                    print("Skipped", item, error)
-                }
+                print("Skipped", item, error)
             }
         }
 
         if fileManager.fileExists(atPath: archiveDestDir.path) {
-            addItem()
+            addItem(false)
         } else {
             group.enter()
             unarchive(itemPath: itemPath, archiveDestDir: archiveDestDir) { (error: Error?) in
                 if let error = error {
                     print("Could not unarchive", itemPath.path, error)
                 } else {
-                    addItem()
+                    addItem(true)
                 }
                 group.leave()
             }

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -43,7 +43,7 @@ func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) 
     }
 }
 
-func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, verbose: Bool) throws -> [ArchiveItem] {
+func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, disableNestedCodeCheck: Bool, verbose: Bool) throws -> [ArchiveItem] {
     if verbose {
         print("Unarchiving to temp directory", archivesDestDir.path)
     }
@@ -73,7 +73,7 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, verbose: Boo
 
         let addItem = { (validateBundle: Bool) in
             do {
-                let item = try ArchiveItem(fromArchive: itemPath, unarchivedDir: archiveDestDir, validateBundle: validateBundle)
+                let item = try ArchiveItem(fromArchive: itemPath, unarchivedDir: archiveDestDir, validateBundle: validateBundle, disableNestedCodeCheck: disableNestedCodeCheck)
                 if verbose {
                     print("Found archive", item)
                 }

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -129,7 +129,7 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .customLong("max-cdata-threshold"), help: .hidden)
     var maxCDATAThreshold: Int = DEFAULT_MAX_CDATA_THRESHOLD
     
-    @Option(name: .customLong("disable-nested-code-check"), help: .hidden)
+    @Flag(name: .customLong("disable-nested-code-check"), help: .hidden)
     var disableNestedCodeCheck: Bool = false
     
     static var configuration = CommandConfiguration(

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -129,6 +129,9 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .customLong("max-cdata-threshold"), help: .hidden)
     var maxCDATAThreshold: Int = DEFAULT_MAX_CDATA_THRESHOLD
     
+    @Option(name: .customLong("disable-nested-code-check"), help: .hidden)
+    var disableNestedCodeCheck: Bool = false
+    
     static var configuration = CommandConfiguration(
         abstract: "Generate appcast from a directory of Sparkle update archives.",
         discussion: """
@@ -217,7 +220,7 @@ struct GenerateAppcast: ParsableCommand {
         let keys = loadPrivateKeys(account, privateDSAKey, privateEdString)
         
         do {
-            let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, cacheDirectory: GenerateAppcast.cacheDirectory, keys: keys, versions: versions, maximumDeltas: maximumDeltas, deltaCompressionModeDescription: deltaCompression, deltaCompressionLevel: deltaCompressionLevel, verbose: verbose)
+            let allUpdates = try makeAppcast(archivesSourceDir: archivesSourceDir, cacheDirectory: GenerateAppcast.cacheDirectory, keys: keys, versions: versions, maximumDeltas: maximumDeltas, deltaCompressionModeDescription: deltaCompression, deltaCompressionLevel: deltaCompressionLevel, disableNestedCodeCheck: disableNestedCodeCheck, verbose: verbose)
             
             // If a URL prefix was provided, set on the archive items
             if downloadURLPrefix != nil || releaseNotesURLPrefix != nil {


### PR DESCRIPTION
1. Verify that new updates are validly signed. If not, log to user that we skip the update.
2. When generating deltas verify that old and new app match signing identities. If not, log a warning to user.

Fixes #955
(in conjunction with #2076)

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generating new updates with generate_appcast where:

1. Everything is valid. Succeeds.
2. New update is invalid. Skips new update and warns user.
3. New update has mismatch signature from old app when delta is being created. Warns user.

macOS version tested: 12.1 (21C52)
