### PR TITLE
Exit with an error if generate_appcast cannot sign an update

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -83,6 +83,7 @@ class ArchiveItem: CustomStringConvertible {
     var edSignature: String?
     var downloadUrlPrefix: URL?
     var releaseNotesURLPrefix: URL?
+    var signingError: Error?
 
     init(version: String, shortVersion: String?, feedURL: URL?, minimumSystemVersion: String?, frameworkVersion: String?, sparkleExecutableFileSize: Int?, sparkleLocales: String?, publicEdKey: String?, supportsDSA: Bool, appPath: URL, archivePath: URL) throws {
         self.version = version


### PR DESCRIPTION
We still allow/ignore the case where the EdDSA keys are changing.

Fixes #2314

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running generate_appcast on updates that failed because no EdDSA key was present.

macOS version tested: 13.0.1 (22A400)
