### PR TITLE
Add delegate method for when user makes an update choice

### DIFF
--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -204,6 +204,15 @@
                 validatedChoice = userChoice;
             }
             
+            if ([self.updaterDelegate respondsToSelector:@selector(updater:userDidMakeChoice:forUpdate:state:)]) {
+                [self.updaterDelegate updater:self.updater userDidMakeChoice:validatedChoice forUpdate:updateItem state:state];
+            } else if (validatedChoice == SPUUserUpdateChoiceSkip && [self.updaterDelegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
+#pragma clang diagnostic pop
+            }
+            
             switch (validatedChoice) {
                 case SPUUserUpdateChoiceInstall: {
                     switch (stage) {
@@ -221,10 +230,6 @@
                 }
                 case SPUUserUpdateChoiceSkip: {
                     [SPUSkippedUpdate skipUpdate:updateItem host:self.host];
-                    
-                    if ([self.updaterDelegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
-                        [self.updaterDelegate updater:self.updater userDidSkipThisVersion:updateItem];
-                    }
                     
                     switch (stage) {
                         case SPUUserUpdateStageDownloaded:

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -9,9 +9,10 @@
 #import <Foundation/Foundation.h>
 #import <Sparkle/SUExport.h>
 #import <Sparkle/SPUUpdateCheck.h>
+#import <Sparkle/SPUUserUpdateState.h>
 
 @protocol SUVersionComparison;
-@class SPUUpdater, SUAppcast, SUAppcastItem;
+@class SPUUpdater, SUAppcast, SUAppcastItem, SPUUserUpdateState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -236,12 +237,23 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 - (BOOL)updater:(SPUUpdater *)updater shouldProceedWithUpdate:(SUAppcastItem *)updateItem updateCheck:(SPUUpdateCheck)updateCheck error:(NSError * __autoreleasing *)error;
 
 /**
- Called when an update is skipped by the user.
+ Called when a user makes a choice to install, dismiss, or skip an update.
+ 
+ If the @c choice is `SPUUserUpdateChoiceDismiss` and @c state.stage is `SPUUserUpdateStageDownloaded` the downloaded update is kept
+ around until the next time Sparkle reminds the user of the update.
+ 
+ If the @c choice is `SPUUserUpdateChoiceDismiss` and  @c state.stage is `SPUUserUpdateStageInstalling` the update is still set to install on application termination.
+ 
+ If the @c choice is `SPUUserUpdateChoiceSkip` the user will not be reminded in the future for this update unless they initiate an update check themselves.
+ 
+ If @c updateItem.isInformationOnlyUpdate is @c YES the @c choice cannot be `SPUUserUpdateChoiceInstall`.
  
  @param updater The updater instance.
- @param item The appcast item corresponding to the update that the user skipped.
+ @param choice The choice (install, dismiss, or skip) the user made for this @c updateItem
+ @param updateItem The appcast item corresponding to the update that the user made a choice on.
+ @param state The current state for the update which includes if the update has already been downloaded or already installing.
  */
-- (void)updater:(SPUUpdater *)updater userDidSkipThisVersion:(SUAppcastItem *)item;
+- (void)updater:(SPUUpdater *)updater userDidMakeChoice:(SPUUserUpdateChoice)choice forUpdate:(SUAppcastItem *)updateItem state:(SPUUserUpdateState *)state;
 
 /**
  Returns whether the release notes (if available) should be downloaded after an update is found and shown.
@@ -445,6 +457,8 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 /* Deprecated methods */
 
 - (BOOL)updaterMayCheckForUpdates:(SPUUpdater *)updater __deprecated_msg("Please use -[SPUUpdaterDelegate updater:mayPerformUpdateCheck:error:] instead.");
+
+- (void)updater:(SPUUpdater *)updater userDidSkipThisVersion:(SUAppcastItem *)item __deprecated_msg("Please use -[SPUUpdaterDelegate updater:userDidMakeChoice:forUpdate:state:] instead.");
 
 @end
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -325,10 +325,10 @@ static NSMutableDictionary *sharedUpdaters = nil;
     }
 }
 
-- (void)updater:(SPUUpdater *)__unused updater userDidSkipThisVersion:(nonnull SUAppcastItem *)item
+- (void)updater:(SPUUpdater *)__unused updater userDidMakeChoice:(SPUUserUpdateChoice)choice forUpdate:(SUAppcastItem *)updateItem state:(SPUUserUpdateState *)__unused state
 {
-    if ([self.delegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
-        [self.delegate updater:self userDidSkipThisVersion:item];
+    if (choice == SPUUserUpdateChoiceSkip && [self.delegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
+        [self.delegate updater:self userDidSkipThisVersion:updateItem];
     }
 }
 

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -32,6 +32,9 @@
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SUUpdater
 #pragma clang diagnostic pop
+{
+    BOOL _delayShowingUserUpdate;
+}
 
 @synthesize updater = _updater;
 @synthesize delegate = _delegate;
@@ -198,7 +201,14 @@ static NSMutableDictionary *sharedUpdaters = nil;
 
 - (void)checkForUpdatesInBackground
 {
-    [self.updater checkForUpdatesInBackground];
+    if (_delayShowingUserUpdate) {
+        // We don't know if SUUpdater delegate will call checkForUpdates: or checkForUpdatesInBackground
+        // to bring a deffered update alert back in 1.x.
+        // So if checkForUpdatesInBackground is called we will bring the update back in focus
+        [self checkForUpdates:nil];
+    } else {
+        [self.updater checkForUpdatesInBackground];
+    }
 }
 
 - (NSDate *)lastUpdateCheckDate
@@ -228,7 +238,7 @@ static NSMutableDictionary *sharedUpdaters = nil;
         SULog(SULogLevelError, @"-[%@ installUpdatesIfAvailable] does not function anymore.. Instead a background scheduled update check will be done.", NSStringFromClass([self class]));
         
         self.loggedInstallUpdatesIfAvailableWarning = YES;
-        }
+    }
 
     [self checkForUpdatesInBackground];
 }
@@ -327,9 +337,38 @@ static NSMutableDictionary *sharedUpdaters = nil;
 
 - (void)updater:(SPUUpdater *)__unused updater userDidMakeChoice:(SPUUserUpdateChoice)choice forUpdate:(SUAppcastItem *)updateItem state:(SPUUserUpdateState *)__unused state
 {
+    // This delegate callback matches 1.x behavior (even though -standardUserDriverWillFinishUpdateSession might be a better place for it)
+    if ([self.delegate respondsToSelector:@selector(updater:didDismissUpdateAlertPermanently:forItem:)]) {
+        [self.delegate updater:self didDismissUpdateAlertPermanently:(choice == SPUUserUpdateChoiceSkip) forItem:updateItem];
+    }
+    
     if (choice == SPUUserUpdateChoiceSkip && [self.delegate respondsToSelector:@selector(updater:userDidSkipThisVersion:)]) {
         [self.delegate updater:self userDidSkipThisVersion:updateItem];
     }
+}
+
+- (BOOL)standardUserDriverShouldHandleShowingScheduledUpdate:(SUAppcastItem *)update andInImmediateFocus:(BOOL)immediateFocus
+{
+    if ([self.delegate respondsToSelector:@selector(updaterShouldShowUpdateAlertForScheduledUpdate:forItem:)]) {
+        // If the delegate returns NO and tries to show the update before
+        // -standardUserDriverWillHandleShowingUpdate:forUpdate:state: is called, this is technically
+        // a violation. However it is also unlikely to happen.
+        return [self.delegate updaterShouldShowUpdateAlertForScheduledUpdate:self forItem:update];
+    } else {
+        return YES;
+    }
+}
+
+- (void)standardUserDriverWillHandleShowingUpdate:(BOOL)handleShowingUpdate forUpdate:(SUAppcastItem *)update state:(SPUUserUpdateState *)state
+{
+    if (!handleShowingUpdate) {
+        _delayShowingUserUpdate = YES;
+    }
+}
+
+- (void)standardUserDriverWillFinishUpdateSession
+{
+    _delayShowingUserUpdate = NO;
 }
 
 - (void)updater:(SPUUpdater *)__unused updater willDownloadUpdate:(SUAppcastItem *)item withRequest:(NSMutableURLRequest *)request

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -121,6 +121,23 @@ __deprecated_msg("Deprecated in Sparkle 2. See SPUUpdaterDelegate instead")
 - (void)updaterDidNotFindUpdate:(SUUpdater *)updater;
 
 /*!
+  Called just before the scheduled update driver prompts the user to install an update.
+
+  \param updater The SUUpdater instance.
+
+  \return YES to allow the update prompt to be shown (the default behavior), or NO to suppress it.
+  */
+ - (BOOL)updaterShouldShowUpdateAlertForScheduledUpdate:(SUUpdater *)updater forItem:(SUAppcastItem *)item;
+
+ /*!
+  Called after the user dismisses the update alert.
+
+  \param updater The SUUpdater instance.
+  \param permanently YES if the alert will not appear again for this update; NO if it may reappear.
+  */
+ - (void)updater:(SUUpdater *)updater didDismissUpdateAlertPermanently:(BOOL)permanently forItem:(SUAppcastItem *)item;
+
+/*!
  Called immediately before downloading the specified update.
  
  \param updater The SUUpdater instance.


### PR DESCRIPTION
This adds a new `SPUUpdater` delegate method:

```objc
- (void)updater:(SPUUpdater *)updater userDidMakeChoice:(SPUUserUpdateChoice)choice forUpdate:(SUAppcastItem *)updateItem state:(SPUUserUpdateState *)state;
```

This could have potentially been part of `SPUStandardUserDriverDelegate` but having it part of the updater delegate makes it work with any user driver, and we also validate the `choice` the user driver made before invoking the delegate.

This also deprecates `-[SPUUpdaterDelegate updater:userDidSkipThisVersion:]`

And lastly this adds the deprecated 1.x delegate callbacks originally implemented in #1363 for `SUUpdater` shim.

Fixes #2250

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested/verified delegate method with test app and other Swift app.
Tested SUUpdater implementation in a test app and verified callbacks work as expected.

macOS version tested: 12.5.1 (21G83)
