### PR TITLE
Show checking window back in focus and activate app if needed

### DIFF
--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -454,7 +454,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     }
     
     if (mayNeedToActivateApp && ![NSApp isActive]) {
-        // Make the app active if it's not already active
+        // Make the app active if it's not already active, e.g, from a menu bar extra
         [NSApp activateIgnoringOtherApps:YES];
     }
 }

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -436,12 +436,26 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
 
 - (void)showUpdateInFocus
 {
+    BOOL mayNeedToActivateApp;
     if (self.activeUpdateAlert != nil) {
         [self setUpActiveUpdateAlertForScheduledUpdate:nil state:nil];
+        mayNeedToActivateApp = NO;
     } else if (self.permissionPrompt != nil) {
         [self.permissionPrompt showWindow:nil];
+        mayNeedToActivateApp = YES;
     } else if (self.statusController != nil) {
         [self.statusController showWindow:nil];
+        mayNeedToActivateApp = YES;
+    } else if (self.checkingController != nil) {
+        [self.checkingController showWindow:nil];
+        mayNeedToActivateApp = YES;
+    } else {
+        mayNeedToActivateApp = NO;
+    }
+    
+    if (mayNeedToActivateApp && ![NSApp isActive]) {
+        // Make the app active if it's not already active
+        [NSApp activateIgnoringOtherApps:YES];
     }
 }
 


### PR DESCRIPTION
We forgot to show the checkingController back in focus. We should also re-activate the app if the app is not already active.

Fixes #2146

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested that the checking for updates window can be brought back to key focus and the app can become active again (from a menu extra).

macOS version tested: 12.4 (21F79)
