### PR TITLE
Remove extra writeData: call when unarchiving disk images

### DIFF
--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -121,8 +121,6 @@
             }
             
             [notifier notifyProgress:0.125];
-
-            [inputPipe.fileHandleForWriting writeData:promptData];
             
             if (@available(macOS 10.15, *)) {
                 if (![inputPipe.fileHandleForWriting writeData:promptData error:&error]) {


### PR DESCRIPTION
Remove extraneous writeData: call when unarchiving disk image files.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Ran unit tests for unarchiving dmg files.

macOS version tested: 14.5 (23F79)
