### PR TITLE
Make displayVersionString non-null and update fallback documentation

### DIFF
--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -65,8 +65,10 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
  This corresponds to the application update's @c CFBundleShortVersionString
  
  This is extracted from the @c <sparkle:shortVersionString> element,  or the @c sparkle:shortVersionString attribute from the @c <enclosure> element.
+ 
+ If no short version string is available, this falls back to the update's `versionString`.
  */
-@property (copy, readonly, nullable) NSString *displayVersionString;
+@property (copy, readonly) NSString *displayVersionString;
 
 /**
  The file URL to the update item if provided.


### PR DESCRIPTION

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested running Test app (with short version string specified and not specified) and otherwise running CI here.

macOS version tested: 12.4 (21F79)
