### PR TITLE
Remove SUFileManager from BinaryDelta and Sparkle Test App

### DIFF
--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -141,7 +141,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
 
     progressCallback(3/7.0);
 
-    if (!copyTree(source, destination)) {
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    
+    if (!copyTree(fileManager, source, destination)) {
         if (verbose) {
             fprintf(stderr, "\n");
         }
@@ -156,7 +158,6 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
     if (verbose) {
         fprintf(stderr, "\nPatching...");
     }
-    NSFileManager *fileManager = [[NSFileManager alloc] init];
     
     // Ensure error is cleared out in advance
     if (error != NULL) {

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -68,7 +68,7 @@ void getRawHashFromDisplayHash(unsigned char *hash, NSString *hexHash);
 extern NSString *hashOfTreeWithVersion(NSString *path, uint16_t majorVersion);
 extern NSString *hashOfTree(NSString *path);
 extern BOOL removeTree(NSString *path);
-extern BOOL copyTree(NSString *source, NSString *dest);
+extern BOOL copyTree(NSFileManager *fileManager, NSString *source, NSString *dest);
 extern BOOL modifyPermissions(NSString *path, mode_t desiredPermissions);
 extern NSString *pathRelativeToDirectory(NSString *directory, NSString *path);
 NSString *temporaryFilename(NSString *base);

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -7,7 +7,6 @@
 //
 
 #include "SUBinaryDeltaCommon.h"
-#import "SUFileManager.h"
 #include <CommonCrypto/CommonDigest.h>
 #include <Foundation/Foundation.h>
 #include <fcntl.h>
@@ -358,10 +357,9 @@ BOOL removeTree(NSString *path)
     return [fileManager removeItemAtPath:path error:nil];
 }
 
-BOOL copyTree(NSString *source, NSString *dest)
+BOOL copyTree(NSFileManager *fileManager, NSString *source, NSString *dest)
 {
-    // SUFileManager will be more reliable for copying items especially across network mounts
-    return [[[SUFileManager alloc] init] copyItemAtURL:[NSURL fileURLWithPath:source] toURL:[NSURL fileURLWithPath:dest] error:NULL];
+    return [fileManager copyItemAtURL:[NSURL fileURLWithPath:source] toURL:[NSURL fileURLWithPath:dest] error:NULL];
 }
 
 BOOL modifyPermissions(NSString *path, mode_t desiredPermissions)

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -293,7 +293,6 @@
 		7267E5E61D3D90AA00D1BF90 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
 		7267E5E71D3D90AA00D1BF90 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
 		7267E5E81D3D90AA00D1BF90 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
-		7267E5EA1D3D90AA00D1BF90 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
 		7267E5EB1D3D90C200D1BF90 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
 		7267E5EC1D3D912900D1BF90 /* SUInstaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5BD1D3D8B2700D1BF90 /* SUInstaller.m */; };
 		7267E5ED1D3D912E00D1BF90 /* SUUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5851D3D89B300D1BF90 /* SUUnarchiver.m */; };
@@ -334,7 +333,6 @@
 		726F2CE51BC9C33D001971A4 /* SUOperatingSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 726F2CE31BC9C33D001971A4 /* SUOperatingSystem.h */; };
 		726F2CE61BC9C33D001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		726F2CE81BC9C48F001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
-		726F2CE91BC9C499001971A4 /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		726F2CEB1BC9C733001971A4 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
 		727DBAE526B5BBFD00111F0C /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 727DBAE426B5BBFD00111F0C /* ArgumentParser */; };
 		727DBAE726B5C47800111F0C /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 727DBAE626B5C47800111F0C /* ArgumentParser */; };
@@ -437,7 +435,6 @@
 		72F0EC4B278A5BB2002A876A /* libxar.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 726E07681CA616A4001A286B /* libxar.tbd */; };
 		72F0EC4C278A5BB9002A876A /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 726E076A1CA616B3001A286B /* libbz2.tbd */; };
 		72F0EC4D278A5BCA002A876A /* libbsdiff.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E280F22B64522004AA304 /* libbsdiff.a */; };
-		72F0EC4E278A73C6002A876A /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
 		72F94F581CC44DE1002DEE68 /* SPUXPCServiceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 72F94F561CC44DE1002DEE68 /* SPUXPCServiceInfo.h */; };
 		72F94F591CC44DE1002DEE68 /* SPUXPCServiceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 72F94F571CC44DE1002DEE68 /* SPUXPCServiceInfo.m */; };
 		72F94F5A1CC450DE002DEE68 /* SUInstallerLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = 726E07B11CAF08D6001A286B /* SUInstallerLauncher.m */; };
@@ -3357,8 +3354,6 @@
 				7267E5781D3D895B00D1BF90 /* SUBinaryDeltaCommon.m in Sources */,
 				7267E57A1D3D895B00D1BF90 /* SUBinaryDeltaCreate.m in Sources */,
 				726F2CE81BC9C48F001971A4 /* SUConstants.m in Sources */,
-				7267E5EA1D3D90AA00D1BF90 /* SUFileManager.m in Sources */,
-				726F2CE91BC9C499001971A4 /* SUOperatingSystem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3412,7 +3407,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72F0EC4E278A73C6002A876A /* SUFileManager.m in Sources */,
 				72F0EC48278A5B95002A876A /* SPUDeltaArchive.m in Sources */,
 				72F0EC49278A5B95002A876A /* SPUSparkleDeltaArchive.m in Sources */,
 				72F0EC4A278A5B95002A876A /* SPUXarDeltaArchive.m in Sources */,

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -8,7 +8,6 @@
 
 #import "SUTestApplicationDelegate.h"
 #import "SUUpdateSettingsWindowController.h"
-#import "SUFileManager.h"
 #import "SUTestWebServer.h"
 #import "TestAppHelperProtocol.h"
 #import "ed25519.h"
@@ -57,15 +56,8 @@
     // Detect as early as possible if the shift key is held down
     BOOL shiftKeyHeldDown = ([NSEvent modifierFlags] & NSEventModifierFlagShift) != 0;
 #endif
-    
-    // Apple's file manager may not work well over the network (on macOS 10.11.4 as of writing this), but at the same time
-    // I don't want to have to export SUFileManager in release mode. The test app is primarily
-    // aimed to be used in debug mode, so I think this is a good compromise
-#if DEBUG
-    SUFileManager *fileManager = [[SUFileManager alloc] init];
-#else
+
     NSFileManager *fileManager = [NSFileManager defaultManager];
-#endif
     
     // Locate user's cache directory
     NSError *cacheError = nil;


### PR DESCRIPTION
Fixes #694

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested warnings no longer show up in Sparkle Test app and that the app works, and that BinaryDelta still works.

macOS version tested: 14.5 (23F79)
