### PR TITLE
Use snprintf instead of sprintf to fix compile warning

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -329,7 +329,7 @@ NSString *displayHashFromRawHash(const unsigned char *hash)
 {
     char hexHash[CC_SHA1_DIGEST_LENGTH * 2 + 1] = {0};
     for (size_t i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
-        sprintf(hexHash + i * 2, "%02x", hash[i]);
+        snprintf(hexHash + i * 2, 2, "%02x", hash[i]);
     }
     return @(hexHash);
 }

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -329,7 +329,7 @@ NSString *displayHashFromRawHash(const unsigned char *hash)
 {
     char hexHash[CC_SHA1_DIGEST_LENGTH * 2 + 1] = {0};
     for (size_t i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
-        snprintf(hexHash + i * 2, 2, "%02x", hash[i]);
+        snprintf(hexHash + i * 2, 3, "%02x", hash[i]);
     }
     return @(hexHash);
 }


### PR DESCRIPTION
This is a new warning showing up in Xcode 14 beta 2.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

CI should test binary delta unit tests for xar / version 2 path.

macOS version tested: NA
