### PR TITLE
Update localisations

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -77,6 +77,12 @@
 "An important update to %@ is ready to install" = "An important update to %@ is ready to install";
 
 /* No comment provided by engineer. */
+"Application Name" = "Application Name";
+
+/* No comment provided by engineer. */
+"Application Version" = "Application Version";
+
+/* No comment provided by engineer. */
 "Cancel" = "Cancel";
 
 /* No comment provided by engineer. */
@@ -84,6 +90,18 @@
 
 /* No comment provided by engineer. */
 "Checking for updates…" = "Checking for updates…";
+
+/* No comment provided by engineer. */
+"CPU is 64-Bit?" = "CPU is 64-Bit?";
+
+/* No comment provided by engineer. */
+"CPU Speed (MHz)" = "CPU Speed (MHz)";
+
+/* No comment provided by engineer. */
+"CPU Subtype" = "CPU Subtype";
+
+/* No comment provided by engineer. */
+"CPU Type" = "CPU Type";
 
 /* Take care not to overflow the status window. */
 "Downloading update…" = "Downloading update…";
@@ -103,11 +121,32 @@
 /* Take care not to overflow the status window. */
 "Installing update…" = "Installing update…";
 
+/* No comment provided by engineer. */
+"Interactive based packages cannot be installed as the root user." = "Interactive based packages cannot be installed as the root user.";
+
 /* Alternate title for 'Install Update' button when there's no download in RSS feed. */
 "Learn More…" = "Learn More…";
 
 /* No comment provided by engineer. */
+"Mac Model" = "Mac Model";
+
+/* No comment provided by engineer. */
+"Memory (MB)" = "Memory (MB)";
+
+/* No comment provided by engineer. */
+"No" = "No";
+
+/* No comment provided by engineer. */
+"Number of CPUs" = "Number of CPUs";
+
+/* No comment provided by engineer. */
 "OK" = "OK";
+
+/* No comment provided by engineer. */
+"OS Version" = "OS Version";
+
+/* No comment provided by engineer. */
+"Preferred Language" = "Preferred Language";
 
 /* No comment provided by engineer. */
 "Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Quit %1$@, move it into your Applications folder, relaunch it from there and try again.";
@@ -117,6 +156,9 @@
 
 /* No comment provided by engineer. */
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu.";
+
+/* No comment provided by engineer. */
+"The installation failed due to not having permission to write the new update." = "The installation failed due to not having permission to write the new update.";
 
 /* No comment provided by engineer. */
 "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version.";
@@ -141,6 +183,12 @@
 
 /* No comment provided by engineer. */
 "Version History" = "Version History";
+
+/* No comment provided by engineer. */
+"Yes" = "Yes";
+
+/* No comment provided by engineer. */
+"You may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management to install future updates." = "You may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management to install future updates.";
 
 /* No comment provided by engineer. */
 "Your macOS version is too new" = "Your macOS version is too new";

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -5,13 +5,13 @@
 "%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ ist zurzeit die neueste verfügbare Version.\n(Die derzeit installierte Version ist %3$@.)";
 
 /* Description text for SUUpdateAlert when the critical update is downloadable. */
-"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Dies ist ein wichtiges Update. Möchtest du die neue Version jetzt laden?";
+"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Dies ist ein wichtiges Update. Möchtest du die neue Version jetzt laden?";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du die neue Version jetzt laden?";
+"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du die neue Version jetzt laden?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du mehr über dieses Update erfahren?";
+"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ist verfügbar – du verwendest Version %3$@. Möchtest du mehr über dieses Update erfahren?";
 
 /* The download progress in a unit of bytes, e.g. 100 KB */
 "%@ downloaded" = "%@ geladen";
@@ -77,6 +77,12 @@
 "An important update to %@ is ready to install" = "Ein wichtiges Update von %@ steht zur Installation bereit";
 
 /* No comment provided by engineer. */
+"Application Name" = "App-Name";
+
+/* No comment provided by engineer. */
+"Application Version" = "App-Version";
+
+/* No comment provided by engineer. */
 "Cancel" = "Abbrechen";
 
 /* No comment provided by engineer. */
@@ -84,6 +90,18 @@
 
 /* No comment provided by engineer. */
 "Checking for updates…" = "Nach Updates suchen …";
+
+/* No comment provided by engineer. */
+"CPU is 64-Bit?" = "CPU ist 64-Bit?";
+
+/* No comment provided by engineer. */
+"CPU Speed (MHz)" = "CPU-Geschwindigkeit (MHz)";
+
+/* No comment provided by engineer. */
+"CPU Subtype" = "CPU-Untertyp";
+
+/* No comment provided by engineer. */
+"CPU Type" = "CPU-Typ";
 
 /* Take care not to overflow the status window. */
 "Downloading update…" = "Update laden …";
@@ -103,11 +121,32 @@
 /* Take care not to overflow the status window. */
 "Installing update…" = "Update installieren …";
 
+/* No comment provided by engineer. */
+"Interactive based packages cannot be installed as the root user." = "Interaktive Installationspakete können nicht als root-Benutzer installiert werden.";
+
 /* Alternate title for 'Install Update' button when there's no download in RSS feed. */
 "Learn More…" = "Mehr über …";
 
 /* No comment provided by engineer. */
+"Mac Model" = "Mac-Modell";
+
+/* No comment provided by engineer. */
+"Memory (MB)" = "Speicher (MB)";
+
+/* No comment provided by engineer. */
+"No" = "Nein";
+
+/* No comment provided by engineer. */
+"Number of CPUs" = "Anzahl der CPUs";
+
+/* No comment provided by engineer. */
 "OK" = "OK";
+
+/* No comment provided by engineer. */
+"OS Version" = "OS-Version";
+
+/* No comment provided by engineer. */
+"Preferred Language" = "Bevorzugte Sprache";
 
 /* No comment provided by engineer. */
 "Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Beende „%1$@“, bewege es in den Ordner „Programme“, starte das Programm von dort erneut und versuche es noch einmal.";
@@ -117,6 +156,9 @@
 
 /* No comment provided by engineer. */
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Soll %1$@ automatisch nach Updates suchen? Du kannst im %1$@-Menü auch manuell nach Updates suchen.";
+
+/* No comment provided by engineer. */
+"The installation failed due to not having permission to write the new update." = "Die Installation ist fehlgeschlagen aufgrund fehlender Berechtigung zum Schreiben des neuen Updates.";
 
 /* No comment provided by engineer. */
 "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "Das Aktualisierungsprogramm wurde nicht richtig gestartet. Du solltest den App-Entwickler kontaktieren, um diesen Fehler zu melden und zu prüfen, ob du die neueste Version hast.";
@@ -141,6 +183,12 @@
 
 /* No comment provided by engineer. */
 "Version History" = "Versionsverlauf";
+
+/* No comment provided by engineer. */
+"Yes" = "Ja";
+
+/* No comment provided by engineer. */
+"You may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management to install future updates." = "Du musst möglicherweise %1$@ in den Systemeinstellungen unter „Datenschutz & Sicherheit“ und „App-Verwaltung“ hinzufügen, um künftige Updates zu installieren.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You’re up to date!" = "Du bist auf dem neuesten Stand!";

--- a/Sparkle/nl.lproj/Sparkle.strings
+++ b/Sparkle/nl.lproj/Sparkle.strings
@@ -5,13 +5,13 @@
 "%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ is momenteel de nieuwste versie.\n(Je gebruikt op dit moment versie %3$@.)";
 
 /* Description text for SUUpdateAlert when the critical update is downloadable. */
-"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Dit is een belangrijke update. Wil je deze nu downloaden?";
+"%@ %@ is now available—you have %@. This is an important update; would you like to download it now?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Dit is een belangrijke update. Wil je deze nu downloaden?";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Wil je de update nu downloaden?";
+"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Wil je de update nu downloaden?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Wil je een webpagina openen met meer informatie?";
+"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ is nu beschikbaar – je hebt %3$@. Wil je een webpagina openen met meer informatie?";
 
 /* The download progress in a unit of bytes, e.g. 100 KB */
 "%@ downloaded" = "%@ gedownload";
@@ -77,13 +77,31 @@
 "An important update to %@ is ready to install" = "Een belangrijke update voor %@ is klaar om te installeren";
 
 /* No comment provided by engineer. */
+"Application Name" = "Appnaam";
+
+/* No comment provided by engineer. */
+"Application Version" = "Appversie";
+
+/* No comment provided by engineer. */
 "Cancel" = "Annuleer";
 
 /* No comment provided by engineer. */
 "Cancel Update" = "Annuleer update";
 
 /* No comment provided by engineer. */
-"Checking for updates…" = "Naar updates zoeken…";
+"Checking for updates…" = "Zoeken naar updates…";
+
+/* No comment provided by engineer. */
+"CPU is 64-Bit?" = "CPU is 64-bits?";
+
+/* No comment provided by engineer. */
+"CPU Speed (MHz)" = "CPU-snelheid (MHz)";
+
+/* No comment provided by engineer. */
+"CPU Subtype" = "CPU-subtype";
+
+/* No comment provided by engineer. */
+"CPU Type" = "CPU-type";
 
 /* Take care not to overflow the status window. */
 "Downloading update…" = "Update downloaden…";
@@ -103,11 +121,32 @@
 /* Take care not to overflow the status window. */
 "Installing update…" = "Update installeren…";
 
+/* No comment provided by engineer. */
+"Interactive based packages cannot be installed as the root user." = "Interactieve Installatieprogramma-pakketen kunnen niet worden geïnstalleerd als de rootgebruiker.";
+
 /* Alternate title for 'Install Update' button when there's no download in RSS feed. */
 "Learn More…" = "Meer informatie…";
 
 /* No comment provided by engineer. */
+"Mac Model" = "Mac-model";
+
+/* No comment provided by engineer. */
+"Memory (MB)" = "Geheuren (MB)";
+
+/* No comment provided by engineer. */
+"No" = "Nee";
+
+/* No comment provided by engineer. */
+"Number of CPUs" = "Aantal CPU's";
+
+/* No comment provided by engineer. */
 "OK" = "OK";
+
+/* No comment provided by engineer. */
+"OS Version" = "OS-versie";
+
+/* No comment provided by engineer. */
+"Preferred Language" = "Voorkeurstaal";
 
 /* No comment provided by engineer. */
 "Quit %1$@, move it into your Applications folder, relaunch it from there and try again." = "Stop %1$@, verplaats het naar de map 'Apps', herstart het van daaruit en probeer opnieuw.";
@@ -117,6 +156,9 @@
 
 /* No comment provided by engineer. */
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Wil je dat %1$@ automatisch naar updates zoekt? Je kunt altijd nog handmatig zoeken naar updates via het %1$@-menu.";
+
+/* No comment provided by engineer. */
+"The installation failed due to not having permission to write the new update." = "De installatie is mislukt omdat je geen bevoegdheden hebt om de nieuwe update te schrijven.";
 
 /* No comment provided by engineer. */
 "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "De updatezoeker is niet goed gestart. Je kunt wellicht met de app-ontwikkelaar contact opnemen om de fout te melden en te controleren dat je de nieuwste versie hebt.";
@@ -141,6 +183,12 @@
 
 /* No comment provided by engineer. */
 "Version History" = "Versiegeschiedenis";
+
+/* No comment provided by engineer. */
+"Yes" = "Ja";
+
+/* No comment provided by engineer. */
+"You may need to allow modifications from %1$@ in System Settings under Privacy & Security and App Management to install future updates." = "Je moet mogelijk %1$@ toevoegen in Systeeminstellingen onder 'Privacy en beveiliging' en 'Appbeheer' om toekomstige updates te installeren.";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
 "You’re up to date!" = "Je hebt de nieuwste versie!";


### PR DESCRIPTION
This adds missing localisable strings to the base localisation and updates the Dutch and German localisations.

Fixes # (issue)

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: [place version here]
