### PR TITLE
Upgrade CI to default to using Xcode 14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         include:
             - xcode: 'xcode13.4.1'
               xcode-path: '/Applications/Xcode_13.4.1.app/Contents/Developer'
-              upload-dist: true
+              upload-dist: false
               run-analyzer: true
               macos: 'macos-12'
             - xcode: 'xcode14.1'
               xcode-path: '/Applications/Xcode_14.1.app/Contents/Developer'
-              upload-dist: false
+              upload-dist: true
               run-analyzer: false
               macos: 'macos-12'
             

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -2,7 +2,7 @@ name: "Create Draft Release"
 
 env:
   BUILDDIR: "build"
-  DEVELOPER_DIR: "/Applications/Xcode_13.4.1.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_14.1.app/Contents/Developer"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing this in CI / GitHub.

macOS version tested: NA
