### PR TITLE
Update Spanish translation for currently running and version history strings, addresses #1429

### DIFF
--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -2,7 +2,7 @@
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ es la versión más nueva disponible.";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ es la versión más nueva disponible.\n(You are currently running version %3$@.)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ es la versión más nueva disponible.\n(Actualmente estás corriendo la versión %3$@.)";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
 "%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ ya está disponible (tienes la %3$@). ¿Quisieras descargarla ahora?";
@@ -87,6 +87,9 @@
 
 /* No comment provided by engineer. */
 "Use Finder to copy %1$@ to the Applications folder, relaunch it from there, and try again." = "Usa Finder para copiar %1$@ a la carpeta Aplicaciones, vuélvela a abrir desde ahí e inténtalo de nuevo.";
+
+/* No comment provided by engineer. */
+"Version History" = "Historial de versiones";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You’re up to date!" = "¡Está actualizado!";


### PR DESCRIPTION
Updates Spanish translations in `es.lproj` for the "You are currently running..." and "Version History" strings. 

Addresses #1429 

I ran these translations by a friend who's first language is Spanish, so they should be reasonably idiomatic, but let me know if not, happy to adjust.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

I ran a `make release` build and replaced the copy of `Sparkle.framework` in my app project. Then I rebuilt my app, customized the language in System Settings for my app to Español — Spanish, launched it, and ran Check For Updates.

<img width="308" alt="up-to-date-es" src="https://github.com/sparkle-project/Sparkle/assets/2420/0844e183-6dd2-40d9-a1bc-a411ab7ac1bf">

macOS version tested: Ventura 13.6
