### PR TITLE
Refine minimizing state for download/extraction/installation status

### DIFF
--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -61,4 +61,14 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  */
 - (void)standardUserDriverShowVersionHistoryForAppcastItem:(SUAppcastItem *_Nonnull)item;
 
+/**
+ Specifies whether or not the download, extraction, and installing status windows allows to be minimized.
+ 
+ By default, the status window showing the current status of the update (download, extraction, ready to install) is allowed to be minimized
+ for regular application bundle updates.
+ 
+ @return @c YES if the status window is allowed to be minimized (default behavior), otherwise @c NO.
+ */
+- (BOOL)standardUserDriverAllowsMinimizableStatusWindow;
+
 @end


### PR DESCRIPTION
Don't allow status window to be minimizable for non-app bundle updates due to atomicity concerns.

Add delegate method to allow developer to configure if they want the status window to be minimizable.

Related to #2100.

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested delegate method works
Tested status window still minimizable for test app by default
Tested status window is not minimizable for app using pkg based update

macOS version tested: 12.3 (21E230)
