### PR TITLE
Add standard user driver APIs for gentle scheduled update reminders

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -118,4 +118,4 @@ GCC_WARN_UNUSED_VARIABLE = YES
 WARNING_CFLAGS_EXTRA = -Wno-custom-atomic-properties -Wno-implicit-atomic-properties
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso $(WARNING_CFLAGS_EXTRA)
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-arc-repeated-use-of-weak -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access $(WARNING_CFLAGS_EXTRA)

--- a/Sparkle/InstallerProgress/ShowInstallerProgress.m
+++ b/Sparkle/InstallerProgress/ShowInstallerProgress.m
@@ -24,7 +24,7 @@
 
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host
 {
-    self.statusController = [[SUStatusController alloc] initWithHost:host minimizable:NO];
+    self.statusController = [[SUStatusController alloc] initWithHost:host centerPointValue:nil minimizable:NO];
     
     [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:nil isDefault:NO];
     [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update…", @"") maxProgressValue:0 statusText:@""];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -132,7 +132,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     if (!_loggedGentleUpdateReminderWarning && (![delegate respondsToSelector:@selector(supportsGentleScheduledUpdateReminders)] || !delegate.supportsGentleScheduledUpdateReminders)) {
         BOOL isBackgroundApp = [SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]];
         if (isBackgroundApp) {
-            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle reminders. Please visit https://sparkle-project.org/documentation/gentle-reminders and implement -[SPUStandardUserDriverDelegate supportsGentleScheduledUpdateReminders]. This warning will only be logged once.");
+            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle reminders. Please visit https://sparkle-project.org/documentation/gentle-reminders for more information. This warning will only be logged once.");
             
             _loggedGentleUpdateReminderWarning = YES;
         }

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -146,8 +146,8 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     BOOL isBackgroundApp = [SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]];
     if (isBackgroundApp) {
         BOOL handleShowingUpdates;
-        if (updateItem != nil && [self.delegate respondsToSelector:@selector(standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:)]) {
-            handleShowingUpdates = [self.delegate standardUserDriverShouldShowAlertForScheduledUpdate:(SUAppcastItem * _Nonnull)updateItem inFocusNow:requestingFocus];
+        if (updateItem != nil && [self.delegate respondsToSelector:@selector(standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:)]) {
+            handleShowingUpdates = [self.delegate standardUserDriverShouldShowUpdateAlertForScheduledUpdate:(SUAppcastItem * _Nonnull)updateItem inFocusNow:requestingFocus];
         } else {
             handleShowingUpdates = YES;
         }
@@ -190,8 +190,8 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
         }
         
         BOOL handleShowingUpdates;
-        if (updateItem != nil && [self.delegate respondsToSelector:@selector(standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:)]) {
-            handleShowingUpdates = [self.delegate standardUserDriverShouldShowAlertForScheduledUpdate:(SUAppcastItem * _Nonnull)updateItem inFocusNow:driverShowingUpdateNow];
+        if (updateItem != nil && [self.delegate respondsToSelector:@selector(standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:)]) {
+            handleShowingUpdates = [self.delegate standardUserDriverShouldShowUpdateAlertForScheduledUpdate:(SUAppcastItem * _Nonnull)updateItem inFocusNow:driverShowingUpdateNow];
         } else {
             handleShowingUpdates = YES;
         }
@@ -261,8 +261,8 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
         reply(choice);
         
         id<SPUStandardUserDriverDelegate> strongDelegate = weakDelegate;
-        if (strongDelegate != nil && [strongDelegate respondsToSelector:@selector(standardUserDriverWillCloseAlertForUpdate:)]) {
-            [strongDelegate standardUserDriverWillCloseAlertForUpdate:appcastItem];
+        if (strongDelegate != nil && [strongDelegate respondsToSelector:@selector(standardUserDriverWillCloseUpdateAlertForUpdate:)]) {
+            [strongDelegate standardUserDriverWillCloseUpdateAlertForUpdate:appcastItem];
         }
         
         SPUStandardUserDriver *strongSelf = weakSelf;
@@ -277,8 +277,8 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
         }
     } didBecomeKeyBlock:^{
         id<SPUStandardUserDriverDelegate> strongDelegate = weakDelegate;
-        if ([strongDelegate respondsToSelector:@selector(standardUserDriverDidMakeAlertWindowKeyForUpdate:)]) {
-            [strongDelegate standardUserDriverDidMakeAlertWindowKeyForUpdate:appcastItem];
+        if ([strongDelegate respondsToSelector:@selector(standardUserDriverDidMakeUpdateAlertWindowKeyForUpdate:)]) {
+            [strongDelegate standardUserDriverDidMakeUpdateAlertWindowKeyForUpdate:appcastItem];
         }
     }];
     

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -28,8 +28,6 @@
 
 #import <AppKit/AppKit.h>
 
-// The amount of time we wait until the app becomes inactive and active again to show an update prompt at an opportune time.
-static const NSTimeInterval SUScheduledUpdateActiveAppLeewayInterval = DEBUG ? 60.0 * 2 : 30 * 60.0;
 // The amount of time the app is allowed to be idle for us to consider showing an update prompt right away when the app is active
 static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 30.0 : 5 * 60.0;
 

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -134,7 +134,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     if (!_loggedGentleUpdateReminderWarning && (![delegate respondsToSelector:@selector(supportsGentleScheduledUpdateReminders)] || !delegate.supportsGentleScheduledUpdateReminders)) {
         BOOL isBackgroundApp = [SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]];
         if (isBackgroundApp) {
-            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle reminders. Please visit https://sparkle-project.org/documentation/gentle-reminders for more information. This warning will only be logged once.");
+            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle reminders. As a result, users may not take notice to update alerts that show up in the background. Please visit https://sparkle-project.org/documentation/gentle-reminders for more information. This warning will only be logged once.");
             
             _loggedGentleUpdateReminderWarning = YES;
         }

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -248,7 +248,8 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
             } else {
                 driverShowingUpdateNow = backgroundApp;
                 immediateFocus = NO;
-                showingUpdateInBack = backgroundApp;
+                // If there is a key window active in the app, show the update alert behind other windows
+                showingUpdateInBack = backgroundApp && ([NSApp keyWindow] != nil);
                 activatingApp = NO;
             }
         } else {

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -90,11 +90,16 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
         _oldHostBundleURL = hostBundle.bundleURL;
         _delegate = delegate;
         
-        if (@available(macOS 10.12, *)) {
-            _initializationTime = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
-        }
+        [self _resetInitializationTime];
     }
     return self;
+}
+
+- (void)_resetInitializationTime
+{
+    if (@available(macOS 10.12, *)) {
+        _initializationTime = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+    }
 }
 
 #pragma mark Update Permission
@@ -109,6 +114,8 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     
     __weak __typeof__(self) weakSelf = self;
     self.permissionPrompt = [[SUUpdatePermissionPrompt alloc] initPromptWithHost:self.host request:request reply:^(SUUpdatePermissionResponse *response) {
+        [weakSelf _resetInitializationTime];
+        
         reply(response);
         weakSelf.permissionPrompt = nil;
     }];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -132,7 +132,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     if (!_loggedGentleUpdateReminderWarning && (![delegate respondsToSelector:@selector(supportsGentleScheduledUpdateReminders)] || !delegate.supportsGentleScheduledUpdateReminders)) {
         BOOL isBackgroundApp = [SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]];
         if (isBackgroundApp) {
-            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle scheduled update reminders. Please visit ... and implement -[SPUStandardUserDriverDelegate supportsGentleScheduledUpdateReminders]. This warning will only be logged once.");
+            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle scheduled update reminders. Please visit https://sparkle-project.org/documentation/gentle-reminders and implement -[SPUStandardUserDriverDelegate supportsGentleScheduledUpdateReminders]. This warning will only be logged once.");
             
             _loggedGentleUpdateReminderWarning = YES;
         }

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -132,7 +132,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     if (!_loggedGentleUpdateReminderWarning && (![delegate respondsToSelector:@selector(supportsGentleScheduledUpdateReminders)] || !delegate.supportsGentleScheduledUpdateReminders)) {
         BOOL isBackgroundApp = [SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]];
         if (isBackgroundApp) {
-            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle scheduled update reminders. Please visit https://sparkle-project.org/documentation/gentle-reminders and implement -[SPUStandardUserDriverDelegate supportsGentleScheduledUpdateReminders]. This warning will only be logged once.");
+            SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle reminders. Please visit https://sparkle-project.org/documentation/gentle-reminders and implement -[SPUStandardUserDriverDelegate supportsGentleScheduledUpdateReminders]. This warning will only be logged once.");
             
             _loggedGentleUpdateReminderWarning = YES;
         }

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -264,6 +264,11 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
             [strongDelegate standardUserDriverWillCloseAlertForUpdate:appcastItem];
         }
         weakSelf.activeUpdateAlert = nil;
+    } didBecomeKeyBlock:^{
+        id<SPUStandardUserDriverDelegate> strongDelegate = weakDelegate;
+        if ([strongDelegate respondsToSelector:@selector(standardUserDriverDidMakeAlertWindowKeyForUpdate:)]) {
+            [strongDelegate standardUserDriverDidMakeAlertWindowKeyForUpdate:appcastItem];
+        }
     }];
     
     _regularApplicationUpdate = [appcastItem.installationType isEqualToString:SPUInstallationTypeApplication];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -121,7 +121,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
 - (void)_logGentleScheduledUpdateReminderWarningIfNeeded
 {
     id<SPUStandardUserDriverDelegate> delegate = self.delegate;
-    if (!_loggedGentleUpdateReminderWarning && (![delegate respondsToSelector:@selector(supportsGentleScheduledUpdateReminders)] || ![delegate supportsGentleScheduledUpdateReminders])) {
+    if (!_loggedGentleUpdateReminderWarning && (![delegate respondsToSelector:@selector(supportsGentleScheduledUpdateReminders)] || !delegate.supportsGentleScheduledUpdateReminders)) {
         BOOL isBackgroundApp = [SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]];
         if (isBackgroundApp) {
             SULog(SULogLevelError, @"Warning: Background app automatically schedules for update checks but does not implement gentle scheduled update reminders. Please visit ... and implement -[SPUStandardUserDriverDelegate supportsGentleScheduledUpdateReminders]. This warning will only be logged once.");

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -194,6 +194,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
             BOOL systemHasBeenIdle;
             {
                 // If the system has been inactive for several minutes, allow the update alert to show up immediately. We assume it's likely the user isn't at their computer in this case.
+                // Note this is not done for background running applications.
                 CFTimeInterval timeSinceLastEvent;
                 if (!appNearUpdaterInitialization && !backgroundApp) {
                     timeSinceLastEvent = CGEventSourceSecondsSinceLastEventType(kCGEventSourceStateHIDSystemState, kCGAnyInputEventType);
@@ -214,7 +215,9 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
                             BOOL foundNoDisplaySleepAssertion = NO;
                             for (NSDictionary<NSString *, id> *assertion in currentProcessAssertions) {
                                 NSString *assertionType = assertion[(NSString *)kIOPMAssertionTypeKey];
-                                if ([assertionType isEqualToString:(NSString *)kIOPMAssertionTypeNoDisplaySleep]) {
+                                NSNumber *assertionLevel = assertion[(NSString *)kIOPMAssertionLevelKey];
+                                if ([assertionType isEqualToString:(NSString *)kIOPMAssertionTypeNoDisplaySleep] && [assertionLevel isEqual:@(kIOPMAssertionLevelOn)]) {
+                                    
                                     foundNoDisplaySleepAssertion = YES;
                                     break;
                                 }

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -81,6 +81,8 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  The delegate may implement scheduled update reminders that are presented in a gentle manner by implementing one or both of:
  `-standardUserDriverWillShowUpdate:state:` and `-standardUserDriverShouldHandleShowingUpdateAlertForScheduledUpdate:andInImmediateFocus:`
  
+ Visit https://sparkle-project.org/documentation/gentle-reminders for more information and examples.
+ 
  @return @c YES if gentle scheduled update reminders are implemented by standard user driver delegate, otherwise @c NO (default).
  */
 @property (nonatomic, readonly) BOOL supportsGentleScheduledUpdateReminders;
@@ -96,7 +98,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  Returning @c YES is the default behavior and allows the standard user driver to handle showing the update.
  
  If the standard user driver handles showing the update, `immediateFocus` reflects whether or not it will show the update in immediate and utmost focus.
- The standard user driver may choose show the update in immediate and utmost focus when the app was launched recently
+ The standard user driver may choose to show the update in immediate and utmost focus when the app was launched recently
  or the system has been idle for some time. If `immediateFocus` is @c NO the standard user driver may want to
  defer showing the update until the user comes back to the app.
  For background running applications, when `immediateFocus` is  @c NO the standard user driver will always want to show
@@ -151,7 +153,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  This occurs either when the user first brings the update alert in utmost focus or when the user makes a choice to install an update or dismiss/skip it.
  
  This may be useful to intercept for dismissing custom attention-based UI indicators (e.g, user notifications) introduced when implementing
- `-standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:`
+ `-standardUserDriverShouldHandleShowingScheduledUpdate:andInImmediateFocus:`
  
  For custom UI indicators that need to still be on screen after the user has started to install an update, please see `standardUserDriverWillFinishUpdateSession`.
  
@@ -166,7 +168,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  For updaters updating external/other bundles, this may also be called after an update has been successfully installed.
  
  This may be useful to intercept for dismissing custom UI indicators introduced when implementing
- `-standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:`
+ `-standardUserDriverShouldHandleShowingScheduledUpdate:andInImmediateFocus:`
  
  For UI indicators that need to be dismissed when the user has given attention to a new update alert,
  please see `standardUserDriverDidReceiveUserAttentionForUpdate:`

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -78,7 +78,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  Declares whether or not gentle scheduled update reminders are supported.
  
  The delegate may implement scheduled update reminders that are presented in a gentle manner by implementing
- `-standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:`
+ `-standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:`
  
  @return @c YES if gentle scheduled update reminders are implemented by standard user driver delegate, otherwise @c NO (default).
  */
@@ -101,7 +101,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  If you return @c NO the standard user driver will not handle showing the update alert but Sparkle's user driver session will still be running.
  At some point you may call `-[SPUStandardUpdateController checkForUpdates:]` or `-[SPUUpdater checkForUpdates]` to bring up the update alert in focus.
  In this case, you may want to show an additional UI indicator in your application that will show this update in focus.
- You may want to dismiss additional UI indicators in `-standardUserDriverWillCloseAlertForUpdate:`
+ You may want to dismiss additional UI indicators in `-standardUserDriverWillCloseUpdateAlertForUpdate:`
  
  If you return @c YES you may still want to intercept this method. For example, you can publish a user notification when the application is not active.
  
@@ -110,7 +110,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  
  @return @c YES if the standard user should automatically handle showing the update (default behavior), otherwise @c NO.
  */
-- (BOOL)standardUserDriverShouldShowAlertForScheduledUpdate:(SUAppcastItem *)update inFocusNow:(BOOL)inFocusNow;
+- (BOOL)standardUserDriverShouldShowUpdateAlertForScheduledUpdate:(SUAppcastItem *)update inFocusNow:(BOOL)inFocusNow;
 
 /**
  Called before an alert window for an update is closed.
@@ -118,18 +118,18 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  The user has either started to install an update, dismiss it, or skip the update.
  
  This may be useful to intercept for dismissing custom UI indicators introduced when implementing
- `-standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:`
+ `-standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:`
  
  @param update The update corresponding to the update alert window the standard user driver is closing.
  */
-- (void)standardUserDriverWillCloseAlertForUpdate:(SUAppcastItem *)update;
+- (void)standardUserDriverWillCloseUpdateAlertForUpdate:(SUAppcastItem *)update;
 
 /**
  Called after the alert window for a new update has become the key window.
  
  This may be a good time to dismiss additional reminders (e.g. notifications) for the new update.
  */
-- (void)standardUserDriverDidMakeAlertWindowKeyForUpdate:(SUAppcastItem *)update;
+- (void)standardUserDriverDidMakeUpdateAlertWindowKeyForUpdate:(SUAppcastItem *)update;
 
 @end
 

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -124,6 +124,13 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  */
 - (void)standardUserDriverWillCloseAlertForUpdate:(SUAppcastItem *)update;
 
+/**
+ Called after the alert window for a new update has become the key window.
+ 
+ This may be a good time to dismiss additional reminders (e.g. notifications) for the new update.
+ */
+- (void)standardUserDriverDidMakeAlertWindowKeyForUpdate:(SUAppcastItem *)update;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -82,7 +82,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  
  @return @c YES if gentle scheduled update reminders are implemented by standard user driver delegate, otherwise @c NO (default).
  */
-- (BOOL)supportsGentleScheduledUpdateReminders;
+@property (nonatomic, readonly) BOOL supportsGentleScheduledUpdateReminders;
 
 /**
  Specifies if the standard user driver should handle showing a new update alert.

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -96,7 +96,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  When @c inFocusNow is @c YES the application is active, and either the updater / application just launched or the user's system was idle for an elapsed threshold.
  
  For backgrounded applications (which do not appear in the Dock), when @c inFocusNow is @c NO, the standard user driver will show the update but not in utmost focus.
- This is to prevent a background application window from stealing focus from another foreground application without the user explicitly making this decision. If @c inFocusNow is @c YES the updater / application just launched.
+ This is to prevent a background application window from stealing focus from another window or foreground application without the user explicitly making this decision. If @c inFocusNow is @c YES the updater / application just launched.
  
  If you return @c NO the standard user driver will not handle showing the update alert but Sparkle's user driver session will still be running.
  At some point you may call `-[SPUStandardUpdateController checkForUpdates:]` or `-[SPUUpdater checkForUpdates]` to bring up the update alert in focus.

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -95,7 +95,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  Rarely, if an opportune time is unavailable after a threshold of elapsed time, the standard user driver may have to show an alert when the application is active however.
  When @c inFocusNow is @c YES the application is active, and either the updater / application just launched or the user's system was idle for an elapsed threshold.
  
- For non-background applications, when @c inFocusNow is @c NO, the standard user driver will show the update but not in utmost focus.
+ For backgrounded applications (which do not appear in the Dock), when @c inFocusNow is @c NO, the standard user driver will show the update but not in utmost focus.
  This is to prevent a background application window from stealing focus from another foreground application without the user explicitly making this decision. If @c inFocusNow is @c YES the updater / application just launched.
  
  If you return @c NO the standard user driver will not handle showing the update alert but Sparkle's user driver session will still be running.
@@ -113,23 +113,32 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
 - (BOOL)standardUserDriverShouldShowUpdateAlertForScheduledUpdate:(SUAppcastItem *)update inFocusNow:(BOOL)inFocusNow;
 
 /**
- Called before an alert window for an update is closed.
+ Called when a new update first receives attention from the user.
  
- The user has either started to install an update, dismiss it, or skip the update.
+ This occurs either when the user first brings the update alert in utmost focus or when the user makes a choice to install an update or dismiss/skip it.
+ 
+ This may be useful to intercept for dismissing custom attention-based UI indicators (e.g, user notifications) introduced when implementing
+ `-standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:`
+ 
+ For custom UI indicators that need to still be on screen after the user has started to install an update, please see `standardUserDriverWillFinishUpdateSession`.
+ 
+ @param update The new update that the user gave attention to.
+ */
+- (void)standardUserDriverDidReceiveUserAttentionForUpdate:(SUAppcastItem *)update;
+
+/**
+ Called before the standard user driver session will finish its current update session.
+ 
+ This may occur after the user has dismissed / skipped a new update or after an update error has occurred.
+ For updaters updating external/other bundles, this may also be called after an update has been successfully installed.
  
  This may be useful to intercept for dismissing custom UI indicators introduced when implementing
  `-standardUserDriverShouldShowUpdateAlertForScheduledUpdate:inFocusNow:`
  
- @param update The update corresponding to the update alert window the standard user driver is closing.
+ For UI indicators that need to be dismissed when the user has given attention to a new update alert,
+ please see `standardUserDriverDidReceiveUserAttentionForUpdate:`
  */
-- (void)standardUserDriverWillCloseUpdateAlertForUpdate:(SUAppcastItem *)update;
-
-/**
- Called after the alert window for a new update has become the key window.
- 
- This may be a good time to dismiss additional reminders (e.g. notifications) for the new update.
- */
-- (void)standardUserDriverDidMakeUpdateAlertWindowKeyForUpdate:(SUAppcastItem *)update;
+- (void)standardUserDriverWillFinishUpdateSession;
 
 @end
 

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -97,10 +97,10 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  
  If the standard user driver handles showing the update, `immediateFocus` reflects whether or not it will show the update in immediate and utmost focus.
  The standard user driver may choose show the update in immediate and utmost focus when the app was launched recently
- or the system has been idle for some time. If `immediateFocus` is @c NO the standard user driver may want to defer showing the update for some time
- until a better opportunity comes up (e.g, when the user comes back to the app).
+ or the system has been idle for some time. If `immediateFocus` is @c NO the standard user driver may want to
+ defer showing the update until the user comes back to the app.
  For background running applications, when `immediateFocus` is  @c NO the standard user driver will always want to show
- the update alert immediately, but behind other running applications.
+ the update alert immediately, but behind other running applications or behind the app's own windows if it's currently active.
  
  There should be no side effects made when implementing this method so you should just return @c YES or @c NO
  You will also want to implement `-standardUserDriverWillHandleShowingUpdate:forUpdate:state:` for adding additional update reminders.
@@ -121,8 +121,9 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  
  If the standard user driver handles showing the update, `handleShowingUpdate` will be @c YES
  In this case, if the update is not user initiated (`state.userInitiated` is @c NO) then the standard user driver may defer showing the update,
- and it may be shown some time after this method is called when a better opportunity opens up (e.g, when the user comes back to the app).
- For a background (dockless) running app, the update alert will always show up immediately but behind other running applications.
+ and it may be shown when the user comes back to the app.
+ For a background (dockless) running app, the update alert will always show up immediately but behind other running applications or behind
+ its own windows if the app is currently active.
  
  If the delegate declared it handles showing the update by returning @c NO in `-standardUserDriverShouldHandleShowingScheduledUpdate:andInImmediateFocus:`
  then the delegate should handle showing update reminders in this method, or at some later point.

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -107,6 +107,8 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  
  This method is not called for user-initiated update checks. The standard user driver always handles those.
  
+ Visit https://sparkle-project.org/documentation/gentle-reminders for more information and examples.
+ 
  @param update The update the standard user driver should show.
  @param immediateFocus If @c immediateFocus is @c YES, then the standard user driver proposes to show the update in immediate and utmost focus. See discussion for more details.
  
@@ -122,7 +124,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  and it may be shown some time after this method is called when a better opportunity opens up (e.g, when the user comes back to the app).
  For a background (dockless) running app, the update alert will always show up immediately but behind other running applications.
  
- If the delegate declared it is handling showing the update by returning @c NO in `-standardUserDriverShouldHandleShowingScheduledUpdate:andInImmediateFocus:`
+ If the delegate declared it handles showing the update by returning @c NO in `-standardUserDriverShouldHandleShowingScheduledUpdate:andInImmediateFocus:`
  then the delegate should handle showing update reminders in this method, or at some later point.
  In this case, `handleShowingUpdate` will be @c NO.
  To bring the update alert in focus, you may call `-[SPUStandardUpdateController checkForUpdates:]` or `-[SPUUpdater checkForUpdates]`
@@ -133,6 +135,8 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  In this case, it may still be useful for the delegate to intercept this method right before a new update will be shown.
  
  This method is not called when bringing an update that has already been presented back in focus.
+ 
+ Visit https://sparkle-project.org/documentation/gentle-reminders for more information and examples.
  
  @param handleShowingUpdate @c YES if the standard user driver handles showing the update, otherwise @c NO if the delegate handles showing the update.
  @param update The update that will be shown.

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -75,6 +75,16 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
 - (BOOL)standardUserDriverAllowsMinimizableStatusWindow;
 
 /**
+ Declares whether or not gentle scheduled update reminders are supported.
+ 
+ The delegate may implement scheduled update reminders that are presented in a gentle manner by implementing
+ `-standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:`
+ 
+ @return @c YES if gentle scheduled update reminders are implemented by standard user driver delegate, otherwise @c NO (default).
+ */
+- (BOOL)supportsGentleScheduledUpdateReminders;
+
+/**
  Specifies if the standard user driver should handle showing a new update alert.
  
  This is called before the standard user driver handles showing an alert for a new update that is found.
@@ -89,9 +99,9 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  This is to prevent a background application window from stealing focus from another foreground application without the user explicitly making this decision. If @c inFocusNow is @c YES the updater / application just launched.
  
  If you return @c NO the standard user driver will not handle showing the update alert but Sparkle's user driver session will still be running.
- At some point you may call -[SPUStandardUserDriver showUpdateInFocus] to bring up the update alert.
- In this case, you may want to show a UI indicator in your application that will show this update in focus.
- You may want to dismiss UI indicators in -standardUserDriverWillCloseAlertForUpdate:
+ At some point you may call `-[SPUStandardUpdateController checkForUpdates:]` or `-[SPUUpdater checkForUpdates]` to bring up the update alert in focus.
+ In this case, you may want to show an additional UI indicator in your application that will show this update in focus.
+ You may want to dismiss additional UI indicators in `-standardUserDriverWillCloseAlertForUpdate:`
  
  If you return @c YES you may still want to intercept this method. For example, you can publish a user notification when the application is not active.
  
@@ -108,7 +118,7 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  The user has either started to install an update, dismiss it, or skip the update.
  
  This may be useful to intercept for dismissing custom UI indicators introduced when implementing
- -standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:
+ `-standardUserDriverShouldShowAlertForScheduledUpdate:inFocusNow:`
  
  @param update The update corresponding to the update alert window the standard user driver is closing.
  */

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -36,6 +36,12 @@
 
 #include "AppKitPrevention.h"
 
+@interface NSObject (SPUStandardUserDriverPrivate)
+
+- (void)_logGentleScheduledUpdateReminderWarningIfNeeded;
+
+@end
+
 NSString *const SUUpdaterDidFinishLoadingAppCastNotification = @"SUUpdaterDidFinishLoadingAppCastNotification";
 NSString *const SUUpdaterDidFindValidUpdateNotification = @"SUUpdaterDidFindValidUpdateNotification";
 NSString *const SUUpdaterDidNotFindUpdateNotification = @"SUUpdaterDidNotFindUpdateNotification";
@@ -510,6 +516,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 if ([self.delegate respondsToSelector:@selector(updater:willScheduleUpdateCheckAfterDelay:)]) {
                     [self.delegate updater:self willScheduleUpdateCheckAfterDelay:delayUntilCheck];
                 }
+                
+                if ([self.userDriver respondsToSelector:@selector(_logGentleScheduledUpdateReminderWarningIfNeeded)]) {
+                    [(NSObject *)self.userDriver _logGentleScheduledUpdateReminderWarningIfNeeded];
+                }
+                
                 [self.updaterTimer startAndFireAfterDelay:delayUntilCheck];
             } else {
                 // We're overdue! Run one now.

--- a/Sparkle/SUStatusController.h
+++ b/Sparkle/SUStatusController.h
@@ -24,7 +24,7 @@
 @property (nonatomic) double maxProgressValue;
 @property (getter=isButtonEnabled) BOOL buttonEnabled;
 
-- (instancetype)initWithHost:(SUHost *)host minimizable:(BOOL)minimizable;
+- (instancetype)initWithHost:(SUHost *)host centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable;
 
 // Pass 0 for the max progress value to get an indeterminate progress bar.
 // Pass nil for the status text to not show it.

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -25,6 +25,10 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @end
 
 @implementation SUStatusController
+{
+    NSValue *_centerPointValue;
+}
+
 @synthesize progressValue;
 @synthesize maxProgressValue;
 @synthesize statusText;
@@ -37,12 +41,13 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @synthesize touchBarButton;
 @synthesize minimizable = _minimizable;
 
-- (instancetype)initWithHost:(SUHost *)aHost minimizable:(BOOL)minimizable
+- (instancetype)initWithHost:(SUHost *)aHost centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable
 {
     self = [super initWithWindowNibName:@"SUStatus" owner:self];
 	if (self)
 	{
         self.host = aHost;
+        _centerPointValue = centerPointValue;
         _minimizable = minimizable;
         [self setShouldCascadeWindows:NO];
     }
@@ -53,8 +58,15 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 
 - (void)windowDidLoad
 {
-    [[self window] center];
-    [[self window] setFrameAutosaveName:@"SUStatusFrame"];
+    NSRect windowFrame = self.window.frame;
+    
+    if (_centerPointValue != nil) {
+        NSPoint centerPoint = _centerPointValue.pointValue;
+        [self.window setFrameOrigin:NSMakePoint(centerPoint.x - windowFrame.size.width / 2.0, centerPoint.y - windowFrame.size.height / 2.0)];
+    } else {
+        [self.window center];
+    }
+    
     if (self.minimizable) {
         self.window.styleMask |= NSWindowStyleMaskMiniaturizable;
     }

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -22,7 +22,7 @@
 
 @property (nonatomic, weak, readonly) id <SUVersionDisplay> versionDisplayer;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData;
 - (void)showReleaseNotesFailedToDownload;

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -22,7 +22,7 @@
 
 @property (nonatomic, weak, readonly) id <SUVersionDisplay> versionDisplayer;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))block;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData;
 - (void)showReleaseNotesFailedToDownload;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -100,6 +100,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         SPUUpdaterSettings *updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:host.bundle];
         _allowsAutomaticUpdates = updaterSettings.allowsAutomaticUpdates && updaterSettings.automaticallyChecksForUpdates && !item.informationOnlyUpdate;
         [self setShouldCascadeWindows:NO];
+    } else {
+        assert(false);
     }
     return self;
 }

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -312,10 +312,6 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
     [self.window setFrameAutosaveName: showReleaseNotes ? @"SUUpdateAlert" : @"SUUpdateAlertSmall" ];
 
-    if ([SUApplicationInfo isBackgroundApplication:[NSApplication sharedApplication]]) {
-        [self.window setLevel:NSFloatingWindowLevel]; // This means the window will float over all other apps, if our app is switched out ?!
-    }
-
     if (self.updateItem.informationOnlyUpdate) {
         [self.installButton setTitle:SULocalizedString(@"Learn More…", @"Alternate title for 'Install Update' button when there's no download in RSS feed.")];
         [self.installButton setAction:@selector(openInfoURL:)];

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -37,7 +37,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 @property (strong) SUAppcastItem *updateItem;
 @property (strong) SUHost *host;
 @property (nonatomic) BOOL allowsAutomaticUpdates;
-@property (nonatomic, copy, nullable) void(^completionBlock)(SPUUserUpdateChoice);
+@property (nonatomic, copy, nullable) void(^completionBlock)(SPUUserUpdateChoice, NSRect, BOOL);
 @property (nonatomic) SPUUserUpdateState *state;
 
 @property (strong) NSProgressIndicator *releaseNotesSpinner;
@@ -85,7 +85,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 @synthesize webView = _webView;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
 {
     self = [super initWithWindowNibName:@"SUUpdateAlert"];
     if (self != nil) {
@@ -121,10 +121,14 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 {
     [self.webView stopLoading];
     [self.webView.view removeFromSuperview]; // Otherwise it gets sent Esc presses (why?!) and gets very confused.
+    
+    BOOL wasKeyWindow = self.window.keyWindow;
+    NSRect windowFrame = self.window.frame;
+    
     [self close];
     
     if (self.completionBlock != nil) {
-        self.completionBlock(choice);
+        self.completionBlock(choice, windowFrame, wasKeyWindow);
         self.completionBlock = nil;
     }
 }

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -58,6 +58,9 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 @end
 
 @implementation SUUpdateAlert
+{
+    void (^_didBecomeKeyBlock)(void);
+}
 
 @synthesize completionBlock = _completionBlock;
 @synthesize state = _state;
@@ -82,7 +85,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
 
 @synthesize webView = _webView;
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))block
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id <SUVersionDisplay>)aVersionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
 {
     self = [super initWithWindowNibName:@"SUUpdateAlert"];
     if (self != nil) {
@@ -91,7 +94,8 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         versionDisplayer = aVersionDisplayer;
         
         _state = state;
-        _completionBlock = [block copy];
+        _completionBlock = [completionBlock copy];
+        _didBecomeKeyBlock = [didBecomeKeyBlock copy];
         
         SPUUpdaterSettings *updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:host.bundle];
         _allowsAutomaticUpdates = updaterSettings.allowsAutomaticUpdates && updaterSettings.automaticallyChecksForUpdates && !item.informationOnlyUpdate;
@@ -365,6 +369,13 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
     }
 
     [self.window center];
+}
+
+- (void)windowDidBecomeKey:(NSNotification *)__unused note
+{
+    if (_didBecomeKeyBlock != NULL) {
+        _didBecomeKeyBlock();
+    }
 }
 
 - (BOOL)windowShouldClose:(NSNotification *) __unused note


### PR DESCRIPTION
This allows developers to provide gentle reminders when scheduled update alerts would normally appear.

This is work a part of #924.

Documentation page written in https://github.com/sparkle-project/sparkle-project.github.io/pull/138

Backgrounded apps no longer steal focus from other active applications when scheduled update alerts show up (unless the app just launched by the user). The update alert window is also not floating above all other app's windows anymore too. A logging message is done for backgrounded apps that schedule update checks but do not implement gentle reminder support.

The progress window (showing downloading, installing) frame position is also now in center to where the update alert window was last placed before being closed, and does not steal focus if the update alert wasn't key.

Foreground apps now wait until the app becomes re-activated before presenting a new update when opting into Sparkle handling showing the update.

APIs are now provided to allow developers to override Sparkle handling of showing updates, or add and dismiss gentle reminders both for foreground and background running applications.

## Misc Checklist:

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested the samples in the documentation PR, while the app is a regular one and a background running one, app scheduled a check near launch and 10 seconds later, while the app was in-active and active (currently frontmost), and while the system has been idle vs has been in active use for non-background running app.

macOS version tested: 12.3 (21E230)
