### PR TITLE
Add delegate method to hide showing version history option

### DIFF
--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -580,31 +580,36 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
             case SPUNoUpdateFoundReasonOnLatestVersion:
             case SPUNoUpdateFoundReasonOnNewerThanLatestVersion: {
                 // Show the user the past version history if available
-                NSString *localizedButtonTitle = SULocalizedString(@"Version History", nil);
 
-                // Check if the delegate implements a Version History action
+                // Check if the delegate allows showing the Version History
                 id <SPUStandardUserDriverDelegate> delegate = self.delegate;
+                BOOL shouldShowVersionHistory = (![delegate respondsToSelector:@selector(standardUserDriverShouldShowVersionHistoryForAppcastItem:)] || [delegate standardUserDriverShouldShowVersionHistoryForAppcastItem:latestAppcastItem]);
                 
-                if ([delegate respondsToSelector:@selector(standardUserDriverShowVersionHistoryForAppcastItem:)]) {
-                    [alert addButtonWithTitle:localizedButtonTitle];
+                if (shouldShowVersionHistory) {
+                    NSString *localizedButtonTitle = SULocalizedString(@"Version History", nil);
                     
-                    secondaryAction = ^{
-                        [delegate standardUserDriverShowVersionHistoryForAppcastItem:latestAppcastItem];
-                    };
-                } else if (latestAppcastItem.fullReleaseNotesURL != nil) {
-                    // Open the full release notes URL if informed
-                    [alert addButtonWithTitle:localizedButtonTitle];
-                    
-                    secondaryAction = ^{
-                        [[NSWorkspace sharedWorkspace] openURL:(NSURL * _Nonnull)latestAppcastItem.fullReleaseNotesURL];
-                    };
-                } else if (latestAppcastItem.releaseNotesURL != nil) {
-                    // Fall back to opening the release notes URL
-                    [alert addButtonWithTitle:localizedButtonTitle];
-                    
-                    secondaryAction = ^{
-                        [[NSWorkspace sharedWorkspace] openURL:(NSURL * _Nonnull)latestAppcastItem.releaseNotesURL];
-                    };
+                    // Check if the delegate implements its own Version History action
+                    if ([delegate respondsToSelector:@selector(standardUserDriverShowVersionHistoryForAppcastItem:)]) {
+                        [alert addButtonWithTitle:localizedButtonTitle];
+                        
+                        secondaryAction = ^{
+                            [delegate standardUserDriverShowVersionHistoryForAppcastItem:latestAppcastItem];
+                        };
+                    } else if (latestAppcastItem.fullReleaseNotesURL != nil) {
+                        // Open the full release notes URL if informed
+                        [alert addButtonWithTitle:localizedButtonTitle];
+                        
+                        secondaryAction = ^{
+                            [[NSWorkspace sharedWorkspace] openURL:(NSURL * _Nonnull)latestAppcastItem.fullReleaseNotesURL];
+                        };
+                    } else if (latestAppcastItem.releaseNotesURL != nil) {
+                        // Fall back to opening the release notes URL
+                        [alert addButtonWithTitle:localizedButtonTitle];
+                        
+                        secondaryAction = ^{
+                            [[NSWorkspace sharedWorkspace] openURL:(NSURL * _Nonnull)latestAppcastItem.releaseNotesURL];
+                        };
+                    }
                 }
                 
                 break;

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -43,6 +43,19 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
 - (_Nullable id <SUVersionDisplay>)standardUserDriverRequestsVersionDisplayer;
 
 /**
+ Decides whether or not the standard user driver should provide an option to show full release notes to the user.
+ 
+ When a user checks for new updates and no new update is found, Sparkle by default will offer to show the application's version history to the user
+ by providing a "Version History" button in the no new update available alert.
+ 
+ If this delegate method is implemented to return `NO`, then Sparkle will not provide an option to show full release notes to the user.
+ 
+ @param item The appcast item corresponding to the latest version available.
+ @return @c YES to allow Sparkle to show full release notes to the user, otherwise @c NO to disallow this.
+ */
+- (BOOL)standardUserDriverShouldShowVersionHistoryForAppcastItem:(SUAppcastItem *)item;
+
+/**
  Handles showing the full release notes to the user.
  
  When a user checks for new updates and no new update is found, Sparkle will offer to show the application's version history to the user


### PR DESCRIPTION
Fixes #2302

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested:
* Not implementing delegate method (version history shown)
* Implementing delegate method and returning YES (version history shown)
* Implementing delegate method and returning NO (version history hidden)

macOS version tested: 13.0.1 (22A400)
