### PR TITLE
Update Traditional Chinese (zh_TW) localization

### DIFF
--- a/Sparkle/zh_TW.lproj/Sparkle.strings
+++ b/Sparkle/zh_TW.lproj/Sparkle.strings
@@ -2,7 +2,7 @@
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ 已是目前最新的版本。";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ 已是目前最新的版本。\n(You are currently running version %3$@.)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ 已是目前最新的版本。\n（您正在執行的版本是 %3$@。）";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ 現在已可取得，您的版本則是 %3$@。您要現在下載嗎？";
@@ -74,7 +74,7 @@
 "Updating %@" = "正在更新 %@";
 
 /* No comment provided by engineer. */
-"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "請將 %1$@ 移至您的“應用程式”檔案夾，從該處重新啟動，然後再試一次。";
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "請將 %1$@ 移至您的「應用程式」檔案夾，從該處重新啟動，然後再試一次。";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "你已有最新版本！";
+"You’re up-to-date!" = "您已有最新版本！";


### PR DESCRIPTION
Update and improve Traditional Chinese (zh_TW) translation.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
