### PR TITLE
Add deprecations/warnings for incorrect feed & update checking usage

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -243,7 +243,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Set the URL of the appcast used to download update information. This method is deprecated.
  
  Setting this property will persist in the host bundle's user defaults.
- To avoid this, please consider implementing
+ To avoid this undesirable behavior, please consider implementing
  `-[SPUUpdaterDelegate feedURLStringForUpdater:]` instead of using this method.
  
  Calling `-clearFeedURLFromUserDefaults` will remove any feed URL that has been set in the host bundle's user defaults.
@@ -253,6 +253,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  If you do not need to alternate between multiple feeds, set the SUFeedURL in your Info.plist instead of invoking this method.
  
  For beta updates, you may consider migrating to `-[SPUUpdaterDelegate allowedChannelsForUpdater:]` in the future.
+ 
+ Updaters that update other developer's bundles should not call this method.
  
  This method must be called on the main thread; calls from background threads will have no effect.
  */
@@ -270,6 +272,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  This method should be called as soon as possible, after your application finished launching or right after the updater has been started
  if you manually manage starting the updater.
+ 
+ Updaters that update other developer's bundles should not call this method.
  
  This method must be called on the main thread.
  

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -265,7 +265,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  You should call this method if you have used `-setFeedURL:` in the past and want to stop using that API.
  Otherwise for compatibility Sparkle will prefer to use the feed URL that was set in the user defaults over the one that was specified in the host bundle's Info.plist,
- which is undesirable.
+ which is often undesirable (except for testing purposes).
  
  If a feed URL is found stored in the host bundle's user defaults (from calling `-setFeedURL:`) before it gets cleared,
  then that previously set URL is returned from this method.

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -100,7 +100,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  You usually do not need to call this method directly. If `automaticallyChecksForUpdates` is @c YES,
  Sparkle calls this method automatically according to its update schedule using the `updateCheckInterval`
  and the `lastUpdateCheckDate`. Therefore, you should typically only consider calling this method directly if you
- opt out of automatic update checks.
+ opt out of automatic update checks. Calling this method when updating your own bundle is invalid if Sparkle is configured
+ to ask the user's permission to check for updates automatically and `automaticallyChecksForUpdates` is `NO`.
  
  This is meant for programmatically initating a check for updates in the background without the user initiating it.
  This check will not show UI if no new updates are found.
@@ -108,7 +109,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  If a new update is found, the updater's user driver may handle showing it at an appropriate (but not necessarily immediate) time.
  If you want control over when and how a new update is shown, please see https://sparkle-project.org/documentation/gentle-reminders/
  
- Note if automated updating is turned on, either a new update may be downloaded in the background to be installed silently,
+ Note if automated downloading/installing is turned on, either a new update may be downloaded in the background to be installed silently,
  or an already downloaded update may be shown.
  
  This will not find updates that the user has opted into skipping.

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -192,7 +192,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         if (self->_updatingMainBundle) {
             NSString *appcastUserDefaultsString = [self.host objectForUserDefaultsKey:SUFeedURLKey];
             if (appcastUserDefaultsString != nil) {
-                SULog(SULogLevelError, @"Warning: A feed URL was found stored in user defaults for %@. This was likely set using -[SPUUpdater setFeedURL:] which is deprecated. Please migrate away from using this API and use -[SPUUpdater clearFeedURLFromUserDefaults] to remove any stored defaults, otherwise Sparkle may continue to use the feed stored from the defaults. Read the documentation for -[SPUUpdater setFeedURL:] regarding migrating away from using the API", self.host.name);
+                SULog(SULogLevelError, @"Warning: A feed URL was found stored in user defaults for %@. This was likely set using -[SPUUpdater setFeedURL:] which is deprecated. Please migrate away from using this API and use -[SPUUpdater clearFeedURLFromUserDefaults] to remove any stored defaults, otherwise Sparkle may continue to use the feed stored from the defaults. If the feed url was set via a defaults write command for testing purposes, then please ignore this warning.", self.host.name);
             }
         }
         

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -919,6 +919,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         return nil;
     }
     
+    // -retrieveFeedURL: strips the feed URL so we should do the same
     NSString *castUrlStr = [self _stripFeedString:appcastString hostName:@"" error:NULL];
     if (castUrlStr == nil) {
         return nil;
@@ -975,7 +976,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         return nil;
     }
     
-    // -retrieveFeedURL: strips the feed URL so we should do the same
     NSString *castUrlStr = [self _stripFeedString:appcastString hostName:hostName error:error];
     if (castUrlStr == nil) {
         return nil;

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -619,7 +619,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             // Check if automatic update checking is disabled or if the user hasn't given permission for Sparkle to check
             BOOL automaticChecksInDefaults = [self automaticallyChecksForUpdates];
             if (!automaticChecksInDefaults) {
-                SULog(SULogLevelError, @"Error: Calling -[SPUUpdater checkForUpdatesInBackground] when Sparkle is set to ask the user permission to check for updates in the background automatically and automaticallyChecksForUpdates is NO leads to incorrect behavior");
+                SULog(SULogLevelError, @"Error: Calling -[SPUUpdater checkForUpdatesInBackground] for your own bundle when Sparkle is set to ask the user permission to check for updates in the background automatically and automaticallyChecksForUpdates is NO leads to incorrect behavior");
             }
         }
     }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -192,7 +192,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         if (self->_updatingMainBundle) {
             NSString *appcastUserDefaultsString = [self.host objectForUserDefaultsKey:SUFeedURLKey];
             if (appcastUserDefaultsString != nil) {
-                SULog(SULogLevelError, @"Warning: A feed URL was found stored in user defaults for %@. This was likely set using -[SPUUpdater setFeedURL:] which is deprecated. Please migrate away from using this API and use -[SPUUpdater clearFeedURLFromUserDefaults] to remove any stored defaults, otherwise Sparkle may continue to use the feed stored from the defaults. If the feed url was set via a defaults write command for testing purposes, then please ignore this warning.", self.host.name);
+                SULog(SULogLevelError, @"Warning: A feed URL was found stored in user defaults for %@. This was likely set using -[SPUUpdater setFeedURL:] which is deprecated. Please migrate away from using this API and call -[SPUUpdater clearFeedURLFromUserDefaults] to remove any stored defaults, otherwise Sparkle may continue to use the feed stored from the defaults. If the feed url was set via a defaults write command for testing purposes, then please ignore this warning.", self.host.name);
             }
         }
         
@@ -619,7 +619,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             // Check if automatic update checking is disabled or if the user hasn't given permission for Sparkle to check
             BOOL automaticChecksInDefaults = [self automaticallyChecksForUpdates];
             if (!automaticChecksInDefaults) {
-                SULog(SULogLevelError, @"Error: Calling -[SPUUpdater checkForUpdatesInBackground] for your own bundle when Sparkle is set to ask the user permission to check for updates in the background automatically and automaticallyChecksForUpdates is NO leads to incorrect behavior");
+                SULog(SULogLevelError, @"Error: Calling -[SPUUpdater checkForUpdatesInBackground] for your own bundle when Sparkle is set to ask the user permission to check for updates in the background automatically and when automaticallyChecksForUpdates is NO leads to incorrect behavior. Recommendation: remove call to checkForUpdatesInBackground");
             }
         }
     }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -72,6 +72,9 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @end
 
 @implementation SPUUpdater
+{
+    BOOL _updatingMainBundle;
+}
 
 @synthesize delegate = _delegate;
 @synthesize userDriver = _userDriver;
@@ -125,10 +128,13 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         
         _delegate = delegate;
         
+        NSBundle *mainBundle = [NSBundle mainBundle];
+        _updatingMainBundle = [hostBundle isEqualTo:mainBundle];
+        
         // Set up default user agent
         // Use the main bundle rather than the bundle to update for retrieving user agent information from
         // We want the user agent to reflect the updater that is doing the updating
-        SUHost *mainBundleHost = [[SUHost alloc] initWithBundle:[NSBundle mainBundle]];
+        SUHost *mainBundleHost = [[SUHost alloc] initWithBundle:mainBundle];
         _userAgentString = SPUMakeUserAgentWithHost(mainBundleHost, nil);
         _mainBundleHost = mainBundleHost;
     }
@@ -180,6 +186,16 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     // Start updater on next update cycle so we make sure the application invoking the updater is ready
     // This also gives the developer a cycle to check for updates before Sparkle's update cycle scheduler kicks in
     dispatch_async(dispatch_get_main_queue(), ^{
+        // Check if legacy/deprecated feed URL from user defaults is being used
+        // We perform this check one runloop cycle after starting the updater to give the developer
+        // a chance to call -clearFeedURLFromUserDefaults before this warning can show up
+        if (self->_updatingMainBundle) {
+            NSString *appcastUserDefaultsString = [self.host objectForUserDefaultsKey:SUFeedURLKey];
+            if (appcastUserDefaultsString != nil) {
+                SULog(SULogLevelError, @"Warning: A feed URL was found stored in user defaults for %@. This was likely set using -[SPUUpdater setFeedURL:] which is deprecated. Please migrate away from using this API and use -[SPUUpdater clearFeedURLFromUserDefaults] to remove any stored defaults, otherwise Sparkle may continue to use the feed stored from the defaults. Read the documentation for -[SPUUpdater setFeedURL:] regarding migrating away from using the API", self.host.name);
+            }
+        }
+        
         if (!self.sessionInProgress) {
             [self startUpdateCycle];
         }
@@ -274,8 +290,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         }
     }
     
-    BOOL updatingMainBundle = [self.host.bundle isEqualTo:mainBundleHost.bundle];
-    
     if (feedURL != nil) {
         servingOverHttps = [[[feedURL scheme] lowercaseString] isEqualToString:@"https"];
         if (!servingOverHttps && !self.loggedATSWarning) {
@@ -295,7 +309,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             if (!foundATSPersistentIssue && !foundXPCDownloaderService) {
                 BOOL foundATSIssue = ([mainBundleHost objectForInfoDictionaryKey:@"NSAppTransportSecurity"] == nil);
                 
-                if (updatingMainBundle) {
+                if (_updatingMainBundle) {
                     // The only way we'll know for sure if there is an issue is if the main bundle is the same as the one we're updating
                     // We don't want to generate false positives..
                     foundATSMainBundleIssue = foundATSIssue;
@@ -339,7 +353,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             }
             return NO;
         } else {
-            if (updatingMainBundle && !self.loggedNoSecureKeyWarning) {
+            if (_updatingMainBundle && !self.loggedNoSecureKeyWarning) {
                 SULog(SULogLevelError, @"Error: Serving updates without an EdDSA key and only using Apple Code Signing is deprecated and may be unsupported in a future release. Visit Sparkle's documentation for more information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns");
                 
                 self.loggedNoSecureKeyWarning = YES;
@@ -347,7 +361,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         }
     } else if (publicKeys.ed25519PubKey == nil) {
         // No EdDSA key is available, so app must be using DSA
-        if (updatingMainBundle) {
+        if (_updatingMainBundle) {
             if (error != NULL) {
                 *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"For security reasons, updates need to be signed with an EdDSA key for %@. Please migrate to using EdDSA (ed25519). Visit Sparkle's documentation for migration information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns.", hostName] }];
             }
@@ -465,7 +479,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     }
     
     if (firingImmediately) {
-        [self checkForUpdatesInBackground];
+        [self _checkForUpdatesInBackground];
     } else {
         // This may not return the same update check interval as the developer has configured
         // Notably it may differ when we have an update that has been already downloaded and needs to resume,
@@ -532,7 +546,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 [self.updaterTimer startAndFireAfterDelay:delayUntilCheck];
             } else {
                 // We're overdue! Run one now.
-                [self checkForUpdatesInBackground];
+                [self _checkForUpdatesInBackground];
             }
         });
     }
@@ -540,21 +554,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)updaterTimerDidFire
 {
-    [self checkForUpdatesInBackground];
+    [self _checkForUpdatesInBackground];
 }
 
-- (void)checkForUpdatesInBackground
+- (void)_checkForUpdatesInBackground
 {
-    if (!self.startedUpdater) {
-        SULog(SULogLevelError, @"Error: checkForUpdatesInBackground - updater hasn't been started yet. Please call -startUpdater: first");
-        return;
-    }
-    
-    if (self.sessionInProgress) {
-        SULog(SULogLevelError, @"Error: -checkForUpdatesInBackground called but .sessionInProgress == YES");
-        return;
-    }
-    
     self.sessionInProgress = YES;
     self.canCheckForUpdates = NO;
     
@@ -592,6 +596,35 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             [strongSelf checkForUpdatesWithDriver:updateDriver updateCheck:SPUUpdateCheckUpdatesInBackground installerInProgress:installerIsRunning];
         });
     }];
+}
+
+// This is the developer-facing checkForUpdatesInBackground
+// Sparkle internally uses _checkForUpdatesInBackground
+- (void)checkForUpdatesInBackground
+{
+    if (!self.startedUpdater) {
+        SULog(SULogLevelError, @"Error: checkForUpdatesInBackground - updater hasn't been started yet. Please call -startUpdater: first");
+        return;
+    }
+    
+    if (self.sessionInProgress) {
+        SULog(SULogLevelError, @"Error: -checkForUpdatesInBackground called but .sessionInProgress == YES");
+        return;
+    }
+    
+    if (_updatingMainBundle) {
+        // Check if Sparkle is configured to ask the user's permission to enable automatic update checks
+        NSNumber *automaticChecksInInfoPlist = [self.host objectForInfoDictionaryKey:SUEnableAutomaticChecksKey];
+        if (automaticChecksInInfoPlist == nil) {
+            // Check if automatic update checking is disabled or if the user hasn't given permission for Sparkle to check
+            BOOL automaticChecksInDefaults = [self automaticallyChecksForUpdates];
+            if (!automaticChecksInDefaults) {
+                SULog(SULogLevelError, @"Error: Calling -[SPUUpdater checkForUpdatesInBackground] when Sparkle is set to ask the user permission to check for updates in the background automatically and automaticallyChecksForUpdates is NO leads to incorrect behavior");
+            }
+        }
+    }
+    
+    [self _checkForUpdatesInBackground];
 }
 
 - (void)checkForUpdates
@@ -863,7 +896,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 - (void)setFeedURL:(NSURL * _Nullable)feedURL
 {
     if (![NSThread isMainThread]) {
-        SULog(SULogLevelError, @"Error: SPUUpdater -setFeedURL: must be called on the main thread. The call from a background thread was ignored.");
+        SULog(SULogLevelError, @"Error: -[SPUUpdater setFeedURL:] must be called on the main thread. The call from a background thread was ignored.");
         return;
     }
 
@@ -871,20 +904,57 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     [self.host setObject:[feedURL absoluteString] forUserDefaultsKey:SUFeedURLKey];
 }
 
+- (nullable NSURL *)clearFeedURLFromUserDefaults
+{
+    if (![NSThread isMainThread]) {
+        // We will allow continuing even if not called on main thread
+        SULog(SULogLevelError, @"Error: -[SPUUpdater clearFeedURLFromUserDefaults] must be called on the main thread.");
+    }
+    
+    NSString *appcastString = [self.host objectForUserDefaultsKey:SUFeedURLKey];
+    
+    [self.host setObject:nil forUserDefaultsKey:SUFeedURLKey];
+    
+    if (appcastString == nil) {
+        return nil;
+    }
+    
+    NSString *castUrlStr = [self _stripFeedString:appcastString hostName:@"" error:NULL];
+    if (castUrlStr == nil) {
+        return nil;
+    }
+    
+    return [NSURL URLWithString:castUrlStr];
+}
+
+- (NSString * _Nullable)_stripFeedString:(NSString *)appcastString hostName:(NSString *)hostName error:(NSError * __autoreleasing *)error
+{
+    NSCharacterSet *quoteSet = [NSCharacterSet characterSetWithCharactersInString:@"\"\'"]; // Some feed publishers add quotes; strip 'em.
+    NSString *castUrlStr = [appcastString stringByTrimmingCharactersInSet:quoteSet];
+    if (castUrlStr == nil || [castUrlStr length] == 0) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidFeedURLError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Appcast feed (%@) after trimming it of quotes is empty for %@!", appcastString, hostName] }];
+        }
+        return nil;
+    }
+    
+    return castUrlStr;
+}
+
 - (NSURL * _Nullable)retrieveFeedURL:(NSError * __autoreleasing *)error
 {
     NSString *hostName = self.host.name;
     
     if (![NSThread isMainThread]) {
-        SULog(SULogLevelError, @"Error: SPUUpdater -retrieveFeedURL:error: must be called on the main thread.");
+        SULog(SULogLevelError, @"Error: -[SPUUpdater retrieveFeedURL:error:] must be called on the main thread.");
         if (error != NULL) {
             *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUIncorrectAPIUsageError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"SUUpdater -retriveFeedURL:error: must be called on the main thread for %@", hostName]}];
         }
         return nil;
     }
     
-    // A value in the user defaults overrides one in the Info.plist (so preferences panels can be created wherein users choose between beta / release feeds).
-    NSString *appcastString = [self.host objectForKey:SUFeedURLKey];
+    // Delegate gets first priority for determining the feed URL
+    NSString *appcastString = nil;
     if ([self.delegate respondsToSelector:@selector((feedURLStringForUpdater:))]) {
         NSString *delegateAppcastString = [self.delegate feedURLStringForUpdater:self];
         if (delegateAppcastString != nil) {
@@ -892,19 +962,22 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         }
     }
     
-    if (!appcastString) { // Can't find an appcast string!
+    // A value in the user defaults overrides one in the Info.plist
+    // (as this used to be used for setting alternative feed URLs but is now deprecated)
+    if (appcastString == nil) {
+        appcastString = [self.host objectForKey:SUFeedURLKey];
+    }
+    
+    if (appcastString == nil) { // Can't find an appcast string!
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidFeedURLError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"You must specify the URL of the appcast as the %@ key in either the Info.plist, or with -feedURLStringForUpdater: delegate method, or by the user defaults of %@!", SUFeedURLKey, hostName] }];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidFeedURLError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"You must specify the URL of the appcast as the %@ key in either the Info.plist, or with -[SPUUpdaterDelegate feedURLStringForUpdater:] for %@!", SUFeedURLKey, hostName] }];
         }
         return nil;
     }
     
-    NSCharacterSet *quoteSet = [NSCharacterSet characterSetWithCharactersInString:@"\"\'"]; // Some feed publishers add quotes; strip 'em.
-    NSString *castUrlStr = [appcastString stringByTrimmingCharactersInSet:quoteSet];
-    if (castUrlStr == nil || [castUrlStr length] == 0) {
-        if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidFeedURLError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Appcast feed (%@) after trimming it of quotes is empty for %@!", appcastString, hostName] }];
-        }
+    // -retrieveFeedURL: strips the feed URL so we should do the same
+    NSString *castUrlStr = [self _stripFeedString:appcastString hostName:hostName error:error];
+    if (castUrlStr == nil) {
         return nil;
     }
     


### PR DESCRIPTION
This change deprecates `-[SPUUpdater setFeedURL:]` and logs warnings when the updater detects that feed URLs from user defaults are still being used. This change also adds an API that needs to be called to clear the feed URL from user defaults when migrating away from `-[SPUUpdater setFeedURL:]`

This change also logs a warning when `-[SPUUpdater checkForUpdatesInBackground]` is used incorrectly if Sparkle is configured to ask the user's permission to check for updates but a check is done when automatic update checking is NO.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested calling checkForUpdatesInBackground incorrectly and calling setFeedURL then forgetting to clear the feed url, then calling clearFeedURLFromUserDefaults both from obj-c and swift projects.

macOS version tested: 13.0.1 (22A400)
