### PR TITLE
Report friendly error if installation fails with no write permission

### DIFF
--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -125,7 +125,7 @@
                     // macOS 13 and later introduce a policy where Gatekeeper can block app modifications if the apps have different Team IDs
                     BOOL warnAboutGatekeeper;
                     if (@available(macOS 13, *)) {
-                        warnAboutGatekeeper = ![mainBundle isEqual:_host.bundle];
+                        warnAboutGatekeeper = ![mainBundle isEqual:self.host.bundle];
                     } else {
                         warnAboutGatekeeper = NO;
                     }

--- a/Sparkle/SUErrors.h
+++ b/Sparkle/SUErrors.h
@@ -74,6 +74,7 @@ typedef NS_ENUM(OSStatus, SUError) {
     SUNotValidUpdateError = 4009,
     SUAgentInvalidationError = 4010,
     SUInstallationRootInteractiveError = 4011,
+    SUInstallationWriteNoPermissionError = 4012,
     
     // API misuse errors.
     SUIncorrectAPIUsageError = 5000

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -27,6 +27,7 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
     CLIErrorExitStatusUpdateCancelledAuthorization = 5,
     CLIErrorExitStatusUpdatePermissionRequested = 6,
     CLIErrorCodeCannotInstallInteractivePackageAsRoot = 7,
+    CLIErrorExitStatusInstallationWriteNoPermissionError = 8,
 };
 
 @interface SPUCommandLineDriver () <SPUUpdaterDelegate>
@@ -246,6 +247,9 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
     } else if (error.code == SUInstallationRootInteractiveError) {
         fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
         exit(CLIErrorCodeCannotInstallInteractivePackageAsRoot);
+    } else if (error.code == SUInstallationWriteNoPermissionError) {
+        fprintf(stderr, "Error: %s\n", error.localizedDescription.UTF8String);
+        exit(CLIErrorExitStatusInstallationWriteNoPermissionError);
     } else {
         fprintf(stderr, "Error: Update has failed due to error %ld (%s). %s\n", (long)error.code, error.domain.UTF8String, error.localizedDescription.UTF8String);
         exit(EXIT_FAILURE);

--- a/sparkle-cli/main.m
+++ b/sparkle-cli/main.m
@@ -35,6 +35,7 @@ static void printUsage(char **argv)
     fprintf(stderr, "  If update permission is requested and --%s is not\n  specified, then checking for updates is aborted.\n\n", GRANT_AUTOMATIC_CHECKING_FLAG);
     fprintf(stderr, "  Unless --%s is specified, this tool will not request for escalated\n  authorization. Alternatively, this tool can be run as root under an active user login\n  session, which will not require (and disallow) interaction.\n\n", INTERACTIVE_FLAG);
     fprintf(stderr, "  If --%s is specified, this tool will exit leaving a spawned process\n  for finishing the installation after the target application terminates.\n\n", DEFER_FLAG);
+    fprintf(stderr, "  If update installation fails due to not having permission (e.g. from Gatekeeper) to replace the old bundle, an exit status of 8 is returned.\n");
     fprintf(stderr, "  Please specify --%s if you intend to use this tool in an automated way.\n", USER_AGENT_NAME);
     fprintf(stderr, "Options:\n");
     fprintf(stderr, " --%s\n    Path to the application to watch for termination and to relaunch.\n    If not provided, this is assumed to be the same as the bundle.\n", APPLICATION_FLAG);


### PR DESCRIPTION
On macOS 13 (Ventura) and later, installation could fail if Gatekeeper blocks app modifications. Note this is only applicable for external updaters like sparkle-cli where the updater and target bundle to update have different team identifiers.

For sparkle-cli, we exit with a new exit status of 8 when such a no write permission error occurs.

I'll need to update sparkle-cli usage page on the web docs later.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested sparkle-cli in the failure case of not having write permission and in success case which still works.

macOS version tested: 13.0 Beta (22A5266r)
