### PR TITLE
Upgrade Xcode builds in CI to 13.4.1 and 14.0 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: ['xcode12.5.1', 'xcode13.3.1']
+        xcode: ['xcode14.0', 'xcode13.4.1']
         include:
-            - xcode: 'xcode13.3.1'
-              xcode-path: '/Applications/Xcode_13.3.1.app/Contents/Developer'
+            - xcode: 'xcode13.4.1'
+              xcode-path: '/Applications/Xcode_13.4.1.app/Contents/Developer'
               upload-dist: true
               run-analyzer: true
               macos: 'macos-12'
-            - xcode: 'xcode12.5.1'
-              xcode-path: '/Applications/Xcode_12.5.1.app/Contents/Developer'
+            - xcode: 'xcode14.0'
+              xcode-path: '/Applications/Xcode_14.0.app/Contents/Developer'
               upload-dist: false
               run-analyzer: false
-              macos: 'macos-11'
+              macos: 'macos-12'
             
     name: Build and Test Sparkle
     runs-on: ${{ matrix.macos }}

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -2,7 +2,7 @@ name: "Create Draft Release"
 
 env:
   BUILDDIR: "build"
-  DEVELOPER_DIR: "/Applications/Xcode_13.3.1.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION


## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing CI here.
