### PR TITLE
Ignore custom icons set via resource forks in delta updates

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -31,6 +31,9 @@
 
 #define MAJOR_VERSION_IS_AT_LEAST(actualMajor, expectedMajor) (actualMajor >= expectedMajor)
 
+// Relative path of custom icon data that may be set on a bundle via a resource fork
+#define CUSTOM_ICON_PATH @"/Icon\r"
+
 // Changes that break backwards compatibility will have different major versions
 // Changes that affect creating but not applying patches will have different minor versions
 typedef NS_ENUM(uint16_t, SUBinaryDeltaMajorVersion)

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -256,8 +256,11 @@ BOOL getRawHashOfTreeAndFileTablesWithVersion(unsigned char *hashBuffer, NSStrin
             continue;
 
         NSString *relativePath = pathRelativeToDirectory(normalizedPath, stringWithFileSystemRepresentation(ent->fts_path));
-        if (relativePath.length == 0)
+        
+        // Ignore icon resource fork data
+        if (relativePath.length == 0 || [relativePath isEqualToString:CUSTOM_ICON_PATH]) {
             continue;
+        }
 
         unsigned char fileHash[CC_SHA1_DIGEST_LENGTH];
         if (!_hashOfFileContents(fileHash, ent, tempBuffer, tempBufferSize)) {

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -440,6 +440,16 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         if (![key length]) {
             continue;
         }
+        
+        if ([key isEqualToString:CUSTOM_ICON_PATH]) {
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing bundles with a custom icon set via a resource fork is not supported. Detected presence of %@", @(ent->fts_path)] }];
+            }
+            return NO;
+        }
 
         NSDictionary *info = infoForFile(ent);
         if (!info) {
@@ -530,6 +540,16 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         NSString *key = pathRelativeToDirectory(destination, stringWithFileSystemRepresentation(ent->fts_path));
         if (![key length]) {
             continue;
+        }
+        
+        if ([key isEqualToString:CUSTOM_ICON_PATH]) {
+            if (verbose) {
+                fprintf(stderr, "\n");
+            }
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Diffing bundles with a custom icon set via a resource fork is not supported. Detected presence of %@", @(ent->fts_path)] }];
+            }
+            return NO;
         }
 
         NSDictionary *info = infoForFile(ent);

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -1729,4 +1729,58 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
     XCTAssertFalse(success);
 }
 
+- (void)testCreatingPatchWithCustomIconInBeforeTree
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([[NSData data] writeToFile:sourceFile atomically:YES]);
+        XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:destinationFile atomically:YES]);
+        
+        NSImage *iconImage = [NSImage imageNamed:NSImageNameAdvanced];
+        XCTAssertNotNil(iconImage);
+        
+        BOOL setIcon = [[NSWorkspace sharedWorkspace] setIcon:iconImage forFile:sourceDirectory options:0];
+        XCTAssertTrue(setIcon);
+    } afterDiffHandler:nil afterPatchHandler:nil];
+    XCTAssertFalse(success);
+}
+
+- (void)testCreatingPatchWithCustomIconInAfterTree
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([[NSData data] writeToFile:sourceFile atomically:YES]);
+        XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:destinationFile atomically:YES]);
+        
+        NSImage *iconImage = [NSImage imageNamed:NSImageNameAdvanced];
+        XCTAssertNotNil(iconImage);
+        
+        BOOL setIcon = [[NSWorkspace sharedWorkspace] setIcon:iconImage forFile:destinationDirectory options:0];
+        XCTAssertTrue(setIcon);
+    } afterDiffHandler:nil afterPatchHandler:nil];
+    XCTAssertFalse(success);
+}
+
+- (void)testApplyingPatchAfterSettingCustomIcon
+{
+    BOOL success = [self createAndApplyPatchWithBeforeDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *destinationDirectory) {
+        NSString *sourceFile = [sourceDirectory stringByAppendingPathComponent:@"A"];
+        NSString *destinationFile = [destinationDirectory stringByAppendingPathComponent:@"A"];
+        
+        XCTAssertTrue([[NSData data] writeToFile:sourceFile atomically:YES]);
+        XCTAssertTrue([[NSData dataWithBytes:"loltest" length:7] writeToFile:destinationFile atomically:YES]);
+    } afterDiffHandler:^(NSFileManager *__unused fileManager, NSString *sourceDirectory, NSString *__unused destinationDirectory) {
+        NSImage *iconImage = [NSImage imageNamed:NSImageNameAdvanced];
+        XCTAssertNotNil(iconImage);
+        
+        BOOL setIcon = [[NSWorkspace sharedWorkspace] setIcon:iconImage forFile:sourceDirectory options:0];
+        XCTAssertTrue(setIcon);
+    } afterPatchHandler:nil];
+    XCTAssertTrue(success);
+}
+
 @end

--- a/Tests/SUCodeSigningVerifierTest.m
+++ b/Tests/SUCodeSigningVerifierTest.m
@@ -47,7 +47,6 @@
     [super setUp];
 
     NSBundle *unitTestBundle = [NSBundle bundleForClass:[self class]];
-    NSString *unitTestBundleIdentifier = unitTestBundle.bundleIdentifier;
     NSString *zippedAppURL = [unitTestBundle pathForResource:@"SparkleTestCodeSignApp" ofType:@"zip"];
 
     SUFileManager *fileManager = [[SUFileManager alloc] init];


### PR DESCRIPTION
For creation, we will disallow creating delta updates if a custom resource fork icon data is found in either the old or app bundles.

For applying, we will just ignore the icon data when performing hash verification and continue applying the patch.

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested BinaryDelta creating a patch manually with custom icons set before and after creating the patch.

macOS version tested: 12.3 (21E230)
