### PR TITLE
Add custom timeout setting for testing unreliable connection

### DIFF
--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -112,7 +112,18 @@
         _delegate = delegate;
         _inBackground = background;
         
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        NSString *customTimeout = processInfo.environment[@"SPARKLE_TIMEOUT"];
+        NSTimeInterval timeout;
+        if (customTimeout != nil) {
+            timeout = customTimeout.doubleValue;
+        } else {
+            timeout = 60.0;
+        }
+        
+        NSLog(@"SPARKLE_TIMEOUT: %f", timeout);
+        
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:timeout];
         
         if (userAgent != nil) {
             [request setValue:(NSString * _Nonnull)userAgent forHTTPHeaderField:@"User-Agent"];


### PR DESCRIPTION
Kicking off a build related to testing #2671

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: [place version here]
