### PR TITLE
Allow user to re-try installing/relaunching application

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -442,7 +442,16 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             if (self.performedStage1Installation) {
                 // Resume the installation if we aren't done with stage 2 yet, and remind the client we are prepared to relaunch
                 dispatch_async(self.installerQueue, ^{
-                    [self performStage2InstallationIfNeeded];
+                    if (!self.performedStage2Installation) {
+                        [self performStage2Installation];
+                    } else {
+                        // If we already performed the 2nd stage, re-purpose this request to re-try sending another termination signal
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            // Don't check if the target is already terminated, leave that to the progress agent
+                            // We could be slightly off if there were multiple instances running
+                            [self.agentConnection.agent sendTerminationSignal];
+                        });
+                    }
                 });
             }
         });
@@ -504,14 +513,10 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     });
 }
 
-- (void)performStage2InstallationIfNeeded
+- (void)performStage2Installation
 {
-    if (self.performedStage2Installation) {
-        return;
-    }
-    
-    BOOL performedSecondStage = self.shouldShowUI || [self.installer canInstallSilently];
-    if (performedSecondStage) {
+    BOOL canPerformSecondStage = self.shouldShowUI || [self.installer canInstallSilently];
+    if (canPerformSecondStage) {
         self.performedStage2Installation = YES;
         
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -563,7 +568,9 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         }
         
         dispatch_async(self.installerQueue, ^{
-            [self performStage2InstallationIfNeeded];
+            if (!self.performedStage2Installation) {
+                [self performStage2Installation];
+            }
             
             if (!self.performedStage2Installation) {
                 // We failed and we're going to exit shortly

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -444,7 +444,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                 dispatch_async(self.installerQueue, ^{
                     if (!self.performedStage2Installation) {
                         [self performStage2Installation];
-                    } else {
+                    } else if (!self.performedStage3Installation) {
                         // If we already performed the 2nd stage, re-purpose this request to re-try sending another termination signal
                         dispatch_async(dispatch_get_main_queue(), ^{
                             // Don't check if the target is already terminated, leave that to the progress agent

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -105,6 +105,8 @@ If the 2nd stage succeeds, the installer sends a `SPUInstallationFinishedStage2`
 
 The updater receives a `SPUInstallationFinishedStage2` message, and reads if the target application had already been terminated. If the target application has not already terminated, the updater tells the user driver to show that the application is being sent a termination request.
 
+In the case termination of the application is delayed or canceled, the user driver may re-try sending a `SPUResumeInstallationToStage2` message to the installer. This time the installer will recognize it already completed stage 2. If it hasn't proceeded onto stage 3 it will send another quit event to the application. This re-try can be done multiple times.
+
 ### Showing Progress
 
 When the target application is terminated, if the updater allowed the installer to show UI progress and the installation type doesn't show progress on its own (only interactive package installer shows progress on its own), then the installer sends a `SPUUpdaterAlivePing` message to the updater. If the updater is still alive by now and receives the message, the updater will then send back a `SPUUpdaterAlivePong` message. This lets the installer know that the updater is still active after the target application is terminated, and whether the installer should later be responsible for displaying updater progress or not if a short time passes by, and the installation is still not finished. If the updater is still not alive, then the installer should be responsible for showing progress if otherwise allowed.

--- a/Sparkle/InstallerProgress/ShowInstallerProgress.m
+++ b/Sparkle/InstallerProgress/ShowInstallerProgress.m
@@ -24,7 +24,7 @@
 
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host
 {
-    self.statusController = [[SUStatusController alloc] initWithHost:host centerPointValue:nil minimizable:NO];
+    self.statusController = [[SUStatusController alloc] initWithHost:host centerPointValue:nil minimizable:NO closable:NO];
     
     [self.statusController setButtonTitle:SULocalizedString(@"Cancel Update", @"") target:nil action:nil isDefault:NO];
     [self.statusController beginActionWithTitle:SULocalizedString(@"Installing update…", @"") maxProgressValue:0 statusText:@""];

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -317,8 +317,19 @@
 
 - (void)installerDidStartInstallingWithApplicationTerminated:(BOOL)applicationTerminated
 {
-    if ([self.userDriver respondsToSelector:@selector(showInstallingUpdateWithApplicationTerminated:)]) {
+    if ([self.userDriver respondsToSelector:@selector(showInstallingUpdateWithApplicationTerminated:retryTerminatingApplication:)]) {
+        __weak __typeof__(self) weakSelf = self;
+        [self.userDriver showInstallingUpdateWithApplicationTerminated:applicationTerminated retryTerminatingApplication:^{
+            if (!applicationTerminated) {
+                __typeof__(self) strongSelf = weakSelf;
+                [strongSelf.coreDriver finishInstallationWithResponse:SPUUserUpdateChoiceInstall displayingUserInterface:YES];
+            }
+        }];
+    } else if ([self.userDriver respondsToSelector:@selector(showInstallingUpdateWithApplicationTerminated:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [self.userDriver showInstallingUpdateWithApplicationTerminated:applicationTerminated];
+#pragma clang diagnostic pop
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -402,7 +402,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  
  @param updater The updater instance.
  @param item The appcast item corresponding to the update that is proposed to be installed.
- @param immediateInstallHandler The install handler for the delegate to immediately install the update. No UI interaction will be shown and the application will be relaunched after installation. This handler can only be used if @c YES is returned and the delegate handles installing the update. This handler can be invoked multiple times in case the application cancels the termination request.
+ @param immediateInstallHandler The install handler for the delegate to immediately install the update. No UI interaction will be shown and the application will be relaunched after installation. This handler can only be used if @c YES is returned and the delegate handles installing the update. For Sparkle 2.3 onwards, this handler can be invoked multiple times in case the application cancels the termination request.
  @return @c YES if the delegate will handle installing the update or @c NO if the updater should be given responsibility.
  */
 - (BOOL)updater:(SPUUpdater *)updater willInstallUpdateOnQuit:(SUAppcastItem *)item immediateInstallationBlock:(void (^)(void))immediateInstallHandler;

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -402,7 +402,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  
  @param updater The updater instance.
  @param item The appcast item corresponding to the update that is proposed to be installed.
- @param immediateInstallHandler The install handler to immediately install the update. No UI interaction will be shown and the application will be relaunched after installation.
+ @param immediateInstallHandler The install handler for the delegate to immediately install the update. No UI interaction will be shown and the application will be relaunched after installation. This handler can only be used if @c YES is returned and the delegate handles installing the update. This handler can be invoked multiple times in case the application cancels the termination request.
  @return @c YES if the delegate will handle installing the update or @c NO if the updater should be given responsibility.
  */
 - (BOOL)updater:(SPUUpdater *)updater willInstallUpdateOnQuit:(SUAppcastItem *)item immediateInstallationBlock:(void (^)(void))immediateInstallHandler;

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -219,8 +219,13 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * If the application hasn't been terminated, a quit event is sent to the running application before installing the update.
  * If the application or user delays or cancels termination, there may be an indefinite period of time before the application fully quits.
  * It is up to the implementor whether or not to decide to continue showing installation progress in this case.
+ *
+ * @param retryTerminatingApplication This handler gives a chance for the application to re-try sending a quit event to the running application before installing the update.
+ * The application may cancel or delay termination. This handler gives the user driver another chance to allow the user to try terminating the application again.
+ * If the application does not delay or cancel application termination, there is no need to invoke this handler. This handler may be invoked multiple times.
+ * Note this handler should not be invoked if @c applicationTerminated is already @c YES
  */
-- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated;
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated retryTerminatingApplication:(void (^)(void))retryTerminatingApplication;
 
 /**
  * Show the user that the update installation finished
@@ -231,7 +236,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * the updater's lifetime is tied to the application it is updating. This implementation must not try to reference
  * the old bundle prior to the installation, which will no longer be around.
  *
- * Before this point, `-showInstallingUpdateWithApplicationTerminated:` will be called.
+ * Before this point, `-showInstallingUpdateWithApplicationTerminated:retryTerminatingApplication:` will be called.
  *
  * @param relaunched Indicates if the update was relaunched.
  * @param acknowledgement Acknowledge to the updater that the finished installation was shown.
@@ -271,9 +276,11 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 
 - (void)dismissUserInitiatedUpdateCheck __deprecated_msg("Transition to new UI appropriately when a new update is shown, when no update is found, or when an update error occurs.");
 
-- (void)showInstallingUpdate __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated: instead.");
+- (void)showInstallingUpdate __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated:retryTerminatingApplication: instead.");
 
-- (void)showSendingTerminationSignal __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated: instead.");
+- (void)showSendingTerminationSignal __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated:retryTerminatingApplication: instead.");
+
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated __deprecated_msg("Implement -showInstallingUpdateWithApplicationTerminated:retryTerminatingApplication: instead.");;
 
 @end
 

--- a/Sparkle/SUStatusController.h
+++ b/Sparkle/SUStatusController.h
@@ -24,7 +24,7 @@
 @property (nonatomic) double maxProgressValue;
 @property (getter=isButtonEnabled) BOOL buttonEnabled;
 
-- (instancetype)initWithHost:(SUHost *)host centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable;
+- (instancetype)initWithHost:(SUHost *)aHost centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable;
 
 // Pass 0 for the max progress value to get an indeterminate progress bar.
 // Pass nil for the status text to not show it.

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -27,6 +27,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @implementation SUStatusController
 {
     NSValue *_centerPointValue;
+    BOOL _closable;
 }
 
 @synthesize progressValue;
@@ -41,7 +42,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @synthesize touchBarButton;
 @synthesize minimizable = _minimizable;
 
-- (instancetype)initWithHost:(SUHost *)aHost centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable
+- (instancetype)initWithHost:(SUHost *)aHost centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable
 {
     self = [super initWithWindowNibName:@"SUStatus" owner:self];
 	if (self)
@@ -49,6 +50,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
         self.host = aHost;
         _centerPointValue = centerPointValue;
         _minimizable = minimizable;
+        _closable = closable;
         [self setShouldCascadeWindows:NO];
     }
     return self;
@@ -69,6 +71,9 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
     
     if (self.minimizable) {
         self.window.styleMask |= NSWindowStyleMaskMiniaturizable;
+    }
+    if (_closable) {
+        self.window.styleMask |= NSWindowStyleMaskClosable;
     }
     [self.progressBar setUsesThreadedAnimation:YES];
     [self.statusTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightRegular]];

--- a/TestApplication/SUPopUpTitlebarUserDriver.m
+++ b/TestApplication/SUPopUpTitlebarUserDriver.m
@@ -251,7 +251,7 @@
     [self addUpdateButtonWithTitle:[NSString stringWithFormat:@"Extracting (%d%%)…", (int)(progress * 100)]];
 }
 
-- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)applicationTerminated retryTerminatingApplication:(void (^)(void))__unused retryTerminatingApplication
 {
     if (applicationTerminated) {
         [self addUpdateButtonWithTitle:@"Installing…"];

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -221,7 +221,7 @@
     }
 }
 
-- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)__unused applicationTerminated
+- (void)showInstallingUpdateWithApplicationTerminated:(BOOL)__unused applicationTerminated retryTerminatingApplication:(void (^)(void))__unused retryTerminatingApplication
 {
     if (self.verbose) {
         fprintf(stderr, "Installing Update...\n");


### PR DESCRIPTION
If the app termination request is delayed or canceled, the user can check for updates again with the standard user driver and try installing/relaunching again, which will trigger the installer to send another quit event to the running application.

Before the install/relaunch window would close but the check for updates option would still be present but not functional.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested test app and other document based app that tried delaying/canceling app termination and later allowed app termination; bringing update status window back in focus allows to relaunch app again (instead of previously doing nothing). Tested that `immediateInstallHandler` the automatic update driver passes to the updater delegate can be invoked multiple times too in case termination is canceled.

macOS version tested: 12.5.1 (21G83)
