### PR TITLE
Don't let skipping a major version to skip subsequent major versions

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		720AC2C92618E89500E25A3E /* SUAppcastItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B5FC5409C5182000B25A18 /* SUAppcastItem.m */; };
 		720AC2DC2618E8A500E25A3E /* SPUSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 726E075B1CA3A6D6001A286B /* SPUSecureCoding.m */; };
 		720B16451C66433D006985FB /* SUTestApplicationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720B16431C66433D006985FB /* SUTestApplicationTest.swift */; };
+		720DC50427A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml in Resources */ = {isa = PBXBuildFile; fileRef = 720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */; };
 		720E217B1D0D00BF003A311C /* SPUUpdaterCycle.h in Headers */ = {isa = PBXBuildFile; fileRef = 720E21791D0D00BF003A311C /* SPUUpdaterCycle.h */; };
 		720E217C1D0D00BF003A311C /* SPUUpdaterCycle.m in Sources */ = {isa = PBXBuildFile; fileRef = 720E217A1D0D00BF003A311C /* SPUUpdaterCycle.m */; };
 		7210C7681B9A9A1500EB90AC /* SUUnarchiverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */; };
@@ -973,6 +974,7 @@
 		720B16431C66433D006985FB /* SUTestApplicationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SUTestApplicationTest.swift; path = UITests/SUTestApplicationTest.swift; sourceTree = SOURCE_ROOT; };
 		720B4C2325EBFAFD005A0592 /* link-tools.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "link-tools.sh"; sourceTree = "<group>"; };
 		720C192827127A3800740C8E /* release-move-tag.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "release-move-tag.sh"; sourceTree = "<group>"; };
+		720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast_minimumAutoupdateVersionSkipping.xml; sourceTree = "<group>"; };
 		720E21791D0D00BF003A311C /* SPUUpdaterCycle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUUpdaterCycle.h; sourceTree = "<group>"; };
 		720E217A1D0D00BF003A311C /* SPUUpdaterCycle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUUpdaterCycle.m; sourceTree = "<group>"; };
 		7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUUnarchiverTest.swift; sourceTree = "<group>"; };
@@ -1764,6 +1766,7 @@
 				5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */,
 				723EDC3E26885A8E000BCBA4 /* testappcast_channels.xml */,
 				725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */,
+				720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */,
 				7202DC99269ABD3500737EC4 /* testappcast_phasedRollout.xml */,
 				722545B526805FF80036465C /* testappcast_info_updates.xml */,
 				5F1510A11C96E591006E1629 /* testnamespaces.xml */,
@@ -3036,6 +3039,7 @@
 				725B3A82263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml in Resources */,
 				14958C6E19AEBC950061B14F /* signed-test-file.txt in Resources */,
 				723EDC3F26885A8E000BCBA4 /* testappcast_channels.xml in Resources */,
+				720DC50427A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml in Resources */,
 				72AC6B2E1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg in Resources */,
 				C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */,
 				72AC6B281B9AAD6700F62325 /* SparkleTestCodeSignApp.tar in Resources */,

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -335,9 +335,8 @@
 {
     NSString *skippedMajorVersion = skippedUpdate.majorVersion;
     
-    if (!hostPassesSkippedMajorVersion && skippedMajorVersion != nil && [versionComparator compareVersion:skippedMajorVersion toVersion:ui.versionString] != NSOrderedDescending) {
-        // Item is on a greater or equal version than a major version we've skipped
-        // So we skip this item
+    if (!hostPassesSkippedMajorVersion && skippedMajorVersion != nil && ui.minimumAutoupdateVersion != nil && [versionComparator compareVersion:skippedMajorVersion toVersion:(NSString * _Nonnull)ui.minimumAutoupdateVersion] != NSOrderedAscending) {
+        // If skipped major version is >= than the item's minimumAutoupdateVersion, we can skip the item.
         return YES;
     }
     

--- a/Tests/Resources/testappcast_minimumAutoupdateVersionSkipping.xml
+++ b/Tests/Resources/testappcast_minimumAutoupdateVersionSkipping.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 4.1</title>
+        <sparkle:version>4.1</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>4.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 4.0</title>
+        <sparkle:version>4.0</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>4.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 3.9</title>
+        <sparkle:version>3.9</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>3.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 3.0</title>
+        <sparkle:version>3.0</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>3.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 2.0</title>
+        <sparkle:version>2.0</sparkle:version>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Skipping an item with `<sparkle:minimumAutoupdateVersion>2.0</sparkle:minimumAutoupdateVersion>` should not automatically skip a future item with `<sparkle:minimumAutoupdateVersion>3.0</sparkle:minimumAutoupdateVersion>`.

The main change we make is we compare the minimumAutoupdateVersion property of the item rather than the item's version itself. This makes more sense because we store the minimumAutoupdateVersion property for major skips.

Related to #2070

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Added unit tests to test above statement, and making sure previous minimumAutoupdateVersion tests pass. Tested behavior manually in the test app making sure future minimumAutoupdateVersion's aren't skipped.

macOS version tested: 12.1 (21C52)
