### PR TITLE
Report an error when detecting duplicate updates in generate_appcast

### DIFF
--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -52,12 +52,14 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, disableNeste
 
     let fileManager = FileManager.default
 
-    var unarchived: [ArchiveItem] = []
-
+    // Create a dictionary of archive destination directories -> archive source path
+    // so we can ignore duplicate archive entries before trying to unarchive archives in parallel
+    var fileEntries: [URL: URL] = [:]
     let dir = try fileManager.contentsOfDirectory(atPath: archivesSourceDir.path)
-    var running = 0
     for item in dir.filter({ !$0.hasPrefix(".") && !$0.hasSuffix(".delta") && !$0.hasSuffix(".xml") && !$0.hasSuffix(".html") && !$0.hasSuffix(".txt") }) {
         let itemPath = archivesSourceDir.appendingPathComponent(item)
+        
+        // Ignore directories
         var isDir: ObjCBool = false
         if fileManager.fileExists(atPath: itemPath.path, isDirectory: &isDir) && isDir.boolValue {
             continue
@@ -69,7 +71,20 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, disableNeste
         } else {
             archiveDestDir = archivesDestDir.appendingPathComponent(itemPath.lastPathComponent)
         }
-
+        
+        // Ignore duplicate archives
+        if let existingItemPath = fileEntries[archiveDestDir] {
+            throw makeError(code: .appcastError, "Duplicate update archives are not supported. Found '\(existingItemPath.lastPathComponent)' and '\(itemPath.lastPathComponent)'. Please remove one of them from the appcast generation directory.")
+        }
+        
+        fileEntries[archiveDestDir] = itemPath
+    }
+    
+    var unarchived: [String: ArchiveItem] = [:]
+    var updateParseError: Error? = nil
+    
+    var running = 0
+    for (archiveDestDir, itemPath) in fileEntries {
         let addItem = { (validateBundle: Bool) in
             do {
                 let item = try ArchiveItem(fromArchive: itemPath, unarchivedDir: archiveDestDir, validateBundle: validateBundle, disableNestedCodeCheck: disableNestedCodeCheck)
@@ -77,10 +92,15 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, disableNeste
                     print("Found archive", item)
                 }
                 objc_sync_enter(unarchived)
-                unarchived.append(item)
+                // Make sure different archives don't contain the same update too
+                if let existingArchive = unarchived[item.version] {
+                    updateParseError = makeError(code: .appcastError, "Duplicate updates are not supported. Found archives '\(existingArchive.archivePath.lastPathComponent)' and '\(itemPath.lastPathComponent)' which contain the same bundle version. Please remove one of these archives from the appcast generation directory.")
+                } else {
+                    unarchived[item.version] = item
+                }
                 objc_sync_exit(unarchived)
             } catch {
-                print("Skipped", item, error)
+                print("Skipped", itemPath.lastPathComponent, error)
             }
         }
 
@@ -107,6 +127,10 @@ func unarchiveUpdates(archivesSourceDir: URL, archivesDestDir: URL, disableNeste
     }
 
     group.wait()
+    
+    if let updateParseError = updateParseError {
+        throw updateParseError
+    }
 
-    return unarchived
+    return Array(unarchived.values)
 }


### PR DESCRIPTION
Fixes #2406

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested using generate_appcast normally
Tested using generate_appcast with duplicate update archives (now with a reported error)
Tested using generate_appcast with different update archives containing same update (now with a reported error)

macOS version tested: 13.4.1 (c) (22F770820d)
