### PR TITLE
Fix memory leaks when using generate_appcast

### DIFF
--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -348,7 +348,11 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
             continue;
         }
         
-        NSString *relativePath = @(pathCString);
+        NSString *relativePath = [[NSString alloc] initWithBytesNoCopy:pathCString length:strlen(pathCString) encoding:NSUTF8StringEncoding freeWhenDone:YES];
+        if (relativePath == nil) {
+            free(pathCString);
+            continue;
+        }
         
         SPUDeltaItemCommands commands = 0;
         {

--- a/generate_appcast/URL+Hashing.swift
+++ b/generate_appcast/URL+Hashing.swift
@@ -33,6 +33,10 @@ extension FileHandle {
 
         CC_SHA256_Final(hash.baseAddress, &context)
 
+        defer {
+            hash.deallocate()
+        }
+        
         return hash.reduce("") { $0 + String(format: "%02x", $1) }
     }
 


### PR DESCRIPTION
We fix one memory leak when calculating sha's, one memory leak in the xar delta applying path, and avoid creating Bundles for reading the Sparkle framework version.

There are some other small leaks with the xar delta creation/applying code but since it's a legacy implementation and the APIs are undocumented I don't want to touch it too much.

The biggest culprit here is the leak when calculating sha's I believe, if you have many archive items.

Related: #1719

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generating updates with generate_appcast 

macOS version tested: 12.4 (21F79)
