### PR TITLE
Swap app bundles with APFS atomic swap if team IDs match

### DIFF
--- a/Autoupdate/SUCodeSigningVerifier.h
+++ b/Autoupdate/SUCodeSigningVerifier.h
@@ -11,6 +11,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 #ifndef BUILDING_SPARKLE_TESTS
 SPU_OBJC_DIRECT_MEMBERS
 #endif
@@ -25,8 +27,10 @@ SPU_OBJC_DIRECT_MEMBERS
 
 + (BOOL)bundleAtURLIsCodeSigned:(NSURL *)bundleURL;
 
-+ (BOOL)teamIdentifierAtURL:(NSURL *)url1 matchesTeamIdentifierAtURL:(NSURL *)url2;
++ (NSString * _Nullable)teamIdentifierAtURL:(NSURL *)url;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif

--- a/Autoupdate/SUCodeSigningVerifier.m
+++ b/Autoupdate/SUCodeSigningVerifier.m
@@ -258,7 +258,7 @@ static id valueOrNSNull(id value) {
     return (result == 0);
 }
 
-static NSString * _Nullable teamIdentifierAtURL(NSURL *url)
++ (NSString * _Nullable)teamIdentifierAtURL:(NSURL *)url
 {
     SecStaticCodeRef staticCode = NULL;
     OSStatus staticCodeResult = SecStaticCodeCreateWithPath((__bridge CFURLRef)url, kSecCSDefaultFlags, &staticCode);
@@ -280,21 +280,6 @@ static NSString * _Nullable teamIdentifierAtURL(NSURL *url)
     
     // Note this will return nil for ad-hoc or unsigned binaries
     return signingInformation[(NSString *)kSecCodeInfoTeamIdentifier];
-}
-
-+ (BOOL)teamIdentifierAtURL:(NSURL *)url1 matchesTeamIdentifierAtURL:(NSURL *)url2
-{
-    NSString *teamIdentifierForURL1 = teamIdentifierAtURL(url1);
-    if (teamIdentifierForURL1 == nil) {
-        return NO;
-    }
-    
-    NSString *teamIdentifierForURL2 = teamIdentifierAtURL(url2);
-    if (teamIdentifierForURL2 == nil) {
-        return NO;
-    }
-    
-    return [teamIdentifierForURL1 isEqualToString:teamIdentifierForURL2];
 }
 
 @end


### PR DESCRIPTION
Swap app bundles with APFS atomic swap only if team IDs match between installer and new update bundle to avoid app replacement issues from OS.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested with sparkle test app, own test app that is dev-id signed, and updating other notarized app with sparkle-cli

macOS version tested:
14.3.1 (23D60)
14.4 Beta (23E5211a)
