### PR TITLE
Log the URL that failed to download correctly

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -158,12 +158,12 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
     });
 }
 
-- (void)URLSession:(NSURLSession *)__unused session downloadTask:(NSURLSessionDownloadTask *) downloadTask didFinishDownloadingToURL:(NSURL *)location
+- (void)URLSession:(NSURLSession *)__unused session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
     NSInteger statusCode = [downloadTask.response isKindOfClass:[NSHTTPURLResponse class]] ? ((NSHTTPURLResponse *)downloadTask.response).statusCode : 200;
     if ((statusCode < 200) || (statusCode >= 400))
     {
-        NSString *message = [NSString stringWithFormat:@"A network error occurred while downloading the update. %@ (%ld)", [NSHTTPURLResponse localizedStringForStatusCode:statusCode], (long)statusCode];
+        NSString *message = [NSString stringWithFormat:@"A network error occurred while downloading %@. %@ (%ld)", downloadTask.originalRequest.URL.absoluteString, [NSHTTPURLResponse localizedStringForStatusCode:statusCode], (long)statusCode];
         NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUDownloadError userInfo:@{ NSLocalizedDescriptionKey: message }];
         [self.delegate downloaderDidFailWithError:error];
     }


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Simulated a fake error with test app and tested URL that failed to download is logged as well as the status code.

macOS version tested: 13.0.1 (22A400)
