### PR TITLE
Handle invalid % character at the end of EdDSA public key in Info.plist

### DIFF
--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -132,7 +132,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *_Nullable)publicEDKey SPU_OBJC_DIRECT
 {
-    return [self objectForInfoDictionaryKey:SUPublicEDKeyKey];
+    NSString *publicKey = [self objectForInfoDictionaryKey:SUPublicEDKeyKey];
+    if [publicKey substringFromIndex:[publicKey length] - 1] == @"%" {
+        return [publicKey substringToIndex:[publicKey length] - 1]
+    }
+    return publicKey
 }
 
 - (NSString *_Nullable)publicDSAKey SPU_OBJC_DIRECT


### PR DESCRIPTION
This change fixes problem when parsing EdDSA public key from Info.plist that would rarely have a % character at the end of Base64 encoded string. This loads just fine with Sparkle 1, but fails to load for Sparkle 2.