### PR TITLE
Update alert activation improvements

### DIFF
--- a/Sparkle/InstallerProgress/ShowInstallerProgress.m
+++ b/Sparkle/InstallerProgress/ShowInstallerProgress.m
@@ -24,7 +24,7 @@
 
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host
 {
-    self.statusController = [[SUStatusController alloc] initWithHost:host];
+    self.statusController = [[SUStatusController alloc] initWithHost:host minimizable:NO];
     
     [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:nil isDefault:NO];
     [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update...", @"") maxProgressValue:0 statusText:@""];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -338,10 +338,6 @@
         [delegate standardUserDriverWillShowModalAlert];
     }
     
-    // When showing a modal alert we need to ensure that background applications
-    // are focused to inform the user since there is no dock icon to notify them.
-    if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) { [[NSApplication sharedApplication] activateIgnoringOtherApps:YES]; }
-    
     [alert setIcon:[SUApplicationInfo bestIconForHost:self.host]];
     
     NSModalResponse response = [alert runModal];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -208,7 +208,7 @@
     
     self.cancellation = cancellation;
     
-    self.checkingController = [[SUStatusController alloc] initWithHost:self.host];
+    self.checkingController = [[SUStatusController alloc] initWithHost:self.host minimizable:NO];
     [[self.checkingController window] center]; // Force the checking controller to load its window.
     [self.checkingController beginActionWithTitle:SULocalizedString(@"Checking for updates...", nil) maxProgressValue:0.0 statusText:nil];
     [self.checkingController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelCheckForUpdates:) isDefault:NO];
@@ -355,7 +355,7 @@
 - (void)createAndShowStatusController
 {
     if (self.statusController == nil) {
-        self.statusController = [[SUStatusController alloc] initWithHost:self.host];
+        self.statusController = [[SUStatusController alloc] initWithHost:self.host minimizable:YES];
         [self.statusController showWindow:self];
     }
 }

--- a/Sparkle/SUStatusController.h
+++ b/Sparkle/SUStatusController.h
@@ -24,7 +24,7 @@
 @property (nonatomic) double maxProgressValue;
 @property (getter=isButtonEnabled) BOOL buttonEnabled;
 
-- (instancetype)initWithHost:(SUHost *)host;
+- (instancetype)initWithHost:(SUHost *)host minimizable:(BOOL)minimizable;
 
 // Pass 0 for the max progress value to get an indeterminate progress bar.
 // Pass nil for the status text to not show it.

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -22,6 +22,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @property (copy) NSString *title, *buttonTitle;
 @property (strong) SUHost *host;
 @property NSButton *touchBarButton;
+@property (nonatomic, readonly) BOOL minimizable;
 @end
 
 @implementation SUStatusController
@@ -35,13 +36,15 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @synthesize progressBar;
 @synthesize statusTextField;
 @synthesize touchBarButton;
+@synthesize minimizable = _minimizable;
 
-- (instancetype)initWithHost:(SUHost *)aHost
+- (instancetype)initWithHost:(SUHost *)aHost minimizable:(BOOL)minimizable
 {
     self = [super initWithWindowNibName:@"SUStatus" owner:self];
 	if (self)
 	{
         self.host = aHost;
+        _minimizable = minimizable;
         [self setShouldCascadeWindows:NO];
     }
     return self;
@@ -53,6 +56,9 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 {
     [[self window] center];
     [[self window] setFrameAutosaveName:@"SUStatusFrame"];
+    if (self.minimizable) {
+        self.window.styleMask |= NSWindowStyleMaskMiniaturizable;
+    }
     [self.progressBar setUsesThreadedAnimation:YES];
 
     if ([SUOperatingSystem isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){10, 11, 0}]) {

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -51,10 +51,6 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 
 - (void)windowDidLoad
 {
-    if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) {
-        [[self window] setLevel:NSFloatingWindowLevel];
-    }
-
     [[self window] center];
     [[self window] setFrameAutosaveName:@"SUStatusFrame"];
     [self.progressBar setUsesThreadedAnimation:YES];


### PR DESCRIPTION
* Don't activate app when bringing up update alert errors
* Don't set status window level to floating
* Add minimize option to status window after checking for updates (i.e, downloading / installing)
* Allow install button to have focus when app has just launched for scheduled updates within a small threshold (1.5 sec)
* Reset install button focus when app becomes active again for scheduled updates

Fixes  #1008
Related to #924

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested scheduled updates in regular and backgrounded/dockless apps, at launch and non-launch scheduled times.
Tested bringing app back in background from scheduled updates after it's been running for some time.
Tested status window is not floating for deckless app and is now minimizable.

macOS version tested: 12.1 (21C52)
