### PR TITLE
Allow developer to always force allowing automatic updates

### DIFF
--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -33,6 +33,12 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
 
 /**
  * Indicates whether or not automatically downloading updates is allowed to be turned on by the user.
+ * If this value is nil, the developer has not explicitly specified this option.
+ */
+@property (readonly, nonatomic, nullable) NSNumber *allowsAutomaticUpdatesOption;
+
+/**
+ * Indicates whether or not automatically downloading updates is allowed to be turned on by the user.
  */
 @property (readonly, nonatomic) BOOL allowsAutomaticUpdates;
 

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -52,9 +52,15 @@
 }
 
 // For allowing automatic downloaded updates to be turned on or off
-- (BOOL)allowsAutomaticUpdates
+- (NSNumber * _Nullable)allowsAutomaticUpdatesOption
 {
     NSNumber *developerAllowsAutomaticUpdates = [self.host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
+    return [developerAllowsAutomaticUpdates isKindOfClass:[NSNumber class]] ? developerAllowsAutomaticUpdates : nil;
+}
+
+- (BOOL)allowsAutomaticUpdates
+{
+    NSNumber *developerAllowsAutomaticUpdates = [self allowsAutomaticUpdatesOption];
     return (developerAllowsAutomaticUpdates == nil || developerAllowsAutomaticUpdates.boolValue);
 }
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -98,7 +98,18 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         _didBecomeKeyBlock = [didBecomeKeyBlock copy];
         
         SPUUpdaterSettings *updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:host.bundle];
-        _allowsAutomaticUpdates = updaterSettings.allowsAutomaticUpdates && updaterSettings.automaticallyChecksForUpdates && !item.informationOnlyUpdate;
+        
+        BOOL allowsAutomaticUpdates;
+        NSNumber *allowsAutomaticUpdatesOption = updaterSettings.allowsAutomaticUpdatesOption;
+        if (item.informationOnlyUpdate) {
+            allowsAutomaticUpdates = NO;
+        } else if (allowsAutomaticUpdatesOption == nil) {
+            allowsAutomaticUpdates = updaterSettings.automaticallyChecksForUpdates;
+        } else {
+            allowsAutomaticUpdates = allowsAutomaticUpdatesOption.boolValue;
+        }
+        _allowsAutomaticUpdates = allowsAutomaticUpdates;
+        
         [self setShouldCascadeWindows:NO];
     } else {
         assert(false);


### PR DESCRIPTION
By default, if the SUAllowsAutomaticUpdates Info.plist key is not specified, the update alert option to allow automatic downloading/installing of updates will only be shown if automatic checking of updates is enabled. However, the developer can now override this by setting SUAllowsAutomaticUpdates to true in Info.plist which indicates the option should be available even if automatic checking of updates is not enabled.

Related to #2209

I need a companion PR for documentation.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app setting SUAllowsAutomaticUpdates to YES and NO and leaving it unspecified.

macOS version tested: 12.5.1 (21G83)
