### PR TITLE
Improve signing error message to developers

### DIFF
--- a/Autoupdate/SPUInstallationInputData.h
+++ b/Autoupdate/SPUInstallationInputData.h
@@ -21,8 +21,10 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPUInstallationInputData : NSObject <NSSecure
  * downloadName - name of update archive in update directory
  * signatures - signatures for the update that came from the appcast item
  * decryptionPassword - optional decryption password for dmg archives
+ * expectedVersion - optional expected version of the new update
+ * expectedContentLength - optional expected content length of the new download archive
  */
-- (instancetype)initWithRelaunchPath:(NSString *)relaunchPath hostBundlePath:(NSString *)hostBundlePath updateURLBookmarkData:(NSData *)updateURLBookmarkData installationType:(NSString *)installationType signatures:(SUSignatures * _Nullable)signatures decryptionPassword:(nullable NSString *)decryptionPassword;
+- (instancetype)initWithRelaunchPath:(NSString *)relaunchPath hostBundlePath:(NSString *)hostBundlePath updateURLBookmarkData:(NSData *)updateURLBookmarkData installationType:(NSString *)installationType signatures:(SUSignatures * _Nullable)signatures decryptionPassword:(nullable NSString *)decryptionPassword expectedVersion:(NSString *)expectedVersion expectedContentLength:(uint64_t)expectedContentLength;
 
 @property (nonatomic, copy, readonly) NSString *relaunchPath;
 @property (nonatomic, copy, readonly) NSString *hostBundlePath;
@@ -30,6 +32,8 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPUInstallationInputData : NSObject <NSSecure
 @property (nonatomic, copy, readonly) NSString *installationType;
 @property (nonatomic, readonly, nullable) SUSignatures *signatures; // nullable because although not using signatures is deprecated, it's still supported
 @property (nonatomic, copy, readonly, nullable) NSString *decryptionPassword;
+@property (nonatomic, copy, readonly, nullable) NSString *expectedVersion;
+@property (nonatomic, readonly) uint64_t expectedContentLength;
 
 @end
 

--- a/Autoupdate/SPUInstallationInputData.m
+++ b/Autoupdate/SPUInstallationInputData.m
@@ -18,6 +18,8 @@ static NSString *SUUpdateURLBookmarkDataKey = @"SUUpdateURLBookmarkData";
 static NSString *SUSignaturesKey = @"SUSignatures";
 static NSString *SUDecryptionPasswordKey = @"SUDecryptionPassword";
 static NSString *SUInstallationTypeKey = @"SUInstallationType";
+static NSString *SUExpectedVersionKey = @"SUExpectedVersion";
+static NSString *SUExpectedContentLength = @"SUExpectedContentLength";
 
 @implementation SPUInstallationInputData
 
@@ -27,8 +29,10 @@ static NSString *SUInstallationTypeKey = @"SUInstallationType";
 @synthesize signatures = _signatures;
 @synthesize decryptionPassword = _decryptionPassword;
 @synthesize installationType = _installationType;
+@synthesize expectedVersion = _expectedVersion;
+@synthesize expectedContentLength = _expectedContentLength;
 
-- (instancetype)initWithRelaunchPath:(NSString *)relaunchPath hostBundlePath:(NSString *)hostBundlePath updateURLBookmarkData:(NSData *)updateURLBookmarkData installationType:(NSString *)installationType signatures:(SUSignatures * _Nullable)signatures decryptionPassword:(nullable NSString *)decryptionPassword
+- (instancetype)initWithRelaunchPath:(NSString *)relaunchPath hostBundlePath:(NSString *)hostBundlePath updateURLBookmarkData:(NSData *)updateURLBookmarkData installationType:(NSString *)installationType signatures:(SUSignatures * _Nullable)signatures decryptionPassword:(nullable NSString *)decryptionPassword expectedVersion:(nonnull NSString *)expectedVersion expectedContentLength:(uint64_t)expectedContentLength
 {
     self = [super init];
     if (self != nil) {
@@ -41,6 +45,9 @@ static NSString *SUInstallationTypeKey = @"SUInstallationType";
         
         _signatures = signatures;
         _decryptionPassword = [decryptionPassword copy];
+        
+        _expectedVersion = [expectedVersion copy];
+        _expectedContentLength = expectedContentLength;
     }
     return self;
 }
@@ -74,7 +81,10 @@ static NSString *SUInstallationTypeKey = @"SUInstallationType";
     
     NSString *decryptionPassword = [decoder decodeObjectOfClass:[NSString class] forKey:SUDecryptionPasswordKey];
     
-    return [self initWithRelaunchPath:relaunchPath hostBundlePath:hostBundlePath updateURLBookmarkData:updateURLBookmarkData installationType:installationType signatures:signatures decryptionPassword:decryptionPassword];
+    NSString *expectedVersion = [decoder decodeObjectOfClass:[NSString class] forKey:SUExpectedVersionKey];
+    uint64_t expectedContentLength = (uint64_t)[decoder decodeInt64ForKey:SUExpectedContentLength];
+    
+    return [self initWithRelaunchPath:relaunchPath hostBundlePath:hostBundlePath updateURLBookmarkData:updateURLBookmarkData installationType:installationType signatures:signatures decryptionPassword:decryptionPassword expectedVersion:expectedVersion expectedContentLength:expectedContentLength];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder
@@ -87,6 +97,10 @@ static NSString *SUInstallationTypeKey = @"SUInstallationType";
     if (_decryptionPassword != nil) {
         [coder encodeObject:_decryptionPassword forKey:SUDecryptionPasswordKey];
     }
+    if (_expectedVersion != nil) {
+        [coder encodeObject:_expectedVersion forKey:SUExpectedVersionKey];
+    }
+    [coder encodeInt64:(int64_t)_expectedContentLength forKey:SUExpectedContentLength];
 }
 
 + (BOOL)supportsSecureCoding

--- a/Autoupdate/SUSignatureVerifier.h
+++ b/Autoupdate/SUSignatureVerifier.h
@@ -18,15 +18,22 @@
 #import <Foundation/Foundation.h>
 @class SUSignatures;
 @class SUPublicKeys;
+@class SPUVerifierInformation;
+
+NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUSignatureVerifier : NSObject
 
-+ (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys error:(NSError * __autoreleasing *)error;
++ (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys verifierInformation:(SPUVerifierInformation * _Nullable)verifierInformation error:(NSError * __autoreleasing *)error;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithPublicKeys:(SUPublicKeys *)pkeys;
 
-- (BOOL)verifyFileAtPath:(NSString *)path signatures:(SUSignatures *)signatures error:(NSError * __autoreleasing *)error;
+- (BOOL)verifyFileAtPath:(NSString *)path signatures:(SUSignatures *)signatures verifierInformation:(SPUVerifierInformation * _Nullable)verifierInformation error:(NSError * __autoreleasing *)error;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -392,6 +392,8 @@
 		72BC6C3D275027BF0083F14B /* SparkleTestCodeSign_apfs.dmg in Resources */ = {isa = PBXBuildFile; fileRef = 72BC6C3C275027BF0083F14B /* SparkleTestCodeSign_apfs.dmg */; };
 		72BEBFEF1D7287570019146B /* SUSpotlightImporterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72BEBFEE1D7287560019146B /* SUSpotlightImporterTest.swift */; };
 		72CCDEBE27421FD500B53718 /* SparkleTestCodeSignApp_bad_header.zip in Resources */ = {isa = PBXBuildFile; fileRef = 72CCDEBD27421FD500B53718 /* SparkleTestCodeSignApp_bad_header.zip */; };
+		72D04F3D2B094C8400A6DEAA /* SPUVerifierInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D04F3C2B094C8400A6DEAA /* SPUVerifierInformation.m */; };
+		72D04F3E2B097D4300A6DEAA /* SPUVerifierInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D04F3C2B094C8400A6DEAA /* SPUVerifierInformation.m */; };
 		72D60CD928C2BAE900189AB8 /* SPUStandardUserDriver+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D60CD828C2BA2100189AB8 /* SPUStandardUserDriver+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72D954811CBACC35006F28BD /* InstallerProgressAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D954801CBACC35006F28BD /* InstallerProgressAppController.m */; };
 		72D954831CBAD34F006F28BD /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D954821CBAD34F006F28BD /* main.m */; };
@@ -1384,6 +1386,8 @@
 		72BC6C3C275027BF0083F14B /* SparkleTestCodeSign_apfs.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSign_apfs.dmg; sourceTree = "<group>"; };
 		72BEBFEE1D7287560019146B /* SUSpotlightImporterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUSpotlightImporterTest.swift; sourceTree = "<group>"; };
 		72CCDEBD27421FD500B53718 /* SparkleTestCodeSignApp_bad_header.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = SparkleTestCodeSignApp_bad_header.zip; sourceTree = "<group>"; };
+		72D04F3B2B094C8400A6DEAA /* SPUVerifierInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUVerifierInformation.h; sourceTree = "<group>"; };
+		72D04F3C2B094C8400A6DEAA /* SPUVerifierInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPUVerifierInformation.m; sourceTree = "<group>"; };
 		72D60CD828C2BA2100189AB8 /* SPUStandardUserDriver+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPUStandardUserDriver+Private.h"; sourceTree = "<group>"; };
 		72D9547F1CBACC35006F28BD /* InstallerProgressAppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InstallerProgressAppController.h; path = Sparkle/InstallerProgress/InstallerProgressAppController.h; sourceTree = SOURCE_ROOT; };
 		72D954801CBACC35006F28BD /* InstallerProgressAppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InstallerProgressAppController.m; path = Sparkle/InstallerProgress/InstallerProgressAppController.m; sourceTree = SOURCE_ROOT; };
@@ -2096,6 +2100,8 @@
 				7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */,
 				7267E59A1D3D8A5A00D1BF90 /* SUSignatureVerifier.h */,
 				7267E59B1D3D8A5A00D1BF90 /* SUSignatureVerifier.m */,
+				72D04F3B2B094C8400A6DEAA /* SPUVerifierInformation.h */,
+				72D04F3C2B094C8400A6DEAA /* SPUVerifierInformation.m */,
 			);
 			name = Verifiers;
 			path = ..;
@@ -3344,6 +3350,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72D04F3E2B097D4300A6DEAA /* SPUVerifierInformation.m in Sources */,
 				72266A8C29464D0200645376 /* SUSignatures.m in Sources */,
 				72266A8B29464CEA00645376 /* SUHost.m in Sources */,
 				72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */,
@@ -3557,6 +3564,7 @@
 				7267E57F1D3D896700D1BF90 /* SUBinaryDeltaUnarchiver.m in Sources */,
 				7267E59C1D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m in Sources */,
 				7267E5CC1D3D8C6B00D1BF90 /* SUConstants.m in Sources */,
+				72D04F3D2B094C8400A6DEAA /* SPUVerifierInformation.m in Sources */,
 				7267E5861D3D89B300D1BF90 /* SUDiskImageUnarchiver.m in Sources */,
 				7267E59D1D3D8A5A00D1BF90 /* SUSignatureVerifier.m in Sources */,
 				7267E5E71D3D90AA00D1BF90 /* SUFileManager.m in Sources */,

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -249,7 +249,7 @@
     
     id<SPUInstallerDriverDelegate> delegate = _delegate;
     
-    SPUInstallationInputData *installationData = [[SPUInstallationInputData alloc] initWithRelaunchPath:pathToRelaunch hostBundlePath:_host.bundlePath updateURLBookmarkData:_updateURLBookmarkData installationType:_updateItem.installationType signatures:_updateItem.signatures decryptionPassword:decryptionPassword];
+    SPUInstallationInputData *installationData = [[SPUInstallationInputData alloc] initWithRelaunchPath:pathToRelaunch hostBundlePath:_host.bundlePath updateURLBookmarkData:_updateURLBookmarkData installationType:_updateItem.installationType signatures:_updateItem.signatures decryptionPassword:decryptionPassword expectedVersion:_updateItem.versionString expectedContentLength:_updateItem.contentLength];
     
     NSData *archivedData = SPUArchiveRootObjectSecurely(installationData);
     if (archivedData == nil) {

--- a/Sparkle/SPUVerifierInformation.h
+++ b/Sparkle/SPUVerifierInformation.h
@@ -1,0 +1,24 @@
+//
+//  SPUVerifierInformation.h
+//  Autoupdate
+//
+//  Copyright © 2023 Sparkle Project. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+SPU_OBJC_DIRECT_MEMBERS @interface SPUVerifierInformation : NSObject
+
+- (instancetype)initWithExpectedVersion:(NSString * _Nullable)expectedVersion expectedContentLength:(uint64_t)expectedContentLength;
+
+@property (nonatomic, readonly, copy, nullable) NSString *expectedVersion;
+@property (nonatomic, readonly) uint64_t expectedContentLength;
+
+@property (nonatomic, copy, nullable) NSString *actualVersion;
+@property (nonatomic) uint64_t actualContentLength;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUVerifierInformation.m
+++ b/Sparkle/SPUVerifierInformation.m
@@ -1,0 +1,27 @@
+//
+//  SPUVerifierInformation.m
+//  Autoupdate
+//
+//  Copyright © 2023 Sparkle Project. All rights reserved.
+//
+
+#import "SPUVerifierInformation.h"
+
+@implementation SPUVerifierInformation
+
+@synthesize expectedVersion = _expectedVersion;
+@synthesize expectedContentLength = _expectedContentLength;
+@synthesize actualVersion = _actualVersion;
+@synthesize actualContentLength = _actualContentLength;
+
+- (instancetype)initWithExpectedVersion:(NSString *)expectedVersion expectedContentLength:(uint64_t)expectedContentLength
+{
+    self = [super init];
+    if (self != nil) {
+        _expectedVersion = [expectedVersion copy];
+        _expectedContentLength = expectedContentLength;
+    }
+    return self;
+}
+
+@end

--- a/Sparkle/SUAppcastItem+Private.h
+++ b/Sparkle/SUAppcastItem+Private.h
@@ -10,6 +10,7 @@
 #define SUAppcastItem_Private_h
 
 #import <Foundation/Foundation.h>
+#import <Sparkle/SUAppcastItem.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sparkle/SUStatus.xib
+++ b/Sparkle/SUStatus.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/Sparkle/SUUpdateValidator.h
+++ b/Sparkle/SUUpdateValidator.h
@@ -10,6 +10,7 @@
 
 @class SUHost;
 @class SUSignatures;
+@class SPUVerifierInformation;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +19,9 @@ SPU_OBJC_DIRECT_MEMBERS
 #endif
 @interface SUUpdateValidator : NSObject
 
-- (instancetype)initWithDownloadPath:(NSString *)downloadPath signatures:(SUSignatures *)signatures host:(SUHost *)host;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithDownloadPath:(NSString *)downloadPath signatures:(SUSignatures *)signatures host:(SUHost *)host verifierInformation:(SPUVerifierInformation * _Nullable)verifierInformation;
 
 // This is "pre" validation, before the archive has been extracted
 - (BOOL)validateDownloadPathWithError:(NSError **)error;

--- a/Tests/SUUpdateValidatorTest.swift
+++ b/Tests/SUUpdateValidatorTest.swift
@@ -106,7 +106,7 @@ class SUUpdateValidatorTest: XCTestCase {
     func testPrevalidation(bundle bundleConfig: BundleConfig, signatures signatureConfig: SignatureConfig, expectedResult: Bool, line: UInt = #line) {
         let host = SUHost(bundle: self.bundle(bundleConfig))
         let signatures = self.signatures(signatureConfig)
-        let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host)
+        let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host, verifierInformation: nil)
 
         let result = (try? validator.validateDownloadPath()) != nil
         XCTAssertEqual(result, expectedResult, "bundle: \(bundleConfig), signatures: \(signatureConfig)", line: line)
@@ -136,7 +136,7 @@ class SUUpdateValidatorTest: XCTestCase {
         let host = SUHost(bundle: oldBundle)
         let signatures = self.signatures(signatureConfig)
 
-        let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host)
+        let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host, verifierInformation: nil)
 
         let updateDirectory = temporaryDirectory("SUUpdateValidatorTest")!
         defer { try! FileManager.default.removeItem(atPath: updateDirectory) }

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -16,6 +16,7 @@
 #import "SUVersionComparisonProtocol.h"
 #import "SUStandardVersionComparator.h"
 #import "SUUpdateValidator.h"
+#import "SPUVerifierInformation.h"
 #import "SUHost.h"
 #import "SPUSkippedUpdate.h"
 #import "SUSignatures.h"


### PR DESCRIPTION
If we detect the wrong archive is being served (i.e, expected content length differs from archive length) we log this out to developers. If the app version in the archive (if available) also differs, we report this discrepancy as well. If the update archive looks the same but signing validation fails, we tell the developer the update may have not been signed correctly.

Fixes #2468 

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested update succeed without errors
Tested update fail with matching content length and version (app bundle, pkg)
Tested update fail with non-matching content length and matching version (app bundle, pkg)
Tested update fail with non-matching content length and non-matching version (app bundle, pkg)

macOS version tested: 14.0 (23A344)
