### PR TITLE
Fix recently introduced bugs in generate_appcast with multiple feeds

### DIFF
--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -273,6 +273,8 @@ struct GenerateAppcast: ParsableCommand {
             
             let oldFilesDirectory = archivesSourceDir.appendingPathComponent(GenerateAppcast.oldFilesDirectoryName)
             
+            let pluralizeWord = { $0 == 1 ? $1 : "\($1)s" }
+            
             for (appcastFile, appcast) in appcastsByFeed {
                 // If an output filename was specified, use it.
                 // Otherwise, use the name of the appcast file found in the archive.
@@ -283,21 +285,20 @@ struct GenerateAppcast: ParsableCommand {
                 let (numNewUpdates, numExistingUpdates, numUpdatesRemoved) = try writeAppcast(appcastDestPath: appcastDestPath, appcast: appcast, fullReleaseNotesLink: fullReleaseNotesURL, maxCDATAThreshold: maxCDATAThreshold, link: link, newChannel: channel, majorVersion: majorVersion, ignoreSkippedUpgradesBelowVersion: ignoreSkippedUpgradesBelowVersion, phasedRolloutInterval: phasedRolloutInterval, criticalUpdateVersion: criticalUpdateVersion, informationalUpdateVersions: informationalUpdateVersions)
 
                 // Inform the user, pluralizing "update" if necessary
-                let pluralizeWord = { $0 == 1 ? $1 : "\($1)s" }
                 let pluralizeUpdates = { pluralizeWord($0, "update") }
                 let newUpdatesString = pluralizeUpdates(numNewUpdates)
                 let existingUpdatesString = pluralizeUpdates(numExistingUpdates)
                 let removedUpdatesString = pluralizeUpdates(numUpdatesRemoved)
                 
-                print("Wrote \(numNewUpdates) new \(newUpdatesString), updated \(numExistingUpdates) existing \(existingUpdatesString), and removed \(numUpdatesRemoved) old \(removedUpdatesString)")
-                
-                let (moveCount, prunedCount) = moveOldUpdatesFromAppcast(archivesSourceDir: archivesSourceDir, oldFilesDirectory: oldFilesDirectory, cacheDirectory: GenerateAppcast.cacheDirectory, appcast: appcast, autoPruneUpdates: autoPruneUpdates)
-                if moveCount > 0 {
-                    print("Moved \(moveCount) old update \(pluralizeWord(moveCount, "file")) to \(oldFilesDirectory.lastPathComponent)")
-                }
-                if prunedCount > 0 {
-                    print("Pruned \(prunedCount) old update \(pluralizeWord(prunedCount, "file"))")
-                }
+                print("Wrote \(numNewUpdates) new \(newUpdatesString), updated \(numExistingUpdates) existing \(existingUpdatesString), and removed \(numUpdatesRemoved) old \(removedUpdatesString) in \(appcastFile)")
+            }
+            
+            let (moveCount, prunedCount) = moveOldUpdatesFromAppcasts(archivesSourceDir: archivesSourceDir, oldFilesDirectory: oldFilesDirectory, cacheDirectory: GenerateAppcast.cacheDirectory, appcasts: Array(appcastsByFeed.values), autoPruneUpdates: autoPruneUpdates)
+            if moveCount > 0 {
+                print("Moved \(moveCount) old update \(pluralizeWord(moveCount, "file")) to \(oldFilesDirectory.lastPathComponent)")
+            }
+            if prunedCount > 0 {
+                print("Pruned \(prunedCount) old update \(pluralizeWord(prunedCount, "file"))")
             }
         } catch {
             print("Error generating appcast from directory", archivesSourceDir.path, "\n", error)


### PR DESCRIPTION
We fix the validation check for using the output option when multiple feeds are present, fix not generating new feeds when no prior feed is available, and fix incorrect logic with cleaning up delta files when multiple feeds are present.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast on a set of archives from one of my apps.

macOS version tested: 12.5 (21G72)
