### PR TITLE
Guard update timer update check against sessionInProgress

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -549,7 +549,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)updaterTimerDidFire
 {
-    [self _checkForUpdatesInBackground];
+    // User can perform a checkForUpdates check around the same time the timer is ready to fire
+    if (!_sessionInProgress)
+    {
+        [self _checkForUpdatesInBackground];
+    }
 }
 
 - (void)_checkForUpdatesInBackground SPU_OBJC_DIRECT
@@ -695,8 +699,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)checkForUpdatesWithDriver:(id <SPUUpdateDriver> )d updateCheck:(SPUUpdateCheck)updateCheck installerInProgress:(BOOL)installerInProgress SPU_OBJC_DIRECT
 {
-    assert(_driver == nil);
     if (_driver != nil) {
+        SULog(SULogLevelError, @"Error: checkForUpdatesWithDriver:updateCheck:installerInProgress: called when _driver != nil");
         return;
     }
     


### PR DESCRIPTION
Make sure we don't perform a background update check when a user update check was initiated. This may have regressed from #2295.

Also replaces an assert with an error log if the _driver already exists.

Fixes #2560

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested scheduled update checks still works with test app and user can still check for updates.

macOS version tested: 14.4.1 (23E224)
