### PR TITLE
Improve permission prompt layout

### DIFF
--- a/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/Base.lproj/SUUpdatePermissionPrompt.xib
@@ -67,7 +67,7 @@
                 <string>SUSendProfileInfo</string>
             </declaredKeys>
         </userDefaultsController>
-        <view misplaced="YES" id="Yrl-Dt-Qvb" userLabel="Prompt View">
+        <view id="Yrl-Dt-Qvb" userLabel="Prompt View">
             <rect key="frame" x="0.0" y="0.0" width="437" height="78"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>


### PR DESCRIPTION
The permission prompt didn't layout the spacing well if the prompt message was short, which you could see in English if you have a short app name.

Old:
<img width="549" alt="old-automatic-short" src="https://github.com/sparkle-project/Sparkle/assets/857267/753d43d5-488e-4cb7-ab0d-2b4a9fbf38ad">

<img width="549" alt="old-short" src="https://github.com/sparkle-project/Sparkle/assets/857267/ff6deac2-5fd5-4f78-bb66-e2e1bf27a51b">

New:
<img width="549" alt="new-automatic-short" src="https://github.com/sparkle-project/Sparkle/assets/857267/c77bb202-e530-4f02-85d0-48993ec8b557">

<img width="549" alt="new-short" src="https://github.com/sparkle-project/Sparkle/assets/857267/9e5d9695-a621-49de-9f9d-c50719c1daae">


## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested long and short messages with anonymous system profile button visible, automatic download button visible, neither of those buttons visible, English, Russian, Chinese..

macOS version tested:
13.5 (22G74)
14.0 Beta (23A5312d)
10.14.6 (18G6032)
