### PR TITLE
Corrected hyphenation for 'already current' status message

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -149,4 +149,4 @@
 "Your macOS version is too old" = "Your macOS version is too old";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "You’re up-to-date!";
+"You’re up-to-date!" = "You’re up to date!";


### PR DESCRIPTION
(See https://github.com/sparkle-project/Sparkle/pull/1654)

Noticed from some clients using the latest Sparkle release that this appears to have regressed. (Likely because Sparkle.strings was removed from en.lproj/ at some point.)

This brings the fix from #1654 into the base loc file in the absence of a dedicated English one.