### PR TITLE
Hide impractical delta compression options only useful for debugging

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -52,9 +52,10 @@ extern SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionLatest;
 extern SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionFirst;
 extern SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionFirstSupported;
 
-#define COMPRESSION_METHOD_ARGUMENT_DESCRIPTION @"The compression method to use for generating delta updates. Supported methods for version 3 delta files are 'lzma', 'bzip2', 'zlib', 'lzfse', 'lz4', 'none', and 'default'. Note that version 2 delta files only support 'bzip2', 'none', and 'default' so other methods will be ignored if version 2 files are being generated. The 'default' compression for version 3 delta files is currently lzma."
+// Additional compression methods for version 3 patches that we have for debugging are zlib, bzip2, none
+#define COMPRESSION_METHOD_ARGUMENT_DESCRIPTION @"The compression method to use for generating delta updates. Supported methods for version 3 delta files are 'lzma' (best compression, slowest), 'lzfse' (good compression, fast), 'lz4' (worse compression, fastest), and 'default'. Note that version 2 delta files only support 'bzip2', and 'default' so other methods will be ignored if version 2 files are being generated. The 'default' compression for version 3 delta files is currently lzma."
 
-#define COMPRESSION_LEVEL_ARGUMENT_DESCRIPTION @"The compression level to use for generating delta updates. This only applies if the compression method used is bzip2 which accepts values from 1 - 9. A special value of 0 will use the default compression level."
+//#define COMPRESSION_LEVEL_ARGUMENT_DESCRIPTION @"The compression level to use for generating delta updates. This only applies if the compression method used is bzip2 which accepts values from 1 - 9. A special value of 0 will use the default compression level."
 
 SPUDeltaCompressionMode deltaCompressionModeFromDescription(NSString *description, BOOL *requestValid);
 NSString *deltaCompressionStringFromMode(SPUDeltaCompressionMode mode);

--- a/BinaryDelta/main.swift
+++ b/BinaryDelta/main.swift
@@ -20,7 +20,7 @@ struct Create: ParsableCommand {
     @Option(name: .long, help: ArgumentHelp(COMPRESSION_METHOD_ARGUMENT_DESCRIPTION, valueName: "compression"))
     var compression: String = "default"
     
-    @Option(name: .long, help: ArgumentHelp(COMPRESSION_LEVEL_ARGUMENT_DESCRIPTION, valueName: "compression-level"))
+    @Option(name: .long, help: .hidden)
     var compressionLevel: UInt8 = 0
     
     @Argument(help: ArgumentHelp("Path to original bundle to create a patch from."))

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -108,7 +108,7 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .long, help: ArgumentHelp(COMPRESSION_METHOD_ARGUMENT_DESCRIPTION, valueName: "delta-compression"))
     var deltaCompression: String = "default"
     
-    @Option(name: .long, help: ArgumentHelp(COMPRESSION_LEVEL_ARGUMENT_DESCRIPTION, valueName: "delta-compression-level"))
+    @Option(name: .long, help: .hidden)
     var deltaCompressionLevel: UInt8 = 0
     
     @Option(name: .long, help: ArgumentHelp("The Sparkle channel name that will be used for generating new updates. By default, no channel is used. Old applications need to be using Sparkle 2 to use this feature.", valueName: "channel-name"))


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running help pages for generate_appcast and BinaryDelta.

macOS version tested: 13.0.1 (22A400)
