### PR TITLE
Extract archives in a separate directory from the input archive (1.x)

### DIFF
--- a/Sparkle/SUBinaryDeltaUnarchiver.h
+++ b/Sparkle/SUBinaryDeltaUnarchiver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUBinaryDeltaUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath updateHostBundlePath:(NSString *)updateHostBundlePath;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory updateHostBundlePath:(NSString *)updateHostBundlePath;
 
 @end
 

--- a/Sparkle/SUBinaryDeltaUnarchiver.m
+++ b/Sparkle/SUBinaryDeltaUnarchiver.m
@@ -20,6 +20,7 @@
 
 @property (nonatomic, copy, readonly) NSString *archivePath;
 @property (nonatomic, copy, readonly) NSString *updateHostBundlePath;
+@property (nonatomic, copy, readonly) NSString *extractionDirectory;
 
 @end
 
@@ -27,6 +28,7 @@
 
 @synthesize archivePath = _archivePath;
 @synthesize updateHostBundlePath = _updateHostBundlePath;
+@synthesize extractionDirectory = _extractionDirectory;
 
 + (BOOL)canUnarchivePath:(NSString *)path
 {
@@ -73,12 +75,13 @@
     }
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath updateHostBundlePath:(NSString *)updateHostBundlePath
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory updateHostBundlePath:(NSString *)updateHostBundlePath
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
         _updateHostBundlePath = [updateHostBundlePath copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -96,7 +99,7 @@
 - (void)extractDeltaWithNotifier:(SUUnarchiverNotifier *)notifier
 {
     NSString *sourcePath = self.updateHostBundlePath;
-    NSString *targetPath = [[self.archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:[sourcePath lastPathComponent]];
+    NSString *targetPath = [self.extractionDirectory stringByAppendingPathComponent:[sourcePath lastPathComponent]];
     
     NSError *applyDiffError = nil;
     BOOL success = applyBinaryDelta(sourcePath, targetPath, self.archivePath, NO, ^(double progress){

--- a/Sparkle/SUDiskImageUnarchiver.h
+++ b/Sparkle/SUDiskImageUnarchiver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUDiskImageUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath decryptionPassword:(nullable NSString *)decryptionPassword;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory decryptionPassword:(nullable NSString *)decryptionPassword;
 
 @end
 

--- a/Sparkle/SUDiskImageUnarchiver.m
+++ b/Sparkle/SUDiskImageUnarchiver.m
@@ -17,6 +17,7 @@
 
 @property (nonatomic, copy, readonly) NSString *archivePath;
 @property (nullable, nonatomic, copy, readonly) NSString *decryptionPassword;
+@property (nonatomic, copy, readonly) NSString *extractionDirectory;
 
 @end
 
@@ -24,6 +25,7 @@
 
 @synthesize archivePath = _archivePath;
 @synthesize decryptionPassword = _decryptionPassword;
+@synthesize extractionDirectory = _extractionDirectory;
 
 + (BOOL)canUnarchivePath:(NSString *)path
 {
@@ -35,12 +37,13 @@
     return NO;
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath decryptionPassword:(nullable NSString *)decryptionPassword
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory decryptionPassword:(nullable NSString *)decryptionPassword
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
         _decryptionPassword = [decryptionPassword copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -158,7 +161,7 @@
         for (NSString *item in contents)
         {
             NSString *fromPath = [mountPoint stringByAppendingPathComponent:item];
-            NSString *toPath = [[self.archivePath stringByDeletingLastPathComponent] stringByAppendingPathComponent:item];
+            NSString *toPath = [self.extractionDirectory stringByAppendingPathComponent:item];
             
             // We skip any files in the DMG which are not readable.
             if (![manager isReadableFileAtPath:fromPath]) {

--- a/Sparkle/SUFlatPackageUnarchiver.h
+++ b/Sparkle/SUFlatPackageUnarchiver.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 // An unarchiver for flat packages that doesn't really do any unarchiving
 @interface SUFlatPackageUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath;
+- (instancetype)initWithFlatPackagePath:(NSString *)flatPackagePath extractionDirectory:(NSString *)extractionDirectory;
 
 @end
 

--- a/Sparkle/SUPipedUnarchiver.h
+++ b/Sparkle/SUPipedUnarchiver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUPipedUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory;
 
 @end
 

--- a/Sparkle/SUPipedUnarchiver.m
+++ b/Sparkle/SUPipedUnarchiver.m
@@ -17,12 +17,14 @@
 @interface SUPipedUnarchiver ()
 
 @property (nonatomic, copy, readonly) NSString *archivePath;
+@property (nonatomic, copy, readonly) NSString *extractionDirectory;
 
 @end
 
 @implementation SUPipedUnarchiver
 
 @synthesize archivePath = _archivePath;
+@synthesize extractionDirectory = _extractionDirectory;
 
 + (nullable NSArray <NSString *> *)commandAndArgumentsConformingToTypeOfPath:(NSString *)path
 {
@@ -63,11 +65,12 @@
     return NO;
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
+        _extractionDirectory = [extractionDirectory copy];
     }
     return self;
 }
@@ -94,7 +97,7 @@
     // *** GETS CALLED ON NON-MAIN THREAD!!!
     @autoreleasepool {
         NSError *error = nil;
-        NSString *destination = [self.archivePath stringByDeletingLastPathComponent];
+        NSString *destination = self.extractionDirectory;
         
         SULog(SULogLevelDefault, @"Extracting using '%@' '%@' < '%@' '%@'", command, [args componentsJoinedByString:@"' '"], self.archivePath, destination);
         

--- a/Sparkle/SUUnarchiver.h
+++ b/Sparkle/SUUnarchiver.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUUnarchiver : NSObject
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword;
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword;
 
 @end
 

--- a/Sparkle/SUUnarchiver.m
+++ b/Sparkle/SUUnarchiver.m
@@ -18,21 +18,20 @@
 
 @implementation SUUnarchiver
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword
 {
     if ([SUPipedUnarchiver canUnarchivePath:path]) {
-        return [[SUPipedUnarchiver alloc] initWithArchivePath:path];
-        
+        return [[SUPipedUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory];
     } else if ([SUDiskImageUnarchiver canUnarchivePath:path]) {
-        return [[SUDiskImageUnarchiver alloc] initWithArchivePath:path decryptionPassword:decryptionPassword];
+        return [[SUDiskImageUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory decryptionPassword:decryptionPassword];
         
     } else if ([SUBinaryDeltaUnarchiver canUnarchivePath:path]) {
         assert(hostPath != nil);
         NSString *nonNullHostPath = hostPath;
-        return [[SUBinaryDeltaUnarchiver alloc] initWithArchivePath:path updateHostBundlePath:nonNullHostPath];
+        return [[SUBinaryDeltaUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory updateHostBundlePath:nonNullHostPath];
         
     } else if ([SUFlatPackageUnarchiver canUnarchivePath:path]) {
-        return [[SUFlatPackageUnarchiver alloc] initWithFlatPackagePath:path];
+        return [[SUFlatPackageUnarchiver alloc] initWithFlatPackagePath:path extractionDirectory:extractionDirectory];
     }
     return nil;
 }

--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -24,10 +24,9 @@ class SUUnarchiverTest: XCTestCase
         let unarchivedSuccessExpectation = super.expectation(description: "Unarchived Success (format: \(archiveExtension))")
         let unarchivedFailureExpectation = super.expectation(description: "Unarchived Failure (format: \(archiveExtension))")
 
-        let tempArchiveURL = tempDirectoryURL.appendingPathComponent(archiveResourceURL.lastPathComponent)
         let extractedAppURL = tempDirectoryURL.appendingPathComponent(appName).appendingPathExtension("app")
 
-        self.unarchiveTestAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, tempArchiveURL: tempArchiveURL, archiveResourceURL: archiveResourceURL, password: password, expectingSuccess: expectingSuccess, testExpectation: unarchivedSuccessExpectation)
+        self.unarchiveTestAppWithExtension(archiveExtension, appName: appName, tempDirectoryURL: tempDirectoryURL, archiveResourceURL: archiveResourceURL, password: password, expectingSuccess: expectingSuccess, testExpectation: unarchivedSuccessExpectation)
         self.unarchiveNonExistentFileTestFailureAppWithExtension(archiveExtension, tempDirectoryURL: tempDirectoryURL, password: password, testExpectation: unarchivedFailureExpectation)
 
         super.waitForExpectations(timeout: 30.0, handler: nil)
@@ -40,7 +39,7 @@ class SUUnarchiverTest: XCTestCase
 
     func unarchiveNonExistentFileTestFailureAppWithExtension(_ archiveExtension: String, tempDirectoryURL: URL, password: String?, testExpectation: XCTestExpectation) {
         let tempArchiveURL = tempDirectoryURL.appendingPathComponent("error-invalid").appendingPathExtension(archiveExtension)
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password)!
+        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             XCTAssertNotNil(error)
@@ -49,13 +48,8 @@ class SUUnarchiverTest: XCTestCase
     }
 
     // swiftlint:disable function_parameter_count
-    func unarchiveTestAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, tempArchiveURL: URL, archiveResourceURL: URL, password: String?, expectingSuccess: Bool, testExpectation: XCTestExpectation) {
-
-        let fileManager = FileManager.default
-
-        try! fileManager.copyItem(at: archiveResourceURL, to: tempArchiveURL)
-
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, updatingHostBundlePath: nil, decryptionPassword: password)!
+    func unarchiveTestAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, archiveResourceURL: URL, password: String?, expectingSuccess: Bool, testExpectation: XCTestExpectation) {
+        let unarchiver = SUUnarchiver.unarchiver(forPath: archiveResourceURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             if expectingSuccess {

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -6,40 +6,17 @@
 import Foundation
 
 func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) -> Void) {
-    let fileManager = FileManager.default
-    let tempDir = archiveDestDir.appendingPathExtension("tmp")
-    let itemCopy = tempDir.appendingPathComponent(itemPath.lastPathComponent)
-
-    _ = try? fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: [:])
-
-    do {
-        do {
-            try fileManager.linkItem(at: itemPath, to: itemCopy)
-        } catch {
-            try fileManager.copyItem(at: itemPath, to: itemCopy)
-        }
-        if let unarchiver = SUUnarchiver.unarchiver(forPath: itemCopy.path, updatingHostBundlePath: nil, decryptionPassword: nil) {
-            unarchiver.unarchive(completionBlock: { (error: Error?) in
-                if error != nil {
-                    callback(error)
-                    return
-                }
-
-                _ = try? fileManager.removeItem(at: itemCopy)
-                do {
-                    try fileManager.moveItem(at: tempDir, to: archiveDestDir)
-                    callback(nil)
-                } catch {
-                    callback(error)
-                }
-            }, progressBlock: nil)
-        } else {
-            _ = try? fileManager.removeItem(at: itemCopy)
-            callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemCopy)"))
-        }
-    } catch {
-        _ = try? fileManager.removeItem(at: tempDir)
-        callback(error)
+    if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: archiveDestDir.path, updatingHostBundlePath: nil, decryptionPassword: nil) {
+        unarchiver.unarchive(completionBlock: { (error: Error?) in
+            if error != nil {
+                callback(error)
+                return
+            }
+            
+            callback(nil)
+        }, progressBlock: nil)
+    } else {
+        callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemPath)"))
     }
 }
 


### PR DESCRIPTION
This is ported from the 2.x branch (#2550).

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested extracting app update with a test app from:
- [x] zip files
- [x] tar* files 
- [x] binary delta files
- [x] dmg files (with Applications alias)
- [x] archived pkg files
- [x] bare pkg file
- [x] generating new updates using generate_appcast works

macOS version tested: 14.4.1 (23E224)
