### PR TITLE
Preserve file system compression when applying delta updates

### DIFF
--- a/Autoupdate/SPUDeltaArchive.m
+++ b/Autoupdate/SPUDeltaArchive.m
@@ -81,16 +81,18 @@ id<SPUDeltaArchiveProtocol> SPUDeltaArchiveReadPatchAndHeader(NSString *patchFil
 
 @synthesize compression = _compression;
 @synthesize compressionLevel = _compressionLevel;
+@synthesize fileSystemCompression = _fileSystemCompression;
 @synthesize majorVersion = _majorVersion;
 @synthesize minorVersion = _minorVersion;
 
-- (instancetype)initWithCompression:(SPUDeltaCompressionMode)compression compressionLevel:(uint8_t)compressionLevel majorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(const unsigned char *)beforeTreeHash afterTreeHash:(const unsigned char *)afterTreeHash
+- (instancetype)initWithCompression:(SPUDeltaCompressionMode)compression compressionLevel:(uint8_t)compressionLevel fileSystemCompression:(bool)fileSystemCompression majorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(const unsigned char *)beforeTreeHash afterTreeHash:(const unsigned char *)afterTreeHash
 {
     self = [super init];
     if (self != nil)
     {
         _compression = compression;
         _compressionLevel = compressionLevel;
+        _fileSystemCompression = fileSystemCompression;
         
         _majorVersion = majorVersion;
         _minorVersion = minorVersion;

--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -26,10 +26,11 @@ typedef NS_ENUM(uint8_t, SPUDeltaItemCommands) {
 // Represents header for our archive
 @interface SPUDeltaArchiveHeader : NSObject
 
-- (instancetype)initWithCompression:(SPUDeltaCompressionMode)compression compressionLevel:(uint8_t)compressionLevel majorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(const unsigned char *)beforeTreeHash afterTreeHash:(const unsigned char *)afterTreeHash;
+- (instancetype)initWithCompression:(SPUDeltaCompressionMode)compression compressionLevel:(uint8_t)compressionLevel fileSystemCompression:(bool)fileSystemCompression majorVersion:(uint16_t)majorVersion minorVersion:(uint16_t)minorVersion beforeTreeHash:(const unsigned char *)beforeTreeHash afterTreeHash:(const unsigned char *)afterTreeHash;
 
 @property (nonatomic, readonly) SPUDeltaCompressionMode compression;
 @property (nonatomic, readonly) uint8_t compressionLevel;
+@property (nonatomic, readonly) bool fileSystemCompression;
 @property (nonatomic, readonly) uint16_t majorVersion;
 @property (nonatomic, readonly) uint16_t minorVersion;
 @property (nonatomic, readonly) unsigned char *beforeTreeHash;

--- a/Autoupdate/SPUSparkleDeltaArchive.h
+++ b/Autoupdate/SPUSparkleDeltaArchive.h
@@ -39,7 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
  [ HEADER (part 1) ]
  magic (length: 4)
  compression (length: 1)
- compressionLevel (length: 1)
+ metadata (See format below. length: 1)
+ 
+    -- METADATA --
+    compressionLevel (bits [0, 4])
+    (bits [5, 6] reserved)
+    fileSystemCompression (bit 7)
  
  -- COMPRESSED --
  

--- a/Autoupdate/SPUSparkleDeltaArchive.m
+++ b/Autoupdate/SPUSparkleDeltaArchive.m
@@ -780,7 +780,7 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
     SparkleDeltaArchiveMetadata metadata = {.compressionLevel = compressionLevel, .fileSystemCompression = header.fileSystemCompression};
     
     if (fwrite(&metadata, sizeof(metadata), 1, file) < 1) {
-        self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: @"Failed to write metadatavalue due to io error" }];
+        self.error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:@{ NSLocalizedDescriptionKey: @"Failed to write metadata value due to io error" }];
         return;
     }
     

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -172,7 +172,7 @@ extern char *xar_get_safe_path(xar_file_t f) __attribute__((weak_import));
     
     // I wasn't able to figure out how to retrieve the compression options from xar,
     // so we will use default flags to indicate the info isn't available
-    return [[SPUDeltaArchiveHeader alloc] initWithCompression:SPUDeltaCompressionModeDefault compressionLevel:0 majorVersion:majorDiffVersion minorVersion:minorDiffVersion beforeTreeHash:rawExpectedBeforeHash afterTreeHash:rawExpectedAfterHash];
+    return [[SPUDeltaArchiveHeader alloc] initWithCompression:SPUDeltaCompressionModeDefault compressionLevel:0 fileSystemCompression:false majorVersion:majorDiffVersion minorVersion:minorDiffVersion beforeTreeHash:rawExpectedBeforeHash afterTreeHash:rawExpectedAfterHash];
 }
 
 - (void)writeHeader:(SPUDeltaArchiveHeader *)header

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -590,10 +590,10 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         // If we find any executable files that are using file system compression, that is sufficient
         // for recording that the applier should re-apply file system compression.
         // We check for executable files because they are likely candidates to be compressed.
-        if (!foundFilesystemCompression && ent->fts_info == FTS_F && (ent->fts_statp->st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0 && (ent->fts_statp->st_flags & UF_COMPRESSED) != 0) {
+        if (!foundFilesystemCompression && MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion3) && ent->fts_info == FTS_F && (ent->fts_statp->st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0 && (ent->fts_statp->st_flags & UF_COMPRESSED) != 0) {
             foundFilesystemCompression = true;
             
-            if (verbose && MAJOR_VERSION_IS_AT_LEAST(majorVersion, SUBinaryDeltaMajorVersion3)) {
+            if (verbose) {
                 fprintf(stderr, " File system compression detected.");
             }
         }

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -1102,7 +1102,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
         NSString *destinationFile2 = [destinationDirectory stringByAppendingPathComponent:@"A2"];
         
-        // Both files should have file system compression applied
+        // Both files should not have file system compression applied
         {
             struct stat statStruct = {0};
             int result = lstat(destinationFile.fileSystemRepresentation, &statStruct);


### PR DESCRIPTION
If the new update has file system compression applied to its app bundle, we re-apply file system compression after applying our delta patch and before final verification.

I will add documentation update later for how to preserve file system compressions for normal updates (use `.tar.*` or `.dmg` and use `ditto --hfsCompression` beforehand).

Fixes #1194

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Added unit tests to ensure file system compression is preserved on a large file. Tested test app with delta updates with some manual adjustments.

macOS version tested: 12.1 (21C52)
