### PR TITLE
Add -p option to sign_update to only print the signed signature

### DIFF
--- a/sign_update/main.swift
+++ b/sign_update/main.swift
@@ -91,6 +91,9 @@ struct SignUpdate: ParsableCommand {
     @Option(name: [.customShort("f"), .customLong("ed-key-file")], help: ArgumentHelp("Path to the file containing the private EdDSA (ed25519) key. '-' can be used to echo the EdDSA key from a 'secret' environment variable to the standard input stream. For example: echo \"$PRIVATE_KEY_SECRET\" | ./\(programName) --ed-key-file -", valueName: "private-key-file"))
     var privateKeyFile: String?
     
+    @Flag(name: .customShort("p"), help: ArgumentHelp("Only prints the signature when signing an update."))
+    var printOnlySignature: Bool = false
+    
     @Argument(help: "The update archive, delta update, or package (pkg) to sign or verify.")
     var updatePath: String
     
@@ -102,7 +105,7 @@ struct SignUpdate: ParsableCommand {
     
     static var configuration: CommandConfiguration = CommandConfiguration(
         abstract: "Sign or verify an update using your EdDSA (ed25519) keys.",
-        discussion: "The EdDSA keys are automatically read from the Keychain if no <private-key-file> is specified.\n\nWhen signing, this tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure.")
+        discussion: "The EdDSA keys are automatically read from the Keychain if no <private-key-file> is specified.\n\nWhen signing, this tool will output an EdDSA signature and length attributes to use for your update's appcast item enclosure. You can use -p to only print the EdDSA signature for automation.")
     
     func validate() throws {
         guard privateKey == nil || privateKeyFile == nil else {
@@ -156,7 +159,12 @@ struct SignUpdate: ParsableCommand {
         } else {
             // Sign the update
             let sig = edSignature(data: data, publicEdKey: pub, privateEdKey: priv)
-            print("sparkle:edSignature=\"\(sig)\" length=\"\(data.count)\"")
+            
+            if printOnlySignature {
+                print(sig)
+            } else {
+                print("sparkle:edSignature=\"\(sig)\" length=\"\(data.count)\"")
+            }
         }
     }
 }

--- a/sign_update/main.swift
+++ b/sign_update/main.swift
@@ -115,6 +115,10 @@ struct SignUpdate: ParsableCommand {
         guard !verify || verifySignature != nil else {
             throw ValidationError("<verify-signature> must be passed as a second argument after <update-path> if --verify is passed.")
         }
+        
+        guard !verify || !printOnlySignature else {
+            throw ValidationError("Both --verify and -p options cannot be provided.")
+        }
     }
     
     func run() throws {


### PR DESCRIPTION
Related to discussion https://github.com/sparkle-project/Sparkle/discussions/2263

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running sign_update with and without -p option.
Validated -p and --verify options cannot be passed together.

macOS version tested: 12.5.1 (21G83)
