### PR TITLE
Fix the WebKit view not transitioning from light to dark mode

### DIFF
--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -322,7 +322,7 @@ static NSString *const SUUpdateAlertTouchBarIdentifier = @"" SPARKLE_BUNDLE_IDEN
         [_releaseNotesView setDrawsBackground:NO];
         
         // Use NSBox to get the proper dynamically colored background behind the release notes view when
-        // the release notes view is transparent
+        // the release notes view background is transparent
         _backgroundView = [[NSBox alloc] initWithFrame:_releaseNotesView.view.frame];
         _backgroundView.boxType = NSBoxCustom;
         _backgroundView.fillColor = [NSColor textBackgroundColor];


### PR DESCRIPTION
adaptReleaseNotesAppearance was over-engineered to update the transparent background state of the web view (which was causing the issue) and the background NSBox view when the system changes to dark or light mode. This is partly because when dark mode support was originally written, it used to use a stylesheet that was only specific to dark aqua (and then the code worsened over time to adapt other view changes only to dark mode). This code has since changed some time ago to use a universal stylesheet for both light/dark mode.

So now when the WebKit view is created, we just opt into a transparent background and set up a background NSBox view once and don't do anything when the effectiveAppearance of the views change. This fixes visual issues on current and older OS systems when changing system appearance.

Fixes #2541

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested modern and legacy WebKit views being initially started in dark or light mode, and switching to other appearance.

macOS version tested:
macOS 14.4.1
macOS 12 VM
macOS 10.15 VM
macOS 10.14 VM
