### PR TITLE
Fix shared classes being defined both in unit tests and Sparkle

### DIFF
--- a/Autoupdate/SUCodeSigningVerifier.h
+++ b/Autoupdate/SUCodeSigningVerifier.h
@@ -14,8 +14,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 #ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
+#define SUCodeSigningVerifierDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUCodeSigningVerifierDefinitionAttribute __attribute__((objc_runtime_name("SUTestCodeSigningVerifier")))
 #endif
+
+SUCodeSigningVerifierDefinitionAttribute
 @interface SUCodeSigningVerifier : NSObject
 
 + (BOOL)codeSignatureIsValidAtBundleURL:(NSURL *)newBundleURL andMatchesSignatureAtBundleURL:(NSURL *)oldBundleURL error:(NSError **)error;

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -173,7 +173,6 @@
 		722545B626805FF80036465C /* testappcast_info_updates.xml in Resources */ = {isa = PBXBuildFile; fileRef = 722545B526805FF80036465C /* testappcast_info_updates.xml */; };
 		72266A872946359600645376 /* SUFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5E41D3D90AA00D1BF90 /* SUFileManager.m */; };
 		72266A88294635BA00645376 /* SUAppcastDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 72B767C91C9B707000A07552 /* SUAppcastDriver.m */; };
-		72266A89294636FB00645376 /* SUStandardVersionComparator.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A225A30D1C4AC000430CCD /* SUStandardVersionComparator.m */; };
 		72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
 		72266A8B29464CEA00645376 /* SUHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 61EF67550E25B58D00F754E0 /* SUHost.m */; };
 		72266A8C29464D0200645376 /* SUSignatures.m in Sources */ = {isa = PBXBuildFile; fileRef = EA1E286D22B665E8004AA304 /* SUSignatures.m */; };
@@ -3386,7 +3385,6 @@
 				72266A8C29464D0200645376 /* SUSignatures.m in Sources */,
 				72266A8B29464CEA00645376 /* SUHost.m in Sources */,
 				72266A8A2946493C00645376 /* SUCodeSigningVerifier.m in Sources */,
-				72266A89294636FB00645376 /* SUStandardVersionComparator.m in Sources */,
 				72266A88294635BA00645376 /* SUAppcastDriver.m in Sources */,
 				72266A872946359600645376 /* SUFileManager.m in Sources */,
 				725EE488277D398100D820CE /* SPUDeltaArchive.m in Sources */,

--- a/Sparkle/SPUSkippedUpdate.h
+++ b/Sparkle/SPUSkippedUpdate.h
@@ -12,15 +12,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SUHost, SUAppcastItem;
 
+#ifndef BUILDING_SPARKLE_TESTS
+#define SPUSkippedUpdateDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SPUSkippedUpdateDefinitionAttribute __attribute__((objc_runtime_name("SPUTestSkippedUpdate")))
+#endif
+
 /*
  A skipped update tracks an optional minor version and an optional major version the user may skip.
  The minor and major versions are independent versions, so the user can choose to skip at most two separate versions.
  The intent is when the user is faced with a major upgrade, they can skip a major version.
  Otherwise they can choose to skip a minor version.
  */
-#ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
-#endif
+SPUSkippedUpdateDefinitionAttribute
 @interface SPUSkippedUpdate : NSObject
 
 + (nullable SPUSkippedUpdate *)skippedUpdateForHost:(SUHost *)host;

--- a/Sparkle/SUAppcastDriver.h
+++ b/Sparkle/SUAppcastDriver.h
@@ -23,8 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 #ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
+#define SUAppcastDriverDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUAppcastDriverDefinitionAttribute __attribute__((objc_runtime_name("SUTestAppcastDriver")))
 #endif
+
+SUAppcastDriverDefinitionAttribute
 @interface SUAppcastDriver : NSObject
 
 - (instancetype)initWithHost:(SUHost *)host updater:(id)updater updaterDelegate:(nullable id <SPUUpdaterDelegate>)updaterDelegate delegate:(nullable id <SUAppcastDriverDelegate>)delegate;

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -11,14 +11,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#ifndef BUILDING_SPARKLE_TESTS
+#define SUFileManagerDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUFileManagerDefinitionAttribute __attribute__((objc_runtime_name("SUTestFileManager")))
+#endif
+
 /**
  * A class used for performing file operations more suitable than NSFileManager for performing installation work.
  * All operations on this class may be used on thread other than the main thread.
  * This class provides just basic file operations and stays away from including much application-level logic.
  */
-#ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
-#endif
+SUFileManagerDefinitionAttribute
 @interface SUFileManager : NSObject
 
 /**

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -12,8 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 @class SUPublicKeys;
 
 #ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
+#define SUHostDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUHostDefinitionAttribute __attribute__((objc_runtime_name("SUTestHost")))
 #endif
+
+SUHostDefinitionAttribute
 @interface SUHost : NSObject
 
 @property (nonatomic, readonly) NSBundle *bundle;

--- a/Sparkle/SUSignatures.h
+++ b/Sparkle/SUSignatures.h
@@ -23,8 +23,12 @@ typedef NS_ENUM(uint8_t, SUSigningInputStatus) {
 };
 
 #ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
+#define SUSignaturesDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUSignaturesDefinitionAttribute __attribute__((objc_runtime_name("SUTestSignatures")))
 #endif
+
+SUSignaturesDefinitionAttribute
 @interface SUSignatures : NSObject <NSSecureCoding>
 #if SPARKLE_BUILD_LEGACY_DSA_SUPPORT
 @property (nonatomic, readonly, nullable) NSData *dsaSignature;
@@ -41,10 +45,13 @@ SPU_OBJC_DIRECT_MEMBERS
 ;
 @end
 
-
 #ifndef BUILDING_SPARKLE_TESTS
-SPU_OBJC_DIRECT_MEMBERS
+#define SUPublicKeysDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUPublicKeysDefinitionAttribute __attribute__((objc_runtime_name("SUTestPublicKeys")))
 #endif
+
+SUPublicKeysDefinitionAttribute
 @interface SUPublicKeys : NSObject
 
 @property (nonatomic, readonly, nullable) NSString *dsaPubKey;


### PR DESCRIPTION
For the unit tests, we will rename the classes so they don't conflict.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 14.6.1 (23G93)
