### PR TITLE
Validate permission bits of Sparkle executable for delta updates

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -15,6 +15,9 @@
 
 #define PERMISSION_FLAGS (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID | S_ISVTX)
 #define VALID_SYMBOLIC_LINK_PERMISSIONS 0755
+// Enforcing Sparkle's executable permissions to be valid allows us to perform a preflight test before
+// downloading delta items
+#define VALID_SPARKLE_EXECUTABLE_PERMISSIONS 0755
 
 #define APPLE_CODE_SIGN_XATTR_CODE_DIRECTORY_KEY "com.apple.cs.CodeDirectory"
 #define APPLE_CODE_SIGN_XATTR_CODE_REQUIREMENTS_KEY "com.apple.cs.CodeRequirements"

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -115,7 +115,7 @@ uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersio
         case SUBinaryDeltaMajorVersion2:
             return 3;
         case SUBinaryDeltaMajorVersion3:
-            return 0;
+            return 1;
     }
     return 0;
 }

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -113,7 +113,7 @@ uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersio
         case SUBinaryDeltaMajorVersion1:
             return 2;
         case SUBinaryDeltaMajorVersion2:
-            return 3;
+            return 4;
         case SUBinaryDeltaMajorVersion3:
             return 1;
     }

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -463,6 +463,20 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
         }
         originalTreeState[key] = info;
 
+        // Ensure Sparkle executable permissions are valid
+        if (ent->fts_info == FTS_F && [key.lastPathComponent isEqualToString:@"Sparkle"] && [key.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent.lastPathComponent isEqualToString:@"Sparkle.framework"]) {
+            mode_t permissions = (mode_t)[(NSNumber *)info[INFO_PERMISSIONS_KEY] shortValue];
+            if (permissions != VALID_SPARKLE_EXECUTABLE_PERMISSIONS) {
+                if (verbose) {
+                    fprintf(stderr, "\n");
+                }
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Permissions for Sparkle executable must be 0%o (found 0%o) on file %@", VALID_SPARKLE_EXECUTABLE_PERMISSIONS, permissions, @(ent->fts_path)] }];
+                }
+                return NO;
+            }
+        }
+        
         if (aclExists(ent)) {
             if (verbose) {
                 fprintf(stderr, "\n");
@@ -563,6 +577,20 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
             return NO;
         }
 
+        // Ensure Sparkle executable permissions are valid
+        if (ent->fts_info == FTS_F && [key.lastPathComponent isEqualToString:@"Sparkle"] && [key.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent.lastPathComponent isEqualToString:@"Sparkle.framework"]) {
+            mode_t permissions = (mode_t)[(NSNumber *)info[INFO_PERMISSIONS_KEY] shortValue];
+            if (permissions != VALID_SPARKLE_EXECUTABLE_PERMISSIONS) {
+                if (verbose) {
+                    fprintf(stderr, "\n");
+                }
+                if (error != NULL) {
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Permissions for Sparkle executable must be 0%o (found 0%o) on file %@", VALID_SPARKLE_EXECUTABLE_PERMISSIONS, permissions, @(ent->fts_path)] }];
+                }
+                return NO;
+            }
+        }
+        
         // We should validate ACLs even if we don't store the info in the diff in the case of ACLs
         // We should also not allow files with code signed extended attributes since Apple doesn't recommend inserting these
         // inside an application, and since we don't preserve extended attribitutes anyway

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
@@ -52,6 +52,13 @@
             ReferencedContainer = "container:Sparkle.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TEST_MODE"
+            value = "DELTA"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This upgrades our preflight test of validating that we can perform delta updates before downloading them. Checking the underlying file system type is not reliable and does not cover cases where a 'tainted' bundle moves across file systems.

We also prevent creating new binary delta updates that have an invalid permission mode for Sparkle's executable.

Fixes #2148 

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested delta update works with test app (setting env test mode), sparkle-cli works in success and failure (bad permission mode) case of updating an app with delta update provided, added unit tests for creating delta updates, tested manually creating delta updates in success and failure cases. Tested update on actual (Ex)FAT volume on Ventura.

macOS version tested: 12.4 (21F79), 13.0 Beta (22A5266r)
