### PR TITLE
Document user driver interaction with authorization

### DIFF
--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -64,7 +64,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  *
  *  `SPUUpdateStateNotDownloaded` - Update has not been downloaded yet.
  *
- *  `SPUUpdateStateDownloaded` - Update has already been downloaded but not started installing yet.
+ *  `SPUUpdateStateDownloaded` - Update has already been downloaded in the background automatically (via `SUAutomaticallyUpdate`) but not started installing yet.
  *
  *  `SPUUpdateStateInstalling` - Update has been downloaded and already started installing.
  *
@@ -78,9 +78,10 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  *
  *  @c appcastItem.criticalUpdate indicates if the update is a critical update.
  *
- * A reply of `SPUUserUpdateChoiceInstall` begins or resumes downloading or installing the update.
+ * A reply of `SPUUserUpdateChoiceInstall` begins or resumes downloading, extracting, or installing the update.
  * If the state.stage is `SPUUserUpdateStateInstalling`, this may send a quit event to the application and relaunch it immediately (in this state, this behaves as a fast "install and Relaunch").
- * Do not use this reply if @c appcastItem.informationOnlyUpdate is YES.
+ * If the state.stage is `SPUUpdateStateNotDownloaded` or `SPUUpdateStateDownloaded` the user may be presented an authorization prompt to install the update before `-showDownloadDidStartExtractingUpdate` is called if authorization is required for installation. For example, this may occur if the update on disk is owned by a different user (e.g. root or admin for non-admin users), or if the update is a package install.
+ * Do not use a reply of `SPUUserUpdateChoiceInstall` if @c appcastItem.informationOnlyUpdate is YES.
  *
  * A reply of `SPUUserUpdateChoiceDismiss` dismisses the update for the time being. The user may be reminded of the update at a later point.
  * If the state.stage is `SPUUserUpdateStateDownloaded`, the downloaded update is kept after dismissing until the next time an update is shown to the user.
@@ -183,8 +184,11 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  *
  * Sparkle uses this to show an indeterminate progress bar.
  *
- * Note that an update can resume at this point after having been downloaded before,
- * so this may be called without any of the download callbacks being invoked prior.
+ * Before this point, `showDownloadDidReceiveDataOfLength:` or `showUpdateFoundWithAppcastItem:state:reply:` may be called.
+ * An update can potentially resume at this point after having been automatically downloaded in the background (without the user driver)  before.
+ *
+ * Also note before extraction starts, the user may be shown an authorization prompt to install the update if authorization is required for installation.
+ * For example, this may occur if the update on disk is owned by a different user (e.g. root or admin for non-admin users), or if the update is a package install.
  */
 - (void)showDownloadDidStartExtractingUpdate;
 


### PR DESCRIPTION
Document user driver interaction with authorization.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: NA
