### PR TITLE
Randomize the download archive name the installer extracts/executes

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -427,9 +427,19 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             // which allow writing in unexpected locations. For zip/tar/dmg archives we may also extract them before
             // performing signing validation (due to key rotation).
             NSString *downloadName;
-            NSString *downloadPathExtension = originalDownloadName.pathExtension;
             NSString *randomizedUUIDString = [[NSUUID UUID] UUIDString];
             if (randomizedUUIDString != nil) {
+                // Find the real path extension of the download name
+                // We cannot use -[NSString pathExtension] because it may not give us the full path extension
+                // E.g. for "foo.tar.xz" we need "tar.xz", not "xz"
+                NSString *downloadPathExtension;
+                NSRange pathExtensionDelimiterRange = [originalDownloadName rangeOfString:@"."];
+                if (pathExtensionDelimiterRange.location == NSNotFound) {
+                    downloadPathExtension = @"";
+                } else {
+                    downloadPathExtension = [originalDownloadName substringFromIndex:pathExtensionDelimiterRange.location + 1];
+                }
+                
                 NSString *randomizedDownloadName = [randomizedUUIDString stringByAppendingPathExtension:downloadPathExtension];
                 if (randomizedDownloadName != nil) {
                     downloadName = randomizedDownloadName;

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -415,11 +415,29 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                 SULog(SULogLevelError, @"Error: bookmark data for update download is stale.. but still continuing.");
             }
             
-            NSString *downloadName = downloadURL.lastPathComponent;
-            if (downloadName == nil) {
+            NSString *originalDownloadName = downloadURL.lastPathComponent;
+            if (originalDownloadName == nil) {
                 [self cleanupAndExitWithStatus:EXIT_FAILURE error:[NSError errorWithDomain:SUSparkleErrorDomain code:SPUInstallerError userInfo:@{ NSLocalizedDescriptionKey: @"Error: Failed to retrieve download name from download URL" }]];
                 
                 return;
+            }
+            
+            // Randomize the download name if possible
+            // This adds better security if there are any vulnerabilities in extracting/executing archives
+            // which allow writing in unexpected locations. For zip/tar/dmg archives we may also extract them before
+            // performing signing validation (due to key rotation).
+            NSString *downloadName;
+            NSString *downloadPathExtension = originalDownloadName.pathExtension;
+            NSString *randomizedUUIDString = [[NSUUID UUID] UUIDString];
+            if (randomizedUUIDString != nil) {
+                NSString *randomizedDownloadName = [randomizedUUIDString stringByAppendingPathExtension:downloadPathExtension];
+                if (randomizedDownloadName != nil) {
+                    downloadName = randomizedDownloadName;
+                } else {
+                    downloadName = originalDownloadName;
+                }
+            } else {
+                downloadName = originalDownloadName;
             }
             
             // Move the download archive to somewhere where probably only we will be touching it


### PR DESCRIPTION
Randomize the download archive name the installer extracts/executes for better security hardening.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Need to test:

- [x] UUID string is not the same on subsequent runs
- [x] zip archives
- [x] tar archives
- [x] dmg archives
- [x] pkg updates
- [x] delta updates
- [x] older OS systems

macOS version tested:
14.5 (23F79)
10.14.6 VM
