### PR TITLE
Expose maximum-versions option to preserve in feed per branch

### DIFF
--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -138,20 +138,23 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                 updatesGroupedByBranch[branch] = Array(versions.sorted(by: descendingVersionComparator).prefix(maxVersionsPerBranchInFeed))
             }
             
-            // Remove extraneous versions for branches that have converged
-            for (branch, versions) in updatesGroupedByBranch {
-                guard branch.channel != nil else {
-                    continue
-                }
-                
-                let defaultChannelBranch = UpdateBranch(minimumSystemVersion: branch.minimumSystemVersion, maximumSystemVersion: branch.maximumSystemVersion, minimumAutoupdateVersion: branch.minimumAutoupdateVersion, channel: nil)
-                
-                guard let defaultChannelVersions = updatesGroupedByBranch[defaultChannelBranch] else {
-                    continue
-                }
-                
-                if descendingVersionComparator(defaultChannelVersions[0], versions[0]) {
-                    updatesGroupedByBranch[branch] = [versions[0]]
+            // Remove extraneous versions for branches that have converged,
+            // as long as the user doesn't opt into keeping all versions in the feed
+            if maxVersionsPerBranchInFeed < Int.max {
+                for (branch, versions) in updatesGroupedByBranch {
+                    guard branch.channel != nil else {
+                        continue
+                    }
+                    
+                    let defaultChannelBranch = UpdateBranch(minimumSystemVersion: branch.minimumSystemVersion, maximumSystemVersion: branch.maximumSystemVersion, minimumAutoupdateVersion: branch.minimumAutoupdateVersion, channel: nil)
+                    
+                    guard let defaultChannelVersions = updatesGroupedByBranch[defaultChannelBranch] else {
+                        continue
+                    }
+                    
+                    if descendingVersionComparator(defaultChannelVersions[0], versions[0]) {
+                        updatesGroupedByBranch[branch] = [versions[0]]
+                    }
                 }
             }
             

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -90,7 +90,16 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .long, help: ArgumentHelp("An optional comma delimited list of application versions (specified by CFBundleVersion) to generate new update items for. By default, new update items are inferred from the available archives and current feed. Use this option if you need to insert only a specific new version or insert an old update in the feed at a different branch point (e.g. with a different minimum OS version or channel).", valueName: "versions"), transform: { Set($0.components(separatedBy: ",")) })
     var versions: Set<String>?
     
-    @Option(name: .long, help: ArgumentHelp("The maximum number of delta items to create for the latest update for each branch point (for example with a different minimum OS requirement).", valueName: "maximum-deltas"))
+    @Option(name: .customLong("maximum-versions"), help: ArgumentHelp("The maximum number of versions to preserve in the generated appcast for each branch point (e.g. with a different minimum OS requirement). If this value is 0, then all items in the appcast are preserved.", valueName: "maximum-versions"), transform: { value -> Int in
+        if let intValue = Int(value) {
+            return (intValue <= 0) ? Int.max : intValue
+        } else {
+            return DEFAULT_MAX_VERSIONS_PER_BRANCH_IN_FEED
+        }
+    })
+    var maxVersionsPerBranchInFeed: Int = DEFAULT_MAX_VERSIONS_PER_BRANCH_IN_FEED
+    
+    @Option(name: .long, help: ArgumentHelp("The maximum number of delta items to create for the latest update for each branch point (e.g. with a different minimum OS requirement).", valueName: "maximum-deltas"))
     var maximumDeltas: Int = DEFAULT_MAXIMUM_DELTAS
     
     @Option(name: .long, help: ArgumentHelp(COMPRESSION_METHOD_ARGUMENT_DESCRIPTION, valueName: "delta-compression"))
@@ -125,11 +134,6 @@ struct GenerateAppcast: ParsableCommand {
     
     @Argument(help: "The path to the directory containing the update archives and delta files.", transform: { URL(fileURLWithPath: $0, isDirectory: true) })
     var archivesSourceDir: URL
-    
-    // Rough indication of how many versions we should keep in the feed per branch point
-    // Keep this option hidden from the user
-    @Option(name: .long, help: .hidden)
-    var maxVersionsPerBranchInFeed: Int = DEFAULT_MAX_VERSIONS_PER_BRANCH_IN_FEED
     
     @Flag(help: .hidden)
     var verbose: Bool = false


### PR DESCRIPTION
Also let a zero or negative value mean that all versions should be preserved.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast using this option and passing different values to it, including 0.

macOS version tested: 12.5.1 (21G83)
