### PR TITLE
Find potential matching translocated running apps in updater agent

### DIFF
--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -224,17 +224,36 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
     NSMutableArray<NSRunningApplication *> *matchedRunningApplications = [[NSMutableArray alloc] init];
     
     if (bundleIdentifier != nil && bundlePathComponents != nil) {
-        NSArray *runningApplications =
-        (bundleIdentifier != nil) ?
-        [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier] :
-        [[NSWorkspace sharedWorkspace] runningApplications];
+        NSArray *runningApplications = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier];
+        
+        // If we find any running application that is translocated and looks like the bundle, we should record those too
+        // We will want to terminate those apps and observe their pids, but we will only do this if we don't find any regular matches
+        NSMutableArray<NSRunningApplication *> *potentialMatchingTranslocatedRunningApplications = [[NSMutableArray alloc] init];
         
         for (NSRunningApplication *runningApplication in runningApplications) {
             // Comparing the URLs hasn't worked well for me in practice, so I'm comparing the file paths instead
             NSString *candidatePath = runningApplication.bundleURL.URLByResolvingSymlinksInPath.path;
-            if (candidatePath != nil && [candidatePath.pathComponents isEqualToArray:bundlePathComponents]) {
-                [matchedRunningApplications addObject:runningApplication];
+            if (candidatePath != nil) {
+                NSArray<NSString *> *candidatePathComponents = candidatePath.pathComponents;
+                if ([candidatePathComponents isEqualToArray:bundlePathComponents]) {
+                    [matchedRunningApplications addObject:runningApplication];
+                } else if (matchedRunningApplications.count == 0 && candidatePathComponents.count > 0 && bundlePathComponents.count > 0) {
+                    NSString *lastBundlePathComponent = bundlePathComponents.lastObject;
+                    NSString *lastCandidatePathComponent = candidatePathComponents.lastObject;
+                    if (lastBundlePathComponent != nil && lastCandidatePathComponent != nil && [lastBundlePathComponent isEqualToString:lastCandidatePathComponent] && [candidatePathComponents containsObject:@"AppTranslocation"]) {
+                        NSString *runningApplicationBundleIdentifier = runningApplication.bundleIdentifier;
+                        if (runningApplicationBundleIdentifier != nil && [runningApplicationBundleIdentifier isEqualToString:bundleIdentifier]) {
+                            [potentialMatchingTranslocatedRunningApplications addObject:runningApplication];
+                        }
+                    }
+                }
             }
+        }
+        
+        // Non-translocated apps take priority first
+        // And we only use translocated version of apps if there are no regular apps matched
+        if (matchedRunningApplications.count == 0) {
+            [matchedRunningApplications addObjectsFromArray:potentialMatchingTranslocatedRunningApplications];
         }
     }
     

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -241,10 +241,7 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
                     NSString *lastBundlePathComponent = bundlePathComponents.lastObject;
                     NSString *lastCandidatePathComponent = candidatePathComponents.lastObject;
                     if (lastBundlePathComponent != nil && lastCandidatePathComponent != nil && [lastBundlePathComponent isEqualToString:lastCandidatePathComponent] && [candidatePathComponents containsObject:@"AppTranslocation"]) {
-                        NSString *runningApplicationBundleIdentifier = runningApplication.bundleIdentifier;
-                        if (runningApplicationBundleIdentifier != nil && [runningApplicationBundleIdentifier isEqualToString:bundleIdentifier]) {
-                            [potentialMatchingTranslocatedRunningApplications addObject:runningApplication];
-                        }
+                        [potentialMatchingTranslocatedRunningApplications addObject:runningApplication];
                     }
                 }
             }


### PR DESCRIPTION
In the installer progress agent, when we find all potential running applications for a host bundle, we should also consider any translocated running apps that look-alike the host bundle.

This matters when updating external bundles. For example if sparkle-cli tries to update an app on disk in ~/Downloads/ but a running instance of the app is translocated, sparkle-cli should terminate the translocated instance of the app before installing the update.

It's possible this could generate a false positive but we err on the side of safety here. We only use running translocated apps if we find no regular matching apps.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested updating app in ~/Downloads recently downloaded from internet using sparkle-cli, and having a running translocated instance and not having a running instance. Tested regular test app as well for normal updating.

macOS version tested: 12.5 (21G72)
