### PR TITLE
Require signing validation for apple archives before extraction

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -193,9 +193,9 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         
         _updateValidator = [[SUUpdateValidator alloc] initWithDownloadPath:archivePath signatures:_signatures host:_host verifierInformation:_verifierInformation];
 
-        // Delta & package updates will require validation before extraction
+        // Delta, package updates, and .aar/.yaa archives will require validation before extraction
         // Normal application updates are a bit more lenient allowing developers to change one of apple dev ID or EdDSA keys
-        BOOL needsPrevalidation = [[unarchiver class] mustValidateBeforeExtraction] || ![_installationType isEqualToString:SPUInstallationTypeApplication];
+        BOOL needsPrevalidation = [[unarchiver class] mustValidateBeforeExtractionWithArchivePath:archivePath] || ![_installationType isEqualToString:SPUInstallationTypeApplication];
 
         if (needsPrevalidation) {
             success = [_updateValidator validateDownloadPathWithError:&unarchiverError];

--- a/Autoupdate/SUBinaryDeltaUnarchiver.m
+++ b/Autoupdate/SUBinaryDeltaUnarchiver.m
@@ -28,7 +28,7 @@
     return [[path pathExtension] isEqualToString:@"delta"];
 }
 
-+ (BOOL)mustValidateBeforeExtraction
++ (BOOL)mustValidateBeforeExtractionWithArchivePath:(NSString *)archivePath
 {
     return YES;
 }

--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -34,7 +34,7 @@
     return [[path pathExtension] isEqualToString:@"dmg"];
 }
 
-+ (BOOL)mustValidateBeforeExtraction
++ (BOOL)mustValidateBeforeExtractionWithArchivePath:(NSString *)archivePath
 {
     return NO;
 }

--- a/Autoupdate/SUFlatPackageUnarchiver.m
+++ b/Autoupdate/SUFlatPackageUnarchiver.m
@@ -28,7 +28,7 @@
     return [path.pathExtension isEqualToString:@"pkg"] || [path.pathExtension isEqualToString:@"mpkg"];
 }
 
-+ (BOOL)mustValidateBeforeExtraction
++ (BOOL)mustValidateBeforeExtractionWithArchivePath:(NSString *)archivePath
 {
     return YES;
 }

--- a/Autoupdate/SUPipedUnarchiver.m
+++ b/Autoupdate/SUPipedUnarchiver.m
@@ -75,9 +75,9 @@ static NSArray <NSString *> * _Nullable _commandAndArgumentsConformingToTypeOfPa
     return _commandAndArgumentsConformingToTypeOfPath(path) != nil;
 }
 
-+ (BOOL)mustValidateBeforeExtraction
++ (BOOL)mustValidateBeforeExtractionWithArchivePath:(NSString *)archivePath
 {
-    return NO;
+    return ([archivePath hasSuffix:@".aar"] || [archivePath hasSuffix:@".yaa"]);
 }
 
 - (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory

--- a/Autoupdate/SUUnarchiverProtocol.h
+++ b/Autoupdate/SUUnarchiverProtocol.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SUUnarchiverProtocol <NSObject>
 
-+ (BOOL)mustValidateBeforeExtraction;
++ (BOOL)mustValidateBeforeExtractionWithArchivePath:(NSString *)archivePath;
 
 - (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock;
 

--- a/Sparkle/SUUpdateValidator.m
+++ b/Sparkle/SUUpdateValidator.m
@@ -121,7 +121,7 @@
     {
         // Because we already validated the EdDSA signature, this is just a consistency check to see
         // if the developer signed their application properly with their Apple ID
-        // Currently, this case only gets hit for binary delta updates
+        // Currently, this case gets hit for binary delta updates and .aar/.yaa archives
         
         NSError *innerError = nil;
         if ([SUCodeSigningVerifier bundleAtURLIsCodeSigned:installSourceURL] && ![SUCodeSigningVerifier codeSignatureIsValidAtBundleURL:installSourceURL error:&innerError]) {


### PR DESCRIPTION
Because .aar support is new and not a widely used format, require validating them before extraction for now (similar to delta based updates). This also means this archive format cannot presently be used for key rotation. Strengthening the validation later will be harder to do if people start to rely on the format, so better to try this now than later.

Related to #2586 

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested aar extraction only works when updating aar archived app when signature is valid with sparkle-cli
Tested policy for updating zipped based app is still the same (more lax).

macOS version tested: 14.5 (23F79)
