### PR TITLE
Skip preflight update check in sparkle-cli if user is root

### DIFF
--- a/sparkle-cli/SPUCommandLineDriver.m
+++ b/sparkle-cli/SPUCommandLineDriver.m
@@ -139,7 +139,17 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
     switch (updateCheck) {
         case SPUUpdateCheckUpdates:
         case SPUUpdateCheckUpdatesInBackground:
-            if (_interactive || !SPUSystemNeedsAuthorizationAccessForBundlePath(_updater.hostBundle.bundlePath)) {
+        {
+            if (_interactive) {
+                return YES;
+            }
+            
+            BOOL rootUser = (geteuid() == 0);
+            if (rootUser) {
+                return YES;
+            }
+            
+            if (!SPUSystemNeedsAuthorizationAccessForBundlePath(_updater.hostBundle.bundlePath)) {
                 return YES;
             }
             
@@ -148,6 +158,7 @@ typedef NS_ENUM(int, CLIErrorExitStatus) {
             }
             
             return NO;
+        }
         case SPUUpdateCheckUpdateInformation:
             return YES;
     }


### PR DESCRIPTION
Fixes issue brought up in https://github.com/sparkle-project/Sparkle/discussions/2644

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested pkg update installation from sparkle-cli as root user without --interactive, and as non-root user which required --interactive.

macOS version tested: 15.0.1 (24A348)
