### PR TITLE
Reset opportune time for showing new updates after preference changes

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		7229E1BA1C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7229E1B81C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m */; };
 		7229E1BD1C98EFF200CB50D0 /* SPUDownloadDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7229E1BB1C98EFF200CB50D0 /* SPUDownloadDriver.h */; };
 		7229E1BE1C98EFF200CB50D0 /* SPUDownloadDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7229E1BC1C98EFF200CB50D0 /* SPUDownloadDriver.m */; };
+		722C9539286EA68C0033908A /* SPUGentleUserDriverReminders.h in Headers */ = {isa = PBXBuildFile; fileRef = 722C9538286EA54A0033908A /* SPUGentleUserDriverReminders.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		722FB7E5260EE53F00EB571C /* SUNormalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 722FB7E4260EE53F00EB571C /* SUNormalization.m */; };
 		722FB7E6260EE53F00EB571C /* SUNormalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 722FB7E4260EE53F00EB571C /* SUNormalization.m */; };
 		72316BD31E0DA8430039EFD9 /* SUUnarchiverNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 72316BD21E0DA8430039EFD9 /* SUUnarchiverNotifier.m */; };
@@ -1010,6 +1011,7 @@
 		7229E1B81C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUScheduledUpdateDriver.m; sourceTree = "<group>"; };
 		7229E1BB1C98EFF200CB50D0 /* SPUDownloadDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUDownloadDriver.h; sourceTree = "<group>"; };
 		7229E1BC1C98EFF200CB50D0 /* SPUDownloadDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUDownloadDriver.m; sourceTree = "<group>"; };
+		722C9538286EA54A0033908A /* SPUGentleUserDriverReminders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUGentleUserDriverReminders.h; sourceTree = "<group>"; };
 		722FB7CA1DD69897001D40CE /* ConfigSwift.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigSwift.xcconfig; sourceTree = "<group>"; };
 		722FB7E3260EE53F00EB571C /* SUNormalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUNormalization.h; sourceTree = "<group>"; };
 		722FB7E4260EE53F00EB571C /* SUNormalization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUNormalization.m; sourceTree = "<group>"; };
@@ -2159,6 +2161,7 @@
 				725CB9581C7121830064365A /* SPUStandardUserDriver.h */,
 				725CB9591C7121830064365A /* SPUStandardUserDriver.m */,
 				726E4A361C89116000C57C6A /* SPUStandardUserDriverDelegate.h */,
+				722C9538286EA54A0033908A /* SPUGentleUserDriverReminders.h */,
 				726DF88D1C84277500188804 /* SPUUserUpdateState.h */,
 				7269E49C2648FC6C0088C213 /* SPUUserUpdateState+Private.h */,
 				7269E4992648F7C00088C213 /* SPUUserUpdateState.m */,
@@ -2433,6 +2436,7 @@
 				7246E0A31C83B685003B4E75 /* SPUStandardUpdaterController.h in Headers */,
 				725CB95A1C7121830064365A /* SPUStandardUserDriver.h in Headers */,
 				726E4A371C89116000C57C6A /* SPUStandardUserDriverDelegate.h in Headers */,
+				722C9539286EA68C0033908A /* SPUGentleUserDriverReminders.h in Headers */,
 				729F7EAF273F1840004592DC /* SPUUserAgent+Private.h in Headers */,
 				72EE17FC26D1CC9D00C58B19 /* SPUInstallationType.h in Headers */,
 				72EF30BE2675CF38008CE987 /* SPUAppcastItemStateResolver.h in Headers */,

--- a/Sparkle/SPUGentleUserDriverReminders.h
+++ b/Sparkle/SPUGentleUserDriverReminders.h
@@ -1,0 +1,22 @@
+//
+//  SPUGentleUserDriverReminders.h
+//  Sparkle
+//
+//  Copyright © 2022 Sparkle Project. All rights reserved.
+//
+
+#ifndef SPUGentleUserDriverReminders_h
+#define SPUGentleUserDriverReminders_h
+
+/**
+ A private protocol for user drivers implementing gentle scheduled reminders
+ */
+@protocol SPUGentleUserDriverReminders
+
+- (void)logGentleScheduledUpdateReminderWarningIfNeeded;
+
+- (void)resetTimeSinceOpportuneUpdateNotice;
+
+@end
+
+#endif /* SPUGentleUserDriverReminders_h */

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -99,8 +99,6 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
             
             _timebaseInfo.numer = 0;
             _timebaseInfo.denom = 0;
-        } else {
-            [self resetTimeSinceOpportuneUpdateNotice];
         }
     }
     return self;

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  Prefer to set initial properties in your bundle's Info.plist as described in [Customizing Sparkle](https://sparkle-project.org/documentation/customization/).
  
- Otherwise only if you need dynamic behavior (eg. for user preferences) should you set properties on the updater such as:
+ Otherwise only if you need dynamic behavior for user preferences should you set properties on the updater such as:
  - `automaticallyChecksForUpdates`
  - `updateCheckInterval`
  - `automaticallyDownloadsUpdates`
@@ -102,18 +102,23 @@ SU_EXPORT @interface SPUUpdater : NSObject
 - (void)checkForUpdates;
 
 /**
- Checks for updates, but does not display any UI unless an update is found.
+ Checks for updates, but does not show any UI unless an update is found.
  
  You usually do not need to call this method directly. If `automaticallyChecksForUpdates` is @c YES,
  Sparkle calls this method automatically according to its update schedule using the `updateCheckInterval`
- and the `lastUpdateCheckDate`.
+ and the `lastUpdateCheckDate`. Therefore, you should typically only consider calling this method directly if you
+ opt out of automatic update checks.
  
- This is meant for programmatically initating a check for updates.
- That is, it will display no UI unless it finds an update, in which case it proceeds as usual.
+ This is meant for programmatically initating a check for updates in the background without the user initiating it.
+ This check will not show UI if no new updates are found.
+ 
+ If a new update is found, the updater's user driver may handle showing it at an appropriate (but not necessarily immediate) time.
+ If you want control over when and how a new update is shown, please see https://sparkle-project.org/documentation/gentle-reminders/
+ 
+ Note if automated updating is turned on, either a new update may be downloaded in the background to be installed silently,
+ or an already downloaded update may be shown.
+ 
  This will not find updates that the user has opted into skipping.
- 
- Note if there is no resumable update found, and automated updating is turned on,
- the update will be downloaded in the background without disrupting the user.
  
  This method does not do anything if there is a `sessionInProgress`.
  */
@@ -177,7 +182,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
  this permission request is not performed however.
  
  Setting this property will persist in the host bundle's user defaults.
- Only set this property if you need dynamic behavior (e.g. user preferences).
+ Only set this property if the user wants to change the default via a user preferences option.
+ For testing environments, you can disable update checks by passing `-SUEnableAutomaticChecks NO`
+ to your app's command line arguments instead of setting this property.
  
  The update schedule cycle will be reset in a short delay after the property's new value is set.
  This is to allow reverting this property without kicking off a schedule change immediately
@@ -187,9 +194,10 @@ SU_EXPORT @interface SPUUpdater : NSObject
 /**
  A property indicating the current automatic update check interval in seconds.
  
+ Prefer to set SUScheduledCheckInterval directly in your Info.plist for setting the initial value.
+ 
  Setting this property will persist in the host bundle's user defaults.
- For this reason, only set this property if you need dynamic behavior (eg user preferences).
- Otherwise prefer to set SUScheduledCheckInterval directly in your Info.plist.
+ Only set this property if the user wants to change the default via a user preferences option.
  
  The update schedule cycle will be reset in a short delay after the property's new value is set.
  This is to allow reverting this property without kicking off a schedule change immediately
@@ -205,7 +213,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  In this case, this property will return NO regardless of how this property is set.
  
  Setting this property will persist in the host bundle's user defaults.
- For this reason, only set this property if you need dynamic behavior (eg user preferences).
+ For this reason, only set this property if the user wants to change the default via a user preferences option.
  Otherwise prefer to set SUAutomaticallyUpdate directly in your Info.plist.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -32,15 +32,10 @@
 #import "SPUResumableUpdate.h"
 #import "SUSignatures.h"
 #import "SPUUserAgent+Private.h"
+#import "SPUGentleUserDriverReminders.h"
 
 
 #include "AppKitPrevention.h"
-
-@interface NSObject (SPUStandardUserDriverPrivate)
-
-- (void)_logGentleScheduledUpdateReminderWarningIfNeeded;
-
-@end
 
 NSString *const SUUpdaterDidFinishLoadingAppCastNotification = @"SUUpdaterDidFinishLoadingAppCastNotification";
 NSString *const SUUpdaterDidFindValidUpdateNotification = @"SUUpdaterDidFindValidUpdateNotification";
@@ -520,8 +515,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                     [self.delegate updater:self willScheduleUpdateCheckAfterDelay:delayUntilCheck];
                 }
                 
-                if ([self.userDriver respondsToSelector:@selector(_logGentleScheduledUpdateReminderWarningIfNeeded)]) {
-                    [(NSObject *)self.userDriver _logGentleScheduledUpdateReminderWarningIfNeeded];
+                if ([self.userDriver respondsToSelector:@selector(logGentleScheduledUpdateReminderWarningIfNeeded)]) {
+                    [(id<SPUGentleUserDriverReminders>)self.userDriver logGentleScheduledUpdateReminderWarningIfNeeded];
                 }
                 
                 [self.updaterTimer startAndFireAfterDelay:delayUntilCheck];
@@ -805,6 +800,12 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     if (!self.startedUpdater) {
         SULog(SULogLevelError, @"Error: resetUpdateCycle - updater hasn't been started yet. Please call -startUpdater: first");
         return; // not even ready yet
+    }
+    
+    // Note this resets the opportune time when user grants Sparkle permission to check for updates
+    // and when the user changes preferences on automatically checking for updates or the update time check interval
+    if ([self.userDriver respondsToSelector:@selector(resetTimeSinceOpportuneUpdateNotice)]) {
+        [(id<SPUGentleUserDriverReminders>)self.userDriver resetTimeSinceOpportuneUpdateNotice];
     }
     
     if (!self.sessionInProgress) {

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -170,6 +170,10 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         return NO;
     }
     
+    if ([self.userDriver respondsToSelector:@selector(resetTimeSinceOpportuneUpdateNotice)]) {
+        [(id<SPUGentleUserDriverReminders>)self.userDriver resetTimeSinceOpportuneUpdateNotice];
+    }
+    
     self.startedUpdater = YES;
     self.canCheckForUpdates = YES;
     


### PR DESCRIPTION
Reset opportune time when updater starts as well rather than when user driver is initialized.

Also update updater header API documentation and add private protocol for gentle scheduled reminder APIs that the updater uses.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested changing checking for updates automatically in the Test App and tested granting permission to check for updates, both still result in timely update notice.

macOS version tested: 12.4 (21F79)
