### PR TITLE
Fix Greek translation in "You are currently running version" string

### DIFF
--- a/Sparkle/el.lproj/Sparkle.strings
+++ b/Sparkle/el.lproj/Sparkle.strings
@@ -2,7 +2,7 @@
 "%@ %@ is currently the newest version available." = "Το %1$@ %2$@ είναι η τελευταία διαθέσιμη έκδοση.";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "Το %1$@ %2$@ είναι η τελευταία διαθέσιμη έκδοση.\n(Die derzeit installierte Version ist %3$@.)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "Το %1$@ %2$@ είναι η τελευταία διαθέσιμη έκδοση.\n(Αυτήν τη στιγμή εκτελείτε την έκδοση %3$@.)";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available—you have %@. Would you like to download it now?" = "Το %1$@ %2$@ είναι πλέον διαθέσιμο--έχετε το %3$@. Θέλετε να το κατεβάσετε τώρα;";


### PR DESCRIPTION
Fixes #2175

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested running app with test app in Greek language and tested this string when no updates are available and less than currently running version.

macOS version tested: 12.4 (21F79)
