### PR TITLE
Add plain-text embedded release notes support for sparkle-cli

### DIFF
--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -80,7 +80,12 @@
         if (appcastItem.itemDescription != nil) {
             NSData *descriptionData = [appcastItem.itemDescription dataUsingEncoding:NSUTF8StringEncoding];
             if (descriptionData != nil) {
-                [self displayHTMLReleaseNotes:descriptionData];
+                NSString *itemDescriptionFormat = appcastItem.itemDescriptionFormat;
+                if (itemDescriptionFormat != nil && [itemDescriptionFormat isEqualToString:@"plain-text"]) {
+                    [self displayPlainTextReleaseNotes:descriptionData encoding:NSUTF8StringEncoding];
+                } else {
+                    [self displayHTMLReleaseNotes:descriptionData];
+                }
             }
         }
     }


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested sparkle-cli with html and plain-text release notes, both embedded in `<description>` and not embedded.

macOS version tested: 13.2.1 (22D68)
