### PR TITLE
Make dark scroll bar in dark theme

### DIFF
--- a/Resources/ReleaseNotesColorStyle.css
+++ b/Resources/ReleaseNotesColorStyle.css
@@ -1,5 +1,6 @@
 @media (prefers-color-scheme: dark) {
     html {
+        color-scheme: dark;
         color: white;
         background: transparent;
     }


### PR DESCRIPTION
Make dark scroll bar in dark theme for Release Notes by default

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

https://github.com/linearmouse/linearmouse/pull/187

macOS version tested: 12.4
