### PR TITLE
Schedule next update check always if we're firing immediately

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -449,7 +449,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 {
     [self.updaterTimer invalidate];
     
-    if (![self automaticallyChecksForUpdates]) {
+    if (!firingImmediately && ![self automaticallyChecksForUpdates]) {
         if ([self.delegate respondsToSelector:@selector(updaterWillNotScheduleUpdateCheck:)]) {
             [self.delegate updaterWillNotScheduleUpdateCheck:self];
         }


### PR DESCRIPTION
Even if the updater is set to not automatically check for updates.

This fixes a bug where an update cycle may not complete if the automatic update driver first started, and the update should have been resumed but automatic update checks were disabled by the developer.

The developer would have had to disable automatic update checks, check updates in the background themselves, have updates set to download automatically/silently, and be in a situation where the update would be deferred to non-silent update (for example, user requiring authorization to install, critical update being presented, info-only update being presented).

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app by disabling automatic checks for updates, inserting manual code to check for updates in background, enabling downloading updates automatically, and setting owner of the app to root.

macOS version tested: 12.4 (21F79)
