### PR TITLE
Improves bsdiff performance by preventing excessive iterations when processing similar data blocks

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -113,11 +113,11 @@ uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersio
         case SUBinaryDeltaMajorVersion1:
             return 2;
         case SUBinaryDeltaMajorVersion2:
-            return 4;
+            return 5;
         case SUBinaryDeltaMajorVersion3:
-            return 1;
+            return 2;
         case SUBinaryDeltaMajorVersion4:
-            return 0;
+            return 1;
     }
     return 0;
 }

--- a/Vendor/bsdiff/bsdiff.c
+++ b/Vendor/bsdiff/bsdiff.c
@@ -84,7 +84,8 @@ static off_t search(off_t *I, u_char *old, off_t oldsize,
     }
 
     x = st + (en - st)/2;
-    /* Ported from ChromiumOS project: https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/58146f74abd6b1b69693943195f37f4ac6a6acef%5E%21/#F0 */
+    /* Modification ported from ChromiumOS project:
+     * https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/58146f74abd6b1b69693943195f37f4ac6a6acef%5E%21/#F0 */
     if (memcmp(old + I[x], new, (size_t)(MIN(oldsize - I[x], newsize))) <= 0) {
         return search(I, old, oldsize, new, newsize, x, en, pos);
     } else {
@@ -213,7 +214,8 @@ int bsdiff(int argc, char *argv[])
     lastoffset = 0;
     while (scan < newsize) {
         oldscore = 0;
-        /* Ported from ChromiumOS project: https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/a055996c743add7a9558839276fd1e4994d16bd3%5E%21/#F0 */
+        /* Modification ported from ChromiumOS project:
+         * https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/a055996c743add7a9558839276fd1e4994d16bd3%5E%21/#F0 */
         /* If we come across a large block of data that only differs
          * by less than 8 bytes, this loop will take a long time to
          * go past that block of data. We need to track the number of
@@ -251,7 +253,8 @@ int bsdiff(int argc, char *argv[])
                 (old[scan + lastoffset] == new[scan]))
                 oldscore--;
 
-            /* Ported from ChromiumOS project: https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/426e4aa1cbeb3c8a73002047d7a796ca8e5e17d4%5E%21/#F0 */
+            /* Modification ported from ChromiumOS project:
+             * https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/426e4aa1cbeb3c8a73002047d7a796ca8e5e17d4%5E%21/#F0 */
             const off_t fuzz = 8;
             if (prev_len - fuzz <= len && len <= prev_len &&
                 prev_oldscore - fuzz <= oldscore &&

--- a/Vendor/bsdiff/bsdiff.c
+++ b/Vendor/bsdiff/bsdiff.c
@@ -84,7 +84,7 @@ static off_t search(off_t *I, u_char *old, off_t oldsize,
     }
 
     x = st + (en - st)/2;
-    if (memcmp(old + I[x], new, (size_t)(MIN(oldsize - I[x], newsize))) < 0) {
+    if (memcmp(old + I[x], new, (size_t)(MIN(oldsize - I[x], newsize))) <= 0) {
         return search(I, old, oldsize, new, newsize, x, en, pos);
     } else {
         return search(I, old, oldsize, new, newsize, st, x, pos);
@@ -212,8 +212,16 @@ int bsdiff(int argc, char *argv[])
     lastoffset = 0;
     while (scan < newsize) {
         oldscore = 0;
-
+        /* If we come across a large block of data that only differs
+         * by less than 8 bytes, this loop will take a long time to
+         * go past that block of data. We need to track the number of
+         * times we're stuck in the block and break out of it. */
+        int num_less_than_eight = 0;
+        off_t prev_len, prev_oldscore, prev_pos;
         for (scsc = scan += len; scan < newsize; scan++) {
+            prev_len = len;
+            prev_oldscore = oldscore;
+            prev_pos = pos;
             /* 'oldscore' is the number of characters that match between the
              * substrings 'old[lastoffset + scan:lastoffset + scsc]' and
              * 'new[scan:scsc]'. */
@@ -240,6 +248,17 @@ int bsdiff(int argc, char *argv[])
             if ((scan + lastoffset < oldsize) &&
                 (old[scan + lastoffset] == new[scan]))
                 oldscore--;
+
+            const off_t fuzz = 8;
+            if (prev_len - fuzz <= len && len <= prev_len &&
+                prev_oldscore - fuzz <= oldscore &&
+                oldscore <= prev_oldscore &&
+                prev_pos <= pos && pos <= prev_pos + fuzz &&
+                oldscore <= len && len <= oldscore + fuzz)
+                ++num_less_than_eight;
+            else
+                num_less_than_eight=0;
+            if (num_less_than_eight > 100) break;
         }
 
         /* Skip this section if we found an exact match that would be

--- a/Vendor/bsdiff/bsdiff.c
+++ b/Vendor/bsdiff/bsdiff.c
@@ -84,6 +84,7 @@ static off_t search(off_t *I, u_char *old, off_t oldsize,
     }
 
     x = st + (en - st)/2;
+    /* Ported from ChromiumOS project: https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/58146f74abd6b1b69693943195f37f4ac6a6acef%5E%21/#F0 */
     if (memcmp(old + I[x], new, (size_t)(MIN(oldsize - I[x], newsize))) <= 0) {
         return search(I, old, oldsize, new, newsize, x, en, pos);
     } else {
@@ -212,6 +213,7 @@ int bsdiff(int argc, char *argv[])
     lastoffset = 0;
     while (scan < newsize) {
         oldscore = 0;
+        /* Ported from ChromiumOS project: https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/a055996c743add7a9558839276fd1e4994d16bd3%5E%21/#F0 */
         /* If we come across a large block of data that only differs
          * by less than 8 bytes, this loop will take a long time to
          * go past that block of data. We need to track the number of
@@ -249,6 +251,7 @@ int bsdiff(int argc, char *argv[])
                 (old[scan + lastoffset] == new[scan]))
                 oldscore--;
 
+            /* Ported from ChromiumOS project: https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/426e4aa1cbeb3c8a73002047d7a796ca8e5e17d4%5E%21/#F0 */
             const off_t fuzz = 8;
             if (prev_len - fuzz <= len && len <= prev_len &&
                 prev_oldscore - fuzz <= oldscore &&


### PR DESCRIPTION
We detected a performance issue in our CI where the BinaryDelta process was taking over 4 hours to generate deltas between our macOS binaries. After timing individual `bsdiff` operations, I identified that a single diff was causing most of the slowdown. The issue occurred in the main macOS binary (`Contents/MacOS/<AppName>`) diffing process after product changes that removed approximately 22MB of binary code. By implementing patches from the ChromiumOS project's version of `bsdiff`, we reduced the entire BinaryDelta process from hours to just 5 minutes.

The changes introduce a mechanism to detect when `bsdiff` gets stuck processing large blocks of data that differ by less than 8 bytes. After 100 iterations in such a state, the algorithm breaks out of the loop to prevent performance degradation. Additionally, the search comparison operator was updated to include equality cases.

**Original ChromiumOS Changes:**
```
426e4aa AU: bsdiff: Expand pathological case where files differ by <8 bytes by Thieu Le · 13 years ago
58146f7 AU: Fix bsdiff hang by Thieu Le · 13 years ago
a055996 bsdiff: Speed up pathological case. by Thieu Le · 14 years ago
```

```
a055996
bsdiff: Speed up pathological case.

bsdiff does not properly handle the case where there is a large block of
data in the new file that only differs from the old file by less than 8
bytes.  This causes bsdiff to continue searching through the files one
byte at a time and at each byte, re-compare the same large block of data
which leads to excessively long run times.  This fix checks for this
edge condition and breaks out of the search loop early.  This retains
the size efficiency of the patch file for most binaries while preserving
the runtime efficiency for files that fall into this category.
```
https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/a055996c743add7a9558839276fd1e4994d16bd3%5E%21/#F0

```
58146f7
AU: Fix bsdiff hang
```
https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/58146f74abd6b1b69693943195f37f4ac6a6acef%5E%21/#F0


```
426e4aa
AU: bsdiff: Expand pathological case where files differ by <8 bytes

Modify bsdiff to better handle the case where files differ by <8 bytes
in some regions, not limitting this case to linear traversal.

BUG=chromium-os:28552
TEST=Manual bsdiff of problematic files, update engine unit tests
```
https://chromium.googlesource.com/chromiumos/third_party/bsdiff/+/426e4aa1cbeb3c8a73002047d7a796ca8e5e17d4%5E%21/#F0

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

macOS version tested: 15.3

