### PR TITLE
Ignore crashes due to SIGPIPE in generate_appcast

### DIFF
--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -248,6 +248,10 @@ struct GenerateAppcast: ParsableCommand {
     }
     
     func run() throws {
+        // Ignore SIGPIPE because we won't want read or write failures due to broken pipe to unexpectably
+        // terminate the process, when extracting archives
+        signal(SIGPIPE, SIG_IGN)
+        
         // Extract the keys
         let privateDSAKey : SecKey?
     #if GENERATE_APPCAST_BUILD_LEGACY_DSA_SUPPORT


### PR DESCRIPTION
Related to #2544, generate_appcast should not unexpectedly halt when encountering SIGPIPE issue when extracting unexpected zip files. We do the same in Autoupdate.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested running generate_appcast on problematic zip file.

macOS version tested: 14.5 (23F79)
