### PR TITLE
Add zh_HK (Chinese, Hong Kong) localization

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -923,6 +923,10 @@
 		149B78641B7D3A4800D7D62C /* ConfigUnitTestCoverage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigUnitTestCoverage.xcconfig; sourceTree = "<group>"; };
 		1EAA4C8A2132C7BF00604473 /* ReleaseNotesColorStyle.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = ReleaseNotesColorStyle.css; sourceTree = "<group>"; };
 		3772FEA813DE0B6B00F79537 /* SUVersionDisplayProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUVersionDisplayProtocol.h; sourceTree = "<group>"; };
+		37A5F28528E9219000891504 /* zh_HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh_HK; path = zh_HK.lproj/Sparkle.strings; sourceTree = "<group>"; };
+		37A5F28628E9219000891504 /* zh_HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh_HK; path = zh_HK.lproj/SUUpdatePermissionPrompt.strings; sourceTree = "<group>"; };
+		37A5F28728E9219000891504 /* zh_HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh_HK; path = zh_HK.lproj/SUUpdateAlert.strings; sourceTree = "<group>"; };
+		37A5F28828E9219000891504 /* zh_HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh_HK; path = zh_HK.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		4607BEA21948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		525A278F133D6AE900FD8D70 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		555CF29A196C52330000B31E /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Sparkle.strings; sourceTree = "<group>"; };
@@ -3051,6 +3055,7 @@
 				Base,
 				hr,
 				fa,
+				zh_HK,
 			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* Sparkle */;
 			packageReferences = (
@@ -3891,6 +3896,7 @@
 				726FD2CC25F4BE5F00123BC6 /* fa */,
 				F67C9B7B281410B600740813 /* hu */,
 				F6E11510281410D10003736C /* ar */,
+				37A5F28528E9219000891504 /* zh_HK */,
 			);
 			name = Sparkle.strings;
 			sourceTree = "<group>";
@@ -3931,6 +3937,7 @@
 				723ABD69259A9C6600BDB4FA /* uk */,
 				72E1DAB625B3E8AE0001BA6D /* hr */,
 				F67C9B7C281410B600740813 /* hu */,
+				37A5F28728E9219000891504 /* zh_HK */,
 			);
 			name = SUUpdateAlert.xib;
 			sourceTree = "<group>";
@@ -3969,6 +3976,7 @@
 				723ABD9F259A9D6000BDB4FA /* tr */,
 				723ABDA0259A9D6300BDB4FA /* uk */,
 				72E1DAB525B3E8AE0001BA6D /* hr */,
+				37A5F28628E9219000891504 /* zh_HK */,
 			);
 			name = SUUpdatePermissionPrompt.xib;
 			sourceTree = "<group>";
@@ -4018,6 +4026,7 @@
 				723ABE39259A9F2E00BDB4FA /* uk */,
 				72E1DAB725B3E8AE0001BA6D /* hr */,
 				726FD2CB25F4BE5F00123BC6 /* fa */,
+				37A5F28828E9219000891504 /* zh_HK */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";

--- a/Sparkle/zh_HK.lproj/SUUpdateAlert.strings
+++ b/Sparkle/zh_HK.lproj/SUUpdateAlert.strings
@@ -1,0 +1,17 @@
+/* Class = "NSWindow"; title = "Software Update"; ObjectID = "5"; */
+"5.title" = "軟體更新";
+
+/* Class = "NSTextFieldCell"; title = "Release Notes:"; ObjectID = "170"; */
+"170.title" = "更新事項：";
+
+/* Class = "NSButtonCell"; title = "Remind Me Later"; ObjectID = "171"; */
+"171.title" = "稍後提醒我";
+
+/* Class = "NSButtonCell"; title = "Skip This Version"; ObjectID = "172"; */
+"172.title" = "跳過此版本";
+
+/* Class = "NSButtonCell"; title = "Install Update"; ObjectID = "173"; */
+"173.title" = "安裝更新";
+
+/* Class = "NSButtonCell"; title = "Automatically download and install updates in the future"; ObjectID = "175"; */
+"175.title" = "以後自動下載並安裝更新";

--- a/Sparkle/zh_HK.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/zh_HK.lproj/SUUpdatePermissionPrompt.strings
@@ -1,0 +1,20 @@
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "43"; */
+"43.title" = "Text Cell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "45"; */
+"45.title" = "Text Cell";
+
+/* Class = "NSTextFieldCell"; title = "Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.\n\nThis is the information that would be sent:"; ObjectID = "183"; */
+"183.title" = "匿名系統概況資訊可用來協助我等計畫未來開發工作。若對此有任何疑問，請聯繫我等。\n\n以下係會傳送嘅資訊：";
+
+/* Class = "NSButtonCell"; title = "Don’t Check"; ObjectID = "cCJ-V0-aTi"; */
+"cCJ-V0-aTi.title" = "毋檢查";
+
+/* Class = "NSTextFieldCell"; title = "Check for updates automatically?"; ObjectID = "gmh-T4-BO0"; */
+"gmh-T4-BO0.title" = "自動檢查更新？";
+
+/* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
+"gz7-LM-gNf.title" = "包含匿名系統概況";
+
+/* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
+"OhZ-1K-DmA.title" = "自動檢查";

--- a/Sparkle/zh_HK.lproj/Sparkle.strings
+++ b/Sparkle/zh_HK.lproj/Sparkle.strings
@@ -1,0 +1,152 @@
+/* Description text for SUUpdateAlert when the critical update has already been downloaded and ready to install. */
+"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ 已下載並可供使用！此爲重要更新，是否立即安裝並重新啓動 %1$@？";
+
+/* Description text for SUUpdateAlert when the update has already been downloaded and ready to install. */
+"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ 已下載並可供使用！是否立即安裝並重新啓動 %1$@？";
+
+/* No comment provided by engineer. */
+"%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@." = "%1$@ %2$@ 現已可供下載，但你嘅 macOS 版本過新以致無法安裝。此更新僅支援至 macOS %3$@。";
+
+/* No comment provided by engineer. */
+"%1$@ %2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required." = "%1$@ %2$@ 現已可供下載，但你嘅 macOS 版本過舊以致無法安裝。最低版本需求爲 macOS %3$@。";
+
+/* No comment provided by engineer. */
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "如果從下載位置運行 %1$@，則無法進行更新。";
+
+/* No comment provided by engineer. */
+"%1$@ can’t be updated, because it was opened from a read-only or a temporary location." = "無法更新 %1$@，因爲佢運行於一個只讀或臨時位置。";
+
+/* No comment provided by engineer. */
+"%@ %@ is currently the newest version available." = "%1$@ %2$@ 已係目前最新版本。";
+
+/* No comment provided by engineer. */
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ 已係目前最新版本。\n（你正在運行版本係 %3$@。）";
+
+/* Description text for SUUpdateAlert when the critical update is downloadable. */
+"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@ 現已可供下載，你目前版本係 %3$@。此爲重要更新，是否立即下載？";
+
+/* Description text for SUUpdateAlert when the update is downloadable. */
+"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ 現已可供下載，你目前版本係 %3$@。是否立即下載？";
+
+/* Description text for SUUpdateAlert when the update informational with no download. */
+"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ 現已可供下載，你目前版本係 %3$@。要毋要去網站度瞭解更多關於此更新嘅資訊？";
+
+/* The download progress in a unit of bytes, e.g. 100 KB */
+"%@ downloaded" = "%@ 已下載";
+
+/* No comment provided by engineer. */
+"%@ is now updated to version %@!" = "%1$@ 已更新至版本 %2$@！";
+
+/* No comment provided by engineer. */
+"%@ is now updated!" = "%@ 已完成更新！";
+
+/* The download progress in units of bytes, e.g. 100 KB of 1,0 MB */
+"%@ of %@" = "%1$@ / %2$@";
+
+/* No comment provided by engineer. */
+"A new version of %@ is available!" = "新版本 %@ 已可供下載！";
+
+/* No comment provided by engineer. */
+"A new version of %@ is ready to install!" = "新版本 %@ 已可供安裝！";
+
+/* No comment provided by engineer. */
+"An error occurred in retrieving update information. Please try again later." = "擷取更新資訊時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An error occurred while connecting to the installer. Please try again later." = "連線到安裝程式時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An error occurred while downloading the update. Please try again later." = "下載更新時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An error occurred while extracting the archive. Please try again later." = "解壓縮時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An error occurred while launching the installer. Please try again later." = "啓動安裝程式時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An error occurred while parsing the update feed." = "剖析更新摘要時發生錯誤。";
+
+/* No comment provided by engineer. */
+"An error occurred while running the updater. Please try again later." = "執行更新程式時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An error occurred while starting the installer. Please try again later." = "啓動安裝程式時發生錯誤。請稍後再試。";
+
+/* No comment provided by engineer. */
+"An important update to %@ is ready to install" = " %@ 重要更新已可供安裝";
+
+/* No comment provided by engineer. */
+"Cancel" = "取消";
+
+/* No comment provided by engineer. */
+"Cancel Update" = "取消更新";
+
+/* No comment provided by engineer. */
+"Checking for updates…" = "檢查緊更新⋯";
+
+/* Take care not to overflow the status window. */
+"Downloading update…" = "下載緊更新⋯";
+
+/* Take care not to overflow the status window. */
+"Extracting update…" = "解壓緊更新⋯";
+
+/* No comment provided by engineer. */
+"Failed to resume installing update." = "嘗試繼續安裝更新失敗。";
+
+/* No comment provided by engineer. */
+"Install and Relaunch" = "安裝並重新啓動";
+
+/* Alternate title for 'Remind Me Later' button when downloaded updates can be resumed */
+"Install on Quit" = "結束時安裝";
+
+/* Take care not to overflow the status window. */
+"Installing update…" = "安裝緊更新⋯";
+
+/* Alternate title for 'Install Update' button when there's no download in RSS feed. */
+"Learn More…" = "瞭解更多⋯";
+
+/* No comment provided by engineer. */
+"OK" = "好";
+
+/* No comment provided by engineer. */
+"Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "請結束 %1$@ 並將其移至「應用程式」檔案夾，從該處重新啓動後再試。";
+
+/* No comment provided by engineer. */
+"Ready to Install" = "已可供安裝";
+
+/* No comment provided by engineer. */
+"Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "%1$@ 是否應自動檢查更新？你可隨時從 %1$@ 選單手動檢查更新。";
+
+/* No comment provided by engineer. */
+"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "更新檢查程式未能正確啓動。你應聯絡軟體開發者以回報此問題並驗證你是否已有最新版本。";
+
+/* No comment provided by engineer. */
+"The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "此更新並未正確簽署且無法驗證。請稍後再試或聯絡軟體開發者。";
+
+/* No comment provided by engineer. */
+"Unable to Check For Updates" = "無法檢查更新";
+
+/* No comment provided by engineer. */
+"Update Error!" = "更新發生錯誤！";
+
+/* No comment provided by engineer. */
+"Update Installed" = "已安裝更新";
+
+/* No comment provided by engineer. */
+"Updating %@" = "更新緊 %@";
+
+/* No comment provided by engineer. */
+"Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "請將 %1$@ 複製至「應用程式」檔案夾，從該處重新啓動後再試。";
+
+/* No comment provided by engineer. */
+"Version History" = "版本歷史";
+
+/* No comment provided by engineer. */
+"Your macOS version is too new" = "你 macOS 版本過新";
+
+/* No comment provided by engineer. */
+"Your macOS version is too old" = "你 macOS 版本過舊";
+
+/* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
+"You’re up-to-date!" = "你用緊最新版本！";

--- a/TestApplication/zh_HK.lproj/MainMenu.strings
+++ b/TestApplication/zh_HK.lproj/MainMenu.strings
@@ -1,0 +1,162 @@
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
+"5.title" = "Bring All to Front";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "19"; */
+"19.title" = "Window";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "23"; */
+"23.title" = "Minimize";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
+"24.title" = "Window";
+
+/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
+"29.title" = "MainMenu";
+
+/* Class = "NSMenuItem"; title = "Sparkle Test App"; ObjectID = "56"; */
+"56.title" = "Sparkle Test App";
+
+/* Class = "NSMenu"; title = "Sparkle Test App"; ObjectID = "57"; */
+"57.title" = "Sparkle Test App";
+
+/* Class = "NSMenuItem"; title = "About Sparkle Test App"; ObjectID = "58"; */
+"58.title" = "About Sparkle Test App";
+
+/* Class = "NSMenuItem"; title = "Open..."; ObjectID = "72"; */
+"72.title" = "Open...";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "73"; */
+"73.title" = "Close";
+
+/* Class = "NSMenuItem"; title = "Save"; ObjectID = "75"; */
+"75.title" = "Save";
+
+/* Class = "NSMenuItem"; title = "Page Setup…"; ObjectID = "77"; */
+"77.title" = "Page Setup…";
+
+/* Class = "NSMenuItem"; title = "Print…"; ObjectID = "78"; */
+"78.title" = "Print…";
+
+/* Class = "NSMenuItem"; title = "Save As…"; ObjectID = "80"; */
+"80.title" = "Save As…";
+
+/* Class = "NSMenu"; title = "File"; ObjectID = "81"; */
+"81.title" = "File";
+
+/* Class = "NSMenuItem"; title = "New"; ObjectID = "82"; */
+"82.title" = "New";
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "83"; */
+"83.title" = "File";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "103"; */
+"103.title" = "Help";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "106"; */
+"106.title" = "Help";
+
+/* Class = "NSMenuItem"; title = "Sparkle Test App Help"; ObjectID = "111"; */
+"111.title" = "Sparkle Test App Help";
+
+/* Class = "NSMenuItem"; title = "Revert"; ObjectID = "112"; */
+"112.title" = "Revert";
+
+/* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "124"; */
+"124.title" = "Open Recent";
+
+/* Class = "NSMenu"; title = "Open Recent"; ObjectID = "125"; */
+"125.title" = "Open Recent";
+
+/* Class = "NSMenuItem"; title = "Clear Menu"; ObjectID = "126"; */
+"126.title" = "Clear Menu";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "130"; */
+"130.title" = "Services";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "131"; */
+"131.title" = "Services";
+
+/* Class = "NSMenuItem"; title = "Hide Sparkle Test App"; ObjectID = "134"; */
+"134.title" = "Hide Sparkle Test App";
+
+/* Class = "NSMenuItem"; title = "Quit Sparkle Test App"; ObjectID = "136"; */
+"136.title" = "Quit Sparkle Test App";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "145"; */
+"145.title" = "Hide Others";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "150"; */
+"150.title" = "Show All";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "154"; */
+"154.title" = "Find…";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "155"; */
+"155.title" = "Jump to Selection";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "157"; */
+"157.title" = "Copy";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "158"; */
+"158.title" = "Undo";
+
+/* Class = "NSMenu"; title = "Find"; ObjectID = "159"; */
+"159.title" = "Find";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "160"; */
+"160.title" = "Cut";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "161"; */
+"161.title" = "Use Selection for Find";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "162"; */
+"162.title" = "Find Previous";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "163"; */
+"163.title" = "Edit";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "164"; */
+"164.title" = "Delete";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "167"; */
+"167.title" = "Find Next";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "168"; */
+"168.title" = "Find";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "169"; */
+"169.title" = "Edit";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "171"; */
+"171.title" = "Paste";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "172"; */
+"172.title" = "Select All";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
+"173.title" = "Redo";
+
+/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "184"; */
+"184.title" = "Spelling";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "185"; */
+"185.title" = "Spelling";
+
+/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "187"; */
+"187.title" = "Spelling…";
+
+/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "189"; */
+"189.title" = "Check Spelling";
+
+/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "191"; */
+"191.title" = "Check Spelling as You Type";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "197"; */
+"197.title" = "Zoom";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "204"; */
+"204.title" = "Paste and Match Style";
+
+/* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "207"; */
+"207.title" = "Check for Updates…";


### PR DESCRIPTION
Add zh_HK (Chinese, Hong Kong) localization.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: 12.6
