### PR TITLE
Fix KVO usage for updaterController.updater.*

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -22,6 +22,10 @@
 // programmatically.
 
 @interface SPUStandardUpdaterController () <NSMenuItemValidation>
+
+// Needed for KVO
+@property (nonatomic) SPUUpdater *updater;
+
 @end
 
 @implementation SPUStandardUpdaterController
@@ -45,7 +49,9 @@
     NSBundle *hostBundle = [NSBundle mainBundle];
     SPUStandardUserDriver *userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:self->userDriverDelegate];
     
-    _updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self->updaterDelegate];
+    SPUUpdater *updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self->updaterDelegate];
+    [self setUpdater:updater];
+    
     _userDriver = userDriver;
 }
 


### PR DESCRIPTION
KVO was not set up properly when trying to retrieve the updater from the updater controller, especially when the updater controller hasn't been fully initialized yet.

Fixes issues brought in discussion #2403

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested with a test app that references `updater.canCheckForUpdates` on an `SPUStandardUpdaterController` instance.

macOS version tested: 13.4.1 (22F82)
