### PR TITLE
Upload temporary sparkle_dist tarball instead of sparkle-dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Sparkle-distribution-${{ matrix.xcode }}.tar.xz
-          path: build/Build/Products/Release/sparkle-dist.tar.xz
+          path: build/Build/Products/Release/sparkle_dist.tar.xz

--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -84,7 +84,7 @@ if [ "$ACTION" = "" ] ; then
     find . \! -type d | rev | sort | rev | tar --no-xattrs -cJvf "../Sparkle-$MARKETING_VERSION.tar.xz" --files-from=-
         
     # Copy archived distribution for CI
-    cp -f "../Sparkle-$MARKETING_VERSION.tar.xz" "../sparkle-dist.tar.xz"
+    cp -f "../Sparkle-$MARKETING_VERSION.tar.xz" "../sparkle_dist.tar.xz"
 
     # Extract archive for testing binary validity
     tar -xf "../Sparkle-$MARKETING_VERSION.tar.xz" -C "/tmp/sparkle-extract"


### PR DESCRIPTION
The release workflow on GitHub uploads files that match "Sparkle-*" which apparently now includes sparkle-dist.tar.xz even though it's not capitalized. Rename the file to sparkle_dist to work around this.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Verified Sparkle distribution tarball is still uploaded on Github actions page from this CI run.

macOS version tested: NA
