### PR TITLE
Ensure install handlers are invoked on main queue

### DIFF
--- a/Sparkle/SPUAutomaticUpdateDriver.m
+++ b/Sparkle/SPUAutomaticUpdateDriver.m
@@ -110,7 +110,9 @@
         if (self.willInstallSilently && [updaterDelegate respondsToSelector:@selector(updater:willInstallUpdateOnQuit:immediateInstallationBlock:)]) {
             __weak SPUAutomaticUpdateDriver *weakSelf = self;
             installationHandledByDelegate = [updaterDelegate updater:self.updater willInstallUpdateOnQuit:self.updateItem immediateInstallationBlock:^{
-                [weakSelf.coreDriver finishInstallationWithResponse:SPUUserUpdateChoiceInstall displayingUserInterface:NO];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakSelf.coreDriver finishInstallationWithResponse:SPUUserUpdateChoiceInstall displayingUserInterface:NO];
+                });
             }];
         }
         

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -321,8 +321,9 @@
         __weak __typeof__(self) weakSelf = self;
         [self.userDriver showInstallingUpdateWithApplicationTerminated:applicationTerminated retryTerminatingApplication:^{
             if (!applicationTerminated) {
-                __typeof__(self) strongSelf = weakSelf;
-                [strongSelf.coreDriver finishInstallationWithResponse:SPUUserUpdateChoiceInstall displayingUserInterface:YES];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakSelf.coreDriver finishInstallationWithResponse:SPUUserUpdateChoiceInstall displayingUserInterface:YES];
+                });
             }
         }];
     } else if ([self.userDriver respondsToSelector:@selector(showInstallingUpdateWithApplicationTerminated:)]) {


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app in both of these code paths.

macOS version tested: 12.5.1 (21G83)
