### PR TITLE
Replace CFUUID* with NSUUID

### DIFF
--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -62,18 +62,8 @@
         NSArray *contents = nil;
         do
 		{
-            // Using NSUUID would make creating UUIDs be done in Cocoa,
-            // and thus managed under ARC. Sadly, the class is in 10.8 and later.
-            CFUUIDRef uuid = CFUUIDCreate(NULL);
-            if (uuid)
-            {
-                NSString *uuidString = CFBridgingRelease(CFUUIDCreateString(NULL, uuid));
-                if (uuidString)
-                {
-                    mountPoint = [@"/Volumes" stringByAppendingPathComponent:uuidString];
-                }
-                CFRelease(uuid);
-            }
+            NSString *uuidString = [[NSUUID UUID] UUIDString];
+            mountPoint = [@"/Volumes" stringByAppendingPathComponent:uuidString];
 		}
         // Note: this check does not follow symbolic links, which is what we want
 		while ([[NSURL fileURLWithPath:mountPoint] checkResourceIsReachableAndReturnError:NULL]);


### PR DESCRIPTION
This resolves a nullability warning by the static analyzer.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I have not tested these changes, but I have tested the NSUUID class and the UUIDString property. Unlike CFUUID*, NSUUID has `_Nonnull` annotations.