### PR TITLE
Ask permission for automatically downloading and installing new updates

### DIFF
--- a/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
@@ -276,11 +276,11 @@ Gw
             <point key="canvasLocation" x="-291" y="554"/>
         </customView>
         <customView id="ov1-yV-Uol" userLabel="Anonymous Info View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="27"/>
+            <rect key="frame" x="0.0" y="0.0" width="437" height="25"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="a0k-dW-Jhx" userLabel="View">
-                    <rect key="frame" x="0.0" y="-26" width="437" height="66"/>
+                    <rect key="frame" x="0.0" y="-26" width="437" height="64"/>
                     <subviews>
                         <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="a90-Iq-FgS" userLabel="IncludeInfoButton">
                             <rect key="frame" x="104" y="25" width="200" height="16"/>
@@ -324,7 +324,7 @@ Gw
                         <constraint firstItem="JW6-0z-Ud3" firstAttribute="leading" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="85" id="6Y1-s7-g6r"/>
                         <constraint firstItem="a90-Iq-FgS" firstAttribute="centerY" secondItem="JW6-0z-Ud3" secondAttribute="centerY" id="BNJ-xV-faQ"/>
                         <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="105" id="ILg-Qu-R6M"/>
-                        <constraint firstItem="a90-Iq-FgS" firstAttribute="top" secondItem="a0k-dW-Jhx" secondAttribute="top" constant="26" id="Mh6-5L-xqM"/>
+                        <constraint firstItem="a90-Iq-FgS" firstAttribute="top" secondItem="a0k-dW-Jhx" secondAttribute="top" constant="24" id="Mh6-5L-xqM"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="a90-Iq-FgS" secondAttribute="trailing" constant="20" id="U4G-Eh-HPu"/>
                         <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="JW6-0z-Ud3" secondAttribute="trailing" constant="4" id="axA-s0-uGg"/>
                         <constraint firstAttribute="width" constant="437" id="iUc-Zs-h9S"/>
@@ -341,11 +341,11 @@ Gw
             <point key="canvasLocation" x="-135.5" y="242.5"/>
         </customView>
         <customView id="37T-Ef-DtX" userLabel="Automatic Download View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="27"/>
+            <rect key="frame" x="0.0" y="0.0" width="437" height="25"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="MEW-2n-kJE" userLabel="View">
-                    <rect key="frame" x="0.0" y="-26" width="437" height="66"/>
+                    <rect key="frame" x="0.0" y="-26" width="437" height="64"/>
                     <subviews>
                         <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="BId-kb-eYW" userLabel="automaticallyDownloadUpdatesButton">
                             <rect key="frame" x="104" y="25" width="248" height="16"/>
@@ -365,7 +365,7 @@ Gw
                         <constraint firstItem="BId-kb-eYW" firstAttribute="leading" secondItem="MEW-2n-kJE" secondAttribute="leading" constant="105" id="MnW-AM-QzP"/>
                         <constraint firstAttribute="bottom" secondItem="BId-kb-eYW" secondAttribute="bottom" constant="26" id="QXK-90-kUJ"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BId-kb-eYW" secondAttribute="trailing" constant="20" id="Vk3-CH-cXd"/>
-                        <constraint firstItem="BId-kb-eYW" firstAttribute="top" secondItem="MEW-2n-kJE" secondAttribute="top" constant="26" id="YrX-aL-LAq"/>
+                        <constraint firstItem="BId-kb-eYW" firstAttribute="top" secondItem="MEW-2n-kJE" secondAttribute="top" constant="24" id="YrX-aL-LAq"/>
                         <constraint firstAttribute="width" constant="437" id="n4W-Z4-w9i"/>
                     </constraints>
                 </customView>

--- a/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
                 <outlet property="anonymousInfoDisclosureButton" destination="JW6-0z-Ud3" id="8Ac-kJ-T5e"/>
+                <outlet property="automaticallyDownloadUpdatesView" destination="37T-Ef-DtX" id="7VP-FF-3iP"/>
                 <outlet property="cancelButton" destination="cFC-wV-H3j" id="L2P-Ux-4Vn"/>
                 <outlet property="checkButton" destination="sMh-ha-r7R" id="2O6-G4-etk"/>
                 <outlet property="infoChoiceView" destination="ov1-yV-Uol" id="A1X-Y9-Hnh"/>
@@ -282,10 +283,9 @@ Gw
                     <rect key="frame" x="0.0" y="-26" width="437" height="66"/>
                     <subviews>
                         <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="a90-Iq-FgS" userLabel="IncludeInfoButton">
-                            <rect key="frame" x="104" y="25" width="313" height="16"/>
+                            <rect key="frame" x="104" y="25" width="200" height="16"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="14" id="MvK-K5-kxt"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="STF-87-eYy"/>
+                                <constraint firstAttribute="height" constant="14" id="STF-87-eYy"/>
                             </constraints>
                             <buttonCell key="cell" type="check" title="Include anonymous system profile" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" focusRingType="none" inset="2" id="gz7-LM-gNf">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -321,12 +321,12 @@ Gw
                         </button>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="JW6-0z-Ud3" firstAttribute="leading" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="85" id="6Y1-s7-g6r"/>
                         <constraint firstItem="a90-Iq-FgS" firstAttribute="centerY" secondItem="JW6-0z-Ud3" secondAttribute="centerY" id="BNJ-xV-faQ"/>
                         <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="105" id="ILg-Qu-R6M"/>
                         <constraint firstItem="a90-Iq-FgS" firstAttribute="top" secondItem="a0k-dW-Jhx" secondAttribute="top" constant="26" id="Mh6-5L-xqM"/>
-                        <constraint firstAttribute="trailing" secondItem="a90-Iq-FgS" secondAttribute="trailing" constant="20" id="U4G-Eh-HPu"/>
-                        <constraint firstItem="JW6-0z-Ud3" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="20" symbolic="YES" id="V3P-iz-aJ9"/>
-                        <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" secondItem="JW6-0z-Ud3" secondAttribute="trailing" constant="4" id="axA-s0-uGg"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="a90-Iq-FgS" secondAttribute="trailing" constant="20" id="U4G-Eh-HPu"/>
+                        <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="JW6-0z-Ud3" secondAttribute="trailing" constant="4" id="axA-s0-uGg"/>
                         <constraint firstAttribute="width" constant="437" id="iUc-Zs-h9S"/>
                         <constraint firstAttribute="bottom" secondItem="a90-Iq-FgS" secondAttribute="bottom" constant="26" id="qij-uH-6Yl"/>
                     </constraints>
@@ -338,7 +338,45 @@ Gw
                 <constraint firstAttribute="trailing" secondItem="a0k-dW-Jhx" secondAttribute="trailing" id="rAn-bJ-Mp6"/>
                 <constraint firstAttribute="bottom" secondItem="a0k-dW-Jhx" secondAttribute="bottom" constant="-26" id="xw5-bj-VOd"/>
             </constraints>
-            <point key="canvasLocation" x="-113" y="145.5"/>
+            <point key="canvasLocation" x="-135.5" y="242.5"/>
+        </customView>
+        <customView id="37T-Ef-DtX" userLabel="Automatic Download View">
+            <rect key="frame" x="0.0" y="0.0" width="437" height="27"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="MEW-2n-kJE" userLabel="View">
+                    <rect key="frame" x="0.0" y="-26" width="437" height="66"/>
+                    <subviews>
+                        <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="BId-kb-eYW" userLabel="automaticallyDownloadUpdatesButton">
+                            <rect key="frame" x="104" y="25" width="248" height="16"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="14" id="kJy-g7-0Un"/>
+                            </constraints>
+                            <buttonCell key="cell" type="check" title="Automatically download and install updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" focusRingType="none" inset="2" id="AUc-33-qGN">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="smallSystem"/>
+                            </buttonCell>
+                            <connections>
+                                <binding destination="-2" name="value" keyPath="self.automaticallyDownloadUpdates" id="V01-B1-yEx"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="BId-kb-eYW" firstAttribute="leading" secondItem="MEW-2n-kJE" secondAttribute="leading" constant="105" id="MnW-AM-QzP"/>
+                        <constraint firstAttribute="bottom" secondItem="BId-kb-eYW" secondAttribute="bottom" constant="26" id="QXK-90-kUJ"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BId-kb-eYW" secondAttribute="trailing" constant="20" id="Vk3-CH-cXd"/>
+                        <constraint firstItem="BId-kb-eYW" firstAttribute="top" secondItem="MEW-2n-kJE" secondAttribute="top" constant="26" id="YrX-aL-LAq"/>
+                        <constraint firstAttribute="width" constant="437" id="n4W-Z4-w9i"/>
+                    </constraints>
+                </customView>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="MEW-2n-kJE" secondAttribute="bottom" constant="-26" id="4iq-ZN-n9x"/>
+                <constraint firstItem="MEW-2n-kJE" firstAttribute="top" secondItem="37T-Ef-DtX" secondAttribute="top" constant="-13" id="FCe-KY-rHW"/>
+                <constraint firstItem="MEW-2n-kJE" firstAttribute="leading" secondItem="37T-Ef-DtX" secondAttribute="leading" id="dsv-fP-ffg"/>
+                <constraint firstAttribute="trailing" secondItem="MEW-2n-kJE" secondAttribute="trailing" id="puT-Df-xgH"/>
+            </constraints>
+            <point key="canvasLocation" x="-136" y="181"/>
         </customView>
         <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AGr-V0-0al" userLabel="Placeholder View">
             <rect key="frame" x="0.0" y="0.0" width="437" height="205"/>

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -206,6 +206,10 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  By default, updates are not automatically downloaded.
  
+ By default starting from Sparkle 2.4, users are provided an option to opt in to automatically downloading and installing updates when they are asked if they want automatic update checks enabled.
+ The default value for this option is based on what the developer sets `SUAutomaticallyUpdate` in their Info.plist.
+ This is not done if `SUEnableAutomaticChecks` is set in the Info.plist however. Please check `automaticallyChecksForUpdates` property for more details.
+ 
  Note that the developer can disallow automatic downloading of updates from being enabled (via `SUAllowsAutomaticUpdates` Info.plist key).
  In this case, this property will return NO regardless of how this property is set.
  

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -427,9 +427,9 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     [self setSendsSystemProfile:response.sendSystemProfile];
     [self setAutomaticallyChecksForUpdates:response.automaticUpdateChecks];
     
-    NSNumber *automaticallyDownloadUpdates = response.automaticallyDownloadUpdates;
-    if (automaticallyDownloadUpdates != nil) {
-        [self setAutomaticallyDownloadsUpdates:automaticallyDownloadUpdates.boolValue];
+    NSNumber *automaticUpdateDownloading = response.automaticUpdateDownloading;
+    if (automaticUpdateDownloading != nil) {
+        [self setAutomaticallyDownloadsUpdates:automaticUpdateDownloading.boolValue];
     }
 }
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -426,6 +426,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 {
     [self setSendsSystemProfile:response.sendSystemProfile];
     [self setAutomaticallyChecksForUpdates:response.automaticUpdateChecks];
+    
+    NSNumber *automaticallyDownloadUpdates = response.automaticallyDownloadUpdates;
+    if (automaticallyDownloadUpdates != nil) {
+        [self setAutomaticallyDownloadsUpdates:automaticallyDownloadUpdates.boolValue];
+    }
 }
 
 - (NSDate *)lastUpdateCheckDate

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -161,14 +161,16 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (IBAction)finishPrompt:(NSButton *)sender
 {
+    BOOL automaticUpdateChecksEnabled = ([sender tag] == 1);
+    
     NSNumber *automaticUpdateDownloading;
     if ([self allowsAutomaticUpdates]) {
-        automaticUpdateDownloading = @(self.automaticallyDownloadUpdates);
+        automaticUpdateDownloading = @(automaticUpdateChecksEnabled && self.automaticallyDownloadUpdates);
     } else {
         automaticUpdateDownloading = nil;
     }
     
-    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) automaticUpdateDownloading:automaticUpdateDownloading sendSystemProfile:self.shouldSendProfile];
+    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:automaticUpdateChecksEnabled automaticUpdateDownloading:automaticUpdateDownloading sendSystemProfile:self.shouldSendProfile];
     self.reply(response);
     
     [self close];

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -87,10 +87,10 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     return [(NSNumber *)[self.host objectForInfoDictionaryKey:SUEnableSystemProfilingKey] boolValue];
 }
 
-- (BOOL)allowsAutomaticDownloadingOfUpdates
+- (BOOL)allowsAutomaticUpdates
 {
-    NSNumber *allowsAutomaticDownloadingOfUpdates = [self.host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
-    return (allowsAutomaticDownloadingOfUpdates == nil || allowsAutomaticDownloadingOfUpdates.boolValue);
+    NSNumber *allowsAutomaticUpdates = [self.host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
+    return (allowsAutomaticUpdates == nil || allowsAutomaticUpdates.boolValue);
 }
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], [self.host bundlePath]]; }
@@ -100,7 +100,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     [self.window center];
     
     self.infoChoiceView.hidden = ![self shouldAskAboutProfile];
-    self.automaticallyDownloadUpdatesView.hidden = ![self allowsAutomaticDownloadingOfUpdates];
+    self.automaticallyDownloadUpdatesView.hidden = ![self allowsAutomaticUpdates];
     
     [self.stackView addArrangedSubview:self.promptView];
     [self.stackView addArrangedSubview:self.automaticallyDownloadUpdatesView];
@@ -161,14 +161,14 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (IBAction)finishPrompt:(NSButton *)sender
 {
-    NSNumber *automaticallyDownloadUpdatesResponse;
-    if ([self allowsAutomaticDownloadingOfUpdates]) {
-        automaticallyDownloadUpdatesResponse = @(self.automaticallyDownloadUpdates);
+    NSNumber *automaticUpdateDownloading;
+    if ([self allowsAutomaticUpdates]) {
+        automaticUpdateDownloading = @(self.automaticallyDownloadUpdates);
     } else {
-        automaticallyDownloadUpdatesResponse = nil;
+        automaticUpdateDownloading = nil;
     }
     
-    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) automaticallyDownloadUpdates:automaticallyDownloadUpdatesResponse sendSystemProfile:self.shouldSendProfile];
+    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) automaticUpdateDownloading:automaticUpdateDownloading sendSystemProfile:self.shouldSendProfile];
     self.reply(response);
     
     [self close];

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -23,6 +23,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 @interface SUUpdatePermissionPrompt () <NSTouchBarDelegate>
 
 @property (nonatomic) BOOL shouldSendProfile;
+@property (nonatomic) BOOL automaticallyDownloadUpdates;
 
 @property (nonatomic) SUHost *host;
 @property (nonatomic) NSArray *systemProfileInformationArray;
@@ -33,6 +34,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 @property (nonatomic) IBOutlet NSView *placeholderView;
 @property (nonatomic) IBOutlet NSView *responseView;
 @property (nonatomic) IBOutlet NSView *infoChoiceView;
+@property (nonatomic) IBOutlet NSView *automaticallyDownloadUpdatesView;
 
 @property (nonatomic) IBOutlet NSButton *cancelButton;
 @property (nonatomic) IBOutlet NSButton *checkButton;
@@ -48,6 +50,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 @synthesize reply = _reply;
 @synthesize shouldSendProfile = _shouldSendProfile;
+@synthesize automaticallyDownloadUpdates = _automaticallyDownloadUpdates;
 @synthesize host = _host;
 @synthesize systemProfileInformationArray = _systemProfileInformationArray;
 @synthesize stackView = _stackView;
@@ -56,6 +59,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 @synthesize placeholderView = _placeholderView;
 @synthesize responseView = _responseView;
 @synthesize infoChoiceView = _infoChoiceView;
+@synthesize automaticallyDownloadUpdatesView = _automaticallyDownloadUpdatesView;
 @synthesize cancelButton = _cancelButton;
 @synthesize checkButton = _checkButton;
 @synthesize anonymousInfoDisclosureButton = _anonymousInfoDisclosureButton;
@@ -70,6 +74,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
         _host = theHost;
         _shouldSendProfile = [self shouldAskAboutProfile];
         _systemProfileInformationArray = request.systemProfile;
+        _automaticallyDownloadUpdates = [theHost boolForKey:SUAutomaticallyUpdateKey];
         [self setShouldCascadeWindows:NO];
     } else {
         assert(false);
@@ -82,6 +87,12 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     return [(NSNumber *)[self.host objectForInfoDictionaryKey:SUEnableSystemProfilingKey] boolValue];
 }
 
+- (BOOL)allowsAutomaticDownloadingOfUpdates
+{
+    NSNumber *allowsAutomaticDownloadingOfUpdates = [self.host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
+    return (allowsAutomaticDownloadingOfUpdates == nil || allowsAutomaticDownloadingOfUpdates.boolValue);
+}
+
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], [self.host bundlePath]]; }
 
 - (void)windowDidLoad
@@ -89,8 +100,10 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
     [self.window center];
     
     self.infoChoiceView.hidden = ![self shouldAskAboutProfile];
+    self.automaticallyDownloadUpdatesView.hidden = ![self allowsAutomaticDownloadingOfUpdates];
     
     [self.stackView addArrangedSubview:self.promptView];
+    [self.stackView addArrangedSubview:self.automaticallyDownloadUpdatesView];
     [self.stackView addArrangedSubview:self.infoChoiceView];
     [self.stackView addArrangedSubview:self.placeholderView];
     [self.stackView addArrangedSubview:self.moreInfoView];
@@ -148,7 +161,14 @@ static NSString *const SUUpdatePermissionPromptTouchBarIndentifier = @"" SPARKLE
 
 - (IBAction)finishPrompt:(NSButton *)sender
 {
-    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) sendSystemProfile:self.shouldSendProfile];
+    NSNumber *automaticallyDownloadUpdatesResponse;
+    if ([self allowsAutomaticDownloadingOfUpdates]) {
+        automaticallyDownloadUpdatesResponse = @(self.automaticallyDownloadUpdates);
+    } else {
+        automaticallyDownloadUpdatesResponse = nil;
+    }
+    
+    SUUpdatePermissionResponse *response = [[SUUpdatePermissionResponse alloc] initWithAutomaticUpdateChecks:([sender tag] == 1) automaticallyDownloadUpdates:automaticallyDownloadUpdatesResponse sendSystemProfile:self.shouldSendProfile];
     self.reply(response);
     
     [self close];

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -48,7 +48,7 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
  
  If this property is `nil`, then no user choice was made for this option.
  
- If  `automaticUpdateChecks` is `NO` then this property should not be `@YES`.
+ If  `automaticUpdateChecks` is `NO` then this property should not be `@(YES)`.
  Set it to `NO` if the user was given the choice of automatically downloading and installing updates,
  otherwise set it to `nil`.
  */

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -46,7 +46,11 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
 /**
  A read-only property indicating if updates should be automatically downloaded and installed.
  
- If this property is nil, then no user choice was made for this option.
+ If this property is `nil`, then no user choice was made for this option.
+ 
+ If  `automaticUpdateChecks` is `NO` then this property should not be `@YES`.
+ Set it to `NO` if the user was given the choice of automatically downloading and installing updates,
+ otherwise set it to `nil`.
  */
 @property (nonatomic, readonly, nullable) NSNumber *automaticUpdateDownloading;
 

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -28,10 +28,10 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
  Initializes a new update permission response instance.
  
  @param automaticUpdateChecks Flag to enable automatic update checks.
- @param automaticallyDownloadUpdates Flag to enable automatic downloading and installing of updates. If this is nil, then no response was made for this option.
+ @param automaticUpdateDownloading Flag to enable automatic downloading and installing of updates. If this is nil, this option will be ignored.
  @param sendSystemProfile Flag for if system profile information should be sent to the server hosting the appcast.
  */
-- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks automaticallyDownloadUpdates:(NSNumber * _Nullable)automaticallyDownloadUpdates sendSystemProfile:(BOOL)sendSystemProfile;
+- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks automaticUpdateDownloading:(NSNumber * _Nullable)automaticUpdateDownloading sendSystemProfile:(BOOL)sendSystemProfile;
 
 /*
  Use -initWithAutomaticUpdateChecks:sendSystemProfile: instead.
@@ -39,14 +39,16 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- A read-only property indicating whether automatic update checks are allowed or not.
+ A read-only property indicating if update checks should be done automatically.
  */
 @property (nonatomic, readonly) BOOL automaticUpdateChecks;
 
 /**
- A read-only property indicating whether automatic downloading and installing of updates is on.
+ A read-only property indicating if updates should be automatically downloaded and installed.
+ 
+ If this property is nil, then no user choice was made for this option.
  */
-@property (nonatomic, readonly, nullable) NSNumber *automaticallyDownloadUpdates;
+@property (nonatomic, readonly, nullable) NSNumber *automaticUpdateDownloading;
 
 /**
  A read-only property indicating if system profile should be sent or not.

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import <Sparkle/SUExport.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  This class represents a response for permission to check updates.
 */
@@ -17,10 +19,19 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
 /**
  Initializes a new update permission response instance.
  
- @param automaticUpdateChecks Flag for whether to allow automatic update checks.
+ @param automaticUpdateChecks Flag to enable automatic update checks.
  @param sendSystemProfile Flag for if system profile information should be sent to the server hosting the appcast.
  */
 - (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks sendSystemProfile:(BOOL)sendSystemProfile;
+
+/**
+ Initializes a new update permission response instance.
+ 
+ @param automaticUpdateChecks Flag to enable automatic update checks.
+ @param automaticallyDownloadUpdates Flag to enable automatic downloading and installing of updates. If this is nil, then no response was made for this option.
+ @param sendSystemProfile Flag for if system profile information should be sent to the server hosting the appcast.
+ */
+- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks automaticallyDownloadUpdates:(NSNumber * _Nullable)automaticallyDownloadUpdates sendSystemProfile:(BOOL)sendSystemProfile;
 
 /*
  Use -initWithAutomaticUpdateChecks:sendSystemProfile: instead.
@@ -33,8 +44,15 @@ SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
 @property (nonatomic, readonly) BOOL automaticUpdateChecks;
 
 /**
+ A read-only property indicating whether automatic downloading and installing of updates is on.
+ */
+@property (nonatomic, readonly, nullable) NSNumber *automaticallyDownloadUpdates;
+
+/**
  A read-only property indicating if system profile should be sent or not.
  */
 @property (nonatomic, readonly) BOOL sendSystemProfile;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SUUpdatePermissionResponse.m
+++ b/Sparkle/SUUpdatePermissionResponse.m
@@ -12,14 +12,14 @@
 #include "AppKitPrevention.h"
 
 static NSString *SUUpdatePermissionAutomaticUpdateChecksKey = @"SUUpdatePermissionAutomaticUpdateChecks";
-static NSString *SUUpdatePermissionAutomaticDownloadingUpdatesKey = @"SUUpdatePermissionAutomaticDownloadingUpdates";
+static NSString *SUUpdatePermissionAutomaticUpdateDownloadingKey = @"SUUpdatePermissionAutomaticUpdateDownloading";
 static NSString *SUUpdatePermissionSendSystemProfileKey = @"SUUpdatePermissionSendSystemProfile";
 
 @implementation SUUpdatePermissionResponse
 
 @synthesize automaticUpdateChecks = _automaticUpdateChecks;
 @synthesize sendSystemProfile = _sendSystemProfile;
-@synthesize automaticallyDownloadUpdates = _automaticallyDownloadUpdates;
+@synthesize automaticUpdateDownloading = _automaticUpdateDownloading;
 
 + (BOOL)supportsSecureCoding
 {
@@ -29,28 +29,28 @@ static NSString *SUUpdatePermissionSendSystemProfileKey = @"SUUpdatePermissionSe
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     BOOL automaticUpdateChecks = [decoder decodeBoolForKey:SUUpdatePermissionAutomaticUpdateChecksKey];
-    NSNumber *automaticallyDownloadUpdates = [decoder decodeObjectOfClass:[NSNumber class] forKey:SUUpdatePermissionAutomaticDownloadingUpdatesKey];
+    NSNumber *automaticUpdateDownloading = [decoder decodeObjectOfClass:[NSNumber class] forKey:SUUpdatePermissionAutomaticUpdateDownloadingKey];
     BOOL sendSystemProfile = [decoder decodeBoolForKey:SUUpdatePermissionSendSystemProfileKey];
-    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks automaticallyDownloadUpdates:automaticallyDownloadUpdates sendSystemProfile:sendSystemProfile];
+    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks automaticUpdateDownloading:automaticUpdateDownloading sendSystemProfile:sendSystemProfile];
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
     [encoder encodeBool:self.automaticUpdateChecks forKey:SUUpdatePermissionAutomaticUpdateChecksKey];
     
-    if (self.automaticallyDownloadUpdates != nil) {
-        [encoder encodeObject:self.automaticallyDownloadUpdates forKey:SUUpdatePermissionAutomaticDownloadingUpdatesKey];
+    if (self.automaticUpdateDownloading != nil) {
+        [encoder encodeObject:self.automaticUpdateDownloading forKey:SUUpdatePermissionAutomaticUpdateDownloadingKey];
     }
     
     [encoder encodeBool:self.sendSystemProfile forKey:SUUpdatePermissionSendSystemProfileKey];
 }
 
-- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks automaticallyDownloadUpdates:(NSNumber * _Nullable)automaticallyDownloadUpdates sendSystemProfile:(BOOL)sendSystemProfile
+- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks automaticUpdateDownloading:(NSNumber * _Nullable)automaticUpdateDownloading sendSystemProfile:(BOOL)sendSystemProfile
 {
     self = [super init];
     if (self != nil) {
         _automaticUpdateChecks = automaticUpdateChecks;
-        _automaticallyDownloadUpdates = automaticallyDownloadUpdates;
+        _automaticUpdateDownloading = automaticUpdateDownloading;
         _sendSystemProfile = sendSystemProfile;
     }
     return self;
@@ -58,7 +58,7 @@ static NSString *SUUpdatePermissionSendSystemProfileKey = @"SUUpdatePermissionSe
 
 - (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks sendSystemProfile:(BOOL)sendSystemProfile
 {
-    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks automaticallyDownloadUpdates:nil sendSystemProfile:sendSystemProfile];
+    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks automaticUpdateDownloading:nil sendSystemProfile:sendSystemProfile];
 }
 
 @end

--- a/Sparkle/SUUpdatePermissionResponse.m
+++ b/Sparkle/SUUpdatePermissionResponse.m
@@ -12,12 +12,14 @@
 #include "AppKitPrevention.h"
 
 static NSString *SUUpdatePermissionAutomaticUpdateChecksKey = @"SUUpdatePermissionAutomaticUpdateChecks";
+static NSString *SUUpdatePermissionAutomaticDownloadingUpdatesKey = @"SUUpdatePermissionAutomaticDownloadingUpdates";
 static NSString *SUUpdatePermissionSendSystemProfileKey = @"SUUpdatePermissionSendSystemProfile";
 
 @implementation SUUpdatePermissionResponse
 
 @synthesize automaticUpdateChecks = _automaticUpdateChecks;
 @synthesize sendSystemProfile = _sendSystemProfile;
+@synthesize automaticallyDownloadUpdates = _automaticallyDownloadUpdates;
 
 + (BOOL)supportsSecureCoding
 {
@@ -27,24 +29,36 @@ static NSString *SUUpdatePermissionSendSystemProfileKey = @"SUUpdatePermissionSe
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
     BOOL automaticUpdateChecks = [decoder decodeBoolForKey:SUUpdatePermissionAutomaticUpdateChecksKey];
+    NSNumber *automaticallyDownloadUpdates = [decoder decodeObjectOfClass:[NSNumber class] forKey:SUUpdatePermissionAutomaticDownloadingUpdatesKey];
     BOOL sendSystemProfile = [decoder decodeBoolForKey:SUUpdatePermissionSendSystemProfileKey];
-    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks sendSystemProfile:sendSystemProfile];
+    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks automaticallyDownloadUpdates:automaticallyDownloadUpdates sendSystemProfile:sendSystemProfile];
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder
 {
     [encoder encodeBool:self.automaticUpdateChecks forKey:SUUpdatePermissionAutomaticUpdateChecksKey];
+    
+    if (self.automaticallyDownloadUpdates != nil) {
+        [encoder encodeObject:self.automaticallyDownloadUpdates forKey:SUUpdatePermissionAutomaticDownloadingUpdatesKey];
+    }
+    
     [encoder encodeBool:self.sendSystemProfile forKey:SUUpdatePermissionSendSystemProfileKey];
 }
 
-- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks sendSystemProfile:(BOOL)sendSystemProfile
+- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks automaticallyDownloadUpdates:(NSNumber * _Nullable)automaticallyDownloadUpdates sendSystemProfile:(BOOL)sendSystemProfile
 {
     self = [super init];
     if (self != nil) {
         _automaticUpdateChecks = automaticUpdateChecks;
+        _automaticallyDownloadUpdates = automaticallyDownloadUpdates;
         _sendSystemProfile = sendSystemProfile;
     }
     return self;
+}
+
+- (instancetype)initWithAutomaticUpdateChecks:(BOOL)automaticUpdateChecks sendSystemProfile:(BOOL)sendSystemProfile
+{
+    return [self initWithAutomaticUpdateChecks:automaticUpdateChecks automaticallyDownloadUpdates:nil sendSystemProfile:sendSystemProfile];
 }
 
 @end

--- a/Sparkle/ar.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/ar.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "تضمين تقرير عن النظام دون ذكر معلومات عن المستخدم";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "تنزيل التحديثات وتثبيتها تلقائيًا في المست";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "التحقق تلقائيًا";

--- a/Sparkle/cs.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/cs.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Odeslat anonymní systémový profil";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Stahovat a instalovat aktualizace automaticky";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Automaticky vyhledávat";

--- a/Sparkle/da.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/da.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Vedhæft anonym systemprofil";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Hent og installer opdateringer automatisk";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Søg automatisk";

--- a/Sparkle/de.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/de.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Anonymisiertes Systemprofil übertragen";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Updates automatisch laden und installieren";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Automatisch suchen";

--- a/Sparkle/el.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/el.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Συμπερίληψη του ανώνυμου προφίλ του συστήματός σας";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Αυτόματη λήψη και εγκατάσταση ενημερώσεων";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Αυτόματος Ελεγχος";

--- a/Sparkle/en.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/en.lproj/SUUpdatePermissionPrompt.strings
@@ -20,5 +20,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "180"; */
 "gz7-LM-gNf.title" = "Include anonymous system profile";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Automatically download and install updates";
+
 /* Class = "NSTextFieldCell"; title = "Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.\n\nThis is the information that would be sent:"; ObjectID = "183"; */
 "183.title" = "Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.\n\nThis is the information that would be sent:";

--- a/Sparkle/es.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/es.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Incluir perfil de sistema anónimo";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Descargar e instalar actualizaciones automáticamente";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Comprobar automáticamente";

--- a/Sparkle/fi.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/fi.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Sisällytä nimetön järjestelmäprofiili";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Hae ja asenna päivitykset automaattisesti";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Tarkista automaattisesti";

--- a/Sparkle/fr.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/fr.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Avec transmission anonyme de mon profil système";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Télécharger et installer automatiquement les mises à jour";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Vérifier automatiquement";

--- a/Sparkle/hr.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/hr.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Uključi anonimizirane podatke o profilu sustava";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Preuzmi i instaliraj nadogradnje automatski";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Provjeri automatski";

--- a/Sparkle/is.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/is.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Innifela nafnlausa kerfisskýrslu";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Sækja og innsetja uppfærslur sjálfkrafa";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Kanna sjálfkrafa";

--- a/Sparkle/it.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/it.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Include profilo di sistema anonimo";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Scarica e installa automaticamente gli aggiornamenti";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Controlla Automaticamente";

--- a/Sparkle/nb.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/nb.lproj/SUUpdatePermissionPrompt.strings
@@ -16,6 +16,9 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Inkluder anonym systemprofil";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Last ned og installer automatisk";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Søk automatisk";
 

--- a/Sparkle/nl.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/nl.lproj/SUUpdatePermissionPrompt.strings
@@ -10,5 +10,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Voeg anoniem systeemprofiel bij";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Download en installeer updates automatisch";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Zoek automatisch";

--- a/Sparkle/pl.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/pl.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Załącz anonimowe informacje o systemie";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Automatycznie pobierz i zainstaluj uaktualnienia";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Sprawdzaj automatycznie";

--- a/Sparkle/pt-BR.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/pt-BR.lproj/SUUpdatePermissionPrompt.strings
@@ -19,5 +19,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Incluir perfil anônimo do sistema";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Baixar e instalar atualizações automaticamente";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Buscar Automaticamente";

--- a/Sparkle/pt-PT.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/pt-PT.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Incluir perfil de sistema anónimo";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Transferir e instalar actualizações automaticamente";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Procurar automaticamente";

--- a/Sparkle/ro.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/ro.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Include profil anomin de sistem";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Descarcă și instalează în automat actualizările";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Verifică în mod automat";

--- a/Sparkle/ru.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/ru.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Включить анонимный профиль системы";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Автоматически загружать и устанавливать обновления";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Проверять автоматически";

--- a/Sparkle/sl.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/sl.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Vključi anonimni profil sistema";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Samodejno namestite posodobitve";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Samodejno preverjaj";

--- a/Sparkle/sv.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/sv.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Inkludera anonym systemprofil";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Hämta och installera nya uppdateringar automatiskt.";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Kontrollera automatiskt";

--- a/Sparkle/th.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/th.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "ส่งข้อมูลระบบแบบนิรนาม";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "ดาวน์โหลดและติดตั้งอัพเดทโดยอัตโนมัติ";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "ตรวจสอบโดยอัตโนมัติ";

--- a/Sparkle/tr.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/tr.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Sistem bilgilerini kimlik gizlenmiş olarak gönder";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Güncellemeleri kendiliğinden indir ve kur";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Otomatik Olarak Ara";

--- a/Sparkle/uk.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/uk.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Автоматично надсилати профіль системи";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "Автоматично завантажувати та встановлювати оновлення";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "Перевіряти автоматично";

--- a/Sparkle/zh_CN.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/zh_CN.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "包括无记名系统概况";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "自动下载并安装更新";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "自动核查";

--- a/Sparkle/zh_HK.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/zh_HK.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "包含匿名系統概況";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "自動下載並安裝更新";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "自動檢查";

--- a/Sparkle/zh_TW.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/zh_TW.lproj/SUUpdatePermissionPrompt.strings
@@ -16,5 +16,8 @@
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "包含匿名的系統描述資料";
 
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "自動下載並安裝更新項目";
+
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "自動檢查";


### PR DESCRIPTION
In the update permission prompt, we add an option/checkbox to allow the user to opt into (or out of) automatically downloading and installing updates:

<img width="549" alt="Screenshot 2022-11-27 at 5 31 36 AM" src="https://user-images.githubusercontent.com/857267/204138354-8e9ef1df-a6bb-4196-92a1-f9f5a9c415cf.png">

<img width="549" alt="Screenshot 2022-11-27 at 5 32 22 AM" src="https://user-images.githubusercontent.com/857267/204138361-22cc5a4e-ba89-491d-90af-57931ad12e77.png">

The default on or off state of automatically downloading and installing updates is based on the value the developer sets for `SUAutomaticallyUpdate` key in their Info.plist. If this is not specified, the default value is off.

After the user responds to the prompt, the updater sets its `automaticallyDownloadsUpdates` property based on the user's response. If the user doesn't want automatic updates checks, we assume the user doesn't want automatic downloading too.

If `SUAllowsAutomaticUpdates` is specified to `NO` then this option and checkbox is hidden in this prompt. In this case, we ignore the response to the user automatically downloading and installing updates.

As usual if the developer overrides and specifies `SUEnableAutomaticChecks` in their Info.plist, this permission prompt does not show up and we also don't record the user's response to this option.

I tried to update many of the localizations based on us already translating a similar key: "Automatically download and install updates in the future". However for this key I wanted to remove "in the future" bit.

I didn't localize and gave up on:

* Chinese (main land)
* Chinese (Taiwan)
* Chinese (Hong Kong)
* Hungarian
* Japanese
* Korean
* Slovak
* Thai

Fixes #2209

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested the permission prompt with the test app in several different languages and tested that `automaticallyDownloadsUpdates` property on `SPUUpdater` is set (or not set) based on the user's response.

macOS version tested: 13.0.1 (22A400)
