### PR TITLE
Call update permission prompt delegate method only when needed

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -382,19 +382,18 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
     id<SPUUpdaterDelegate> delegate = _delegate;
     
-    // If the user has been asked about automatic checks, don't bother prompting
+    // If the user has been asked about automatic checks or the developer has overridden the setting, don't bother prompting
     // When the user answers to the permission prompt, this will be set to either @YES or @NO instead of nil
-    if ([_host objectForUserDefaultsKey:SUEnableAutomaticChecksKey] != nil) {
+    if ([_host objectForKey:SUEnableAutomaticChecksKey] != nil) {
         shouldPrompt = NO;
     }
     // Does the delegate want to take care of the logic for when we should ask permission to update?
     else if ([delegate respondsToSelector:@selector((updaterShouldPromptForPermissionToCheckForUpdates:))]) {
         shouldPrompt = [delegate updaterShouldPromptForPermissionToCheckForUpdates:self];
     }
-    // Has the user been asked already? And don't ask if the host has a default value set in its Info.plist.
-    else if ([_host objectForKey:SUEnableAutomaticChecksKey] == nil) {
+    else {
         // We wait until the second launch of the updater for this host bundle, unless explicitly overridden via SUPromptUserOnFirstLaunchKey.
-        shouldPrompt = [_host objectForKey:SUPromptUserOnFirstLaunchKey] || hasLaunchedBefore;
+        shouldPrompt = hasLaunchedBefore || [_host boolForInfoDictionaryKey:SUPromptUserOnFirstLaunchKey];
     }
     
     if (!hasLaunchedBefore) {

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -137,7 +137,10 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 /**
  Returns whether Sparkle should prompt the user about checking for new updates automatically.
  
- Use this to override the default behavior. This method is not called if SUEnableAutomaticChecks is defined in Info.plist or
+ Use this to override the default behavior, which is to prompt for permission to check for updates on second app launch
+ (if SUEnableAutomaticChecks is not specified).
+ 
+ This method is not called if SUEnableAutomaticChecks is defined in Info.plist or
  if the user has responded to a permission prompt before.
  
  @param updater The updater instance.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -137,7 +137,8 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 /**
  Returns whether Sparkle should prompt the user about checking for new updates automatically.
  
- Use this to override the default behavior.
+ Use this to override the default behavior. This method is not called if SUEnableAutomaticChecks is defined in Info.plist or
+ if the user has responded to a permission prompt before.
  
  @param updater The updater instance.
  @return @c YES if the updater should prompt for permission to check for new updates automatically, otherwise @c NO

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -292,7 +292,7 @@ static NSMutableDictionary *sharedUpdaters = nil;
 - (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SPUUpdater *)__unused updater
 {
     BOOL shouldPrompt = YES;
-    if ([_delegate respondsToSelector:@selector(updater:didFinishLoadingAppcast:)]) {
+    if ([_delegate respondsToSelector:@selector(updaterShouldPromptForPermissionToCheckForUpdates:)]) {
         shouldPrompt = [_delegate updaterShouldPromptForPermissionToCheckForUpdates:self];
     }
     return shouldPrompt;


### PR DESCRIPTION
The delegate method is not called if SUEnableAutomaticChecks is specified in the Info.plist (now) or if the user has responded to a permission prompt request.

Also fixes a respondsToSelector check in legacy SUUpdater adaptor (fixes #2618).

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested clean state of test app where SUEnableAutomaticChecks is defined in the Info.plist as YES or NO, or if it's absent, and implementing permission prompt delegate method returning YES or NO.

macOS version tested: 14.6.1 (23G93)
