### PR TITLE
Critical update alerts may not show up as promptly as they should when automatically installing them

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -492,9 +492,8 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             self.installer = installer;
             
             uint8_t targetTerminated = (uint8_t)self.terminationListener.terminated;
-            uint8_t supportsAppcastItemRegisteredMessage = 1;
             
-            uint8_t sendInformation[] = {canPerformSilentInstall, targetTerminated, supportsAppcastItemRegisteredMessage};
+            uint8_t sendInformation[] = {canPerformSilentInstall, targetTerminated};
             
             NSData *sendData = [NSData dataWithBytes:sendInformation length:sizeof(sendInformation)];
             

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -34,6 +34,7 @@
 
 #define FIRST_UPDATER_MESSAGE_TIMEOUT 18ull
 #define RETRIEVE_PROCESS_IDENTIFIER_TIMEOUT 8ull
+#define UPDATER_APPCAST_ITEM_REGISTRATION_TIMEOUT 8ull
 
 /**
  * Show display progress UI after a delay from starting the final part of the installation.
@@ -425,11 +426,22 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSData *archivedData = SPUArchiveRootObjectSecurely(installationInfo);
             if (archivedData != nil) {
+                __block BOOL receivedCompletion = NO;
+                
                 [self.agentConnection.agent registerInstallationInfoData:archivedData completionHandler:^{
                     dispatch_async(dispatch_get_main_queue(), ^{
+                        receivedCompletion = YES;
                         [self.communicator handleMessageWithIdentifier:SPUInstallerRegisteredAppcastItem data:[NSData data]];
                     });
                 }];
+                
+                // Not receiving that we've registered the appcast item in a timely manner is not a fatal issue
+                // If this operation takes too long, just let assume the item will be registered
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(UPDATER_APPCAST_ITEM_REGISTRATION_TIMEOUT * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    if (!receivedCompletion) {
+                        [self.communicator handleMessageWithIdentifier:SPUInstallerRegisteredAppcastItem data:[NSData data]];
+                    }
+                });
             }
         }
     } else if (identifier == SPUResumeInstallationToStage2 && data.length == sizeof(uint8_t) * 2) {

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -425,7 +425,11 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             
             NSData *archivedData = SPUArchiveRootObjectSecurely(installationInfo);
             if (archivedData != nil) {
-                [self.agentConnection.agent registerInstallationInfoData:archivedData];
+                [self.agentConnection.agent registerInstallationInfoData:archivedData completionHandler:^{
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [self.communicator handleMessageWithIdentifier:SPUInstallerRegisteredAppcastItem data:[NSData data]];
+                    });
+                }];
             }
         }
     } else if (identifier == SPUResumeInstallationToStage2 && data.length == sizeof(uint8_t) * 2) {
@@ -488,8 +492,9 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             self.installer = installer;
             
             uint8_t targetTerminated = (uint8_t)self.terminationListener.terminated;
+            uint8_t supportsAppcastItemRegisteredMessage = 1;
             
-            uint8_t sendInformation[] = {canPerformSilentInstall, targetTerminated};
+            uint8_t sendInformation[] = {canPerformSilentInstall, targetTerminated, supportsAppcastItemRegisteredMessage};
             
             NSData *sendData = [NSData dataWithBytes:sendInformation length:sizeof(sendInformation)];
             

--- a/Autoupdate/SPUMessageTypes.h
+++ b/Autoupdate/SPUMessageTypes.h
@@ -23,7 +23,8 @@ typedef NS_ENUM(int32_t, SPUInstallerMessageType)
     SPUInstallationFinishedStage2 = 7,
     SPUInstallationFinishedStage3 = 8,
     SPUUpdaterAlivePing = 9,
-    SPUInstallerError = 10
+    SPUInstallerError = 10,
+    SPUInstallerRegisteredAppcastItem = 11,
 };
 
 typedef NS_ENUM(int32_t, SPUUpdaterMessageType)

--- a/Autoupdate/SPUMessageTypes.m
+++ b/Autoupdate/SPUMessageTypes.m
@@ -48,7 +48,7 @@ BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUI
             legal = (oldMessageType == SPUInstallationFinishedStage1 || oldMessageType == SPUInstallerRegisteredAppcastItem);
             break;
         case SPUInstallationFinishedStage3:
-            legal = (oldMessageType == SPUInstallationFinishedStage2 || oldMessageType == SPUInstallerRegisteredAppcastItem);
+            legal = (oldMessageType == SPUInstallationFinishedStage2);
             break;
         case SPUInstallerError:
         case SPUUpdaterAlivePing:

--- a/Autoupdate/SPUMessageTypes.m
+++ b/Autoupdate/SPUMessageTypes.m
@@ -23,7 +23,7 @@
 
 BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUInstallerMessageType newMessageType)
 {
-    BOOL legal;
+    BOOL legal = NO;
     switch (newMessageType) {
         case SPUInstallerNotStarted:
             legal = (oldMessageType == SPUInstallerNotStarted);
@@ -45,16 +45,19 @@ BOOL SPUInstallerMessageTypeIsLegal(SPUInstallerMessageType oldMessageType, SPUI
             legal = (oldMessageType == SPUInstallationStartedStage1);
             break;
         case SPUInstallationFinishedStage2:
-            legal = (oldMessageType == SPUInstallationFinishedStage1);
+            legal = (oldMessageType == SPUInstallationFinishedStage1 || oldMessageType == SPUInstallerRegisteredAppcastItem);
             break;
         case SPUInstallationFinishedStage3:
-            legal = (oldMessageType == SPUInstallationFinishedStage2);
+            legal = (oldMessageType == SPUInstallationFinishedStage2 || oldMessageType == SPUInstallerRegisteredAppcastItem);
             break;
         case SPUInstallerError:
         case SPUUpdaterAlivePing:
             // Having this state being dependent on other installation states would make the complicate our logic
             // So just always allow these type of messages
             legal = YES;
+            break;
+        case SPUInstallerRegisteredAppcastItem:
+            legal = (oldMessageType == SPUInstallationFinishedStage1);
             break;
     }
     return legal;

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -284,7 +284,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
     });
 }
 
-- (void)registerInstallationInfoData:(NSData *)installationInfoData
+- (void)registerInstallationInfoData:(NSData *)installationInfoData completionHandler:(void (^)(void))completionHandler
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (self.statusInfo.installationInfoData == nil && installationInfoData != nil) {
@@ -297,6 +297,8 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
                 SULog(SULogLevelError, @"Error: Failed to decode initial installation info from installer: %@", installationInfoData);
             }
         }
+        
+        completionHandler();
     });
 }
 

--- a/Sparkle/InstallerProgress/SPUInstallerAgentProtocol.h
+++ b/Sparkle/InstallerProgress/SPUInstallerAgentProtocol.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)registerApplicationBundlePath:(NSString *)applicationBundlePath reply:(void (^)(NSNumber * _Nullable processIdentifier))reply;
 
-- (void)registerInstallationInfoData:(NSData *)installationInfoData;
+- (void)registerInstallationInfoData:(NSData *)installationInfoData completionHandler:(void (^)(void))completionHandler;
 
 - (void)sendTerminationSignal;
 

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -332,7 +332,7 @@
         // The installer letting us know when the appcast item was registered (SPUInstallerRegisteredAppcastItem)
         // was added later. In earlier versions of Sparkle, we could have notified the update too early
         // before the installer finished registering the appcast item.
-        // Note don't need to handle an "old" installer because Sparkle and the installer should still be aligned at this point.
+        // Note we don't need to handle an "old" installer because Sparkle and the installer should still be aligned at this point.
         _canInstallSilently = canInstallSilently;
         _hasTargetTerminated = hasTargetTerminated;
     } else if (identifier == SPUInstallerRegisteredAppcastItem) {

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -330,20 +330,11 @@
         }
         
         // The installer letting us know when the appcast item was registered (SPUInstallerRegisteredAppcastItem)
-        // was added later. Old installers may not send this message, but new ones will let us know if they will send it.
-        // In earlier versions of Sparkle, we could have notified the update too early
+        // was added later. In earlier versions of Sparkle, we could have notified the update too early
         // before the installer finished registering the appcast item.
-        BOOL supportsRegisteredAppcastItemDataMessage = NO;
-        if (data.length >= sizeof(uint8_t) * 3) {
-            supportsRegisteredAppcastItemDataMessage = (BOOL)*((const uint8_t *)data.bytes + 2);
-        }
-        
-        if (!supportsRegisteredAppcastItemDataMessage) {
-            [self.delegate installerDidFinishPreparationAndWillInstallImmediately:hasTargetTerminated silently:canInstallSilently];
-        } else {
-            _canInstallSilently = canInstallSilently;
-            _hasTargetTerminated = hasTargetTerminated;
-        }
+        // Note don't need to handle an "old" installer because Sparkle and the installer should still be aligned at this point.
+        _canInstallSilently = canInstallSilently;
+        _hasTargetTerminated = hasTargetTerminated;
     } else if (identifier == SPUInstallerRegisteredAppcastItem) {
         self.currentStage = identifier;
         


### PR DESCRIPTION
This fixes a potential race issue where sometimes the automatic update driver on completion would not trigger to prompt an update alert immediately for critical updates. Note when this occurs, the update would still be installed on app termination and would still be scheduled to alert the user on the regular update check interval, so this is not a big issue.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested with test app that automatic update driver finishes and alerts the user of critical update. Tested resuming update with sparkle-cli too.

macOS version tested: 12.5 (21G72)
