### PR TITLE
Hide automatic install check box when allowsAutomaticUpdates is disabled

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -347,13 +347,12 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
             NSLayoutConstraint *skipButtonToReleaseNotesContainerConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.releaseNotesContainerView attribute:NSLayoutAttributeBottom multiplier:1.0 constant:12.0];
             
             [self.window.contentView addConstraint:skipButtonToReleaseNotesContainerConstraint];
-            
-            [self.automaticallyInstallUpdatesButton removeFromSuperview];
         } else {
-            // Disable automatic install updates option if the developer wishes for it in Info.plist
-            // If we are showing release notes, this button will be hidden instead
-            self.automaticallyInstallUpdatesButton.enabled = NO;
+            NSLayoutConstraint *skipButtonToDescriptionConstraint = [NSLayoutConstraint constraintWithItem:self.skipButton attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.descriptionField attribute:NSLayoutAttributeBottom multiplier:1.0 constant:40.0];
+
+            [self.window.contentView addConstraint:skipButtonToDescriptionConstraint];
         }
+        [self.automaticallyInstallUpdatesButton removeFromSuperview];
     }
     
     if (self.state.stage == SPUUserUpdateStageInstalling) {


### PR DESCRIPTION
Hide automatic install updates checkbox instead of disabling it when there's no release note.

before
![image](https://user-images.githubusercontent.com/2881736/178641124-043ba1ef-fb40-4061-8d18-7d982798f692.png)

after
![image](https://user-images.githubusercontent.com/2881736/178641097-78aec6a4-38fa-4f9d-a1fa-67f7902bff7e.png)

Fixes #2201

Hide automatically downloads/install button when update checks are disabled and no release notes are shown #2201

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: 12.3.1
