### PR TITLE
Improve robustness around dmg passwords

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -236,7 +236,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
                  
                  [self->_communicator handleMessageWithIdentifier:SPUExtractedArchiveWithProgress data:data];
              }
-         }];
+         } waitForCleanup:NO];
     }
 }
 

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -499,6 +499,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             self->_signatures = installationData.signatures;
             self->_updateDirectoryPath = cacheInstallationPath;
             self->_extractionDirectory = extractionDirectory;
+            self->_decryptionPassword = installationData.decryptionPassword;
             self->_host = [[SUHost alloc] initWithBundle:hostBundle];
             self->_verifierInformation = [[SPUVerifierInformation alloc] initWithExpectedVersion:installationData.expectedVersion expectedContentLength:installationData.expectedContentLength];
             

--- a/Autoupdate/SUBinaryDeltaUnarchiver.m
+++ b/Autoupdate/SUBinaryDeltaUnarchiver.m
@@ -83,7 +83,7 @@ SPU_OBJC_DIRECT
     return self;
 }
 
-- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock waitForCleanup:(BOOL)__unused waitForCleanup
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @autoreleasepool {

--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -100,11 +100,11 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
         
         // Prepare stdin data for passwords and license agreements
         {
+            // If no password is supplied, we will still be asked a password.
+            // In that case we respond with an empty password.
             NSData *decryptionPasswordData = [_decryptionPassword dataUsingEncoding:NSUTF8StringEncoding];
             if (decryptionPasswordData != nil) {
                 [inputData appendData:decryptionPasswordData];
-            } else {
-                [inputData appendBytes:"y" length:1];
             }
             
             // From the hdiutil docs:

--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -11,6 +11,7 @@
 #import "SUDiskImageUnarchiver.h"
 #import "SUUnarchiverNotifier.h"
 #import "SULog.h"
+#import "SUErrors.h"
 
 
 #include "AppKitPrevention.h"
@@ -50,11 +51,11 @@
     return self;
 }
 
-- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock waitForCleanup:(BOOL)waitForCleanup
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         SUUnarchiverNotifier *notifier = [[SUUnarchiverNotifier alloc] initWithCompletionBlock:completionBlock progressBlock:progressBlock];
-        [self extractDMGWithNotifier:notifier];
+        [self extractDMGWithNotifier:notifier waitForCleanup:waitForCleanup];
     });
 }
 
@@ -78,7 +79,7 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
 }
 
 // Called on a non-main thread.
-- (void)extractDMGWithNotifier:(SUUnarchiverNotifier *)notifier SPU_OBJC_DIRECT
+- (void)extractDMGWithNotifier:(SUUnarchiverNotifier *)notifier waitForCleanup:(BOOL)waitForCleanup SPU_OBJC_DIRECT
 {
 	@autoreleasepool {
         BOOL mountedSuccessfully = NO;
@@ -95,24 +96,31 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
         // Note: this check does not follow symbolic links, which is what we want
         while ([[NSURL fileURLWithPath:mountPoint] checkResourceIsReachableAndReturnError:NULL]);
         
-        NSData *promptData = [NSData dataWithBytes:"yes\n" length:4];
+        NSMutableData *inputData = [NSMutableData data];
         
-        // Finder doesn't verify disk images anymore beyond the code signing signature (if available)
-        // Opt out of the old CRC checksum checks
-        NSMutableArray *arguments = [@[@"attach", _archivePath, @"-mountpoint", mountPoint, @"-noverify", @"-nobrowse", @"-noautoopen"] mutableCopy];
-        
-        if (_decryptionPassword) {
-            NSMutableData *passwordData = [[_decryptionPassword dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+        // Prepare stdin data for passwords and license agreements
+        {
+            NSData *decryptionPasswordData = [_decryptionPassword dataUsingEncoding:NSUTF8StringEncoding];
+            if (decryptionPasswordData != nil) {
+                [inputData appendData:decryptionPasswordData];
+            } else {
+                [inputData appendBytes:"y" length:1];
+            }
+            
             // From the hdiutil docs:
             // read a null-terminated passphrase from standard input
             //
-            // Add the null terminator, then the newline
-            [passwordData appendData:[NSData dataWithBytes:"\0" length:1]];
-            [passwordData appendData:promptData];
-            promptData = passwordData;
+            // Add the null terminator
+            [inputData appendBytes:"\0" length:1];
             
-            [arguments addObject:@"-stdinpass"];
+            // Append prompt data for license agreements
+            [inputData appendBytes:"yes\n" length:4];
         }
+        
+        // Finder doesn't verify disk images anymore beyond the code signing signature (if available)
+        // Opt out of the old CRC checksum checks
+        // Also always pass -stdinpass so we gracefully handle password protected disk images even if we aren't expecting them
+        NSArray *arguments = @[@"attach", _archivePath, @"-mountpoint", mountPoint, @"-noverify", @"-nobrowse", @"-noautoopen", @"-stdinpass"];
         
         NSData *output = nil;
         NSInteger taskResult = -1;
@@ -153,7 +161,7 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
             }
             
             if (@available(macOS 10.15, *)) {
-                if (![inputPipe.fileHandleForWriting writeData:promptData error:&error]) {
+                if (![inputPipe.fileHandleForWriting writeData:inputData error:&error]) {
                     goto reportError;
                 }
             }
@@ -161,7 +169,7 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
             else
             {
                 @try {
-                    [inputPipe.fileHandleForWriting writeData:promptData];
+                    [inputPipe.fileHandleForWriting writeData:inputData];
                 } @catch (NSException *) {
                     goto reportError;
                 }
@@ -175,12 +183,16 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
             
             taskResult = task.terminationStatus;
         }
-
+        
         if (taskResult != 0) {
             NSString *resultStr = output ? [[NSString alloc] initWithData:output encoding:NSUTF8StringEncoding] : nil;
             SULog(SULogLevelError, @"hdiutil failed with code: %ld data: <<%@>>", (long)taskResult, resultStr);
+            
+            error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Extraction failed due to hdiutil returning %ld status: %@", (long)taskResult, resultStr]}];
+            
             goto reportError;
         }
+        
         mountedSuccessfully = YES;
         
         // Mounting can take some time, so increment progress
@@ -271,13 +283,21 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
         
         [notifier notifyProgress:1.0];
         
-        [notifier notifySuccess];
+        BOOL success = YES;
         goto finally;
         
     reportError:
-        [notifier notifyFailureWithError:error];
+        success = NO;
 
     finally:
+        if (!waitForCleanup) {
+            if (success) {
+                [notifier notifySuccess];
+            } else {
+                [notifier notifyFailureWithError:error];
+            }
+        }
+        
         if (mountedSuccessfully) {
             NSTask *task = [[NSTask alloc] init];
             task.launchPath = @"/usr/bin/hdiutil";
@@ -289,9 +309,19 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
             if (![task launchAndReturnError:&launchCleanupError]) {
                 SULog(SULogLevelError, @"Failed to unmount %@", mountPoint);
                 SULog(SULogLevelError, @"Error: %@", launchCleanupError);
+            } else if (waitForCleanup) {
+                [task waitUntilExit];
             }
         } else {
             SULog(SULogLevelError, @"Can't mount DMG %@", _archivePath);
+        }
+        
+        if (waitForCleanup) {
+            if (success) {
+                [notifier notifySuccess];
+            } else {
+                [notifier notifyFailureWithError:error];
+            }
         }
     }
 }

--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -290,14 +290,6 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
         success = NO;
 
     finally:
-        if (!waitForCleanup) {
-            if (success) {
-                [notifier notifySuccess];
-            } else {
-                [notifier notifyFailureWithError:error];
-            }
-        }
-        
         if (mountedSuccessfully) {
             NSTask *task = [[NSTask alloc] init];
             task.launchPath = @"/usr/bin/hdiutil";
@@ -316,12 +308,10 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
             SULog(SULogLevelError, @"Can't mount DMG %@", _archivePath);
         }
         
-        if (waitForCleanup) {
-            if (success) {
-                [notifier notifySuccess];
-            } else {
-                [notifier notifyFailureWithError:error];
-            }
+        if (success) {
+            [notifier notifySuccess];
+        } else {
+            [notifier notifyFailureWithError:error];
         }
     }
 }

--- a/Autoupdate/SUFlatPackageUnarchiver.m
+++ b/Autoupdate/SUFlatPackageUnarchiver.m
@@ -44,7 +44,7 @@
     return self;
 }
 
-- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock waitForCleanup:(BOOL)__unused waitForCleanup
 {
     SUUnarchiverNotifier *notifier = [[SUUnarchiverNotifier alloc] initWithCompletionBlock:completionBlock progressBlock:progressBlock];
     

--- a/Autoupdate/SUPipedUnarchiver.m
+++ b/Autoupdate/SUPipedUnarchiver.m
@@ -96,7 +96,7 @@ static NSArray<NSString *> * _Nullable _argumentsConformingToTypeOfPath(NSString
     return self;
 }
 
-- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock waitForCleanup:(BOOL)__unused waitForCleanup
 {
     NSString *command = nil;
     NSArray<NSString *> *arguments = _argumentsConformingToTypeOfPath(_archivePath, YES, &command);

--- a/Autoupdate/SUUnarchiverProtocol.h
+++ b/Autoupdate/SUUnarchiverProtocol.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)mustValidateBeforeExtractionWithArchivePath:(NSString *)archivePath;
 
-- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock;
+- (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock waitForCleanup:(BOOL)waitForCleanup;
 
 - (NSString *)description;
 

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -171,6 +171,12 @@
 		721D8A861D4ADFEB0032E472 /* SPULocalCacheDirectory.m in Sources */ = {isa = PBXBuildFile; fileRef = 721BC20D1D1CDE55002BC71E /* SPULocalCacheDirectory.m */; };
 		721D8A871D4C5BF10032E472 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		722545B626805FF80036465C /* testappcast_info_updates.xml in Resources */ = {isa = PBXBuildFile; fileRef = 722545B526805FF80036465C /* testappcast_info_updates.xml */; };
+		72266A872946359600645376 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
+		72266A88294635BA00645376 /* SUAppcastDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 72B767C91C9B707000A07552 /* SUAppcastDriver.m */; };
+		72266A89294636FB00645376 /* SUStandardVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A225A30D1C4AC000430CCD /* SUStandardVersionComparator.m */; };
+		72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
+		72266A8B29464CEA00645376 /* SUHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 61EF67550E25B58D00F754E0 /* SUHost.m */; };
+		72266A8C29464D0200645376 /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E286D22B665E8004AA304 /* SUSignatures.m */; };
 		7229E1B61C97C91100CB50D0 /* SPUUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7229E1B51C97C91100CB50D0 /* SPUUpdateDriver.h */; };
 		7229E1B91C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7229E1B71C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.h */; };
 		7229E1BA1C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7229E1B81C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m */; };
@@ -306,6 +312,7 @@
 		7267E5FD1D3DD1B700D1BF90 /* SPUResumableUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7267E5FB1D3DD1B700D1BF90 /* SPUResumableUpdate.h */; };
 		7269E494264798200088C213 /* SPUSkippedUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7269E492264798200088C213 /* SPUSkippedUpdate.h */; };
 		7269E496264798200088C213 /* SPUSkippedUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7269E493264798200088C213 /* SPUSkippedUpdate.m */; };
+		7269E4982648D3460088C213 /* SPUSkippedUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7269E493264798200088C213 /* SPUSkippedUpdate.m */; };
 		7269E49A2648F7C00088C213 /* SPUUserUpdateState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7269E4992648F7C00088C213 /* SPUUserUpdateState.m */; };
 		726DF88E1C84277600188804 /* SPUUserUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = 726DF88D1C84277500188804 /* SPUUserUpdateState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		726E075C1CA3A6D6001A286B /* SPUSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 726E075A1CA3A6D6001A286B /* SPUSecureCoding.h */; };
@@ -3376,8 +3383,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				72D04F3E2B097D4300A6DEAA /* SPUVerifierInformation.m in Sources */,
+				72266A8C29464D0200645376 /* SUSignatures.m in Sources */,
+				72266A8B29464CEA00645376 /* SUHost.m in Sources */,
+				72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */,
+				72266A89294636FB00645376 /* SUStandardVersionComparator.m in Sources */,
+				72266A88294635BA00645376 /* SUAppcastDriver.m in Sources */,
+				72266A872946359600645376 /* SUFileManager.m in Sources */,
 				725EE488277D398100D820CE /* SPUDeltaArchive.m in Sources */,
 				725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */,
+				7269E4982648D3460088C213 /* SPUSkippedUpdate.m in Sources */,
 				721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				725F97771C8A62F500265BE4 /* SUAdHocCodeSigning.m in Sources */,
 				5A4094481C74EA5200983BE0 /* SUAppcastTest.swift in Sources */,

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -171,12 +171,6 @@
 		721D8A861D4ADFEB0032E472 /* SPULocalCacheDirectory.m in Sources */ = {isa = PBXBuildFile; fileRef = 721BC20D1D1CDE55002BC71E /* SPULocalCacheDirectory.m */; };
 		721D8A871D4C5BF10032E472 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		722545B626805FF80036465C /* testappcast_info_updates.xml in Resources */ = {isa = PBXBuildFile; fileRef = 722545B526805FF80036465C /* testappcast_info_updates.xml */; };
-		72266A872946359600645376 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
-		72266A88294635BA00645376 /* SUAppcastDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 72B767C91C9B707000A07552 /* SUAppcastDriver.m */; };
-		72266A89294636FB00645376 /* SUStandardVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A225A30D1C4AC000430CCD /* SUStandardVersionComparator.m */; };
-		72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
-		72266A8B29464CEA00645376 /* SUHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 61EF67550E25B58D00F754E0 /* SUHost.m */; };
-		72266A8C29464D0200645376 /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E286D22B665E8004AA304 /* SUSignatures.m */; };
 		7229E1B61C97C91100CB50D0 /* SPUUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7229E1B51C97C91100CB50D0 /* SPUUpdateDriver.h */; };
 		7229E1B91C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7229E1B71C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.h */; };
 		7229E1BA1C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7229E1B81C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.m */; };
@@ -312,7 +306,6 @@
 		7267E5FD1D3DD1B700D1BF90 /* SPUResumableUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7267E5FB1D3DD1B700D1BF90 /* SPUResumableUpdate.h */; };
 		7269E494264798200088C213 /* SPUSkippedUpdate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7269E492264798200088C213 /* SPUSkippedUpdate.h */; };
 		7269E496264798200088C213 /* SPUSkippedUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7269E493264798200088C213 /* SPUSkippedUpdate.m */; };
-		7269E4982648D3460088C213 /* SPUSkippedUpdate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7269E493264798200088C213 /* SPUSkippedUpdate.m */; };
 		7269E49A2648F7C00088C213 /* SPUUserUpdateState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7269E4992648F7C00088C213 /* SPUUserUpdateState.m */; };
 		726DF88E1C84277600188804 /* SPUUserUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = 726DF88D1C84277500188804 /* SPUUserUpdateState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		726E075C1CA3A6D6001A286B /* SPUSecureCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 726E075A1CA3A6D6001A286B /* SPUSecureCoding.h */; };
@@ -3383,15 +3376,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				72D04F3E2B097D4300A6DEAA /* SPUVerifierInformation.m in Sources */,
-				72266A8C29464D0200645376 /* SUSignatures.m in Sources */,
-				72266A8B29464CEA00645376 /* SUHost.m in Sources */,
-				72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */,
-				72266A89294636FB00645376 /* SUStandardVersionComparator.m in Sources */,
-				72266A88294635BA00645376 /* SUAppcastDriver.m in Sources */,
-				72266A872946359600645376 /* SUFileManager.m in Sources */,
 				725EE488277D398100D820CE /* SPUDeltaArchive.m in Sources */,
 				725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */,
-				7269E4982648D3460088C213 /* SPUSkippedUpdate.m in Sources */,
 				721D5ABC25C680A300D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
 				725F97771C8A62F500265BE4 /* SUAdHocCodeSigning.m in Sources */,
 				5A4094481C74EA5200983BE0 /* SUAppcastTest.swift in Sources */,

--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -50,7 +50,7 @@ class SUUnarchiverTest: XCTestCase
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             XCTAssertNotNil(error)
             testExpectation.fulfill()
-        }, progressBlock: nil)
+        }, progressBlock: nil, waitForCleanup: true)
     }
 
     // swiftlint:disable function_parameter_count
@@ -65,7 +65,7 @@ class SUUnarchiverTest: XCTestCase
                 XCTAssertNotNil(error)
             }
             testExpectation.fulfill()
-        }, progressBlock: nil)
+        }, progressBlock: nil, waitForCleanup: true)
     }
 
     func testUnarchivingZip()
@@ -132,9 +132,34 @@ class SUUnarchiverTest: XCTestCase
         self.unarchiveTestAppWithExtension("enc.nolicense.dmg", password: "testpass")
     }
     
+    func testUnarchivingEncryptedDmgWithLicenseAndWithIncorrectPassword()
+    {
+        self.unarchiveTestAppWithExtension("enc.dmg", password: "moo", expectingSuccess: false)
+    }
+    
+    func testUnarchivingEncryptedDmgWithLicenseAndWithoutPassword()
+    {
+        self.unarchiveTestAppWithExtension("enc.dmg", expectingSuccess: false)
+    }
+    
+    func testUnarchivingEncryptedDmgWithoutLicenseAndWithIncorrectPassword()
+    {
+        self.unarchiveTestAppWithExtension("enc.nolicense.dmg", password: "moo", expectingSuccess: false)
+    }
+    
+    func testUnarchivingEncryptedDmgWithoutLicenseAndWithoutPassword()
+    {
+        self.unarchiveTestAppWithExtension("enc.nolicense.dmg", expectingSuccess: false)
+    }
+    
     func testUnarchivingAPFSDMG()
     {
         self.unarchiveTestAppWithExtension("dmg", resourceName: "SparkleTestCodeSign_apfs")
+    }
+    
+    func testUnarchivingAPFSDMGWithBogusPassword()
+    {
+        self.unarchiveTestAppWithExtension("dmg", password: "moo", resourceName: "SparkleTestCodeSign_apfs")
     }
     
     func testUnarchivingAPFSAdhocSignedDMGWithAuxFiles()

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -25,7 +25,7 @@ func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) 
             } catch {
                 callback(error)
             }
-        }, progressBlock: nil)
+        }, progressBlock: nil, waitForCleanup: true)
     } else {
         callback(makeError(code: .unarchivingError, "Not a supported archive format: \(itemPath.path)"))
     }


### PR DESCRIPTION
* Fix bug where updater's decryption password was not properly passed to installer
* Handle failing to unarchive password-protected dmgs when a password is not expected by the updater gracefully
* Wait for dmgs to be detached for unit tests and tools for better robustness
* Expand tests for unarchiving dmgs with passwords and/or license agreements

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested unarchiving in sample app:

- [x] Regular dmg
- [x] license agreement dmg
- [x] password protected dmg
- [x] license agreement + password protected dmg

macOS version tested:
10.14 VM
14.6.1 (23G93)
15.0 Beta (24A5331b)
