### PR TITLE
added zh_CN l10n for "Version History"

### DIFF
--- a/Sparkle/zh_CN.lproj/Sparkle.strings
+++ b/Sparkle/zh_CN.lproj/Sparkle.strings
@@ -88,5 +88,8 @@
 /* No comment provided by engineer. */
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "移动 %1$@ 到应用程序文件夹并再试一次。";
 
+/* No comment provided by engineer. */
+"Version History" = "版本历史记录";
+
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You’re up-to-date!" = "您使用的就是最新版！";


### PR DESCRIPTION
Update version history:: added zh_CN l10n for key "Version History"

(Insert summary of your pull request here)

Fixes # (issue)

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
