### PR TITLE
Fix Updater.app not starting when running Sparkle as root on Sonoma

### DIFF
--- a/Sparkle/SPULocalCacheDirectory.h
+++ b/Sparkle/SPULocalCacheDirectory.h
@@ -21,6 +21,10 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPULocalCacheDirectory : NSObject
 // and then create a unique temporary directory inside it (using +createUniqueDirectoryInDirectory:)
 + (NSString *)cachePathForBundleIdentifier:(NSString *)bundleIdentifier;
 
+// Variant of cachePathForBundleIdentifier: that specifies a userName to create the cache path for
+// Only use this when running from as root
++ (NSString *)cachePathForBundleIdentifier:(NSString *)bundleIdentifier userName:(NSString *)userName;
+
 // Remove old files inside a directory
 // A caller may want to invoke this on a directory they own rather than remove and re-create an entire directory
 // This does nothing if the supplied directory does not exist yet
@@ -29,6 +33,7 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPULocalCacheDirectory : NSObject
 // Create a unique directory inside a parent directory
 // The parent directory doesn't have to exist yet. If it doesn't exist, intermediate directories will be created.
 + (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory;
++ (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory intermediateDirectoryFileAttributes:(nullable NSDictionary<NSFileAttributeKey, id> *)attributes;
 
 @end
 


### PR DESCRIPTION
This may occur for example when you run sparkle-cli as root or use Sparkle.framework in a root process. This is not typically a common use case, but could be used from daemons.

The issue is that Sonoma doesn't like starting our Updater app in the user domain when intermediate directories containing it are root owned (due to lack of file permission access that wasn't present in Ventura). So now we try to create intermediate directories in the standard user's home directory.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running sparkle-cli as root to update bundle.
Tested test app still works.

macOS version tested:
14.0 Beta (23A5337a)
13.5.1 (22G90)
