### PR TITLE
Add option to ignore skipped upgrades

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		720AC2DC2618E8A500E25A3E /* SPUSecureCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 726E075B1CA3A6D6001A286B /* SPUSecureCoding.m */; };
 		720B16451C66433D006985FB /* SUTestApplicationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 720B16431C66433D006985FB /* SUTestApplicationTest.swift */; };
 		720DC50427A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml in Resources */ = {isa = PBXBuildFile; fileRef = 720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */; };
+		720DC50627A62CDC00DFF3EC /* testappcast_minimumAutoupdateVersionSkipping2.xml in Resources */ = {isa = PBXBuildFile; fileRef = 720DC50527A62CDC00DFF3EC /* testappcast_minimumAutoupdateVersionSkipping2.xml */; };
 		720E217B1D0D00BF003A311C /* SPUUpdaterCycle.h in Headers */ = {isa = PBXBuildFile; fileRef = 720E21791D0D00BF003A311C /* SPUUpdaterCycle.h */; };
 		720E217C1D0D00BF003A311C /* SPUUpdaterCycle.m in Sources */ = {isa = PBXBuildFile; fileRef = 720E217A1D0D00BF003A311C /* SPUUpdaterCycle.m */; };
 		7210C7681B9A9A1500EB90AC /* SUUnarchiverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */; };
@@ -975,6 +976,7 @@
 		720B4C2325EBFAFD005A0592 /* link-tools.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "link-tools.sh"; sourceTree = "<group>"; };
 		720C192827127A3800740C8E /* release-move-tag.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "release-move-tag.sh"; sourceTree = "<group>"; };
 		720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast_minimumAutoupdateVersionSkipping.xml; sourceTree = "<group>"; };
+		720DC50527A62CDC00DFF3EC /* testappcast_minimumAutoupdateVersionSkipping2.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast_minimumAutoupdateVersionSkipping2.xml; sourceTree = "<group>"; };
 		720E21791D0D00BF003A311C /* SPUUpdaterCycle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUUpdaterCycle.h; sourceTree = "<group>"; };
 		720E217A1D0D00BF003A311C /* SPUUpdaterCycle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUUpdaterCycle.m; sourceTree = "<group>"; };
 		7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUUnarchiverTest.swift; sourceTree = "<group>"; };
@@ -1767,6 +1769,7 @@
 				723EDC3E26885A8E000BCBA4 /* testappcast_channels.xml */,
 				725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */,
 				720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */,
+				720DC50527A62CDC00DFF3EC /* testappcast_minimumAutoupdateVersionSkipping2.xml */,
 				7202DC99269ABD3500737EC4 /* testappcast_phasedRollout.xml */,
 				722545B526805FF80036465C /* testappcast_info_updates.xml */,
 				5F1510A11C96E591006E1629 /* testnamespaces.xml */,
@@ -3053,6 +3056,7 @@
 				14958C6F19AEBC980061B14F /* test-pubkey.pem in Resources */,
 				5AF6C74F1AEA46D10014A3AB /* test.pkg in Resources */,
 				72BC6C3D275027BF0083F14B /* SparkleTestCodeSign_apfs.dmg in Resources */,
+				720DC50627A62CDC00DFF3EC /* testappcast_minimumAutoupdateVersionSkipping2.xml in Resources */,
 				5AD0FA7F1C73F2E2004BCEFF /* testappcast.xml in Resources */,
 				FA30773D24CBC295007BA37D /* testlocalizedreleasenotesappcast.xml in Resources */,
 				72CCDEBE27421FD500B53718 /* SparkleTestCodeSignApp_bad_header.zip in Resources */,

--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -95,9 +95,6 @@
 /* Title confirmation for skipping major upgrade and future updates */
 "Are you sure you want to skip this upgrade?" = "Are you sure you want to skip this upgrade?";
 
-/* Confirmation message for skipping major upgrade and future updates */
-"Skipping this major upgrade will opt out of alerts for future updates." = "Skipping this major upgrade will opt out of alerts for future updates.";
-
 /* Skipping major upgrade */
 "Skip Upgrade" = "Skip Upgrade";
 

--- a/Sparkle/SPUSkippedUpdate.h
+++ b/Sparkle/SPUSkippedUpdate.h
@@ -27,11 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)skipUpdate:(SUAppcastItem *)updateItem host:(SUHost *)host;
 
 // At least one of minorVersion or majorVersion should be non-nil
-- (instancetype)initWithMinorVersion:(nullable NSString *)minorVersion majorVersion:(nullable NSString *)majorVersion;
+- (instancetype)initWithMinorVersion:(nullable NSString *)minorVersion majorVersion:(nullable NSString *)majorVersion majorSubreleaseVersion:(nullable NSString *)majorSubreleaseVersion;
 
-// At least one of these version properties will be non-nil
+// At least one of these two version properties will be non-nil
 @property (nonatomic, readonly, nullable) NSString *minorVersion;
 @property (nonatomic, readonly, nullable) NSString *majorVersion;
+
+@property (nonatomic, readonly, nullable) NSString *majorSubreleaseVersion;
 
 @end
 

--- a/Sparkle/SPUSkippedUpdate.m
+++ b/Sparkle/SPUSkippedUpdate.m
@@ -18,13 +18,15 @@
 
 @synthesize minorVersion = _minorVersion;
 @synthesize majorVersion = _majorVersion;
+@synthesize majorSubreleaseVersion = _majorSubreleaseVersion;
 
-- (instancetype)initWithMinorVersion:(nullable NSString *)minorVersion majorVersion:(nullable NSString *)majorVersion
+- (instancetype)initWithMinorVersion:(nullable NSString *)minorVersion majorVersion:(nullable NSString *)majorVersion majorSubreleaseVersion:(nullable NSString *)majorSubreleaseVersion
 {
     self = [super init];
     if (self != nil) {
         _minorVersion = [minorVersion copy];
         _majorVersion = [majorVersion copy];
+        _majorSubreleaseVersion = [majorSubreleaseVersion copy];
         
         assert(_minorVersion != nil || _majorVersion != nil);
     }
@@ -35,9 +37,10 @@
 {
     NSString *minorVersion = [host objectForUserDefaultsKey:SUSkippedMinorVersionKey];
     NSString *majorVersion = [host objectForUserDefaultsKey:SUSkippedMajorVersionKey];
+    NSString *majorSubreleaseVersion = [host objectForUserDefaultsKey:SUSkippedMajorSubreleaseVersionKey];
     
     if (minorVersion != nil || majorVersion != nil) {
-        return [[SPUSkippedUpdate alloc] initWithMinorVersion:minorVersion majorVersion:majorVersion];
+        return [[SPUSkippedUpdate alloc] initWithMinorVersion:minorVersion majorVersion:majorVersion majorSubreleaseVersion:majorSubreleaseVersion];
     } else {
         return nil;
     }
@@ -47,17 +50,20 @@
 {
     [host setObject:nil forUserDefaultsKey:SUSkippedMinorVersionKey];
     [host setObject:nil forUserDefaultsKey:SUSkippedMajorVersionKey];
+    [host setObject:nil forUserDefaultsKey:SUSkippedMajorSubreleaseVersionKey];
 }
 
 + (void)skipUpdate:(SUAppcastItem *)updateItem host:(SUHost *)host
 {
+    NSString *version = updateItem.versionString;
+    
     if (updateItem.majorUpgrade) {
         NSString *majorVersion = updateItem.minimumAutoupdateVersion;
         assert(majorVersion != nil);
         
         [host setObject:majorVersion forUserDefaultsKey:SUSkippedMajorVersionKey];
+        [host setObject:version forUserDefaultsKey:SUSkippedMajorSubreleaseVersionKey];
     } else {
-        NSString *version = updateItem.versionString;
         [host setObject:version forUserDefaultsKey:SUSkippedMinorVersionKey];
     }
 }

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -85,7 +85,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * If the state.stage is `SPUUserUpdateStateInstalling`, the installing update is also preserved after dismissing. In this state however, the update will also still be installed after the application is terminated.
  *
  * A reply of `SPUUserUpdateChoiceSkip` skips this particular version and won't notify the user again, unless they initiate an update check themselves.
- * If @c appcastItem.majorUpgrade is YES, the major update and any future minor updates to that major release are skipped.
+ * If @c appcastItem.majorUpgrade is YES, the major update and any future minor updates to that major release are skipped, unless a future minor update specifies a `<sparkle:ignoreSkippedUpgradesBelowVersion>` requirement.
  * If the state.stage is `SPUUpdateStateInstalling`, the installation is also canceled when the update is skipped.
  *
  * @param appcastItem The Appcast Item containing information that reflects the new update.

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -334,9 +334,12 @@
 + (BOOL)item:(SUAppcastItem *)ui containsSkippedUpdate:(SPUSkippedUpdate * _Nullable)skippedUpdate hostPassesSkippedMajorVersion:(BOOL)hostPassesSkippedMajorVersion versionComparator:(id<SUVersionComparison>)versionComparator
 {
     NSString *skippedMajorVersion = skippedUpdate.majorVersion;
+    NSString *skippedMajorSubreleaseVersion = skippedUpdate.majorSubreleaseVersion;
     
-    if (!hostPassesSkippedMajorVersion && skippedMajorVersion != nil && ui.minimumAutoupdateVersion != nil && [versionComparator compareVersion:skippedMajorVersion toVersion:(NSString * _Nonnull)ui.minimumAutoupdateVersion] != NSOrderedAscending) {
+    if (!hostPassesSkippedMajorVersion && skippedMajorVersion != nil && ui.minimumAutoupdateVersion != nil && [versionComparator compareVersion:skippedMajorVersion toVersion:(NSString * _Nonnull)ui.minimumAutoupdateVersion] != NSOrderedAscending && (ui.ignoreSkippedUpgradesBelowVersion == nil || (skippedMajorSubreleaseVersion != nil && [versionComparator compareVersion:skippedMajorSubreleaseVersion toVersion:(NSString * _Nonnull)ui.ignoreSkippedUpgradesBelowVersion] != NSOrderedAscending))) {
         // If skipped major version is >= than the item's minimumAutoupdateVersion, we can skip the item.
+        // But if there is an ignoreSkippedUpgradesBelowVersion, we can only skip the item if the last skipped subrelease
+        // version is >= than that version provided by the item
         return YES;
     }
     

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -265,7 +265,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  
  Otherwise if the requirement is not met, the user is always  prompted to install the update. In this case, the update is assumed to be a `majorUpgrade`.
  
- If the update is a `majorUpgrade` and the update is skipped by the user, other future update alerts with the same `minimumAutoupdateVersion` will also be skipped.
+ If the update is a `majorUpgrade` and the update is skipped by the user, other future update alerts with the same `minimumAutoupdateVersion` will also be skipped automatically unless an update specifies `ignoreSkippedUpgradesBelowVersion`.
  
  This version string corresponds to the application's @c CFBundleVersion
  */
@@ -277,6 +277,15 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  An update is a major upgrade if the application's bundle version doesn't meet the `minimumAutoupdateVersion` requirement.
  */
 @property (getter=isMajorUpgrade, readonly) BOOL majorUpgrade;
+
+/**
+ Previously skipped upgrades by the user will be ignored if they skipped an update whose version precedes this version.
+ 
+ This can only be applied if the update is a `majorUpgrade`.
+ 
+ This version string corresponds to the application's @c CFBundleVersion
+ */
+@property (nonatomic, readonly, nullable) NSString *ignoreSkippedUpgradesBelowVersion;
 
 /**
  Indicates whether or not the update item is critical.

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -289,7 +289,7 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  
  This is extracted from the @c <sparkle:ignoreSkippedUpgradesBelowVersion> element.
  
- Old applications must be using Sparkle 2.1, otherwise this property will be ignored.
+ Old applications must be using Sparkle 2.1 or later, otherwise this property will be ignored.
  */
 @property (nonatomic, readonly, nullable) NSString *ignoreSkippedUpgradesBelowVersion;
 

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -268,6 +268,8 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  If the update is a `majorUpgrade` and the update is skipped by the user, other future update alerts with the same `minimumAutoupdateVersion` will also be skipped automatically unless an update specifies `ignoreSkippedUpgradesBelowVersion`.
  
  This version string corresponds to the application's @c CFBundleVersion
+ 
+ This is extracted from the @c <sparkle:minimumAutoupdateVersion> element.
  */
 @property (copy, readonly, nullable) NSString *minimumAutoupdateVersion;
 
@@ -284,6 +286,10 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  This can only be applied if the update is a `majorUpgrade`.
  
  This version string corresponds to the application's @c CFBundleVersion
+ 
+ This is extracted from the @c <sparkle:ignoreSkippedUpgradesBelowVersion> element.
+ 
+ Old applications must be using Sparkle 2.1, otherwise this property will be ignored.
  */
 @property (nonatomic, readonly, nullable) NSString *ignoreSkippedUpgradesBelowVersion;
 

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -73,6 +73,7 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
 @synthesize propertiesDictionary = _propertiesDictionary;
 @synthesize installationType = _installationType;
 @synthesize minimumAutoupdateVersion = _minimumAutoupdateVersion;
+@synthesize ignoreSkippedUpgradesBelowVersion = _ignoreSkippedUpgradesBelowVersion;
 @synthesize phasedRolloutInterval = _phasedRolloutInterval;
 @synthesize state = _state;
 @synthesize hasCriticalInformation = _hasCriticalInformation;
@@ -115,6 +116,7 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
         _maximumSystemVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastItemMaximumSystemVersionKey] copy];
         _minimumSystemVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastItemMinimumSystemVersionKey] copy];
         _minimumAutoupdateVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastElementMinimumAutoupdateVersion] copy];
+        _ignoreSkippedUpgradesBelowVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastElementIgnoreSkippedUpgradesBelowVersion] copy];
         _releaseNotesURL = [decoder decodeObjectOfClass:[NSURL class] forKey:SUAppcastItemReleaseNotesURLKey];
         _fullReleaseNotesURL = [decoder decodeObjectOfClass:[NSURL class] forKey:SUAppcastItemFullReleaseNotesURLKey];
         _title = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastItemTitleKey] copy];
@@ -181,6 +183,10 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
     
     if (self.minimumAutoupdateVersion != nil) {
         [encoder encodeObject:self.minimumAutoupdateVersion forKey:SUAppcastElementMinimumAutoupdateVersion];
+    }
+    
+    if (self.ignoreSkippedUpgradesBelowVersion != nil) {
+        [encoder encodeObject:self.ignoreSkippedUpgradesBelowVersion forKey:SUAppcastElementIgnoreSkippedUpgradesBelowVersion];
     }
     
     if (self.state != nil) {
@@ -462,6 +468,8 @@ static NSString *SUAppcastItemStateKey = @"SUAppcastItemState";
         _minimumSystemVersion = [(NSString *)[dict objectForKey:SUAppcastElementMinimumSystemVersion] copy];
         _maximumSystemVersion = [(NSString *)[dict objectForKey:SUAppcastElementMaximumSystemVersion] copy];
         _minimumAutoupdateVersion = [(NSString *)[dict objectForKey:SUAppcastElementMinimumAutoupdateVersion] copy];
+        
+        _ignoreSkippedUpgradesBelowVersion = [(NSString *)[dict objectForKey:SUAppcastElementIgnoreSkippedUpgradesBelowVersion] copy];
         
         NSString *channel = [dict objectForKey:SUAppcastElementChannel];
         if (channel != nil) {

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -42,6 +42,7 @@ extern NSString *const SURelaunchHostBundleKey;
 extern NSString *const SUShowReleaseNotesKey;
 extern NSString *const SUSkippedMinorVersionKey;
 extern NSString *const SUSkippedMajorVersionKey;
+extern NSString *const SUSkippedMajorSubreleaseVersionKey;
 extern NSString *const SUScheduledCheckIntervalKey;
 extern NSString *const SULastCheckTimeKey;
 extern NSString *const SUExpectsDSASignatureKey;
@@ -95,6 +96,7 @@ extern NSString *const SUAppcastElementPhasedRolloutInterval;
 extern NSString *const SUAppcastElementInformationalUpdate;
 extern NSString *const SUAppcastElementChannel;
 extern NSString *const SUAppcastElementBelowVersion;
+extern NSString *const SUAppcastElementIgnoreSkippedUpgradesBelowVersion;
 
 extern NSString *const SURSSAttributeURL;
 extern NSString *const SURSSAttributeLength;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -38,6 +38,7 @@ NSString *const SURelaunchHostBundleKey = @"SURelaunchHostBundle";
 NSString *const SUShowReleaseNotesKey = @"SUShowReleaseNotes";
 NSString *const SUSkippedMinorVersionKey = @"SUSkippedVersion";
 NSString *const SUSkippedMajorVersionKey = @"SUSkippedMajorVersion";
+NSString *const SUSkippedMajorSubreleaseVersionKey = @"SUSkippedMajorSubreleaseVersion";
 NSString *const SUScheduledCheckIntervalKey = @"SUScheduledCheckInterval";
 NSString *const SULastCheckTimeKey = @"SULastCheckTime";
 NSString *const SUExpectsDSASignatureKey = @"SUExpectsDSASignature";
@@ -92,6 +93,7 @@ NSString *const SUAppcastElementPhasedRolloutInterval = @"sparkle:phasedRolloutI
 NSString *const SUAppcastElementInformationalUpdate = @"sparkle:informationalUpdate";
 NSString *const SUAppcastElementChannel = @"sparkle:channel";
 NSString *const SUAppcastElementBelowVersion = @"sparkle:belowVersion";
+NSString *const SUAppcastElementIgnoreSkippedUpgradesBelowVersion = @"sparkle:ignoreSkippedUpgradesBelowVersion";
 
 NSString *const SURSSAttributeURL = @"url";
 NSString *const SURSSAttributeLength = @"length";

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -141,23 +141,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 - (IBAction)skipThisVersion:(id)__unused sender
 {
-    if (self.updateItem.majorUpgrade) {
-        NSAlert *alert = [[NSAlert alloc] init];
-        alert.alertStyle = NSAlertStyleInformational;
-        alert.informativeText = SULocalizedString(@"Skipping this major upgrade will opt out of alerts for future updates.", nil);
-        alert.messageText = SULocalizedString(@"Are you sure you want to skip this upgrade?", nil);
-        
-        [alert addButtonWithTitle:SULocalizedString(@"Skip Upgrade", nil)];
-        [alert addButtonWithTitle:SULocalizedString(@"Don't Skip", nil)];
-        
-        [alert beginSheetModalForWindow:(NSWindow * _Nonnull)self.window completionHandler:^(NSModalResponse response) {
-            if (response == NSAlertFirstButtonReturn) {
-                [self endWithSelection:SPUUserUpdateChoiceSkip];
-            }
-        }];
-    } else {
-        [self endWithSelection:SPUUserUpdateChoiceSkip];
-    }
+    [self endWithSelection:SPUUserUpdateChoiceSkip];
 }
 
 - (IBAction)remindMeLater:(id)__unused sender

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -155,9 +155,6 @@
 /* Skipping major upgrade */
 "Skip Upgrade" = "Update überspringen";
 
-/* Confirmation message for skipping major upgrade and future updates */
-"Skipping this major upgrade will opt out of alerts for future updates." = "Wenn du dieses Hauptupdate überspringst, wirst du keine Hinweise für zukünftige Updates erhalten.";
-
 /* (No Comment) */
 "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version" = "Das Aktualisierungsprogramm wurde nicht richtig gestartet. Du solltest den App-Entwickler kontaktieren, um diesen Fehler zu melden und zu prüfen, ob du die neueste Version hast.";
 

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -91,9 +91,6 @@
 /* Title confirmation for skipping major upgrade and future updates */
 "Are you sure you want to skip this upgrade?" = "このアップグレードをスキップしてもよろしいですか?";
 
-/* Confirmation message for skipping major upgrade and future updates */
-"Skipping this major upgrade will opt out of alerts for future updates." = "このメジャーアップグレードをスキップすると、今後のアップデートも通知されなくなります。";
-
 /* Skipping major upgrade */
 "Skip Upgrade" = "アップグレードをスキップ";
 

--- a/Sparkle/nl.lproj/Sparkle.strings
+++ b/Sparkle/nl.lproj/Sparkle.strings
@@ -155,9 +155,6 @@
 /* Skipping major upgrade */
 "Skip Upgrade" = "Sla update over";
 
-/* Confirmation message for skipping major upgrade and future updates */
-"Skipping this major upgrade will opt out of alerts for future updates." = "Als je deze hoofdupdate overslaat, zul je geen meldingen voor toekomstige updates ontvangen.";
-
 /* (No Comment) */
 "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version" = "Het bijwerkprogramma is niet goed gestart. Je kunt wellicht met de app-ontwikkelaar contact opnemen om de fout te melden en te controleren dat je de nieuwste versie hebt";
 

--- a/Tests/Resources/testappcast_minimumAutoupdateVersionSkipping2.xml
+++ b/Tests/Resources/testappcast_minimumAutoupdateVersionSkipping2.xml
@@ -29,6 +29,8 @@
     </item>
     <item>
         <title>Version 2.0</title>
+        <!-- this should have no effect because there is no minimumAutoupdateVersion -->
+        <sparkle:ignoreSkippedUpgradesBelowVersion>2.0</sparkle:ignoreSkippedUpgradesBelowVersion>
         <sparkle:version>2.0</sparkle:version>
         <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
     </item>

--- a/Tests/Resources/testappcast_minimumAutoupdateVersionSkipping2.xml
+++ b/Tests/Resources/testappcast_minimumAutoupdateVersionSkipping2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 4.1</title>
+        <sparkle:version>4.1</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>4.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 4.0</title>
+        <sparkle:version>4.0</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>4.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 3.9</title>
+        <sparkle:version>3.9</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>3.0</sparkle:minimumAutoupdateVersion>
+        <sparkle:ignoreSkippedUpgradesBelowVersion>3.5</sparkle:ignoreSkippedUpgradesBelowVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 3.0</title>
+        <sparkle:version>3.0</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>3.0</sparkle:minimumAutoupdateVersion>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+    <item>
+        <title>Version 2.0</title>
+        <sparkle:version>2.0</sparkle:version>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+    </item>
+  </channel>
+</rss>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -358,7 +358,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // There should be no items if 2.0 is skipped from 1.0 and 3.0 fails minimum autoupdate version
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.0", majorVersion: nil)
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.0", majorVersion: nil, majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: true)
                 
@@ -367,7 +367,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // Try again but allowing minimum autoupdate version to fail
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.0", majorVersion: nil)
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.0", majorVersion: nil, majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
                 
@@ -380,7 +380,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // Allow minimum autoupdate version to fail and only skip 3.0
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0")
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0", majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
                 
@@ -393,7 +393,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // Allow minimum autoupdate version to fail skipping both 2.0 and 3.0
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.0", majorVersion: "3.0")
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.0", majorVersion: "3.0", majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
                 
@@ -403,7 +403,7 @@ class SUAppcastTest: XCTestCase {
                 // Allow minimum autoupdate version to fail and only skip "2.5"
                 // This should implicitly only skip 2.0
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.5", majorVersion: nil)
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.5", majorVersion: nil, majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
                 
@@ -416,7 +416,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // This should not skip anything but require passing minimum autoupdate version
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: nil)
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: nil, majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: true)
                 
@@ -429,7 +429,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // This should not skip anything but allow failing minimum autoupdate version
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: nil)
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: nil, majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
                 
@@ -442,7 +442,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // This should not skip anything but require passing minimum autoupdate version
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: "1.0")
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: "1.0", majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: true)
                 
@@ -455,7 +455,7 @@ class SUAppcastTest: XCTestCase {
                 
                 // This should not skip anything but allow failing minimum autoupdate version
                 do {
-                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: "1.0")
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "1.5", majorVersion: "1.0", majorSubreleaseVersion: nil)
                     
                     let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
                 
@@ -516,7 +516,7 @@ class SUAppcastTest: XCTestCase {
                 let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
                 let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
                 
-                let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0")
+                let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0", majorSubreleaseVersion: nil)
                 
                 let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
             
@@ -535,7 +535,7 @@ class SUAppcastTest: XCTestCase {
                 let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
                 let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
                 
-                let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0")
+                let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0", majorSubreleaseVersion: nil)
                 
                 let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: true)
             
@@ -554,7 +554,7 @@ class SUAppcastTest: XCTestCase {
                 let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
                 let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
                 
-                let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "4.0")
+                let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "4.0", majorSubreleaseVersion: nil)
                 
                 let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
             
@@ -563,6 +563,128 @@ class SUAppcastTest: XCTestCase {
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
                 XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+            }
+        } catch let err as NSError {
+            NSLog("%@", err)
+            XCTFail(err.localizedDescription)
+        }
+    }
+    
+    func testMinimumAutoupdateVersionIgnoringSkipping() {
+        let testURL = Bundle(for: SUAppcastTest.self).url(forResource: "testappcast_minimumAutoupdateVersionSkipping2", withExtension: "xml")!
+        
+        do {
+            let testData = try Data(contentsOf: testURL)
+            
+            let versionComparator = SUStandardVersionComparator()
+            
+            let currentDate = Date()
+            
+            do {
+                let hostVersion = "1.0"
+                
+                let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
+                let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
+                
+                // Allow minimum autoupdate version to fail and only skip major version "3.0" with no subrelease version
+                // This should skip all 3.x versions except for 3.9 which ignores skipped upgrades below 3.5, but not 4.x versions nor 2.x versions
+                do {
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0", majorSubreleaseVersion: nil)
+                    
+                    let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
+                
+                    XCTAssertEqual(4, supportedAppcast.items.count)
+                    
+                    XCTAssertEqual(supportedAppcast.items[0].versionString, "4.1")
+                    XCTAssertEqual(supportedAppcast.items[1].versionString, "4.0")
+                    XCTAssertEqual(supportedAppcast.items[2].versionString, "3.9")
+                    XCTAssertEqual(supportedAppcast.items[3].versionString, "2.0")
+                    
+                    let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
+                    
+                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                }
+                
+                // Allow minimum autoupdate version to fail and only skip major version "3.0" with subrelease version 3.4
+                // This should skip all 3.x versions except for 3.9 which ignores skipped upgrades below 3.5, but not 4.x versions nor 2.x versions
+                do {
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.4", majorSubreleaseVersion: nil)
+                    
+                    let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
+                
+                    XCTAssertEqual(4, supportedAppcast.items.count)
+                    
+                    XCTAssertEqual(supportedAppcast.items[0].versionString, "4.1")
+                    XCTAssertEqual(supportedAppcast.items[1].versionString, "4.0")
+                    XCTAssertEqual(supportedAppcast.items[2].versionString, "3.9")
+                    XCTAssertEqual(supportedAppcast.items[3].versionString, "2.0")
+                    
+                    let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
+                    
+                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                }
+                
+                // Allow minimum autoupdate version to fail and only skip major version "3.0" with subrelease version 3.5
+                // This should skip all 3.x versions, but not 4.x versions nor 2.x versions
+                do {
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0", majorSubreleaseVersion: "3.5")
+                    
+                    let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
+                
+                    XCTAssertEqual(3, supportedAppcast.items.count)
+                    
+                    XCTAssertEqual(supportedAppcast.items[0].versionString, "4.1")
+                    XCTAssertEqual(supportedAppcast.items[1].versionString, "4.0")
+                    XCTAssertEqual(supportedAppcast.items[2].versionString, "2.0")
+                    
+                    let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
+                    
+                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                }
+                
+                // Allow minimum autoupdate version to fail and only skip major version "3.0" with subrelease version 3.5.1
+                // This should skip all 3.x versions, but not 4.x versions nor 2.x versions
+                do {
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "3.0", majorSubreleaseVersion: "3.5.1")
+                    
+                    let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
+                
+                    XCTAssertEqual(3, supportedAppcast.items.count)
+                    
+                    XCTAssertEqual(supportedAppcast.items[0].versionString, "4.1")
+                    XCTAssertEqual(supportedAppcast.items[1].versionString, "4.0")
+                    XCTAssertEqual(supportedAppcast.items[2].versionString, "2.0")
+                    
+                    let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
+                    
+                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                }
+                
+                // Allow minimum autoupdate version to fail and only skip major version "4.0" with subrelease version 4.0
+                // This should skip all 3.x versions and 4.x versions, but not 2.x versions
+                do {
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: nil, majorVersion: "4.0", majorSubreleaseVersion: "4.0")
+                    
+                    let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
+                
+                    XCTAssertEqual(1, supportedAppcast.items.count)
+                    
+                    XCTAssertEqual(supportedAppcast.items[0].versionString, "2.0")
+                    
+                    let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
+                    
+                    XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                }
+                
+                // Allow minimum autoupdate version to fail and only skip major version "4.0" with subrelease version 4.0, and skip minor version 2.1
+                // This should skip everything
+                do {
+                    let skippedUpdate = SPUSkippedUpdate(minorVersion: "2.1", majorVersion: "4.0", majorSubreleaseVersion: "4.0")
+                    
+                    let supportedAppcast = SUAppcastDriver.filterSupportedAppcast(appcast, phasedUpdateGroup: nil, skippedUpdate: skippedUpdate, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator, testOSVersion: true, testMinimumAutoupdateVersion: false)
+                
+                    XCTAssertEqual(0, supportedAppcast.items.count)
+                }
             }
         } catch let err as NSError {
             NSLog("%@", err)


### PR DESCRIPTION
Normally when a major upgrade is skipped, future updates to that upgrade are automatically skipped. This option allows ignoring skipped updates older than a specific skipped version. This change also removes the user alert we have for telling the user that future updates will be skipped. This is now in control by the developer.

Related to #2070

Documentation and generate_appcast changes coming later.

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Added unit tests for testing new element and modified test app to test the changes.

macOS version tested: 12.1 (21C52)
