### PR TITLE
Extract archives in a separate directory from the input archive

### DIFF
--- a/Autoupdate/SUBinaryDeltaUnarchiver.h
+++ b/Autoupdate/SUBinaryDeltaUnarchiver.h
@@ -19,7 +19,7 @@ SPU_OBJC_DIRECT_MEMBERS
 #endif
 @interface SUBinaryDeltaUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath updateHostBundlePath:(NSString *)updateHostBundlePath;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory updateHostBundlePath:(NSString *)updateHostBundlePath;
 
 + (BOOL)canUnarchivePath:(NSString *)path;
 

--- a/Autoupdate/SUBinaryDeltaUnarchiver.m
+++ b/Autoupdate/SUBinaryDeltaUnarchiver.m
@@ -20,6 +20,7 @@
 {
     NSString *_archivePath;
     NSString *_updateHostBundlePath;
+    NSString *_extractionDirectory;
 }
 
 + (BOOL)canUnarchivePath:(NSString *)path
@@ -71,12 +72,13 @@ SPU_OBJC_DIRECT
     }
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath updateHostBundlePath:(NSString *)updateHostBundlePath
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory updateHostBundlePath:(NSString *)updateHostBundlePath
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
         _updateHostBundlePath = [updateHostBundlePath copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -94,7 +96,7 @@ SPU_OBJC_DIRECT
 - (void)extractDeltaWithNotifier:(SUUnarchiverNotifier *)notifier
 {
     NSString *sourcePath = _updateHostBundlePath;
-    NSString *targetPath = [[_archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:[sourcePath lastPathComponent]];
+    NSString *targetPath = [_extractionDirectory stringByAppendingPathComponent:[sourcePath lastPathComponent]];
     
     NSError *applyDiffError = nil;
     BOOL success = applyBinaryDelta(sourcePath, targetPath, _archivePath, NO, ^(double progress){

--- a/Autoupdate/SUDiskImageUnarchiver.h
+++ b/Autoupdate/SUDiskImageUnarchiver.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUDiskImageUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath decryptionPassword:(nullable NSString *)decryptionPassword;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory decryptionPassword:(nullable NSString *)decryptionPassword;
 
 + (BOOL)canUnarchivePath:(NSString *)path;
 

--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -19,6 +19,7 @@
 {
     NSString *_archivePath;
     NSString *_decryptionPassword;
+    NSString *_extractionDirectory;
 }
 
 + (BOOL)canUnarchivePath:(NSString *)path
@@ -31,12 +32,13 @@
     return NO;
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath decryptionPassword:(nullable NSString *)decryptionPassword
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory decryptionPassword:(nullable NSString *)decryptionPassword
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
         _decryptionPassword = [decryptionPassword copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -171,7 +173,7 @@
 		for (NSString *item in contents)
 		{
             NSString *fromPath = [mountPoint stringByAppendingPathComponent:item];
-            NSString *toPath = [[_archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:item];
+            NSString *toPath = [_extractionDirectory stringByAppendingPathComponent:item];
             
             itemsCopied += 1.0;
             [notifier notifyProgress:0.5 + itemsCopied/(totalItems*2.0)];

--- a/Autoupdate/SUFlatPackageUnarchiver.h
+++ b/Autoupdate/SUFlatPackageUnarchiver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 // An unarchiver for flat packages that doesn't really do any unarchiving
 SPU_OBJC_DIRECT_MEMBERS @interface SUFlatPackageUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath expectingInstallationType:(NSString *)installationType;
+- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath extractionDirectory:(NSString *)extractionDirectory expectingInstallationType:(NSString *)installationType;
 
 + (BOOL)canUnarchivePath:(NSString *)path;
 

--- a/Autoupdate/SUFlatPackageUnarchiver.m
+++ b/Autoupdate/SUFlatPackageUnarchiver.m
@@ -20,6 +20,7 @@
 {
     NSString *_flatPackagePath;
     NSString *_expectedInstallationType;
+    NSString *_extractionDirectory;
 }
 
 + (BOOL)canUnarchivePath:(NSString *)path
@@ -32,12 +33,13 @@
     return YES;
 }
 
-- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath expectingInstallationType:(NSString *)installationType
+- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath extractionDirectory:(NSString *)extractionDirectory expectingInstallationType:(NSString *)installationType
 {
     self = [super init];
     if (self != nil) {
         _flatPackagePath = [flatPackagePath copy];
         _expectedInstallationType = [installationType copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -53,8 +55,20 @@
     } else if (![[NSFileManager defaultManager] fileExistsAtPath:_flatPackagePath isDirectory:&isDirectory] || isDirectory) {
         [notifier notifyFailureWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Flat package does not exist at %@", _flatPackagePath]}]];
     } else {
-        [notifier notifyProgress:1.0];
-        [notifier notifySuccess];
+        // Copying the flat package should be very fast, especially on APFS
+        NSError *copyError = nil;
+        if (![[NSFileManager defaultManager] copyItemAtPath:_flatPackagePath toPath:[_extractionDirectory stringByAppendingPathComponent:_flatPackagePath.lastPathComponent] error:&copyError]) {
+            NSMutableDictionary *userInfoDictionary = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Flat package (%@) cannot be copied to extraction directory (%@)", _flatPackagePath, _extractionDirectory]}];
+            
+            if (copyError != nil) {
+                userInfoDictionary[NSUnderlyingErrorKey] = copyError;
+            }
+            
+            [notifier notifyFailureWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:userInfoDictionary]];
+        } else {
+            [notifier notifyProgress:1.0];
+            [notifier notifySuccess];
+        }
     }
 }
 

--- a/Autoupdate/SUPipedUnarchiver.h
+++ b/Autoupdate/SUPipedUnarchiver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUPipedUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory;
 
 + (BOOL)canUnarchivePath:(NSString *)path;
 

--- a/Autoupdate/SUPipedUnarchiver.m
+++ b/Autoupdate/SUPipedUnarchiver.m
@@ -17,6 +17,7 @@
 @implementation SUPipedUnarchiver
 {
     NSString *_archivePath;
+    NSString *_extractionDirectory;
 }
 
 static NSArray <NSString *> * _Nullable _commandAndArgumentsConformingToTypeOfPath(NSString *path)
@@ -59,11 +60,12 @@ static NSArray <NSString *> * _Nullable _commandAndArgumentsConformingToTypeOfPa
     return NO;
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -89,7 +91,7 @@ static NSArray <NSString *> * _Nullable _commandAndArgumentsConformingToTypeOfPa
 {
     // *** GETS CALLED ON NON-MAIN THREAD!!!
 	@autoreleasepool {
-        NSString *destination = [_archivePath stringByDeletingLastPathComponent];
+        NSString *destination = _extractionDirectory;
         
         SULog(SULogLevelDefault, @"Extracting using '%@' '%@' < '%@' '%@'", command, [args componentsJoinedByString:@"' '"], _archivePath, destination);
         

--- a/Autoupdate/SUUnarchiver.h
+++ b/Autoupdate/SUUnarchiver.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUUnarchiver : NSObject
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType;
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType;
 
 @end
 

--- a/Autoupdate/SUUnarchiver.m
+++ b/Autoupdate/SUUnarchiver.m
@@ -18,27 +18,25 @@
 
 @implementation SUUnarchiver
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType
 {
     if ([SUPipedUnarchiver canUnarchivePath:path]) {
-        return [[SUPipedUnarchiver alloc] initWithArchivePath:path];
-        
+        return [[SUPipedUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory];
     }
 #if SPARKLE_BUILD_DMG_SUPPORT
     else if ([SUDiskImageUnarchiver canUnarchivePath:path]) {
-        return [[SUDiskImageUnarchiver alloc] initWithArchivePath:path decryptionPassword:decryptionPassword];
-        
+        return [[SUDiskImageUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory decryptionPassword:decryptionPassword];
     }
 #endif
     else if ([SUBinaryDeltaUnarchiver canUnarchivePath:path]) {
         assert(hostPath != nil);
         NSString *nonNullHostPath = hostPath;
-        return [[SUBinaryDeltaUnarchiver alloc] initWithArchivePath:path updateHostBundlePath:nonNullHostPath];
+        return [[SUBinaryDeltaUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory updateHostBundlePath:nonNullHostPath];
     }
 #if SPARKLE_BUILD_PACKAGE_SUPPORT
     else if ([SUFlatPackageUnarchiver canUnarchivePath:path]) {
         // Flat packages are only supported for guided packaage installs
-        return [[SUFlatPackageUnarchiver alloc] initWithFlatPackagePath:path expectingInstallationType:installationType];
+        return [[SUFlatPackageUnarchiver alloc] initWithFlatPackagePath:path extractionDirectory:extractionDirectory expectingInstallationType:installationType];
     }
 #endif
     return nil;

--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -24,10 +24,9 @@ class SUUnarchiverTest: XCTestCase
         let unarchivedSuccessExpectation = super.expectation(description: "Unarchived Success (format: \(archiveExtension))")
         let unarchivedFailureExpectation = super.expectation(description: "Unarchived Failure (format: \(archiveExtension))")
 
-        let tempArchiveURL = tempDirectoryURL.appendingPathComponent(archiveResourceURL.lastPathComponent)
         let extractedAppURL = tempDirectoryURL.appendingPathComponent(extractedAppName).appendingPathExtension("app")
 
-        self.unarchiveTestAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, tempArchiveURL: tempArchiveURL, archiveResourceURL: archiveResourceURL, password: password, expectingInstallationType: installationType, expectingSuccess: expectingSuccess, testExpectation: unarchivedSuccessExpectation)
+        self.unarchiveTestAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, archiveResourceURL: archiveResourceURL, password: password, expectingInstallationType: installationType, expectingSuccess: expectingSuccess, testExpectation: unarchivedSuccessExpectation)
         self.unarchiveNonExistentFileTestFailureAppWithExtension(archiveExtension, tempDirectoryURL: tempDirectoryURL, password: password, expectingInstallationType: installationType, testExpectation: unarchivedFailureExpectation)
 
         super.waitForExpectations(timeout: 30.0, handler: nil)
@@ -40,7 +39,7 @@ class SUUnarchiverTest: XCTestCase
 
     func unarchiveNonExistentFileTestFailureAppWithExtension(_ archiveExtension: String, tempDirectoryURL: URL, password: String?, expectingInstallationType installationType: String, testExpectation: XCTestExpectation) {
         let tempArchiveURL = tempDirectoryURL.appendingPathComponent("error-invalid").appendingPathExtension(archiveExtension)
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
+        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             XCTAssertNotNil(error)
@@ -49,13 +48,9 @@ class SUUnarchiverTest: XCTestCase
     }
 
     // swiftlint:disable function_parameter_count
-    func unarchiveTestAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, tempArchiveURL: URL, archiveResourceURL: URL, password: String?, expectingInstallationType installationType: String, expectingSuccess: Bool, testExpectation: XCTestExpectation) {
-
-        let fileManager = FileManager.default
-
-        try! fileManager.copyItem(at: archiveResourceURL, to: tempArchiveURL)
-
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
+    func unarchiveTestAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, archiveResourceURL: URL, password: String?, expectingInstallationType installationType: String, expectingSuccess: Bool, testExpectation: XCTestExpectation) {
+        
+        let unarchiver = SUUnarchiver.unarchiver(forPath: archiveResourceURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             if expectingSuccess {
@@ -133,7 +128,7 @@ class SUUnarchiverTest: XCTestCase
 #endif
     
 #if SPARKLE_BUILD_PACKAGE_SUPPORT
-    func testUnarchivingFlatPackage()
+    func testUnarchivingBarePackage()
     {
         self.unarchiveTestAppWithExtension("pkg", resourceName: "test", expectingInstallationType: SPUInstallationTypeGuidedPackage)
         

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -6,40 +6,17 @@
 import Foundation
 
 func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) -> Void) {
-    let fileManager = FileManager.default
-    let tempDir = archiveDestDir.appendingPathExtension("tmp")
-    let itemCopy = tempDir.appendingPathComponent(itemPath.lastPathComponent)
+    if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: archiveDestDir.path, updatingHostBundlePath: nil, decryptionPassword: nil, expectingInstallationType: SPUInstallationTypeApplication) {
+        unarchiver.unarchive(completionBlock: { (error: Error?) in
+            if error != nil {
+                callback(error)
+                return
+            }
 
-    _ = try? fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: [:])
-
-    do {
-        do {
-            try fileManager.linkItem(at: itemPath, to: itemCopy)
-        } catch {
-            try fileManager.copyItem(at: itemPath, to: itemCopy)
-        }
-        if let unarchiver = SUUnarchiver.unarchiver(forPath: itemCopy.path, updatingHostBundlePath: nil, decryptionPassword: nil, expectingInstallationType: SPUInstallationTypeApplication) {
-            unarchiver.unarchive(completionBlock: { (error: Error?) in
-                if error != nil {
-                    callback(error)
-                    return
-                }
-
-                _ = try? fileManager.removeItem(at: itemCopy)
-                do {
-                    try fileManager.moveItem(at: tempDir, to: archiveDestDir)
-                    callback(nil)
-                } catch {
-                    callback(error)
-                }
-            }, progressBlock: nil)
-        } else {
-            _ = try? fileManager.removeItem(at: itemCopy)
-            callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemCopy)"))
-        }
-    } catch {
-        _ = try? fileManager.removeItem(at: tempDir)
-        callback(error)
+            callback(nil)
+        }, progressBlock: nil)
+    } else {
+        callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemPath)"))
     }
 }
 


### PR DESCRIPTION
Fixes #960 and may later help me work around #2544

This also fixes a vulnerability issue where an attacker could overwrite the input archive file since it resided in the same directory as the one being extracted into.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested extracting app update with a test app from:
- [x] zip files
- [x] tar* files 
- [x] binary delta files
- [x] dmg files (with Applications alias)
- [x] archived pkg files
- [x] bare pkg file
- [x] generating new updates using generate_appcast works

macOS version tested: 14.4.1 (23E224)
