### PR TITLE
Use recovery suggestion key for update permission error

### DIFF
--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -131,9 +131,9 @@
                     // macOS 13 and later introduce a policy where Gatekeeper can block app modifications if the apps have different Team IDs
                     if (@available(macOS 13, *)) {
                         NSBundle *mainBundle = [NSBundle mainBundle];
-                        SUHost *mainBundleHost = [[SUHost alloc] initWithBundle:mainBundle];
-                        
                         if (![mainBundle isEqual:self.host.bundle]) {
+                            SUHost *mainBundleHost = [[SUHost alloc] initWithBundle:mainBundle];
+                            
                             userInfo[NSLocalizedRecoverySuggestionErrorKey] = [NSString stringWithFormat:SULocalizedString(@"You may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management to install future updates.", nil), mainBundleHost.name];
                         }
                     }

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -121,28 +121,22 @@
             } else if (underlyingError.code == SUInstallationError) {
                 NSError *secondUnderlyingError = underlyingError.userInfo[NSUnderlyingErrorKey];
                 if (secondUnderlyingError != nil && [secondUnderlyingError.domain isEqualToString:NSCocoaErrorDomain] && secondUnderlyingError.code == NSFileWriteNoPermissionError) {
-                    NSBundle *mainBundle = [NSBundle mainBundle];
-                    // macOS 13 and later introduce a policy where Gatekeeper can block app modifications if the apps have different Team IDs
-                    BOOL warnAboutGatekeeper;
-                    if (@available(macOS 13, *)) {
-                        warnAboutGatekeeper = ![mainBundle isEqual:self.host.bundle];
-                    } else {
-                        warnAboutGatekeeper = NO;
-                    }
-                    
                     // Note: these error strings will only surface for external app updaters like sparkle-cli (i.e, updaters that update other app bundles)
-                    NSString *errorDescription;
-                    if (warnAboutGatekeeper) {
-                        SUHost *mainBundleHost = [[SUHost alloc] initWithBundle:mainBundle];
-                        errorDescription = [NSString stringWithFormat:SULocalizedString(@"The installation failed due to not having permission to write the new update. To install the update, you may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management", nil), mainBundleHost.name];
-                    } else {
-                        errorDescription = SULocalizedString(@"The installation failed due to not having permission to write the new update.", nil);
-                    }
                     
-                    NSDictionary *userInfo = @{
-                        NSLocalizedDescriptionKey: errorDescription,
+                    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{
+                        NSLocalizedDescriptionKey: SULocalizedString(@"The installation failed due to not having permission to write the new update.", nil),
                         NSUnderlyingErrorKey: (NSError * _Nonnull)currentInstallerError
-                    };
+                    }];
+                    
+                    // macOS 13 and later introduce a policy where Gatekeeper can block app modifications if the apps have different Team IDs
+                    if (@available(macOS 13, *)) {
+                        NSBundle *mainBundle = [NSBundle mainBundle];
+                        SUHost *mainBundleHost = [[SUHost alloc] initWithBundle:mainBundle];
+                        
+                        if (![mainBundle isEqual:self.host.bundle]) {
+                            userInfo[NSLocalizedRecoverySuggestionErrorKey] = [NSString stringWithFormat:SULocalizedString(@"You may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management to install future updates.", nil), mainBundleHost.name];
+                        }
+                    }
                     
                     customError = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationWriteNoPermissionError userInfo:userInfo];
                 }

--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -248,7 +248,11 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
         fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
         exit(CLIErrorCodeCannotInstallInteractivePackageAsRoot);
     } else if (error.code == SUInstallationWriteNoPermissionError) {
-        fprintf(stderr, "Error: %s\n", error.localizedDescription.UTF8String);
+        fprintf(stderr, "Error: %s", error.localizedDescription.UTF8String);
+        if (error.localizedRecoverySuggestion != nil) {
+            fprintf(stderr, " %s", error.localizedRecoverySuggestion.UTF8String);
+        }
+        fprintf(stderr, "\n");
         exit(CLIErrorExitStatusInstallationWriteNoPermissionError);
     } else {
         fprintf(stderr, "Error: Update has failed due to error %ld (%s). %s\n", (long)error.code, error.domain.UTF8String, error.localizedDescription.UTF8String);


### PR DESCRIPTION
Use recovery suggestion key for update permission error.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested with sparkle-cli

macOS version tested: 13.0 Beta (22A5286j)
