### PR TITLE
Create and use temp extraction directory in generate_appcast again (1.x)

### DIFF
--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -6,17 +6,28 @@
 import Foundation
 
 func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) -> Void) {
-    if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: archiveDestDir.path, updatingHostBundlePath: nil, decryptionPassword: nil) {
+    let fileManager = FileManager.default
+    let tempDir = archiveDestDir.appendingPathExtension("tmp")
+
+    _ = try? fileManager.removeItem(at: tempDir)
+    _ = try? fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: [:])
+
+    if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: tempDir.path, updatingHostBundlePath: nil, decryptionPassword: nil) {
         unarchiver.unarchive(completionBlock: { (error: Error?) in
             if error != nil {
                 callback(error)
                 return
             }
-            
-            callback(nil)
+
+            do {
+                try fileManager.moveItem(at: tempDir, to: archiveDestDir)
+                callback(nil)
+            } catch {
+                callback(error)
+            }
         }, progressBlock: nil)
     } else {
-        callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemPath)"))
+        callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemPath.path)"))
     }
 }
 


### PR DESCRIPTION
Port of #2555 to 1.x

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast on unarchiving:
- [x] DMG file
- [x] tar.* file
- [x] zip file

macOS version tested: 14.4.1 (23E224)
