### PR TITLE
Update last update check time when choosing to install update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Fixes # (issue)
 
-## Misc Checklist:
+## Misc Checklist
 
 - [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
 - [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

--- a/Sparkle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sparkle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
-        }
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "83b23d940471b313427da226196661856f6ba3e0",
+        "version" : "0.4.4"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Sparkle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sparkle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,16 @@
 {
-  "pins" : [
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "83b23d940471b313427da226196661856f6ba3e0",
-        "version" : "0.4.4"
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
+        }
       }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -61,6 +61,11 @@
 {
 }
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+    [self.coreDriver setUpdateWillInstallHandler:updateWillInstallHandler];
+}
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
 {
     [self.coreDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES requiresSilentInstall:YES];

--- a/Sparkle/SPUCoreBasedUpdateDriver.h
+++ b/Sparkle/SPUCoreBasedUpdateDriver.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setCompletionHandler:(SPUUpdateDriverCompletion)completionBlock;
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler;
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background requiresSilentInstall:(BOOL)silentInstall;
 
 - (void)resumeInstallingUpdate;

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -48,6 +48,9 @@
 @end
 
 @implementation SPUCoreBasedUpdateDriver
+{
+    void (^_updateWillInstallHandler)(void);
+}
 
 @synthesize basicDriver = _basicDriver;
 @synthesize downloadDriver = _downloadDriver;
@@ -87,6 +90,11 @@
 - (void)setCompletionHandler:(SPUUpdateDriverCompletion)completionBlock
 {
     [self.basicDriver setCompletionHandler:completionBlock];
+}
+
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+    _updateWillInstallHandler = [updateWillInstallHandler copy];
 }
 
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background requiresSilentInstall:(BOOL)silentInstall
@@ -304,6 +312,10 @@
             [self.installerDriver cancelUpdate];
             break;
         case SPUUserUpdateChoiceInstall:
+            if (_updateWillInstallHandler != NULL) {
+                _updateWillInstallHandler();
+            }
+            
             [self.installerDriver installWithToolAndRelaunch:YES displayingUserInterface:displayingUserInterface];
             break;
     }

--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -48,9 +48,6 @@
 @end
 
 @implementation SPUCoreBasedUpdateDriver
-{
-    void (^_updateWillInstallHandler)(void);
-}
 
 @synthesize basicDriver = _basicDriver;
 @synthesize downloadDriver = _downloadDriver;
@@ -94,7 +91,7 @@
 
 - (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
 {
-    _updateWillInstallHandler = [updateWillInstallHandler copy];
+    [self.installerDriver setUpdateWillInstallHandler:updateWillInstallHandler];
 }
 
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background requiresSilentInstall:(BOOL)silentInstall
@@ -312,10 +309,6 @@
             [self.installerDriver cancelUpdate];
             break;
         case SPUUserUpdateChoiceInstall:
-            if (_updateWillInstallHandler != NULL) {
-                _updateWillInstallHandler();
-            }
-            
             [self.installerDriver installWithToolAndRelaunch:YES displayingUserInterface:displayingUserInterface];
             break;
     }

--- a/Sparkle/SPUInstallerDriver.h
+++ b/Sparkle/SPUInstallerDriver.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)resumeInstallingUpdateWithUpdateItem:(SUAppcastItem *)updateItem systemDomain:(BOOL)systemDomain;
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler;
+
 - (void)extractDownloadedUpdate:(SPUDownloadedUpdate *)downloadedUpdate silently:(BOOL)silently completion:(void (^)(NSError * _Nullable))completionHandler;
 
 - (void)installWithToolAndRelaunch:(BOOL)relaunch displayingUserInterface:(BOOL)showUI;

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -64,6 +64,9 @@
 @end
 
 @implementation SPUInstallerDriver
+{
+    void (^_updateWillInstallHandler)(void);
+}
 
 @synthesize host = _host;
 @synthesize applicationBundle = _applicationBundle;
@@ -93,6 +96,11 @@
         _delegate = delegate;
     }
     return self;
+}
+
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+    _updateWillInstallHandler = [updateWillInstallHandler copy];
 }
 
 - (void)_reportInstallerError:(nullable NSError *)currentInstallerError genericErrorCode:(NSInteger)genericErrorCode genericUserInfo:(NSDictionary *)genericUserInfo
@@ -474,6 +482,10 @@
                 return;
             }
         }
+    }
+    
+    if (_updateWillInstallHandler != NULL) {
+        _updateWillInstallHandler();
     }
     
     // Set up connection to the installer if one is not set up already

--- a/Sparkle/SPUProbingUpdateDriver.m
+++ b/Sparkle/SPUProbingUpdateDriver.m
@@ -42,6 +42,10 @@
 {
 }
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+}
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
 {
     [self.basicDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES];

--- a/Sparkle/SPUScheduledUpdateDriver.m
+++ b/Sparkle/SPUScheduledUpdateDriver.m
@@ -48,6 +48,11 @@
     self.updateDidShowHandler = handler;
 }
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+    [self.uiDriver setUpdateWillInstallHandler:updateWillInstallHandler];
+}
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
 {
     [self.uiDriver checkForUpdatesAtAppcastURL:appcastURL withUserAgent:userAgent httpHeaders:httpHeaders inBackground:YES];

--- a/Sparkle/SPUUIBasedUpdateDriver.h
+++ b/Sparkle/SPUUIBasedUpdateDriver.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setCompletionHandler:(SPUUpdateDriverCompletion)completionBlock;
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler;
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background;
 
 - (void)resumeInstallingUpdate;

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -132,6 +132,11 @@
     [self.coreDriver setCompletionHandler:completionBlock];
 }
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+    [self.coreDriver setUpdateWillInstallHandler:updateWillInstallHandler];
+}
+
 - (void)_clearSkippedUpdatesIfUserInitiated
 {
     if (self.userInitiated) {

--- a/Sparkle/SPUUpdateDriver.h
+++ b/Sparkle/SPUUpdateDriver.h
@@ -23,6 +23,8 @@ typedef void (^SPUUpdateDriverCompletion)(BOOL shouldShowUpdateImmediately, id<S
 
 - (void)setUpdateShownHandler:(void (^)(void))updateShownHandler;
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler;
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders;
 
 - (void)resumeInstallingUpdate;

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -766,6 +766,10 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         weakSelf.canCheckForUpdates = YES;
     }];
     
+    [self.driver setUpdateWillInstallHandler:^{
+        [weakSelf updateLastUpdateCheckDate];
+    }];
+    
     if (installerInProgress) {
         // Resume an update that has already begun installing in the background
         [self.driver resumeInstallingUpdate];

--- a/Sparkle/SPUUserInitiatedUpdateDriver.m
+++ b/Sparkle/SPUUserInitiatedUpdateDriver.m
@@ -53,6 +53,11 @@
     self.updateDidShowHandler = handler;
 }
 
+- (void)setUpdateWillInstallHandler:(void (^)(void))updateWillInstallHandler
+{
+    [self.uiDriver setUpdateWillInstallHandler:updateWillInstallHandler];
+}
+
 - (void)checkForUpdatesAtAppcastURL:(NSURL *)appcastURL withUserAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders
 {
     self.showingUserInitiatedProgress = YES;


### PR DESCRIPTION
In the UI driver, this is when the user chooses to Install & Relaunch.

In the automatic download based driver, this is when Sparkle hands off responsibility to its delegate to install the update and they trigger the callback to relaunch the app.

This defers checking for updates on next relaunch too quick when an update was just installed. This matters if there is a long delay between the user being presented an update and them actually installing it, for example.

Fixes #2135

## Misc Checklist:

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested that test app updated and last check update time in user defaults got updated.
Probe update check works from sparkle-cli (when new update is available and isn't available).
Tested that automatic update driver updates last check date when delegate calls block to install/relaunch app, using Test App.

macOS version tested: 12.4 (21F79)
