### PR TITLE
Remove duplicate Sparkle localization strings in Updater app

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -212,7 +212,6 @@
 		724BB3AA1D3347C2005D534A /* SUInstallerStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 724BB3971D333832005D534A /* SUInstallerStatus.m */; };
 		724BB3B71D35ABA8005D534A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		724F76F91D6EAD0D00ECD062 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 525A278F133D6AE900FD8D70 /* Cocoa.framework */; };
-		725264A91D5FBD9100CD6400 /* Sparkle.strings in Resources */ = {isa = PBXBuildFile; fileRef = 61AAE8220A321A7F00D8810D /* Sparkle.strings */; };
 		725602D51C83551C00DAA70E /* SUApplicationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 725602D31C83551C00DAA70E /* SUApplicationInfo.h */; };
 		725602D61C83551C00DAA70E /* SUApplicationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 725602D41C83551C00DAA70E /* SUApplicationInfo.m */; };
 		725B3A82263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml in Resources */ = {isa = PBXBuildFile; fileRef = 725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */; };
@@ -3141,7 +3140,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				725264A91D5FBD9100CD6400 /* Sparkle.strings in Resources */,
 				72EB87EC1CB8887E00C37F42 /* SUStatus.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sparkle/InstallerProgress/InstallerProgress-Info.plist
+++ b/Sparkle/InstallerProgress/InstallerProgress-Info.plist
@@ -28,6 +28,44 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<string>1</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ca</string>
+		<string>ar</string>
+		<string>cs</string>
+		<string>da</string>
+		<string>de</string>
+		<string>el</string>
+		<string>en</string>
+		<string>es</string>
+		<string>fa</string>
+		<string>fi</string>
+		<string>fr</string>
+		<string>he</string>
+		<string>hr</string>
+		<string>hu</string>
+		<string>is</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>ko</string>
+		<string>nb</string>
+		<string>nl</string>
+		<string>pl</string>
+		<string>pt-BR</string>
+		<string>pt-PT</string>
+		<string>ro</string>
+		<string>ru</string>
+		<string>sk</string>
+		<string>sl</string>
+		<string>sv</string>
+		<string>th</string>
+		<string>tr</string>
+		<string>uk</string>
+		<string>zh_CN</string>
+		<string>zh_HK</string>
+		<string>zh_TW</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -119,6 +119,8 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
         _application = application;
         _delegate = delegate;
         
+        [delegate loadLocalizationStringsFromHost:host];
+        
         _connection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SPUInstallerAgentProtocol)];
         _connection.exportedObject = self;
         

--- a/Sparkle/InstallerProgress/InstallerProgressDelegate.h
+++ b/Sparkle/InstallerProgress/InstallerProgressDelegate.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol InstallerProgressDelegate <NSObject>
 
+- (void)loadLocalizationStringsFromHost:(SUHost *)host;
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host;
 - (void)installerProgressShouldStop;
 

--- a/Sparkle/InstallerProgress/ShowInstallerProgress.m
+++ b/Sparkle/InstallerProgress/ShowInstallerProgress.m
@@ -25,6 +25,10 @@
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host
 {
     // Try to retrieve localization strings from the old bundle if possible
+    // Note in Sparkle 2 in the common case it should be unlikely that this progress window will show up
+    // Uncommon cases where the install process may be slower are if the app to be installed is on a network mount
+    // or e.g. USB mount or a different mount in general.
+    // In case we fail to load the localizations we will show English strings, which is not a big deal here.
     
     NSBundle *hostSparkleBundle;
     {

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -508,7 +508,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     
     self.cancellation = cancellation;
     
-    self.checkingController = [[SUStatusController alloc] initWithHost:self.host centerPointValue:nil minimizable:NO closable:NO];
+    self.checkingController = [[SUStatusController alloc] initWithHost:self.host windowTitle:[NSString stringWithFormat:SULocalizedString(@"Updating %@", nil), [self.host name]] centerPointValue:nil minimizable:NO closable:NO];
     [[self.checkingController window] center]; // Force the checking controller to load its window.
     [self.checkingController beginActionWithTitle:SULocalizedString(@"Checking for updates…", nil) maxProgressValue:0.0 statusText:nil];
     [self.checkingController setButtonTitle:SULocalizedString(@"Cancel", nil) target:self action:@selector(cancelCheckForUpdates:) isDefault:NO];
@@ -676,7 +676,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
             centerPointValue = nil;
         }
         
-        self.statusController = [[SUStatusController alloc] initWithHost:self.host centerPointValue:centerPointValue minimizable:minimizable closable:closable];
+        self.statusController = [[SUStatusController alloc] initWithHost:self.host windowTitle:[NSString stringWithFormat:SULocalizedString(@"Updating %@", nil), [self.host name]] centerPointValue:centerPointValue minimizable:minimizable closable:closable];
         
         if (_updateAlertWindowWasInactive) {
             [self.statusController.window orderFront:nil];

--- a/Sparkle/SULocalizations.h
+++ b/Sparkle/SULocalizations.h
@@ -11,6 +11,8 @@
 
 #import "SUConstants.h"
 
-#define SULocalizedString(key, comment) NSLocalizedStringFromTableInBundle(key, @"Sparkle", (NSBundle * _Nonnull)([NSBundle bundleWithIdentifier:SUBundleIdentifier] ? [NSBundle bundleWithIdentifier:SUBundleIdentifier] : [NSBundle mainBundle]), comment)
+#define SULocalizedStringFromTableInBundle(key, tbl, bundle, comment) NSLocalizedStringFromTableInBundle(key, tbl, bundle, comment)
+
+#define SULocalizedString(key, comment) SULocalizedStringFromTableInBundle(key, @"Sparkle", (NSBundle * _Nonnull)([NSBundle bundleWithIdentifier:SUBundleIdentifier] ? [NSBundle bundleWithIdentifier:SUBundleIdentifier] : [NSBundle mainBundle]), comment)
 
 #endif /* SULocalizations_h */

--- a/Sparkle/SUStatus.xib
+++ b/Sparkle/SUStatus.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/Sparkle/SUStatus.xib
+++ b/Sparkle/SUStatus.xib
@@ -103,9 +103,6 @@
                     <constraint firstItem="8" firstAttribute="top" secondItem="6" secondAttribute="top" constant="15" id="tAo-wJ-XR0"/>
                 </constraints>
             </view>
-            <connections>
-                <binding destination="-2" name="title" keyPath="windowTitle" id="24"/>
-            </connections>
             <point key="canvasLocation" x="-158" y="132"/>
         </window>
     </objects>

--- a/Sparkle/SUStatusController.h
+++ b/Sparkle/SUStatusController.h
@@ -24,7 +24,7 @@
 @property (nonatomic) double maxProgressValue;
 @property (getter=isButtonEnabled) BOOL buttonEnabled;
 
-- (instancetype)initWithHost:(SUHost *)aHost centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable;
+- (instancetype)initWithHost:(SUHost *)aHost windowTitle:(NSString *)windowTitle centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable;
 
 // Pass 0 for the max progress value to get an indeterminate progress bar.
 // Pass nil for the status text to not show it.

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -79,12 +79,8 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
     }
     [self.progressBar setUsesThreadedAnimation:YES];
     [self.statusTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightRegular]];
-}
-
-// Accessed via bindings
-- (NSString *)windowTitle
-{
-    return (_windowTitle != nil) ? _windowTitle : @"";
+    
+    self.window.title = _windowTitle;
 }
 
 - (NSImage *)applicationIcon

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -26,6 +26,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 
 @implementation SUStatusController
 {
+    NSString *_windowTitle;
     NSValue *_centerPointValue;
     BOOL _closable;
 }
@@ -42,7 +43,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
 @synthesize touchBarButton;
 @synthesize minimizable = _minimizable;
 
-- (instancetype)initWithHost:(SUHost *)aHost centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable
+- (instancetype)initWithHost:(SUHost *)aHost windowTitle:(NSString *)windowTitle centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable
 {
     self = [super initWithWindowNibName:@"SUStatus" owner:self];
 	if (self)
@@ -51,6 +52,7 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
         _centerPointValue = centerPointValue;
         _minimizable = minimizable;
         _closable = closable;
+        _windowTitle = [windowTitle copy];
         [self setShouldCascadeWindows:NO];
     }
     return self;
@@ -79,9 +81,10 @@ static NSString *const SUStatusControllerTouchBarIndentifier = @"" SPARKLE_BUNDL
     [self.statusTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightRegular]];
 }
 
+// Accessed via bindings
 - (NSString *)windowTitle
 {
-    return [NSString stringWithFormat:SULocalizedString(@"Updating %@", nil), [self.host name]];
+    return (_windowTitle != nil) ? _windowTitle : @"";
 }
 
 - (NSImage *)applicationIcon


### PR DESCRIPTION
Load the localization strings from the old bundle after we validated new update is good and are showing progress to the user. Note in many cases in Sparkle 2 the installation will complete before this UI gets a chance to show up (only in slow installation scenarios such as updating an app on a different volume / external drive / network mount this UI shows up). It's not a big deal if we fail to load the strings and default to English for whatever reason.

Fixes #577

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested with test app and tested changing system language with Spanish, Japanese, Korean, English

macOS version tested: 13.0.1 (22A400)
