### PR TITLE
Create and use temp extraction directory in generate_appcast again

### DIFF
--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -9,6 +9,7 @@ func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) 
     let fileManager = FileManager.default
     let tempDir = archiveDestDir.appendingPathExtension("tmp")
 
+    _ = try? fileManager.removeItem(at: tempDir)
     _ = try? fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: [:])
 
     if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: tempDir.path, updatingHostBundlePath: nil, decryptionPassword: nil, expectingInstallationType: SPUInstallationTypeApplication) {


### PR DESCRIPTION
Fixes #2554

This restores how the code used to work in 2.6.0 except we don't create a link to the archive file, and remove the temp directory before starting. I had removed too much of the prior code in 2.6.1 which included creating the extraction directory in generate_appcast.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast on unarchiving:
- [x] DMG file
- [x] tar.* file
- [x] zip file

macOS version tested: 14.4.1 (23E224)
