### PR TITLE
Bump initial installer message timeouts and declare daemon/agents as Interactive

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -32,8 +32,8 @@
 
 #include "AppKitPrevention.h"
 
-#define FIRST_UPDATER_MESSAGE_TIMEOUT 7ull
-#define RETRIEVE_PROCESS_IDENTIFIER_TIMEOUT 5ull
+#define FIRST_UPDATER_MESSAGE_TIMEOUT 18ull
+#define RETRIEVE_PROCESS_IDENTIFIER_TIMEOUT 8ull
 
 /**
  * Show display progress UI after a delay from starting the final part of the installation.

--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -81,7 +81,8 @@
         jobDictionary[@"EnableTransactions"] = @NO;
         jobDictionary[@"KeepAlive"] = @{@"SuccessfulExit" : @NO};
         jobDictionary[@"RunAtLoad"] = @NO;
-        jobDictionary[@"NICE"] = @0;
+        jobDictionary[@"Nice"] = @0;
+        jobDictionary[@"ProcessType"] = @"Interactive";
         jobDictionary[@"LaunchOnlyOnce"] = @YES;
         jobDictionary[@"MachServices"] = @{SPUStatusInfoServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES};
         
@@ -277,7 +278,7 @@
             }
         }
         
-        NSDictionary *jobDictionary = @{@"Label" : label, @"ProgramArguments" : arguments, @"EnableTransactions" : @NO, @"KeepAlive" : @{@"SuccessfulExit" : @NO}, @"RunAtLoad" : @NO, @"Nice" : @0, @"LaunchOnlyOnce": @YES, @"MachServices" : @{SPUInstallerServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES, SPUProgressAgentServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES}};
+        NSDictionary *jobDictionary = @{@"Label" : label, @"ProgramArguments" : arguments, @"EnableTransactions" : @NO, @"KeepAlive" : @{@"SuccessfulExit" : @NO}, @"RunAtLoad" : @NO, @"Nice" : @0, @"ProcessType": @"Interactive", @"LaunchOnlyOnce": @YES, @"MachServices" : @{SPUInstallerServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES, SPUProgressAgentServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES}};
         
         CFErrorRef submitError = NULL;
 #pragma clang diagnostic push


### PR DESCRIPTION
I haven't been able to notice any difference specifying the processes as Interactive but it shouldn't hurt and maybe hopefully give processes priority in cases where the OS may not.

Also increase the timeout on the messages per discussion in https://github.com/sparkle-project/Sparkle/discussions/2159

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Testing CI, tested test app adding arbitrary sleeps.

macOS version tested: 12.4 (21F79)
