### PR TITLE
Fallback in case SULocalizedStringFromTableInBundle() fails

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -169,4 +169,4 @@ GCC_WARN_UNUSED_PARAMETER = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Werror=undef
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Werror=undef

--- a/Sparkle/SULocalizations.h
+++ b/Sparkle/SULocalizations.h
@@ -17,7 +17,8 @@
 
     #define SPARKLE_TABLE @"Sparkle"
 
-    #define SULocalizedStringFromTableInBundle(key, tbl, bundle, comment) NSLocalizedStringFromTableInBundle(key, tbl, bundle, comment)
+    #define SULocalizedStringFromTableInBundle(key, tbl, bundle, comment) (NSLocalizedStringFromTableInBundle(key, tbl, bundle, comment) ?: key)
+
 #else
     #define SULocalizedStringFromTableInBundle(key, tbl, bundle, comment) key
 #endif


### PR DESCRIPTION
SULocalizedStringFromTableInBundle() should only fail in the abnormal situation where the app bundle may have been moved while it was running. Technically the app is running in an unsupported state but I suppose we can guard against it here.

This is a continuation of #2527 and fixes https://github.com/sparkle-project/Sparkle/issues/2524

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app works and works with another language still.

macOS version tested: 14.4 (23E214)
