### PR TITLE
Add sparkle:belowVersion element for informational updates

### DIFF
--- a/Sparkle/SPUAppcastItemStateResolver.m
+++ b/Sparkle/SPUAppcastItemStateResolver.m
@@ -98,8 +98,22 @@
         return YES;
     }
     
+    NSString *hostVersion = self.hostVersion;
+    
     // Informational update only for a set of host versions we're updating from
-    return [informationalUpdateVersions containsObject:self.hostVersion];
+    if ([informationalUpdateVersions containsObject:hostVersion]) {
+        return YES;
+    }
+    
+    // If an informational update version has a '<' prefix, this is an informational update if
+    // hostVersion < this info update version
+    for (NSString *informationalUpdateVersion in informationalUpdateVersions) {
+        if ([informationalUpdateVersion hasPrefix:@"<"] && [self.applicationVersionComparator compareVersion:hostVersion toVersion:[informationalUpdateVersion substringFromIndex:1]] == NSOrderedAscending) {
+            return YES;
+        }
+    }
+    
+    return NO;
 }
 
 - (SPUAppcastItemState *)resolveStateWithInformationalUpdateVersions:(NSSet<NSString *> * _Nullable)informationalUpdateVersions minimumOperatingSystemVersion:(NSString * _Nullable)minimumOperatingSystemVersion maximumOperatingSystemVersion:(NSString * _Nullable)maximumOperatingSystemVersion minimumAutoupdateVersion:(NSString * _Nullable)minimumAutoupdateVersion criticalUpdateDictionary:(NSDictionary * _Nullable)criticalUpdateDictionary

--- a/Sparkle/SUAppcast.m
+++ b/Sparkle/SUAppcast.m
@@ -159,10 +159,16 @@
                 NSMutableSet *informationalUpdateVersions = [NSMutableSet set];
                 NSEnumerator *childEnum = [[node children] objectEnumerator];
                 for (NSXMLNode *child in childEnum) {
-                    if ([child.name isEqualToString:SUAppcastAttributeVersion]) {
+                    if ([child.name isEqualToString:SUAppcastElementVersion]) {
                         NSString *version = child.stringValue;
                         if (version != nil) {
                             [informationalUpdateVersions addObject:version];
+                        }
+                    } else if ([child.name isEqualToString:SUAppcastElementBelowVersion]) {
+                        NSString *version = child.stringValue;
+                        if (version != nil) {
+                            // Denote version is used as an upper bound by using '<'
+                            [informationalUpdateVersions addObject:[NSString stringWithFormat:@"<%@", version]];
                         }
                     }
                 }

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -94,6 +94,7 @@ extern NSString *const SUAppcastElementTags;
 extern NSString *const SUAppcastElementPhasedRolloutInterval;
 extern NSString *const SUAppcastElementInformationalUpdate;
 extern NSString *const SUAppcastElementChannel;
+extern NSString *const SUAppcastElementBelowVersion;
 
 extern NSString *const SURSSAttributeURL;
 extern NSString *const SURSSAttributeLength;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -91,6 +91,7 @@ NSString *const SUAppcastElementTags = @"sparkle:tags";
 NSString *const SUAppcastElementPhasedRolloutInterval = @"sparkle:phasedRolloutInterval";
 NSString *const SUAppcastElementInformationalUpdate = @"sparkle:informationalUpdate";
 NSString *const SUAppcastElementChannel = @"sparkle:channel";
+NSString *const SUAppcastElementBelowVersion = @"sparkle:belowVersion";
 
 NSString *const SURSSAttributeURL = @"url";
 NSString *const SURSSAttributeLength = @"length";

--- a/Tests/Resources/testappcast_info_updates.xml
+++ b/Tests/Resources/testappcast_info_updates.xml
@@ -16,6 +16,7 @@
         <sparkle:informationalUpdate>
             <sparkle:version>2.5</sparkle:version>
             <sparkle:version>2.4</sparkle:version>
+            <sparkle:belowVersion>0.5</sparkle:belowVersion>
         </sparkle:informationalUpdate>
         <link>http://sparkle-project.org</link>
     </item>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -205,6 +205,16 @@ class SUAppcastTest: XCTestCase {
                 }
             }
             
+            // Test informational updates from version 2.3
+            do {
+                let hostVersion = "2.3"
+                let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
+                
+                let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
+                
+                XCTAssertFalse(appcast.items[1].isInformationOnlyUpdate)
+            }
+            
             // Test informational updates from version 2.4
             do {
                 let hostVersion = "2.4"
@@ -233,6 +243,36 @@ class SUAppcastTest: XCTestCase {
                 let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
                 
                 XCTAssertFalse(appcast.items[1].isInformationOnlyUpdate)
+            }
+            
+            // Test informational updates from version 0.5
+            do {
+                let hostVersion = "0.5"
+                let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
+                
+                let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
+                
+                XCTAssertFalse(appcast.items[1].isInformationOnlyUpdate)
+            }
+            
+            // Test informational updates from version 0.4
+            do {
+                let hostVersion = "0.4"
+                let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
+                
+                let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
+                
+                XCTAssertTrue(appcast.items[1].isInformationOnlyUpdate)
+            }
+            
+            // Test informational updates from version 0.0
+            do {
+                let hostVersion = "0.0"
+                let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
+                
+                let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
+                
+                XCTAssertTrue(appcast.items[1].isInformationOnlyUpdate)
             }
             
         } catch let err as NSError {


### PR DESCRIPTION
This allows marking all updates below a specific version as informational only.

A new element (sparkle:belowVersion) was introduced this over a new attribute for sparkle:version due to compatibility reasons.

I will get to documentation update later.

Related to #2070

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Added unit tests to test info only updates. Tested modified version of test app.

macOS version tested: 12.1 (21C52)
