### PR TITLE
Remove old checksum verification checks for dmg archives

### DIFF
--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -72,7 +72,9 @@
         
         NSData *promptData = [NSData dataWithBytes:"yes\n" length:4];
         
-        NSMutableArray *arguments = [@[@"attach", _archivePath, @"-mountpoint", mountPoint, /*@"-noverify",*/ @"-nobrowse", @"-noautoopen"] mutableCopy];
+        // Finder doesn't verify disk images anymore beyond the code signing signature (if available)
+        // Opt out of the old CRC checksum checks
+        NSMutableArray *arguments = [@[@"attach", _archivePath, @"-mountpoint", mountPoint, @"-noverify", @"-nobrowse", @"-noautoopen"] mutableCopy];
         
         if (_decryptionPassword) {
             NSMutableData *passwordData = [[_decryptionPassword dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];


### PR DESCRIPTION
These are antiquated checks and they can take considerable time to perform. HTTPS or EdDSA verification will validate that an archive isn't corrupt.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 14.5 (23F79)
