### PR TITLE
Allow developer to use custom URL schemes in release notes view

### DIFF
--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -62,6 +62,7 @@ extern NSString *const SULastProfileSubmitDateKey;
 extern NSString *const SUPromptUserOnFirstLaunchKey;
 extern NSString *const SUDefaultsDomainKey;
 extern NSString *const SUEnableJavaScriptKey;
+extern NSString *const SUAllowedURLSchemesKey;
 extern NSString *const SUFixedHTMLDisplaySizeKey __attribute__((deprecated("This key is obsolete and has no effect.")));
 extern NSString *const SUAppendVersionNumberKey __attribute__((deprecated("This key is obsolete. See SPARKLE_APPEND_VERSION_NUMBER.")));
 extern NSString *const SUEnableAutomatedDowngradesKey __attribute__((deprecated("This key is obsolete. See SPARKLE_AUTOMATED_DOWNGRADES.")));

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -57,6 +57,7 @@ NSString *const SUUpdateGroupIdentifierKey = @"SUUpdateGroupIdentifier";
 NSString *const SULastProfileSubmitDateKey = @"SULastProfileSubmissionDate";
 NSString *const SUPromptUserOnFirstLaunchKey = @"SUPromptUserOnFirstLaunch";
 NSString *const SUEnableJavaScriptKey = @"SUEnableJavaScript";
+NSString *const SUAllowedURLSchemesKey = @"SUAllowedURLSchemes";
 NSString *const SUFixedHTMLDisplaySizeKey = @"SUFixedHTMLDisplaySize";
 NSString *const SUDefaultsDomainKey = @"SUDefaultsDomain";
 NSString *const SUSparkleErrorDomain = @"SUSparkleErrorDomain";

--- a/Sparkle/SULegacyWebView.h
+++ b/Sparkle/SULegacyWebView.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SULegacyWebView : NSObject <SUReleaseNotesView>
 
-- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled;
+- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
 
 @end
 

--- a/Sparkle/SULegacyWebView.m
+++ b/Sparkle/SULegacyWebView.m
@@ -22,11 +22,12 @@
 @implementation SULegacyWebView
 {
     WebView *_webView;
+    NSArray<NSString *> *_customAllowedURLSchemes;
     
     void (^_completionHandler)(NSError * _Nullable);
 }
 
-- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled
+- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
 {
     self = [super init];
     if (self != nil) {
@@ -53,6 +54,8 @@
         _webView.policyDelegate = self;
         _webView.frameLoadDelegate = self;
         _webView.UIDelegate = self;
+        
+        _customAllowedURLSchemes = customAllowedURLSchemes;
     }
     return self;
 }
@@ -110,7 +113,7 @@
 {
     NSURL *requestURL = request.URL;
     BOOL isAboutBlank = NO;
-    BOOL safeURL = SUReleaseNotesIsSafeURL(requestURL, &isAboutBlank);
+    BOOL safeURL = SUReleaseNotesIsSafeURL(requestURL, _customAllowedURLSchemes, &isAboutBlank);
 
     // Do not allow redirects to dangerous protocols such as file://
     if (!safeURL) {

--- a/Sparkle/SUPlainTextReleaseNotesView.h
+++ b/Sparkle/SUPlainTextReleaseNotesView.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUPlainTextReleaseNotesView : NSObject <SUReleaseNotesView>
 
-- (instancetype)initWithFontPointSize:(int)fontPointSize;
+- (instancetype)initWithFontPointSize:(int)fontPointSize customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
 
 @end
 

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -22,10 +22,11 @@
 {
     NSScrollView *_scrollView;
     NSTextView *_textView;
+    NSArray<NSString *> *_customAllowedURLSchemes;
     int _fontPointSize;
 }
 
-- (instancetype)initWithFontPointSize:(int)fontPointSize
+- (instancetype)initWithFontPointSize:(int)fontPointSize customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
 {
     self = [super init];
     if (self != nil) {
@@ -34,6 +35,7 @@
         _textView.delegate = self;
         _scrollView.documentView = _textView;
         _fontPointSize = fontPointSize;
+        _customAllowedURLSchemes = customAllowedURLSchemes;
     }
     return self;
 }
@@ -125,7 +127,7 @@
     }
     
     BOOL isAboutBlankURL;
-    if (!SUReleaseNotesIsSafeURL(linkURL, &isAboutBlankURL)) {
+    if (!SUReleaseNotesIsSafeURL(linkURL, _customAllowedURLSchemes, &isAboutBlankURL)) {
         SULog(SULogLevelDefault, @"Blocked display of %@ URL which may be dangerous", linkURL.scheme);
         return YES;
     }

--- a/Sparkle/SUReleaseNotesCommon.h
+++ b/Sparkle/SUReleaseNotesCommon.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BOOL SUReleaseNotesIsSafeURL(NSURL *url, BOOL *isAboutBlankURL);
+BOOL SUReleaseNotesIsSafeURL(NSURL *url, NSArray<NSString *> *customAllowedURLSchemes, BOOL *isAboutBlankURL);
 
 NS_ASSUME_NONNULL_END
 

--- a/Sparkle/SUReleaseNotesCommon.m
+++ b/Sparkle/SUReleaseNotesCommon.m
@@ -13,15 +13,15 @@
 
 #include "AppKitPrevention.h"
 
-BOOL SUReleaseNotesIsSafeURL(NSURL *url, BOOL *isAboutBlankURL)
+BOOL SUReleaseNotesIsSafeURL(NSURL *url, NSArray<NSString *> *customAllowedURLSchemes, BOOL *isAboutBlankURL)
 {
     NSString *scheme = url.scheme;
     BOOL isAboutBlank = [url.absoluteString isEqualToString:@"about:blank"] || [url.absoluteString isEqualToString:@"about:srcdoc"];
-    BOOL whitelistedSafe = isAboutBlank || [@[@"http", @"https", @"macappstore", @"macappstores", @"itms-apps", @"itms-appss"] containsObject:scheme];
+    BOOL safeURL = isAboutBlank || [@[@"http", @"https", @"macappstore", @"macappstores", @"itms-apps", @"itms-appss"] containsObject:scheme] || [customAllowedURLSchemes containsObject:scheme.lowercaseString];
     
     *isAboutBlankURL = isAboutBlank;
     
-    return whitelistedSafe;
+    return safeURL;
 }
 
 #endif

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -322,8 +322,23 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         }
     }
     
+    NSArray<NSString *> *customAllowedURLSchemes;
+    {
+        NSMutableArray<NSString *> *allowedSchemes = [NSMutableArray array];
+        id hostAllowedURLSchemes = [_host objectForInfoDictionaryKey:SUAllowedURLSchemesKey];
+        if ([(NSObject *)hostAllowedURLSchemes isKindOfClass:[NSArray class]]) {
+            for (id urlScheme in (NSArray *)hostAllowedURLSchemes) {
+                if ([(NSObject *)urlScheme isKindOfClass:[NSString class]]) {
+                    [allowedSchemes addObject:[(NSString *)urlScheme lowercaseString]];
+                }
+            }
+        }
+        
+        customAllowedURLSchemes = [allowedSchemes copy];
+    }
+    
     if (usesPlainText) {
-        _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize];
+        _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize customAllowedURLSchemes:customAllowedURLSchemes];
     } else {
         NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
         
@@ -337,11 +352,11 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
         BOOL useWKWebView = !SPUXPCServiceIsEnabled(SUEnableDownloaderServiceKey);
         if (!useWKWebView) {
-            _releaseNotesView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+            _releaseNotesView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled customAllowedURLSchemes:customAllowedURLSchemes];
         } else
 #endif
         {
-            _releaseNotesView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled];
+            _releaseNotesView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled customAllowedURLSchemes:customAllowedURLSchemes];
         }
     }
     

--- a/Sparkle/SUWKWebView.h
+++ b/Sparkle/SUWKWebView.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUWKWebView : NSObject <SUReleaseNotesView>
 
-- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled;
+- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
 
 @end
 

--- a/Sparkle/SUWKWebView.m
+++ b/Sparkle/SUWKWebView.m
@@ -28,6 +28,7 @@
 {
     WKWebView *_webView;
     WKNavigation *_currentNavigation;
+    NSArray<NSString *> *_customAllowedURLSchemes;
     
     void (^_completionHandler)(NSError * _Nullable);
     
@@ -52,7 +53,7 @@ static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
     return [[WKUserScript alloc] initWithSource:scriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];
 }
 
-- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled
+- (instancetype)initWithColorStyleSheetLocation:(NSURL *)colorStyleSheetLocation fontFamily:(NSString *)fontFamily fontPointSize:(int)fontPointSize javaScriptEnabled:(BOOL)javaScriptEnabled customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
 {
     self = [super init];
     if (self != nil) {
@@ -96,6 +97,8 @@ static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
         
         _webView = [[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration];
         _webView.navigationDelegate = self;
+        
+        _customAllowedURLSchemes = customAllowedURLSchemes;
     }
     return self;
 }
@@ -179,7 +182,7 @@ static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
     NSURLRequest *request = navigationAction.request;
     NSURL *requestURL = request.URL;
     BOOL isAboutBlank = NO;
-    BOOL safeURL = SUReleaseNotesIsSafeURL(requestURL, &isAboutBlank);
+    BOOL safeURL = SUReleaseNotesIsSafeURL(requestURL, _customAllowedURLSchemes, &isAboutBlank);
     
     // Do not allow redirects to dangerous protocols such as file://
     if (!safeURL) {


### PR DESCRIPTION
## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested with test app that custom specified URL scheme works.
Tested legacy web view implementation too.

macOS version tested: 13.4 (22F66)
