### PR TITLE
Expose installed version string to update notes HTML page

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -334,7 +334,7 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         } else
 #endif
         {
-            _releaseNotesView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+            _releaseNotesView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled installedVersion: _host.version];
         }
     }
     

--- a/Sparkle/SUWKWebView.h
+++ b/Sparkle/SUWKWebView.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUWKWebView : NSObject <SUReleaseNotesView>
 
-- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled;
+- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled installedVersion:(NSString *)installedVersion;
 
 @end
 


### PR DESCRIPTION
In the HTML page that contains the release notes:
- Inject a `sparkleInstalledVersion` global variable containing the version string of the current app install
- Add the `sparkle-installed-version` class on elements with a matching `data-sparkle-version` attribute

Initial discussion in #2367.

## Misc Checklist

- [X] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [X] Sparkle Test App (using tweaked sample release notes from my own app)
	- HTML notes contain 0, 1, or 2 matching `data-sparkle-version` elements
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 13.3.1 (22E261)
