### PR TITLE
Set Package.swift minimum deployment to macOS 10.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/S
 
 let package = Package(
     name: "Sparkle",
-    platforms: [.macOS(.v10_11)],
+    platforms: [.macOS(.v10_13)],
     products: [
         .library(
             name: "Sparkle",


### PR DESCRIPTION
This was not included in #2196.

In one project we mistakenly included Sparkle 2.3+ in an app that still supported macOS 10.12. Xcode did not give a warning or build error and I could not figure out why. I suppose that this commit resolves that.

Fixes # (issue)

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
