### PR TITLE
Retry extracting zip file without piping if extraction fails

### DIFF
--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -43,7 +43,8 @@ class SUUnarchiverTest: XCTestCase
     }
 
     func unarchiveNonExistentFileTestFailureAppWithExtension(_ archiveExtension: String, tempDirectoryURL: URL, password: String?, expectingInstallationType installationType: String, testExpectation: XCTestExpectation) {
-        let tempArchiveURL = tempDirectoryURL.appendingPathComponent("error-invalid").appendingPathExtension(archiveExtension)
+        let tempArchiveURL = tempDirectoryURL.deletingLastPathComponent().appendingPathComponent("error-invalid").appendingPathExtension(archiveExtension)
+        
         let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in


### PR DESCRIPTION
This is to workaround a bug in ditto failing to extract certain kinds of zip files while streaming prior to macOS 15.

Fixes #2544

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast extracting affected zip files and tested Sparkle Test App trying to extract the zip file.

macOS version tested:
14.6.1 (23G93)
15.0 Beta (24A5331b)
