### PR TITLE
Ignore file URL scheme in custom allowed URL schemes

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -329,7 +329,12 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         if ([(NSObject *)hostAllowedURLSchemes isKindOfClass:[NSArray class]]) {
             for (id urlScheme in (NSArray *)hostAllowedURLSchemes) {
                 if ([(NSObject *)urlScheme isKindOfClass:[NSString class]]) {
-                    [allowedSchemes addObject:[(NSString *)urlScheme lowercaseString]];
+                    NSString *allowedURLScheme = [(NSString *)urlScheme lowercaseString];
+                    if (![allowedURLScheme isEqualToString:@"file"]) {
+                        [allowedSchemes addObject:allowedURLScheme];
+                    } else {
+                        SULog(SULogLevelError, @"Error: Found 'file' scheme in %@. Ignoring because this scheme is unsafe.", SUAllowedURLSchemesKey);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested file:// is ignored in new SUAllowedURLSchemesKey feature.

macOS version tested: 13.5 (22G74)
