### PR TITLE
Use default NSURLRequest timeoutInterval (currently 60s)

### DIFF
--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -112,7 +112,8 @@
         _delegate = delegate;
         _inBackground = background;
         
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL];
+        request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
         
         if (userAgent != nil) {
             [request setValue:(NSString * _Nonnull)userAgent forHTTPHeaderField:@"User-Agent"];


### PR DESCRIPTION
## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested downloading data (release notes, feed, update) still works.

macOS version tested: 15.1 (24B83)
