### PR TITLE
Remove hyphenation in "You're up to date" message

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -149,4 +149,4 @@
 "Your macOS version is too old" = "Your macOS version is too old";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "You’re up-to-date!";
+"You’re up to date!" = "You’re up to date!";

--- a/Sparkle/SPUBasicUpdateDriver.m
+++ b/Sparkle/SPUBasicUpdateDriver.m
@@ -199,13 +199,13 @@
             switch (hostToLatestAppcastItemComparisonResult) {
                 case NSOrderedDescending:
                     // This means the user is a 'newer than latest' version. give a slight hint to the user instead of wrongly claiming this version is identical to the latest feed version.
-                    localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up-to-date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+                    localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up to date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
                     
                     reason = SPUNoUpdateFoundReasonOnNewerThanLatestVersion;
                     break;
                 case NSOrderedSame:
                     // No new update is available and we're on the latest
-                    localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up-to-date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+                    localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up to date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
                     
                     reason = SPUNoUpdateFoundReasonOnLatestVersion;
                     break;
@@ -222,7 +222,7 @@
                         reason = SPUNoUpdateFoundReasonSystemIsTooNew;
                     } else {
                         // We shouldn't realistically get here
-                        localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up-to-date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+                        localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up to date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
                         
                         reason = SPUNoUpdateFoundReasonUnknown;
                     }
@@ -233,7 +233,7 @@
             // We will need to assume the user is up to date if the feed doen't have any applicable update items
             // There could be update items on channels the updater is not subscribed to for example. But we can't tell the user about them.
             // There could also only be update items available for other platforms or none at all.
-            localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up-to-date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
+            localizedDescription = SULocalizedStringFromTableInBundle(@"You’re up to date!", SPARKLE_TABLE, sparkleBundle, "Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates.");
             
             reason = SPUNoUpdateFoundReasonOnLatestVersion;
         }

--- a/Sparkle/ca.lproj/Sparkle.strings
+++ b/Sparkle/ca.lproj/Sparkle.strings
@@ -59,4 +59,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Moveu %1$@ al vostre directori Aplicacions, reinicieu-lo, i torneu a provar-ho.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Ja esteu al dia!";
+"You’re up to date!" = "Ja esteu al dia!";

--- a/Sparkle/cs.lproj/Sparkle.strings
+++ b/Sparkle/cs.lproj/Sparkle.strings
@@ -143,7 +143,7 @@
 "Version History" = "Historie verzí";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Vaše verze je aktuální!";
+"You’re up to date!" = "Vaše verze je aktuální!";
 
 /* No comment provided by engineer. */
 "Your macOS version is too new" = "Vaše verze macOS je příliš nová";

--- a/Sparkle/da.lproj/Sparkle.strings
+++ b/Sparkle/da.lproj/Sparkle.strings
@@ -83,4 +83,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Flyt %1$@ til mappen Programmer, genstart derfra og prøv igen.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Der er ingen opdateringer";
+"You’re up to date!" = "Der er ingen opdateringer";

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -143,7 +143,7 @@
 "Version History" = "Versionsverlauf";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Du bist auf dem neuesten Stand!";
+"You’re up to date!" = "Du bist auf dem neuesten Stand!";
 
 /* No comment provided by engineer. */
 "Your macOS version is too new" = "Deine Version von macOS ist zu neu";

--- a/Sparkle/el.lproj/Sparkle.strings
+++ b/Sparkle/el.lproj/Sparkle.strings
@@ -77,4 +77,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Αντιγράψτε το %1$@ στον φάκελο εφαρμογών συστήματος, επανεκκινήστε το από εκεί και ξαναδοκιμάστε.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Είστε ενημερωμένοι!";
+"You’re up to date!" = "Είστε ενημερωμένοι!";

--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -89,4 +89,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Usa Finder para copiar %1$@ a la carpeta Aplicaciones, vuélvela a abrir desde ahí e inténtalo de nuevo.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "¡Está actualizado!";
+"You’re up to date!" = "¡Está actualizado!";

--- a/Sparkle/fa.lproj/Sparkle.strings
+++ b/Sparkle/fa.lproj/Sparkle.strings
@@ -95,4 +95,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "از Finder برای کپی کردن %1$@ به پوشهٔ برنامه استفاده کنید، سپس %1$@ را دوباره باز کرده و مجدداً امتحان کنید.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "برنامهٔ شما به‌روز است";
+"You’re up to date!" = "برنامهٔ شما به‌روز است";

--- a/Sparkle/fi.lproj/Sparkle.strings
+++ b/Sparkle/fi.lproj/Sparkle.strings
@@ -53,4 +53,4 @@
 "Updating %@" = "Päivitetään %@";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Sinulla on viimeisin versio!";
+"You’re up to date!" = "Sinulla on viimeisin versio!";

--- a/Sparkle/fr.lproj/Sparkle.strings
+++ b/Sparkle/fr.lproj/Sparkle.strings
@@ -98,4 +98,4 @@
 "Version History" = "Historique des versions";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Votre logiciel est à jour !";
+"You’re up to date!" = "Votre logiciel est à jour !";

--- a/Sparkle/he.lproj/Sparkle.strings
+++ b/Sparkle/he.lproj/Sparkle.strings
@@ -50,4 +50,4 @@
 "Updating %@" = "מעדכן %@";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "התכנה עדכנית!";
+"You’re up to date!" = "התכנה עדכנית!";

--- a/Sparkle/hr.lproj/Sparkle.strings
+++ b/Sparkle/hr.lproj/Sparkle.strings
@@ -89,4 +89,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Kopiraj %1$@ u mapu Aplikacije, pokreni je odande i pokušaj ponovo.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Koristiš najnoviju verziju!";
+"You’re up to date!" = "Koristiš najnoviju verziju!";

--- a/Sparkle/is.lproj/Sparkle.strings
+++ b/Sparkle/is.lproj/Sparkle.strings
@@ -50,4 +50,4 @@
 "Updating %@" = "Uppfæri %@";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Það er allt uppfært hjá þér!";
+"You’re up to date!" = "Það er allt uppfært hjá þér!";

--- a/Sparkle/it.lproj/Sparkle.strings
+++ b/Sparkle/it.lproj/Sparkle.strings
@@ -149,4 +149,4 @@
 "Your macOS version is too old" = "La tua versione di macOS è troppo vecchia";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "La tua applicazione è aggiornata!";
+"You’re up to date!" = "La tua applicazione è aggiornata!";

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -149,4 +149,4 @@
 "Your macOS version is too old" = "このmacOSのバージョンは古すぎます";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "最新版を使用しています!";
+"You’re up to date!" = "最新版を使用しています!";

--- a/Sparkle/ko.lproj/Sparkle.strings
+++ b/Sparkle/ko.lproj/Sparkle.strings
@@ -77,4 +77,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@을(를) 응용프로그램 폴더로 이동하여 다시 실행해 주십시오.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "최신 버전입니다.";
+"You’re up to date!" = "최신 버전입니다.";

--- a/Sparkle/nb.lproj/Sparkle.strings
+++ b/Sparkle/nb.lproj/Sparkle.strings
@@ -86,5 +86,5 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Flytt %1$@ til Programmer-katalogen, start på ny og prøv igjen.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Ingen nye oppdateringer";
+"You’re up to date!" = "Ingen nye oppdateringer";
 

--- a/Sparkle/nl.lproj/Sparkle.strings
+++ b/Sparkle/nl.lproj/Sparkle.strings
@@ -143,7 +143,7 @@
 "Version History" = "Versiegeschiedenis";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Je hebt de nieuwste versie!";
+"You’re up to date!" = "Je hebt de nieuwste versie!";
 
 /* No comment provided by engineer. */
 "Your macOS version is too new" = "Je versie van macOS is te nieuw";

--- a/Sparkle/pl.lproj/Sparkle.strings
+++ b/Sparkle/pl.lproj/Sparkle.strings
@@ -80,4 +80,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Użyj Findera, aby skopiować %1$@ do folderu Programy, uruchom z nowej lokacji i spróbuj ponownie.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Jesteś na bieżąco!";
+"You’re up to date!" = "Jesteś na bieżąco!";

--- a/Sparkle/pt-BR.lproj/Sparkle.strings
+++ b/Sparkle/pt-BR.lproj/Sparkle.strings
@@ -140,7 +140,7 @@
 "Version History" = "Histórico de Versões";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "O app está atualizado!";
+"You’re up to date!" = "O app está atualizado!";
 
 /* No comment provided by engineer. */
 "Your macOS version is too new" = "A versão do macOS é nova demais";

--- a/Sparkle/pt-PT.lproj/Sparkle.strings
+++ b/Sparkle/pt-PT.lproj/Sparkle.strings
@@ -77,4 +77,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Use o Finder para copiar o %1$@ para a sua pasta Aplicações, reinicie-o aí e tente novamente.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Está actualizado!";
+"You’re up to date!" = "Está actualizado!";

--- a/Sparkle/ro.lproj/Sparkle.strings
+++ b/Sparkle/ro.lproj/Sparkle.strings
@@ -86,4 +86,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Mută %1$@ în directorul Aplicații, repornește-o de acolo și încearcă din nou.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Ai ultima versiune!";
+"You’re up to date!" = "Ai ultima versiune!";

--- a/Sparkle/ru.lproj/Sparkle.strings
+++ b/Sparkle/ru.lproj/Sparkle.strings
@@ -80,4 +80,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Переместите %1$@ в Папку приложений, перезапустите его оттуда и повторите попытку.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "У вас все обновлено!";
+"You’re up to date!" = "У вас все обновлено!";

--- a/Sparkle/sk.lproj/Sparkle.strings
+++ b/Sparkle/sk.lproj/Sparkle.strings
@@ -77,4 +77,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Presuňte aplikáciu %1$@ do priečinka Applications, spustite ju odtiaľ a potom znova skúste aktualizáciu.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Máte aktuálnu verziu!";
+"You’re up to date!" = "Máte aktuálnu verziu!";

--- a/Sparkle/sl.lproj/Sparkle.strings
+++ b/Sparkle/sl.lproj/Sparkle.strings
@@ -77,4 +77,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Poskusite %1$@ premakniti v direktorij z aplikacijami (Applications), ga ponovno zagnati in šele nato posodobiti.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Uporabljate zadnjo verzijo.";
+"You’re up to date!" = "Uporabljate zadnjo verzijo.";

--- a/Sparkle/sv.lproj/Sparkle.strings
+++ b/Sparkle/sv.lproj/Sparkle.strings
@@ -77,4 +77,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Flytta %1$@ till mappen Program, starta om det därifrån, och försök igen.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Du är uppdaterad!";
+"You’re up to date!" = "Du är uppdaterad!";

--- a/Sparkle/th.lproj/Sparkle.strings
+++ b/Sparkle/th.lproj/Sparkle.strings
@@ -80,4 +80,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "%1$@ ไปยังโฟลเดอร์แอปพลิเคชัน และเรียกใช้งาน จากนั้นลองใหม่อีกครั้ง";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "คุณมีเวอร์ชั่นล่าสุดแล้ว!";
+"You’re up to date!" = "คุณมีเวอร์ชั่นล่าสุดแล้ว!";

--- a/Sparkle/tr.lproj/Sparkle.strings
+++ b/Sparkle/tr.lproj/Sparkle.strings
@@ -80,4 +80,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Lütfen %1$@ uygulamasını Uygulamalar dizinine kopyalayıp yeniden başlatınız.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "Uygulama güncel!";
+"You’re up to date!" = "Uygulama güncel!";

--- a/Sparkle/uk.lproj/Sparkle.strings
+++ b/Sparkle/uk.lproj/Sparkle.strings
@@ -80,4 +80,4 @@
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Перемістіть %1$@ у папку з програмами, перезавантажте його звідти і спробуйте ще раз.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "У вас остання версія!";
+"You’re up to date!" = "У вас остання версія!";

--- a/Sparkle/zh_CN.lproj/Sparkle.strings
+++ b/Sparkle/zh_CN.lproj/Sparkle.strings
@@ -92,4 +92,4 @@
 "Version History" = "版本历史记录";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "您使用的就是最新版！";
+"You’re up to date!" = "您使用的就是最新版！";

--- a/Sparkle/zh_HK.lproj/Sparkle.strings
+++ b/Sparkle/zh_HK.lproj/Sparkle.strings
@@ -149,4 +149,4 @@
 "Your macOS version is too old" = "你 macOS 版本過舊";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "你用緊最新版本！";
+"You’re up to date!" = "你用緊最新版本！";

--- a/Sparkle/zh_TW.lproj/Sparkle.strings
+++ b/Sparkle/zh_TW.lproj/Sparkle.strings
@@ -149,4 +149,4 @@
 "Your macOS version is too old" = "您的 macOS 版本過舊";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up-to-date!" = "您已有最新版本！";
+"You’re up to date!" = "您已有最新版本！";


### PR DESCRIPTION
See #2422. This likely regressed from https://github.com/sparkle-project/Sparkle/pull/2113

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested "You're up to date" messages with a modified test app in English, Japanese, Spanish.

macOS version tested: 13.5 (22G74)
