### PR TITLE
Deprecate -s flag and add --ed-key-file option to generate_appcast

### DIFF
--- a/sign_update/main.swift
+++ b/sign_update/main.swift
@@ -22,7 +22,7 @@ func findKeysInKeychain(account: String) throws -> (Data, Data) {
     if res == errSecSuccess, let encoded = item as? Data, let keys = Data(base64Encoded: encoded) {
         return (keys[0..<64], keys[64..<(64+32)])
     } else if res == errSecItemNotFound {
-        print("ERROR! Signing key not found for account \(account). Please run generate_keys tool first or provide key with -f <private_key_file> or -s <private_key> parameter.")
+        print("ERROR! Signing key not found for account \(account). Please run generate_keys tool first or provide key with --ed-key-file <private_key_file>")
     } else if res == errSecAuthFailed {
         print("ERROR! Access denied. Can't get keys from the keychain.")
         print("Go to Keychain Access.app, lock the login keychain, then unlock it again.")
@@ -37,7 +37,17 @@ func findKeysInKeychain(account: String) throws -> (Data, Data) {
 }
 
 func findKeys(inFile privateAndPublicBase64KeyFile: String) throws -> (Data, Data) {
-    let privateAndPublicBase64Key = try String(contentsOfFile: privateAndPublicBase64KeyFile)
+    let privateAndPublicBase64Key: String
+    if privateAndPublicBase64KeyFile == "-" && !FileManager.default.fileExists(atPath: privateAndPublicBase64KeyFile) {
+        if let line = readLine(strippingNewline: true) {
+            privateAndPublicBase64Key = line
+        } else {
+            print("ERROR! Unable to read EdDSA private key from standard input")
+            throw ExitCode(1)
+        }
+    } else {
+        privateAndPublicBase64Key = try String(contentsOfFile: privateAndPublicBase64KeyFile)
+    }
     return try findKeys(inString: privateAndPublicBase64Key)
 }
 
@@ -70,16 +80,15 @@ func edSignature(data: Data, publicEdKey: Data, privateEdKey: Data) -> String {
 }
 
 struct SignUpdate: ParsableCommand {
+    static let programName = "sign_update"
+    
     @Option(help: ArgumentHelp("The account name in your keychain associated with your private EdDSA (ed25519) key to use for signing the update."))
     var account: String = "ed25519"
     
     @Flag(help: ArgumentHelp("Verify that the update is signed correctly. If this is set, a second argument <verify-signature> denoting the signature must be passed after the <update-path>.", valueName: "verify"))
     var verify: Bool = false
     
-    @Option(name: .customShort("s"), help: ArgumentHelp("The private EdDSA (ed25519) key.", valueName: "private-key"))
-    var privateKey: String?
-    
-    @Option(name: .customShort("f"), help: ArgumentHelp("Path to the file containing the private EdDSA (ed25519) key.", valueName: "private-key-file"))
+    @Option(name: [.customShort("f"), .customLong("ed-key-file")], help: ArgumentHelp("Path to the file containing the private EdDSA (ed25519) key. '-' can be used to echo the EdDSA key from a 'secret' environment variable to the standard input stream. For example: echo \"$PRIVATE_KEY_SECRET\" | ./\(programName) --ed-key-file -", valueName: "private-key-file"))
     var privateKeyFile: String?
     
     @Argument(help: "The update archive, delta update, or package (pkg) to sign or verify.")
@@ -88,13 +97,16 @@ struct SignUpdate: ParsableCommand {
     @Argument(help: "The signature to verify when --verify is passed.")
     var verifySignature: String?
     
+    @Option(name: .customShort("s"), help: ArgumentHelp("(DEPRECATED): The private EdDSA (ed25519) key. Please use the Keychain, or pass the key as standard input when using --ed-key-file - instead.", valueName: "private-key"))
+    var privateKey: String?
+    
     static var configuration: CommandConfiguration = CommandConfiguration(
         abstract: "Sign or verify an update using your EdDSA (ed25519) keys.",
-        discussion: "The EdDSA keys are automatically read from the Keychain if no <private-key> or <private-key-file> is specified.\n\nWhen signing, this tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure.")
+        discussion: "The EdDSA keys are automatically read from the Keychain if no <private-key-file> is specified.\n\nWhen signing, this tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure.")
     
     func validate() throws {
         guard privateKey == nil || privateKeyFile == nil else {
-            throw ValidationError("Both -s <private-key> and -f <private-key-file> options cannot be provided.")
+            throw ValidationError("Both --ed-key-file <private-key-file> and -s <private-key> options cannot be provided.")
         }
         
         guard !verify || verifySignature != nil else {
@@ -106,6 +118,8 @@ struct SignUpdate: ParsableCommand {
         let (priv, pub): (Data, Data)
         
         if let privateKey = privateKey {
+            fputs("Warning: The -s option for passing the private EdDSA key is insecure and deprecated. Please see its help usage for more information.\n", stderr)
+            
             (priv, pub) = try findKeys(inString: privateKey)
         } else if let privateKeyFile = privateKeyFile {
             (priv, pub) = try findKeys(inFile: privateKeyFile)


### PR DESCRIPTION
Passing a raw secret to command line argument (even when using a 'secret' environment variable) is discouraged and unsafe. After reading up several sources online, it's recommended to pass such a secret that CI platforms may provide as standard input to the program, using a built-in like `echo`. 

So we deprecate the `-s` flag in sign_update and generate_appcast, add a `--ed-key-file` option to `generate_appcast` that takes a file just like `sign_update -f` (or `--ed-key-file` now), and interpret `-` as the standard input file to read the key from.

I'm pretty certain now this is the right way forward but I'll leave this PR open a bit in case anyone wants to chime in. 

As our documentation generally recommends using the keychain which is the default path for these tools, I don't think we need to update any website documentation (edit: I should update the migration page). The help pages for these tools will be updated.

Fixes #2168

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

For `sign_update` and `generate_appcast` tested that:
* `--ed-key-file path-to-file` works
* `--ed-key-file -` works
* `-s` still works and prints deprecation warning to stderr for `sign_update`, and to stdout for `generate_appcast`

macOS version tested: 12.4 (21F79)
