### PR TITLE
Remove assert on download response being available

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -249,7 +249,6 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
         NSData *data = [NSData dataWithContentsOfFile:_downloadFilename];
         if (data != nil) {
             NSURLResponse *response = _download.response;
-            assert(response != nil);
 
             NSURL *responseURL = response.URL;
             if (responseURL == nil) {


### PR DESCRIPTION
This assert shouldn't be there because we have fallbacks for the response URL.

Fixes #2546

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI
