### PR TITLE
Fix false positive analyzer warning about resumableUpdate type

### DIFF
--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -190,8 +190,9 @@
 
 - (void)extractDownloadedUpdate
 {
-    assert(_resumableUpdate != nil);
-    [self extractUpdate:_resumableUpdate];
+    id<SPUResumableUpdate> resumableUpdate = _resumableUpdate;
+    assert(resumableUpdate != nil && [resumableUpdate isKindOfClass:[SPUDownloadedUpdate class]]);
+    [self extractUpdate:(SPUDownloadedUpdate *)resumableUpdate];
 }
 
 - (void)clearDownloadedUpdate


### PR DESCRIPTION
Fixes #2453

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested stepping into `extractDownloadedUpdate` in debugger for automatically downloaded update requiring authorization.

macOS version tested: 14.0 (23A344)
