### PR TITLE
Fail gracefully when auxiliary tool cannot be located

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -326,10 +326,17 @@
     } else {
         auxiliaryToolURL = [bundle URLForAuxiliaryExecutable:nameWithExtension];
     }
-    assert(auxiliaryToolURL != nil);
+    
+    if (auxiliaryToolURL == nil) {
+        SULog(SULogLevelError, @"Error: Cannot retrieve path for auxiliary tool: %@", nameWithExtension);
+        return nil;
+    }
     
     NSURL *resolvedAuxiliaryToolURL = [auxiliaryToolURL URLByResolvingSymlinksInPath];
-    assert(resolvedAuxiliaryToolURL != nil);
+    if (resolvedAuxiliaryToolURL == nil) {
+        SULog(SULogLevelError, @"Error: Cannot retrieve resolved path for auxiliary tool path: %@", auxiliaryToolURL.path);
+        return nil;
+    }
     
     return resolvedAuxiliaryToolURL.path;
 }


### PR DESCRIPTION
Fixes #2435

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

Only bug fixes to regressions or security fixes are being backported to the 1.x (master) branch now. If you believe your change is significant enough to backport, please also create a separate pull request against the master branch.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app (sandboxed)
Tested sparkle-cli on app (non-sandboxed)

macOS version tested: 13.5.1 (22G90)
