### PR TITLE
Synchronize usage of XPC connections to main queue

### DIFF
--- a/Autoupdate/AgentConnection.m
+++ b/Autoupdate/AgentConnection.m
@@ -78,7 +78,9 @@
     
     __weak AgentConnection *weakSelf = self;
     newConnection.interruptionHandler = ^{
-        [weakSelf.activeConnection invalidate];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.activeConnection invalidate];
+        });
     };
     
     newConnection.invalidationHandler = ^{

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -147,7 +147,9 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     
     __weak AppInstaller *weakSelf = self;
     newConnection.interruptionHandler = ^{
-        [weakSelf.activeConnection invalidate];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.activeConnection invalidate];
+        });
     };
     
     newConnection.invalidationHandler = ^{

--- a/InstallerConnection/SUInstallerConnection.h
+++ b/InstallerConnection/SUInstallerConnection.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SUInstallerConnection : NSObject <SUInstallerConnectionProtocol>
 
 // Due to XPC reasons, this delegate is strongly referenced, until it's invalidated
-- (instancetype)initWithDelegate:(id<SUInstallerCommunicationProtocol>)delegate;
+- (instancetype)initWithDelegate:(id<SUInstallerCommunicationProtocol>)delegate remote:(BOOL)remote;
 
 @end
 

--- a/InstallerConnection/SUInstallerConnection.h
+++ b/InstallerConnection/SUInstallerConnection.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 // Due to XPC reasons, this delegate is strongly referenced, until it's invalidated
 - (instancetype)initWithDelegate:(id<SUInstallerCommunicationProtocol>)delegate remote:(BOOL)remote;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/InstallerConnection/main.m
+++ b/InstallerConnection/main.m
@@ -26,7 +26,7 @@
     newConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SUInstallerConnectionProtocol)];
     newConnection.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SUInstallerCommunicationProtocol)];
     
-    SUInstallerConnection *exportedObject = [[SUInstallerConnection alloc] initWithDelegate:newConnection.remoteObjectProxy];
+    SUInstallerConnection *exportedObject = [[SUInstallerConnection alloc] initWithDelegate:newConnection.remoteObjectProxy remote:YES];
     
     newConnection.exportedObject = exportedObject;
     

--- a/InstallerStatus/SUInstallerStatus.h
+++ b/InstallerStatus/SUInstallerStatus.h
@@ -14,4 +14,6 @@
 
 - (instancetype)initWithRemote:(BOOL)remote;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @end

--- a/InstallerStatus/SUInstallerStatus.h
+++ b/InstallerStatus/SUInstallerStatus.h
@@ -12,4 +12,6 @@
 // This object implements the protocol which we have defined. It provides the actual behavior for the service. It is 'exported' by the service to make it available to the process hosting the service over an NSXPCConnection.
 @interface SUInstallerStatus : NSObject <SUInstallerStatusProtocol>
 
+- (instancetype)initWithRemote:(BOOL)remote;
+
 @end

--- a/InstallerStatus/main.m
+++ b/InstallerStatus/main.m
@@ -25,7 +25,7 @@
     newConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SUInstallerStatusProtocol)];
     
     // Next, set the object that the connection exports. All messages sent on the connection to this service will be sent to the exported object to handle. The connection retains the exported object.
-    SUInstallerStatus *exportedObject = [SUInstallerStatus new];
+    SUInstallerStatus *exportedObject = [[SUInstallerStatus alloc] initWithRemote:YES];
     newConnection.exportedObject = exportedObject;
     
     // Resuming the connection allows the system to deliver more incoming messages.

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -126,7 +126,9 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
         
         __weak InstallerProgressAppController *weakSelf = self;
         _connection.interruptionHandler = ^{
-            [weakSelf.connection invalidate];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [weakSelf.connection invalidate];
+            });
         };
         
         _connection.invalidationHandler = ^{

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -176,7 +176,7 @@
     assert(hostBundleIdentifier != nil);
     
     if (!SPUXPCServiceIsEnabled(SUEnableInstallerConnectionServiceKey)) {
-        self.installerConnection = [[SUInstallerConnection alloc] initWithDelegate:self];
+        self.installerConnection = [[SUInstallerConnection alloc] initWithDelegate:self remote:NO];
     } else {
         self.installerConnection = [[SUXPCInstallerConnection alloc] initWithDelegate:self];
     }

--- a/Sparkle/SPUProbeInstallStatus.m
+++ b/Sparkle/SPUProbeInstallStatus.m
@@ -30,7 +30,7 @@
     id<SUInstallerStatusProtocol> installerStatus = nil;
     BOOL usesXPC = SPUXPCServiceIsEnabled(SUEnableInstallerStatusServiceKey);
     if (!usesXPC) {
-        installerStatus = [[SUInstallerStatus alloc] init];
+        installerStatus = [[SUInstallerStatus alloc] initWithRemote:NO];
     } else {
         installerStatus = [[SUXPCInstallerStatus alloc] init];
     }

--- a/Sparkle/SPUProbeInstallStatus.m
+++ b/Sparkle/SPUProbeInstallStatus.m
@@ -93,7 +93,7 @@
     id<SUInstallerStatusProtocol> installerStatus = nil;
     BOOL usesXPC = SPUXPCServiceIsEnabled(SUEnableInstallerStatusServiceKey);
     if (!usesXPC) {
-        installerStatus = [[SUInstallerStatus alloc] init];
+        installerStatus = [[SUInstallerStatus alloc] initWithRemote:NO];
     } else {
         installerStatus = [[SUXPCInstallerStatus alloc] init];
     }


### PR DESCRIPTION
Synchronize usage of XPC connections to main queue to prevent potential race conditions.

Maybe fixes #2176

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app with and without using connection/status XPC Services, when there is already a staged update available to be installed and when there isn't.

macOS version tested: 12.4 (21F79)
