### PR TITLE
Silence deprecation warnings when bumping deployment target

### DIFF
--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -269,7 +269,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     __block SecGroupTransformRef group = SecTransformCreateGroupTransform();
-#pragma clang diagnostic pop
     __block SecTransformRef dataReadTransform = NULL;
     __block SecTransformRef dataDigestTransform = NULL;
     __block SecTransformRef dataVerifyTransform = NULL;
@@ -301,7 +300,7 @@
         
         return cleanup();
     }
-
+    
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdirect-ivar-access"
     dataVerifyTransform = SecVerifyTransformCreate(dsaPubKeySecKey, (__bridge CFDataRef)dsaSignature, &error);
@@ -321,6 +320,7 @@
         
         return cleanup();
     }
+#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -211,7 +211,10 @@
                                 CFStringRef uti = (__bridge CFStringRef)[UTTypePNG identifier];
                                 imageDestination = CGImageDestinationCreateWithURL((CFURLRef)tempIconDestinationURL, uti, 1, NULL);
                             } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                                 imageDestination = CGImageDestinationCreateWithURL((CFURLRef)tempIconDestinationURL, kUTTypePNG, 1, NULL);
+#pragma clang diagnostic pop
                             }
                             if (imageDestination != NULL) {
                                 CGImageDestinationAddImageFromSource(imageDestination, imageSource, imageIndex, (CFDictionaryRef)@{});

--- a/Sparkle/SUApplicationInfo.m
+++ b/Sparkle/SUApplicationInfo.m
@@ -42,8 +42,11 @@
             UTType *contentType = isMainBundle ? UTTypeApplication : UTTypeBundle;
             icon = [[NSWorkspace sharedWorkspace] iconForContentType:contentType];
         } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             NSString *fileType = isMainBundle ? (__bridge NSString *)kUTTypeApplication : (__bridge NSString *)kUTTypeBundle;
             icon = [[NSWorkspace sharedWorkspace] iconForFileType:fileType];
+#pragma clang diagnostic pop
         }
     }
     return icon;


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing CI

macOS version tested: CI's environment
