### PR TITLE
Use strcoll_l() for locale-independent comparisons

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -16,6 +16,7 @@
 #include <sys/mman.h>
 #include <sys/param.h>
 #include <sys/stat.h>
+#include <xlocale.h>
 
 #include "AppKitPrevention.h"
 
@@ -89,7 +90,7 @@ NSString *deltaCompressionStringFromMode(SPUDeltaCompressionMode mode)
 
 int compareFiles(const FTSENT **a, const FTSENT **b)
 {
-    return strcoll((*a)->fts_name, (*b)->fts_name);
+    return strcoll_l((*a)->fts_name, (*b)->fts_name, _c_locale);
 }
 
 NSString *pathRelativeToDirectory(NSString *directory, NSString *path)


### PR DESCRIPTION
The update code uses the compareFiles function to determine the sort order of file names in a directory, which is then compared with a list of files in the Sparkle update info. If the list of files of a directory from Sparkle's update is different than what is on disk, the Sparkle abandons the update and does a full download. This bug would prevent Sparkle from updating properly when the file lists are calculated on an English language system, but then checked on a destination Japanese system.

The fix is to use strcoll_l(), which is locale-independent, when comparing file names for sorting. This will ignore any locale changes the host application has made that could potentially affect Sparkle's sort order.

(Insert summary of your pull request here)

Fixes # (issue)

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
