### PR TITLE
Finnish localization grammar fixes

### DIFF
--- a/Sparkle/fi.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/fi.lproj/SUUpdatePermissionPrompt.strings
@@ -11,7 +11,7 @@
 "cCJ-V0-aTi.title" = "Älä tarkista";
 
 /* Class = "NSTextFieldCell"; title = "Check for updates automatically?"; ObjectID = "gmh-T4-BO0"; */
-"gmh-T4-BO0.title" = "Tarkista päivityksiä käynnistyksen yhteydessä?";
+"gmh-T4-BO0.title" = "Tarkista päivitykset käynnistyksen yhteydessä?";
 
 /* Class = "NSButtonCell"; title = "Include anonymous system profile"; ObjectID = "gz7-LM-gNf"; */
 "gz7-LM-gNf.title" = "Sisällytä nimetön järjestelmäprofiili";

--- a/Sparkle/fi.lproj/Sparkle.strings
+++ b/Sparkle/fi.lproj/Sparkle.strings
@@ -2,10 +2,10 @@
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ on uusin saatavilla oleva versio.";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ on uusin saatavilla oleva versio.\n(You are currently running version %3$@.)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ on uusin saatavilla oleva versio.\n(Asennettu versio on %3$@.)";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ on nyt saatavilla (sinulla on %3$@). Haluatko ladata sen nyt?";
+"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ on nyt saatavilla (nykyinen versiosi on %3$@). Haluatko ladata päivityksen nyt?";
 
 /* The download progress in units of bytes, e.g. 100 KB of 1,0 MB */
 "%@ of %@" = "%1$@ / %2$@";
@@ -17,7 +17,7 @@
 "An error occurred in retrieving update information. Please try again later." = "Päivitystietojen haussa tapahtui virhe. Yritä myöhemmin uudelleen.";
 
 /* No comment provided by engineer. */
-"An error occurred while extracting the archive. Please try again later." = "Pakkauksen purkamisen yhteydessä tapahtui virhe. Yritä myöhemmin uudelleen.";
+"An error occurred while extracting the archive. Please try again later." = "Pakkauksen purkamisessa tapahtui virhe. Yritä myöhemmin uudelleen.";
 
 /* No comment provided by engineer. */
 "Cancel" = "Kumoa";
@@ -29,16 +29,16 @@
 "Checking for updates…" = "Tarkistetaan päivityksiä…";
 
 /* Take care not to overflow the status window. */
-"Downloading update…" = "Haen päivitystä…";
+"Downloading update…" = "Haetaan päivitystä…";
 
 /* Take care not to overflow the status window. */
-"Extracting update…" = "Puran päivitystä…";
+"Extracting update…" = "Puretaan päivitystä…";
 
 /* No comment provided by engineer. */
 "Install and Relaunch" = "Asenna ja käynnistä ohjelma uudelleen";
 
 /* Take care not to overflow the status window. */
-"Installing update…" = "Asennan päivityksen…";
+"Installing update…" = "Päivitys asennetaan…";
 
 /* No comment provided by engineer. */
 "OK" = "OK";
@@ -47,10 +47,10 @@
 "Ready to Install" = "Valmiina asentamaan";
 
 /* No comment provided by engineer. */
-"Update Error!" = "Virhe päivityksessä!";
+"Update Error!" = "Virhe päivityksessä";
 
 /* No comment provided by engineer. */
-"Updating %@" = "Päivitän %@";
+"Updating %@" = "Päivitetään %@";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You’re up-to-date!" = "Sinulla on viimeisin versio!";


### PR DESCRIPTION
Minor fixes to Finnish localization:
• one missing translation
• one grammar error
• changed action verbs to use passive subject instead of first person in *Extracting*, *Installing* etc.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [X] My own app
- [ ] Other (please specify)

macOS version tested: 12.5.1
