### PR TITLE
Deprecate custom version comparators

### DIFF
--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -386,7 +386,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  @param updater The updater instance.
  @return The custom version comparator or @c nil if you don't want to be delegated this task.
  */
-- (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater __deprecated_msg("Custom version comparators are deprecated because they are incompatible with the way the system compares different versions of an app.");
+- (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater __deprecated_msg("Custom version comparators are deprecated because they are incompatible with how the system compares different versions of an app.");
 
 /**
  Called when a background update will be scheduled after a delay.

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -386,7 +386,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
  @param updater The updater instance.
  @return The custom version comparator or @c nil if you don't want to be delegated this task.
  */
-- (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater;
+- (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater __deprecated_msg("Custom version comparators are deprecated because they are incompatible with the way the system compares different versions of an app.");
 
 /**
  Called when a background update will be scheduled after a delay.

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -429,11 +429,14 @@ SPU_OBJC_DIRECT
 {
     id<SUVersionComparison> comparator = nil;
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // Give the delegate a chance to provide a custom version comparator
     id<SPUUpdaterDelegate> updaterDelegate = _updaterDelegate;
     if ([updaterDelegate respondsToSelector:@selector((versionComparatorForUpdater:))]) {
         comparator = [updaterDelegate versionComparatorForUpdater:_updater];
     }
+#pragma clang diagnostic pop
     
     // If we don't get a comparator from the delegate, use the default comparator
     if (comparator == nil) {

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -460,6 +460,8 @@ static NSMutableDictionary *sharedUpdaters = nil;
     }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)__unused updater
 {
     id<SUVersionComparison> versionComparator;
@@ -468,6 +470,7 @@ static NSMutableDictionary *sharedUpdaters = nil;
     }
     return versionComparator;
 }
+#pragma clang diagnostic pop
 
 // Private SPUUpdater API that allows us to defer providing an application path to relaunch
 - (NSString * _Nullable)_pathToRelaunchForUpdater:(SPUUpdater *)__unused updater


### PR DESCRIPTION
Fixes #2585

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)
