### PR TITLE
Fix Sparkle not building when SPARKLE_COPY_LOCALIZATIONS=0

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -28,6 +28,7 @@
 #import "SPUInstallationType.h"
 #import "SPULocalCacheDirectory.h"
 #import "SPUVerifierInformation.h"
+#import "SUConstants.h"
 
 
 #include "AppKitPrevention.h"


### PR DESCRIPTION
Need to import SUConstants.h explicitly.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested building works when disabling SPARKLE_COPY_LOCALIZATIONS in common configuration file.

macOS version tested: 15.3.1 (24D70)
