### PR TITLE
Don't clean up update directory when Autoupdate receives SIGTERM

### DIFF
--- a/Autoupdate/main.m
+++ b/Autoupdate/main.m
@@ -26,6 +26,16 @@ int main(int __unused argc, const char __unused *argv[])
         // terminate the process (e.g, when extracting archives or performing package installs).
         signal(SIGPIPE, SIG_IGN);
         
+        dispatch_source_t sigtermSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, dispatch_get_main_queue());
+        dispatch_source_set_event_handler(sigtermSource, ^{
+            // Don't clear the update directory because the installer may be in middle of installing an update
+            // We still need to set an event handler for receiving SIGTERM though, otherwise our job may not terminate
+            // (This is also recommended from the developer documentation).
+            // Simply exit with SIGTERM if we recieve this signal
+            exit(SIGTERM);
+        });
+        dispatch_resume(sigtermSource);
+        
         [[NSRunLoop currentRunLoop] run];
     }
 


### PR DESCRIPTION
Under rare circumstances, if Autoupdate receives SIGTERM (like during system shutdown) while the installer queue is installing an update this could cause potential corruption.

Fixes #2478 

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Cannot reproduce actual corruption issue without inserting sleep() calls at specific points + sending a quit event to Autoupdate as the timing window is hard to target / rare. The change here is removing cleanup code that was not necessary (because old items get cleared out the next time an update is installed).

Tested Autoupdate can still be terminated gracefully via SIGTERM.

macOS version tested: 14.1.2 (23B92)
