### PR TITLE
Improve unable decode private key error messages

### DIFF
--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -26,11 +26,11 @@ func loadPrivateKeys(_ account: String, _ privateDSAKey: SecKey?, _ privateEdStr
                 print("Error: specifying private key as the argument is no longer supported.")
                 return nil
             } else {
-                print("Error: Private key not found in decoded argument, which has \(data.count) bytes. Please provide a valid key.")
+                print("Error: Private key not decoded from the argument, which has \(data.count) bytes. Please provide a valid key and confirm the contents of the key are correct.")
                 return nil
             }
         } else {
-            print("Error: Private key not found in the argument. Please provide a valid key.")
+            print("Error: Private key not decoded from the argument because it isn't base64 encoded. Please provide a valid key and confirm the contents of the key are correct.")
             return nil
         }
     }


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

(Describe all the cases that were tested)

macOS version tested: 15.1 (24B83)
