### PR TITLE
Update Xcode in CI to 13.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,21 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: ['xcode12.5.1', 'xcode13.2.1']
+        xcode: ['xcode12.5.1', 'xcode13.3.1']
         include:
+            - xcode: 'xcode13.3.1'
+              xcode-path: '/Applications/Xcode_13.3.1.app/Contents/Developer'
+              upload-dist: true
+              run-analyzer: true
+              macos: 'macos-12'
             - xcode: 'xcode12.5.1'
               xcode-path: '/Applications/Xcode_12.5.1.app/Contents/Developer'
               upload-dist: false
               run-analyzer: false
-            - xcode: 'xcode13.2.1'
-              xcode-path: '/Applications/Xcode_13.2.1.app/Contents/Developer'
-              upload-dist: true
-              run-analyzer: true
+              macos: 'macos-11'
             
     name: Build and Test Sparkle
-    runs-on: macos-11
+    runs-on: ${{ matrix.macos }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Update Xcode in CI to 13.3.1

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI

macOS version tested: macOS 12 in CI
