### PR TITLE
fix: add RLM chars to he locale (#2575)

### DIFF
--- a/Sparkle/he.lproj/Sparkle.strings
+++ b/Sparkle/he.lproj/Sparkle.strings
@@ -1,14 +1,14 @@
 /* Description text for SUUpdateAlert when the critical update has already been downloaded and ready to install. */
-"%1$@ %2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ הורד והוא מוכן לשימוש! זהו עדכון חשוב; האם תרצה להתקין אותו ולהפעיל מחדש את %1$@ כעת?";
+"%1$@ ‏%2$@ has been downloaded and is ready to use! This is an important update; would you like to install it and relaunch %1$@ now?" = "‏%1$@ ‏%2$@ הורד והוא מוכן לשימוש! זהו עדכון חשוב; האם תרצה להתקין אותו ולהפעיל מחדש את %1$@ כעת?";
 
 /* Description text for SUUpdateAlert when the update has already been downloaded and ready to install. */
-"%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "%1$@ %2$@ הורד והוא מוכן לשימוש! האם תרצה להתקין אותו ולהפעיל מחדש את %1$@ כעת?";
+"%1$@ ‏%2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "‏%1$@ ‏%2$@ הורד והוא מוכן לשימוש! האם תרצה להתקין אותו ולהפעיל מחדש את %1$@ כעת?";
 
 /* No comment provided by engineer. */
-"%1$@ %2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@." = "%1$@ %2$@ זמין, אך גרסת ה-macOS שלך חדשה מדי עבור עדכון זה. עדכון זה תומך רק עד macOS %3$@.";
+"%1$@ ‏%2$@ is available but your macOS version is too new for this update. This update only supports up to macOS %3$@." = "‏%1$@ ‏%2$@ זמין, אך גרסת ה-macOS שלך חדשה מדי עבור עדכון זה. עדכון זה תומך רק עד macOS %3$@.";
 
 /* No comment provided by engineer. */
-"%1$@ %2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required." = "%1$@ %2$@ זמין אך גרסת ה-macOS שלך ישנה מדי. נדרשת לפחות macOS %3$@.";
+"%1$@ ‏%2$@ is available but your macOS version is too old to install it. At least macOS %3$@ is required." = "‏%1$@ ‏%2$@ זמין, אך גרסת ה-macOS שלך ישנה מדי. נדרשת לפחות macOS %3$@.";
 
 /* No comment provided by engineer. */
 "%1$@ can’t be updated if it’s running from the location it was downloaded to." = "לא ניתן לעדכן את %1$@ כשהוא פועל מתיקיית ההורדות.";
@@ -17,31 +17,31 @@
 "%1$@ can’t be updated, because it was opened from a read-only or a temporary location." = "לא ניתן לעדכן את %1$@ מכיוון שהוא נפתח ממיקום זמני או לקריאה בלבד.";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available." = "%@ %@ היא הגרסה החדשה ביותר שזמינה כרגע.";
+"%@ %@ is currently the newest version available." = "‏%@ ‏%@ היא הגרסה החדשה ביותר שזמינה כרגע.";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%@ %@ היא הגרסה החדשה ביותר שזמינה.\n(אתה מפעיל כעת את גרסה %@.)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "‏%@ ‏%@ היא הגרסה החדשה ביותר שזמינה.\n(אתה מפעיל כעת את גרסה %@.)";
 
 /* Description text for SUUpdateAlert when the critical update is downloadable. */
-"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "%@ %@ זמין - אתה משתמש ב-%@. זהו עדכון חשוב; האם תרצה להוריד אותו כעת?";
+"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "‏%@ ‏%@ זמין - אתה משתמש ב-%@. זהו עדכון חשוב; האם תרצה להוריד אותו כעת?";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available—you have %@. Would you like to download it now?" = "%@ %@ זמין - אתה משתמש ב-%@. האם תרצה להוריד אותו כעת?";
+"%@ %@ is now available—you have %@. Would you like to download it now?" = "‏%@ ‏%@ זמין - אתה משתמש ב-%@. האם תרצה להוריד אותו כעת?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%@ %@ זמין - אתה משתמש ב-%@. האם תרצה ללמוד עוד על עדכון זה?";
+"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "‏%@ ‏%@ זמין - אתה משתמש ב-%@. האם תרצה ללמוד עוד על עדכון זה?";
 
 /* The download progress in a unit of bytes, e.g. 100 KB */
-"%@ downloaded" = "%@ הורדו";
+"%@ downloaded" = "‏%@ הורדו";
 
 /* No comment provided by engineer. */
-"%@ is now updated to version %@!" = "%@ מעודכן כעת לגרסה %@!";
+"%@ is now updated to version %@!" = "‏%@ מעודכן כעת לגרסה %@!";
 
 /* No comment provided by engineer. */
-"%@ is now updated!" = "%@ מעודכן כעת!";
+"%@ is now updated!" = "‏%@ מעודכן כעת!";
 
 /* The download progress in units of bytes, e.g. 100 KB of 1,0 MB */
-"%@ of %@" = "%@ מתוך %@";
+"%@ of %@" = "‏%@ מתוך %@";
 
 /* No comment provided by engineer. */
 "A new version of %@ is available!" = "גרסה חדשה של %@ זמינה!";


### PR DESCRIPTION
https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/SupportingRight-To-LeftLanguages/SupportingRight-To-LeftLanguages.html

(Insert summary of your pull request here)

Fixes #2575 (Partially)

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: 14.5