### PR TITLE
Move old updates to old_updates in generate_appcast

### DIFF
--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -426,7 +426,7 @@ func moveOldUpdatesFromAppcast(archivesSourceDir: URL, oldFilesDirectory: URL, c
             print("Warning: failed to move \(archivePath.lastPathComponent) to \(oldFilesDirectory.lastPathComponent): \(error)")
         }
         
-        let releaseNotesFile = archivePath.deletingLastPathComponent().appendingPathExtension("html")
+        let releaseNotesFile = archivePath.deletingPathExtension().appendingPathExtension("html")
         if fileManager.fileExists(atPath: releaseNotesFile.path) {
             do {
                 try suFileManager.updateModificationAndAccessTimeOfItem(at: releaseNotesFile)

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -88,6 +88,9 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
         } else {
             // If the user doesn't specify which versions to generate updates for,
             // then by default we ignore generating updates that are less than the latest update in the existing feed
+            // The reason why we need to do this is because new branch-specific flags the user can specify like the channel
+            // or the major version will be applied to new unknown updates. We can only absolutely be sure to apply this to
+            // updates that are greater in version than the top of the current feed, or if the user uses --versions.
             for latestUpdateCandidate in updates {
                 if feedUpdateBranches[latestUpdateCandidate.version] != nil {
                     // Found the latest update in the feed
@@ -209,6 +212,7 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
             
             // We only generate deltas for the latest version per branch,
             // but we still wanted to record the used delta updates for a batch of recent updates
+            // This is to support rollback in case the top newly generated update isn't exactly what the user wants
             let generatingDeltas = latestVersionPerBranch.contains(version)
             var numDeltas = 0
             let appBaseName = latestItem.appPath.deletingPathExtension().lastPathComponent

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -58,17 +58,16 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, disableNeste
     var running = 0
     for item in dir.filter({ !$0.hasPrefix(".") && !$0.hasSuffix(".delta") && !$0.hasSuffix(".xml") && !$0.hasSuffix(".html") }) {
         let itemPath = archivesSourceDir.appendingPathComponent(item)
+        var isDir: ObjCBool = false
+        if fileManager.fileExists(atPath: itemPath.path, isDirectory: &isDir) && isDir.boolValue {
+            continue
+        }
+        
         let archiveDestDir: URL
-
         if let hash = itemPath.sha256String() {
             archiveDestDir = archivesDestDir.appendingPathComponent(hash)
         } else {
             archiveDestDir = archivesDestDir.appendingPathComponent(itemPath.lastPathComponent)
-        }
-
-        var isDir: ObjCBool = false
-        if fileManager.fileExists(atPath: itemPath.path, isDirectory: &isDir) && isDir.boolValue {
-            continue
         }
 
         let addItem = { (validateBundle: Bool) in

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -147,7 +147,11 @@ struct GenerateAppcast: ParsableCommand {
         Appcast files and deltas will be written to the archives directory.
         
         If an appcast file is already present in the archives directory, that file will be re-used and updated with new entries.
-        Old entries in the appcast that are still needed are kept intact. Otherwise, a new appcast file will be generated and written.
+        Otherwise, a new appcast file will be generated and written.
+        
+        Old updates are automatically removed from the generated appcast feed and their update files are moved to \(oldFilesDirectoryName)/
+        If --auto-prune-update-files is passed, old update files in this directory are deleted after 2 weeks.
+        You may want to exclude files from this directory from being uploaded.
         
         Use the --versions option if you need to insert an update that is older than the latest update in your feed, or
         if you need to insert only a specific new version with certain parameters.
@@ -173,10 +177,8 @@ struct GenerateAppcast: ParsableCommand {
         
         For more advanced options that can be used for publishing updates, see https://sparkle-project.org/documentation/publishing/ for further documentation.
         
-        Extracted archives are cached in \((cacheDirectory.path as NSString).abbreviatingWithTildeInPath) to avoid re-computation in subsequent runs.
-        
-        Old updates are automatically removed from the generated appcast feed and their update files are moved to \(oldFilesDirectoryName). If --auto-prune-update-files is passed, old update files in this directory are deleted after 2 weeks.
-        
+        Extracted archives that are needed are cached in \((cacheDirectory.path as NSString).abbreviatingWithTildeInPath) to avoid re-computation in subsequent runs.
+                
         Note that \(programName) does not support package-based (.pkg) updates.
         """)
     

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -296,7 +296,7 @@ struct GenerateAppcast: ParsableCommand {
                     print("Moved \(moveCount) old update \(pluralizeWord(moveCount, "file")) to \(oldFilesDirectory.lastPathComponent)")
                 }
                 if prunedCount > 0 {
-                    print("Pruned \(moveCount) old update \(pluralizeWord(moveCount, "file"))")
+                    print("Pruned \(prunedCount) old update \(pluralizeWord(prunedCount, "file"))")
                 }
             }
         } catch {

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -87,7 +87,7 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .long, help: ArgumentHelp("A URL to the application's website which Sparkle may use for directing users to if they cannot download a new update from within the application. This will be used for new generated update items. By default, no product link is used.", valueName: "link"))
     var link: String?
     
-    @Option(name: .long, help: ArgumentHelp("An optional comma delimited list of application versions (specified by CFBundleVersion) to generate new update items for. By default, new update items are inferred from the available archives. Use this option if you need to insert old updates in the feed at a different branch point (for example with a different minimum OS requirement).", valueName: "versions"), transform: { Set($0.components(separatedBy: ",")) })
+    @Option(name: .long, help: ArgumentHelp("An optional comma delimited list of application versions (specified by CFBundleVersion) to generate new update items for. By default, new update items are inferred from the available archives and current feed. Use this option if you need to insert only a specific new version or insert an old update in the feed at a different branch point (e.g. with a different minimum OS version or channel).", valueName: "versions"), transform: { Set($0.components(separatedBy: ",")) })
     var versions: Set<String>?
     
     @Option(name: .long, help: ArgumentHelp("The maximum number of delta items to create for the latest update for each branch point (for example with a different minimum OS requirement).", valueName: "maximum-deltas"))
@@ -145,6 +145,9 @@ struct GenerateAppcast: ParsableCommand {
         
         If an appcast file is already present in the archives directory, that file will be re-used and updated with new entries.
         Old entries in the appcast that are still needed are kept intact. Otherwise, a new appcast file will be generated and written.
+        
+        Use the --versions option if you need to insert an update that is older than the latest update in your feed, or
+        if you need to insert only a specific new version with certain parameters.
         
         .html files that have the same filename as an archive (except for the file extension) will be used for release notes for that item.
         If the contents of these files are short (< \(DEFAULT_MAX_CDATA_THRESHOLD) characters) and do not include a DOCTYPE or body tags, they will be treated as embedded CDATA release notes.

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -52,7 +52,7 @@ struct GenerateAppcast: ParsableCommand {
     static let programName = "generate_appcast"
     static let programNamePath: String = CommandLine.arguments.first ?? "./\(programName)"
     static let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0].appendingPathComponent("Sparkle_generate_appcast")
-    static let oldFilesDirectoryName = ".old-updates"
+    static let oldFilesDirectoryName = "old-updates"
     
     static let DEFAULT_MAX_VERSIONS_PER_BRANCH_IN_FEED = 3
     static let DEFAULT_MAXIMUM_DELTAS = 5

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -52,7 +52,7 @@ struct GenerateAppcast: ParsableCommand {
     static let programName = "generate_appcast"
     static let programNamePath: String = CommandLine.arguments.first ?? "./\(programName)"
     static let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0].appendingPathComponent("Sparkle_generate_appcast")
-    static let oldFilesDirectoryName = "old-updates"
+    static let oldFilesDirectoryName = "old_updates"
     
     static let DEFAULT_MAX_VERSIONS_PER_BRANCH_IN_FEED = 3
     static let DEFAULT_MAXIMUM_DELTAS = 5
@@ -165,6 +165,7 @@ struct GenerateAppcast: ParsableCommand {
                 MyApp 1.1.zip
                 MyApp 1.1.html
                 appcast.xml
+                \(oldFilesDirectoryName)/
                 
         EXAMPLES:
             \(programNamePath) ./my-app-release-zipfiles/


### PR DESCRIPTION
Move old updates to a non-hidden directory in generate_appcast which won't be as confusing. There is now a `--auto-prune-update-files` option to automatically remove files from this directory. For safety, files won't be automatically pruned. Also take release notes files in account as well.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested that old update files are moved in new directory and release note files are moved too. Tested files are pruned automatically using --auto-prune-update-files

macOS version tested: 12.5 (21G72)
