### PR TITLE
Make binary delta version 4 the default

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -22,7 +22,7 @@
 
 // Note: the framework bundle version must be bumped, and generate_appcast must be updated to compare it,
 // when we add/change new major versions and defaults. Unit tests need to be updated to use new versions too.
-SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionDefault = SUBinaryDeltaMajorVersion3;
+SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionDefault = SUBinaryDeltaMajorVersion4;
 SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionLatest = SUBinaryDeltaMajorVersion4;
 SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionFirst = SUBinaryDeltaMajorVersion1;
 SUBinaryDeltaMajorVersion SUBinaryDeltaMajorVersionFirstSupported = SUBinaryDeltaMajorVersion2;

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -283,13 +283,20 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                         // Decide the most appropriate delta version
                         let deltaVersion: SUBinaryDeltaMajorVersion
                         if let frameworkVersion = item.frameworkVersion {
-                            switch standardComparator.compareVersion(frameworkVersion, toVersion: "2010") {
+                            switch standardComparator.compareVersion(frameworkVersion, toVersion: "2041") {
                             case .orderedSame:
                                 fallthrough
                             case .orderedDescending:
-                                deltaVersion = .version3
+                                deltaVersion = .version4
                             case .orderedAscending:
-                                deltaVersion = .version2
+                                switch standardComparator.compareVersion(frameworkVersion, toVersion: "2010") {
+                                case .orderedSame:
+                                    fallthrough
+                                case .orderedDescending:
+                                    deltaVersion = .version3
+                                case .orderedAscending:
+                                    deltaVersion = .version2
+                                }
                             }
                         } else {
                             deltaVersion = SUBinaryDeltaMajorVersionDefault


### PR DESCRIPTION
Make binary delta version 4 the default in tools.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast creates version 3 delta patch when old app version is 2.6.4, and can be applied with BinaryDelta (both new and old one from 2.6.4 distribution).
Tested generate_appcast creates version 4 delta patch when old app version is 2.7, and can be applied with BinaryDelta.

macOS version tested: 15.1 (24B83)
