### PR TITLE
Add support for running framework and CLI as root

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -390,14 +390,10 @@ static BOOL SPUSystemNeedsAuthorizationAccess(NSString *path, NSString *installa
         BOOL rootUser = (geteuid() == 0);
         
         BOOL needsSystemAuthorization = SPUSystemNeedsAuthorizationAccess(hostBundlePath, installationType);
-        BOOL inSystemDomain = (needsSystemAuthorization || rootUser);
         
-        // As the root user (not normal path), we don't support installing interactive pkg's
-        if (rootUser && [installationType isEqualToString:SPUInstallationTypeInteractivePackage]) {
-            SULog(SULogLevelError, @"Installing interactive packages is not supported under the root user.");
-            completionHandler(SUInstallerLauncherFailure, inSystemDomain);
-            return;
-        }
+        // If we are the root user we use the system domain even if we don't need escalated authorization
+        // Unless we are dealing with an interactive pkg (I can't wait to drop support for these)
+        BOOL inSystemDomain = (needsSystemAuthorization || (rootUser && ![installationType isEqualToString:SPUInstallationTypeInteractivePackage]));
         
         NSBundle *hostBundle = [NSBundle bundleWithPath:hostBundlePath];
         if (hostBundle == nil) {

--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -377,9 +377,9 @@ static BOOL SPUUsesSystemDomainForBundlePath(NSString *path, NSString *installat
             return SPUSystemNeedsAuthorizationAccessForBundlePath(path);
         }
     } else {
-        // If we are the root user we use the system domain even if we don't need escalated authorization
-        // Unless we are dealing with an interactive pkg (I can't wait to drop support for these)
-        return ![installationType isEqualToString:SPUInstallationTypeInteractivePackage];
+        // If we are the root user we use the system domain even if we don't need escalated authorization.
+        // Note interactive package installations are not supported as root.
+        return YES;
     }
 }
 

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -143,7 +143,7 @@
         if (!resuming) {
             // interactive pkg based updates are not supported under root user
             if ([updateItem.installationType isEqualToString:SPUInstallationTypeInteractivePackage] && geteuid() == 0) {
-                [self.delegate basicDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey: SULocalizedString(@"Interactive based packages cannot be installed as the root user.", nil) }]];
+                [self.delegate basicDriverIsRequestingAbortUpdateWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationRootInteractiveError userInfo:@{ NSLocalizedDescriptionKey: SULocalizedString(@"Interactive based packages cannot be installed as the root user.", nil) }]];
                 return;
             } else {
                 // Give the delegate a chance to bail

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -73,6 +73,7 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUInstallationAuthorizeLaterError = 4008,
     SUNotValidUpdateError = 4009,
     SUAgentInvalidationError = 4010,
+    SUInstallationRootInteractiveError = 4011,
     
     // API misuse errors.
     SUIncorrectAPIUsageError = 5000

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -109,6 +109,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)changeOwnerAndGroupOfItemAtRootURL:(NSURL *)targetURL toMatchURL:(NSURL *)matchURL error:(NSError **)error;
 
 /**
+ Changes the owner and group ID of an item at a specified target URL
+ @param targetURL A URL pointing to the target item whose owner and group IDs to alter. The item at this URL must exist.
+ @param ownerID The new owner ID to set on the item.
+ @param groupID The new group ID to set on the item.
+ @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.
+ @return YES if the target item's owner and group IDs have changed, otherwise NO along with a populated error object.
+ 
+ Unlike -changeOwnerAndGroupOfItemAtRootURL:toMatchURL:error: this method does not recursively try to change the owner and group IDs if the target item is a directory.
+ */
+- (BOOL)changeOwnerAndGroupOfItemAtURL:(NSURL *)targetURL ownerID:(uid_t)ownerID groupID:(gid_t)groupID error:(NSError * __autoreleasing *)error;
+
+/**
  * Updates the modification and access time of an item at a specified target URL to the current time
  * @param targetURL A URL pointing to the target item whose modification and access time to update. The item at this URL must exist.
  * @param error If an error occurs, upon returns contains an NSError object that describes the problem. If you are not interested in possible errors, you may pass in NULL.

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -25,7 +25,8 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
     CLIErrorExitStatusInstallerInteractionNotAllowed = 3,
     CLIErrorExitStatusUpdateNotFound = 4,
     CLIErrorExitStatusUpdateCancelledAuthorization = 5,
-    CLIErrorExitStatusUpdatePermissionRequested = 6
+    CLIErrorExitStatusUpdatePermissionRequested = 6,
+    CLIErrorCodeCannotInstallInteractivePackageAsRoot = 7,
 };
 
 @interface SPUCommandLineDriver () <SPUUpdaterDelegate>
@@ -242,6 +243,9 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
             fprintf(stderr, "Update was cancelled.\n");
         }
         exit(CLIErrorExitStatusUpdateCancelledAuthorization);
+    } else if (error.code == SUInstallationRootInteractiveError) {
+        fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
+        exit(CLIErrorCodeCannotInstallInteractivePackageAsRoot);
     } else {
         fprintf(stderr, "Error: Update has failed due to error %ld (%s). %s\n", (long)error.code, error.domain.UTF8String, error.localizedDescription.UTF8String);
         exit(EXIT_FAILURE);

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -17,7 +17,8 @@
 typedef NS_ENUM(NSInteger, CLIErrorCode) {
     CLIErrorCodeCannotPerformCheck = 1,
     CLIErrorCodeCannotInstallPackage,
-    CLIErrorCodeCannotInstallMajorUpgrade
+    CLIErrorCodeCannotInstallMajorUpgrade,
+    CLIErrorCodeCannotInstallInteractivePackageAsRoot
 };
 
 typedef NS_ENUM(int, CLIErrorExitStatus) {
@@ -176,12 +177,25 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
         return NO;
     }
     
-    if (!self.interactive && ![updateItem.installationType isEqualToString:SPUInstallationTypeApplication]) {
-        if (error != NULL) {
-            *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallPackage userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new package-based update has been found (%@), but installing it will require user authorization. Please use --interactive to allow this.", updateItem.versionString] }];
+    if (!self.interactive) {
+        BOOL rootUser = (geteuid() == 0);
+        if (!rootUser) {
+            if (![updateItem.installationType isEqualToString:SPUInstallationTypeApplication]) {
+                // Any package based updates will require authorization and therefore interaction
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallPackage userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new package-based update has been found (%@), but installing it will require user authorization. Please use --interactive to allow this.", updateItem.versionString] }];
+                }
+                return NO;
+            }
+        } else {
+            if ([updateItem.installationType isEqualToString:SPUInstallationTypeInteractivePackage]) {
+                // If we are root, only interactive package installs require interaction
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallInteractivePackageAsRoot userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new interactive based package-based update has been found (%@), but installing it will require user interaction. Please use --interactive to allow this.", updateItem.versionString] }];
+                }
+                return NO;
+            }
         }
-        
-        return NO;
     }
     
     return YES;

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -150,7 +150,7 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
             }
             
             if (error != NULL) {
-                *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotPerformCheck userInfo:@{ NSLocalizedDescriptionKey: @"A new update check cannot be performed because updating this bundle will require user authorization. Please use --interactive to allow this." }];
+                *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotPerformCheck userInfo:@{ NSLocalizedDescriptionKey: @"A new update check cannot be performed because updating this bundle will require user authorization. Please use --interactive or run as root to allow this." }];
             }
             
             return NO;
@@ -171,6 +171,14 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
     if (updateItem.majorUpgrade && !self.allowMajorUpgrades) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallMajorUpgrade userInfo:@{ NSLocalizedDescriptionKey: @"Major upgrade available but not allowed to install it. Pass --allow-major-upgrades to allow this." }];
+        }
+        
+        return NO;
+    }
+    
+    if (geteuid() == 0 && [updateItem.installationType isEqualToString:SPUInstallationTypeInteractivePackage]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallPackage userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new interactive based package-based update has been found (%@), but installing interactive package-based updates under root is not supported. Please use --interactive under the normal user to install this.", updateItem.versionString] }];
         }
         
         return NO;

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -176,14 +176,6 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
         return NO;
     }
     
-    if (geteuid() == 0 && [updateItem.installationType isEqualToString:SPUInstallationTypeInteractivePackage]) {
-        if (error != NULL) {
-            *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallPackage userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new interactive based package-based update has been found (%@), but installing interactive package-based updates under root is not supported. Please use --interactive under the normal user to install this.", updateItem.versionString] }];
-        }
-        
-        return NO;
-    }
-    
     if (!self.interactive && ![updateItem.installationType isEqualToString:SPUInstallationTypeApplication]) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:SPARKLE_CLI_ERROR_DOMAIN code:CLIErrorCodeCannotInstallPackage userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"A new package-based update has been found (%@), but installing it will require user authorization. Please use --interactive to allow this.", updateItem.versionString] }];

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -65,8 +65,12 @@
 - (void)displayHTMLReleaseNotes:(NSData *)releaseNotes
 {
     // Note: this is the only API we rely on here that references AppKit
-    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithHTML:releaseNotes documentAttributes:nil];
-    [self displayReleaseNotes:attributedString.string.UTF8String];
+    // We shouldn't invoke it when the calling process is ran under root.
+    // If only there was an API to translated HTML -> text that didn't rely on AppKit..
+    if (geteuid() != 0) {
+        NSAttributedString *attributedString = [[NSAttributedString alloc] initWithHTML:releaseNotes documentAttributes:nil];
+        [self displayReleaseNotes:attributedString.string.UTF8String];
+    }
 }
 
 - (void)displayPlainTextReleaseNotes:(NSData *)releaseNotes encoding:(NSStringEncoding)encoding

--- a/sparkle-cli/main.m
+++ b/sparkle-cli/main.m
@@ -33,7 +33,7 @@ static void printUsage(char **argv)
     fprintf(stderr, "  To check if an update is available without installing, use --%s.\n\n", PROBE_FLAG);
     fprintf(stderr, "  if no updates are available now, or if the last update check was recently\n  (unless --%s is specified) then nothing is done.\n\n", CHECK_NOW_FLAG);
     fprintf(stderr, "  If update permission is requested and --%s is not\n  specified, then checking for updates is aborted.\n\n", GRANT_AUTOMATIC_CHECKING_FLAG);
-    fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization. Running as root is not supported.\n\n", INTERACTIVE_FLAG);
+    fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization.\n\n", INTERACTIVE_FLAG);
     fprintf(stderr, "  If --%s is specified, this tool will exit leaving a spawned process\n  for finishing the installation after the target application terminates.\n\n", DEFER_FLAG);
     fprintf(stderr, "  Please specify --%s if you intend to use this tool in an automated way.\n", USER_AGENT_NAME);
     fprintf(stderr, "Options:\n");
@@ -55,11 +55,6 @@ int main(int argc, char **argv)
 {
     @autoreleasepool
     {
-        if (geteuid() == 0 && [@(getenv("USER")) isEqualToString:@"root"]) {
-            fprintf(stderr, "Error: Running as root with $USER set to 'root' is not supported. If you want to run sparkle-cli as root, please specify $USER as the user name the app may run in.\n");
-            return EXIT_FAILURE;
-        }
-        
         struct option longOptions[] = {
             {APPLICATION_FLAG, required_argument, NULL, 0},
             {CHANNELS_FLAG, required_argument, NULL, 0},

--- a/sparkle-cli/main.m
+++ b/sparkle-cli/main.m
@@ -33,7 +33,7 @@ static void printUsage(char **argv)
     fprintf(stderr, "  To check if an update is available without installing, use --%s.\n\n", PROBE_FLAG);
     fprintf(stderr, "  if no updates are available now, or if the last update check was recently\n  (unless --%s is specified) then nothing is done.\n\n", CHECK_NOW_FLAG);
     fprintf(stderr, "  If update permission is requested and --%s is not\n  specified, then checking for updates is aborted.\n\n", GRANT_AUTOMATIC_CHECKING_FLAG);
-    fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization.\n\n", INTERACTIVE_FLAG);
+    fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization. This tool can also be run as root under an active user login\n  session, which will not require further escalation.\n\n", INTERACTIVE_FLAG);
     fprintf(stderr, "  If --%s is specified, this tool will exit leaving a spawned process\n  for finishing the installation after the target application terminates.\n\n", DEFER_FLAG);
     fprintf(stderr, "  Please specify --%s if you intend to use this tool in an automated way.\n", USER_AGENT_NAME);
     fprintf(stderr, "Options:\n");

--- a/sparkle-cli/main.m
+++ b/sparkle-cli/main.m
@@ -33,7 +33,7 @@ static void printUsage(char **argv)
     fprintf(stderr, "  To check if an update is available without installing, use --%s.\n\n", PROBE_FLAG);
     fprintf(stderr, "  if no updates are available now, or if the last update check was recently\n  (unless --%s is specified) then nothing is done.\n\n", CHECK_NOW_FLAG);
     fprintf(stderr, "  If update permission is requested and --%s is not\n  specified, then checking for updates is aborted.\n\n", GRANT_AUTOMATIC_CHECKING_FLAG);
-    fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization. This tool can also be run as root under an active user login\n  session, which will not require further escalation.\n\n", INTERACTIVE_FLAG);
+    fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization. Alternatively, this tool can be run as root under an active user login\n  session, which will not require (and disallow) interaction.\n\n", INTERACTIVE_FLAG);
     fprintf(stderr, "  If --%s is specified, this tool will exit leaving a spawned process\n  for finishing the installation after the target application terminates.\n\n", DEFER_FLAG);
     fprintf(stderr, "  Please specify --%s if you intend to use this tool in an automated way.\n", USER_AGENT_NAME);
     fprintf(stderr, "Options:\n");
@@ -168,6 +168,11 @@ int main(int argc, char **argv)
         
         if (probeForUpdates && (applicationPath != nil || deferInstall || checkForUpdatesNow || interactive)) {
             fprintf(stderr, "Error: --%s does not work together with --%s, --%s, --%s, --%s\n", PROBE_FLAG, APPLICATION_FLAG, DEFER_FLAG, CHECK_NOW_FLAG, INTERACTIVE_FLAG);
+            return EXIT_FAILURE;
+        }
+        
+        if (interactive && geteuid() == 0) {
+            fprintf(stderr, "Error: --%s is not supported when running as root\n", INTERACTIVE_FLAG);
             return EXIT_FAILURE;
         }
         

--- a/sparkle-cli/main.m
+++ b/sparkle-cli/main.m
@@ -55,8 +55,8 @@ int main(int argc, char **argv)
 {
     @autoreleasepool
     {
-        if (geteuid() == 0) {
-            fprintf(stderr, "Error: Running as root is not supported\n");
+        if (geteuid() == 0 && [@(getenv("USER")) isEqualToString:@"root"]) {
+            fprintf(stderr, "Error: Running as root with $USER set to 'root' is not supported. If you want to run sparkle-cli as root, please specify $USER as the user name the app may run in.\n");
             return EXIT_FAILURE;
         }
         


### PR DESCRIPTION
We add support for running the framework and sparkle-cli as root by ensuring we launch the installer in the system domain, and launch the updater progress tool agent in the user domain. 

When running as the root user, there is also no need to attempt authorization or show a prompt. We also need to fetch the agent user name and home directory so we can pass that when running guided package installations with custom scripts.

Rather than explicitly specifying what user to "drop down" to for the agent, we infer the user from the current console / GUI login session. Launchd makes inferences here as well for using this user when we submit the launchd agent job.

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running sparkle-cli as sudo and without on the Test Application, without any authorization prompts.
Tested ssh'ing on my machine (from the same machine) and tested updating still works.
Tested ssh'ing from a remote machine and tested updating still works, as long as the the logged in ssh user matches the active GUI user session on the machine (if these do not match, updating will not work).
Tested running sparkle-cli as sudo and without (with interactive) on guided pkg installation.
Tested running sparkle-cli as sudo with interactive based pkg are unsupported.
Tested resuming an update to be installed (without privileges) with sparkle-cli as sudo works.

macOS version tested: 12.3 (21E230)
