### PR TITLE
Fix make release not building distribution successfully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: build
 
 ifndef BUILDDIR
-    BUILDDIR := $(shell mktemp -d "$(TMPDIR)/Sparkle.XXXXXX")
+    BUILDDIR := $(shell mkdir -p "build" && mktemp -d "build/Sparkle.XXXXXX")
 endif
 
 localizable-strings:

--- a/README.markdown
+++ b/README.markdown
@@ -54,7 +54,7 @@ If you are adding a symbol to the public API you must decorate the declaration w
 
 You do not usually need to build a Sparkle distribution unless you're making changes to Sparkle itself.
 
-To build a Sparkle distribution, `cd` to the root of the Sparkle source tree and run `make release`. Sparkle-*VERSION*.tar.xz (or .bz2) will be created in a temporary directory and revealed in Finder after the build has completed.
+To build a Sparkle distribution, `cd` to the root of the Sparkle source tree and run `make release`. Sparkle-*VERSION*.tar.xz (or .bz2) will be created and revealed in Finder after the build has completed.
 
 Alternatively, build the Distribution scheme in the Xcode UI.
 


### PR DESCRIPTION
For some reason, the default BUILDDIR that was set was problematic. We are now defaulting BUILDDIR inside of ./build which resolves this issue. This also means by default, builds are not placed inside of system temp directories anymore.

I do not know when this stopped working or why.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested `make release` built successfully on my machine.

macOS version tested:
13.5 (22G74)
14.0 (23A5328b)
