### PR TITLE
Skip safe atomic swap if update has custom update security policy

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -76,6 +76,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     BOOL _showingPermissionRequest;
     BOOL _loggedATSWarning;
     BOOL _loggedNoSecureKeyWarning;
+    BOOL _loggedUpdateSecurityPolicyWarning;
     BOOL _updatingMainBundle;
 }
 
@@ -358,6 +359,14 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUNoPublicDSAFoundError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"For security reasons, updates need to be signed with an EdDSA key for %@. Please migrate to using EdDSA (ed25519). Visit Sparkle's documentation for migration information: https://sparkle-project.org/documentation/#3-segue-for-security-concerns.", hostName] }];
             }
             return NO;
+        }
+    }
+    
+    if (_updatingMainBundle) {
+        if (!_loggedUpdateSecurityPolicyWarning && mainBundleHost.hasUpdateSecurityPolicy) {
+            SULog(SULogLevelDefault, @"Warning: %@ has a custom NSUpdateSecurityPolicy in its Info.plist. This may cause issues when installing updates. Please consider removing this key for your builds using Sparkle if you do not really require a custom update security policy.", hostName);
+            
+            _loggedUpdateSecurityPolicyWarning = YES;
         }
     }
     

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -33,6 +33,8 @@ SPU_OBJC_DIRECT_MEMBERS
 @property (getter=isRunningTranslocated, nonatomic, readonly) BOOL runningTranslocated;
 @property (readonly, nonatomic, copy, nullable) NSString *publicDSAKeyFileKey;
 
+@property (nonatomic, readonly) BOOL hasUpdateSecurityPolicy;
+
 - (nullable id)objectForInfoDictionaryKey:(NSString *)key;
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key;
 - (nullable id)objectForUserDefaultsKey:(NSString *)defaultName;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -161,6 +161,13 @@ NS_ASSUME_NONNULL_BEGIN
     return key;
 }
 
+- (BOOL)hasUpdateSecurityPolicy
+{
+    NSDictionary<NSString *, id> *updateSecurityPolicy = [self objectForInfoDictionaryKey:@"NSUpdateSecurityPolicy"];
+    
+    return (updateSecurityPolicy != nil);
+}
+
 - (SUPublicKeys *)publicKeys
 {
     return [[SUPublicKeys alloc] initWithEd:[self publicEDKey]


### PR DESCRIPTION

Fixes #2591

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

Also we emit a warning if the app has a NSUpdateSecurityPolicy when checking if the updater is configured correctly.

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Workflows:

- Tested old notarized app (no NSUpdateSecurityPolicy) updating to new notarized app (no NSUpdateSecurityPolicy) (regular workflow)
- Tested old notarized app (setapp-like NSUpdateSecurityPolicy) updating to new notarized app (no NSUpdateSecurityPolicy) -- atomic swap works without prompt
- Tested old notarized app (no NSUpdateSecurityPolicy) updating to new notarized app (setapp-like NSUpdateSecurityPolicy) -- no atomic swap
- Tested old notarized app (setapp-like NSUpdateSecurityPolicy) updating to new notarized app (setapp-like NSUpdateSecurityPolicy) -- no atomic swap
- Tested warnings are logged whenever app adopts NSUpdateSecurityPolicy
 
macOS version tested: 14.5 (23F79)
