### PR TITLE
Bump CI runner to Xcode 16.1 / macOS 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: ['xcode16', 'xcode15.4']
+        xcode: ['xcode16.1', 'xcode15.4']
         include:
             - xcode: 'xcode15.4'
               xcode-path: '/Applications/Xcode_15.4.app/Contents/Developer'
-              upload-dist: true
-              run-analyzer: true
-              macos: 'macos-14'
-            - xcode: 'xcode16'
-              xcode-path: '/Applications/Xcode_16.app'
               upload-dist: false
               run-analyzer: false
               macos: 'macos-14'
+            - xcode: 'xcode16.1'
+              xcode-path: '/Applications/Xcode_16.1.app'
+              upload-dist: true
+              run-analyzer: true
+              macos: 'macos-15'
             
     name: Build and Test Sparkle
     runs-on: ${{ matrix.macos }}

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -2,7 +2,7 @@ name: "Create Draft Release"
 
 env:
   BUILDDIR: "build"
-  DEVELOPER_DIR: "/Applications/Xcode_15.4.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_16.1.app/Contents/Developer"
 
 on:
   workflow_dispatch:
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   release:
     name: "Publish binaries for release"
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - name: "Checkout sources"

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -434,7 +434,10 @@ SPU_OBJC_DIRECT
     // Give the delegate a chance to provide a custom version comparator
     id<SPUUpdaterDelegate> updaterDelegate = _updaterDelegate;
     if ([updaterDelegate respondsToSelector:@selector((versionComparatorForUpdater:))]) {
-        comparator = [updaterDelegate versionComparatorForUpdater:_updater];
+        SPUUpdater *updater = _updater;
+        if (updater != nil) {
+            comparator = [updaterDelegate versionComparatorForUpdater:updater];
+        }
     }
 #pragma clang diagnostic pop
     

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -434,7 +434,7 @@ SPU_OBJC_DIRECT
     // Give the delegate a chance to provide a custom version comparator
     id<SPUUpdaterDelegate> updaterDelegate = _updaterDelegate;
     if ([updaterDelegate respondsToSelector:@selector((versionComparatorForUpdater:))]) {
-        SPUUpdater *updater = _updater;
+        id updater = _updater;
         if (updater != nil) {
             comparator = [updaterDelegate versionComparatorForUpdater:updater];
         }


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
