### PR TITLE
Reject DSA only configurations for setting up the updater

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -347,10 +347,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         }
     } else if (publicKeys.ed25519PubKey == nil) {
         // No EdDSA key is available, so app must be using DSA
-        if (updatingMainBundle && !self.loggedNoSecureKeyWarning) {
-            SULog(SULogLevelError, @"Error: Serving updates without an EdDSA key is insecure and deprecated. DSA support may be removed in a future Sparkle release. Please migrate to using EdDSA (ed25519). Visit Sparkle's documentation for migration information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns");
-            
-            self.loggedNoSecureKeyWarning = YES;
+        if (updatingMainBundle) {
+            if (error != NULL) {
+                *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"For security reasons, updates need to be signed with an EdDSA key for %@. Please migrate to using EdDSA (ed25519). Visit Sparkle's documentation for migration information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns.", hostName] }];
+            }
+            return NO;
         }
     }
     


### PR DESCRIPTION
The one exception is an updater that is targeted to update another / non-main bundle.

Note we still allow configuration of not using DSA or EdDSA with the deprecation warning in tact.

Fixes #2167

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested bad DSA only configuration was rejected in a custom test app, and that other configurations were allowed (EdDSA only, EdDSA + DSA, no Ed(DSA) with deprecation)

Tested that sparkle-cli, updating another bundle, was not impacted by this change.

macOS version tested: 12.4 (21F79)
