### PR TITLE
Ignore -Wobjc-interface-ivars warning

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
   */
 SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-interface-ivars"
     /**
      * Interface builder outlet for the updater's delegate.
      */
@@ -47,6 +49,7 @@ SU_EXPORT @interface SPUStandardUpdaterController : NSObject
      * Interface builder outlet for the user driver's delegate.
      */
     IBOutlet __weak id<SPUStandardUserDriverDelegate> userDriverDelegate;
+#pragma clang diagnostic pop
 }
 
 /**


### PR DESCRIPTION
Ignore -Wobjc-interface-ivars warning in SPUStandardUpdaterController. It's an interface detail used by clients (to hook up outlets from interface builder) but at the same time we don't want to generate publicly visible setters or accessors for the delegates. So classic ivars solves this problem best and we aim to suppress the warning for this rare case.

Fixes #2093

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested sample app including Sparkle with all warnings enabled and confirmed this change silences the warning.

macOS version tested: 12.1 (21C52)
