### PR TITLE
Update Japanese localization (#2285)

### DIFF
--- a/Sparkle/ja.lproj/SUUpdateAlert.strings
+++ b/Sparkle/ja.lproj/SUUpdateAlert.strings
@@ -5,7 +5,7 @@
 "170.title" = "リリースノート:";
 
 /* Class = "NSButtonCell"; title = "Remind Me Later"; ObjectID = "171"; */
-"171.title" = "後で通知";
+"171.title" = "あとで通知";
 
 /* Class = "NSButtonCell"; title = "Skip This Version"; ObjectID = "172"; */
 "172.title" = "このバージョンはスキップ";

--- a/Sparkle/ja.lproj/SUUpdatePermissionPrompt.strings
+++ b/Sparkle/ja.lproj/SUUpdatePermissionPrompt.strings
@@ -18,3 +18,6 @@
 
 /* Class = "NSButtonCell"; title = "Check Automatically"; ObjectID = "OhZ-1K-DmA"; */
 "OhZ-1K-DmA.title" = "自動で確認";
+
+/* Class = "NSButtonCell"; title = "Automatically download and install updates"; ObjectID = "AUc-33-qGN"; */
+"AUc-33-qGN.title" = "アップデートを自動でダウンロードしてインストール";

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -29,7 +29,7 @@
 "%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@がダウンロードされました! これは重要なアップデートです。今すぐ%1$@をインストールして再起動しますか?";
 
 /* Description text for SUUpdateAlert when the update has already been downloaded and ready to install. */
-"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@がダウンロードされました! 今すぐ %1$@ をインストールして再起動しますか?";
+"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@がダウンロードされました! 今すぐ%1$@をインストールして再起動しますか?";
 
 /* No comment provided by engineer. */
 "%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@." = "%1$@ %2$@が入手可能ですが、インストールするにはmacOSのバージョンが新しすぎます。このアップデートはmacOS %3$@までしか対応していません。";
@@ -38,10 +38,10 @@
 "%1$@ %2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required." = "%1$@ %2$@が入手可能ですが、インストールするにはmacOSのバージョンが古すぎます。macOS %3$@以降が必要です。";
 
 /* No comment provided by engineer. */
-"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "この場所ではダウンロードされたアップデータを%1$@に適用できません。";
+"%1$@ can’t be updated if it’s running from the location it was downloaded to." = "この場所ではダウンロードされたアップデートを%1$@に適用できません。";
 
 /* No comment provided by engineer. */
-"%1$@ can’t be updated, because it was opened from a read-only or a temporary location." = "%1$@は読み出し専用またはテンポラリな場所で開かれているためアップデートできません。";
+"%1$@ can’t be updated, because it was opened from a read-only or a temporary location." = "%1$@は読み出し専用または一時的な場所で開かれているためアップデートできません。";
 
 /* No comment provided by engineer. */
 "A new version of %@ is available!" = "新しいバージョンの%@が入手できます!";


### PR DESCRIPTION
I improved the Japanese localization to fit the latest macOS expressions.
In addition, I added the localization of the new string mentioned in #2285 (Sorry, I totally missed the reference).

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
