### PR TITLE
Fall back to regular update if delta update fails to download

### DIFF
--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -168,7 +168,6 @@
             regularItemFromDelegate = nil;
             delegateOptedOutOfSelection = NO;
         } else {
-            assert(!candidateItem.deltaUpdate);
             if (candidateItem.deltaUpdate) {
                 // Client would have to go out of their way to examine the .deltaUpdates to return one
                 // We need them to give us a regular update item back instead..
@@ -278,6 +277,12 @@
         // We will never care about other OS's
         BOOL macOSUpdate = [item isMacOsUpdate];
         if (!macOSUpdate) {
+            return NO;
+        }
+        
+        // Delta updates cannot be top-level entries
+        BOOL isDeltaUpdate = [item isDeltaUpdate];
+        if (isDeltaUpdate) {
             return NO;
         }
         

--- a/Tests/Resources/testappcast_channels.xml
+++ b/Tests/Resources/testappcast_channels.xml
@@ -54,5 +54,11 @@
         <sparkle:version>6.0</sparkle:version>
         <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" sparkle:os="windows" />
     </item>
+    <!-- An invalid release with top level delta item -->
+    <item>
+        <title>Version 7.0</title>
+        <sparkle:version>7.0</sparkle:version>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" sparkle:deltaFrom="5.0" sparkle:edSignature="..." />
+    </item>
   </channel>
 </rss>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -91,7 +91,7 @@ class SUAppcastTest: XCTestCase {
             let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
             
             let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
-            XCTAssertEqual(5, appcast.items.count)
+            XCTAssertEqual(6, appcast.items.count)
             
             do {
                 let filteredAppcast = SUAppcastDriver.filterAppcast(appcast, forMacOSAndAllowedChannels: ["beta", "nightly"])


### PR DESCRIPTION
Also log out the download failure when a delta update fails to download (such as a 404 error for example).

Additionally, add a check to make sure that top-level appcast items cannot be delta update items.

Fixes #994

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested sparkle-cli gracefully fails when installing update for app where delta update link is 404.
Tested delta update succeeds on normal path.
Tested that sparkle-cli gracefully fails when delta applying fails.
Tested that top-level delta updates are now ignored with sparkle-cli.

macOS version tested: 12.3 (21E230)
