### PR TITLE
Fix compiler warnings for Xcode 16.3

### DIFF
--- a/Autoupdate/SPUSparkleDeltaArchive.m
+++ b/Autoupdate/SPUSparkleDeltaArchive.m
@@ -1141,7 +1141,7 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
             } else if (S_ISLNK(extractMode)) {
                 off_t fileSize = itemFileInfo.st_size;
                 if (fileSize > UINT16_MAX) {
-                    _error = [NSError errorWithDomain:SPARKLE_DELTA_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_ARCHIVE_ERROR_CODE_LINK_TOO_LONG userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path has a destination that is too long: %llu bytes", fileSize] }];
+                    _error = [NSError errorWithDomain:SPARKLE_DELTA_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_ARCHIVE_ERROR_CODE_LINK_TOO_LONG userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Link path has a destination that is too long: %lld bytes", fileSize] }];
                     break;
                 }
                 

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -389,7 +389,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
             }
 
             if (verbose) {
-                fprintf(stderr, "\n👮  %s %s (0%o)", VERBOSE_MODIFIED, [relativePath fileSystemRepresentation], mode & PERMISSION_FLAGS);
+                fprintf(stderr, "\n👮  %s %s (0%o)", VERBOSE_MODIFIED, [relativePath fileSystemRepresentation], (unsigned int)(mode & PERMISSION_FLAGS));
             }
         }
     }];

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -477,7 +477,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                     fprintf(stderr, "\n");
                 }
                 if (error != NULL) {
-                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Permissions for Sparkle executable must be 0%o (found 0%o) on file %@", VALID_SPARKLE_EXECUTABLE_PERMISSIONS, permissions, @(ent->fts_path)] }];
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Permissions for Sparkle executable must be 0%o (found 0%o) on file %@", (unsigned int)VALID_SPARKLE_EXECUTABLE_PERMISSIONS, permissions, @(ent->fts_path)] }];
                 }
                 return NO;
             }
@@ -591,7 +591,7 @@ BOOL createBinaryDelta(NSString *source, NSString *destination, NSString *patchF
                     fprintf(stderr, "\n");
                 }
                 if (error != NULL) {
-                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Permissions for Sparkle executable must be 0%o (found 0%o) on file %@", VALID_SPARKLE_EXECUTABLE_PERMISSIONS, permissions, @(ent->fts_path)] }];
+                    *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Permissions for Sparkle executable must be 0%o (found 0%o) on file %@", (unsigned int)VALID_SPARKLE_EXECUTABLE_PERMISSIONS, permissions, @(ent->fts_path)] }];
                 }
                 return NO;
             }

--- a/Autoupdate/SUCodeSigningVerifier.m
+++ b/Autoupdate/SUCodeSigningVerifier.m
@@ -68,7 +68,7 @@
     // See https://github.com/sparkle-project/Sparkle/issues/376#issuecomment-48824267 and https://developer.apple.com/library/mac/technotes/tn2206
     // Additionally, there are several reasons to stay away from deep verification and to prefer EdDSA signing the download archive instead.
     // See https://github.com/sparkle-project/Sparkle/pull/523#commitcomment-17549302 and https://github.com/sparkle-project/Sparkle/issues/543
-    SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
+    SecCSFlags flags = kSecCSCheckAllArchitectures;
     result = SecStaticCodeCheckValidityWithErrors(staticCode, flags, requirement, &cfError);
     
     if (result != errSecSuccess) {
@@ -154,7 +154,7 @@ finally:
     }
 
     // See in -codeSignatureIsValidAtBundleURL:andMatchesSignatureAtBundleURL:error: for why kSecCSCheckNestedCode is not always passed
-    SecCSFlags flags = (SecCSFlags) (kSecCSDefaultFlags | kSecCSCheckAllArchitectures);
+    SecCSFlags flags = kSecCSCheckAllArchitectures;
     if (checkNestedCode) {
         flags |= kSecCSCheckNestedCode;
     }

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -164,4 +164,4 @@ GCC_WARN_UNUSED_PARAMETER = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Werror=undef
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-pre-c11-compat -Wno-missing-include-dirs -Werror=undef

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -164,4 +164,4 @@ GCC_WARN_UNUSED_PARAMETER = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-pre-c11-compat -Wno-missing-include-dirs -Werror=undef
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Werror=undef

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -3016,7 +3016,7 @@
 			attributes = {
 				CLASSPREFIX = SU;
 				LastSwiftUpdateCheck = 1020;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1630;
 				ORGANIZATIONNAME = "Sparkle Project";
 				TargetAttributes = {
 					5D06E8CF0FD68C7C005AE3F6 = {

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/BinaryDelta.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/BinaryDelta.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Distribution.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Distribution.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/generate_appcast.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/generate_appcast.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/generate_keys.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/generate_keys.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/sign_update.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/sign_update.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/sparkle-cli.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/sparkle-cli.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -163,7 +163,7 @@
                         if (fileSize != nil && ![deltaItem.deltaFromSparkleExecutableSize isEqualToNumber:fileSize]) {
                             sparkleExecutableIsOK = NO;
                             
-                            SULog(SULogLevelDefault, @"Expected file size (%lld) of Sparkle's executable does not match actual file size (%lld). Skipping delta update.", deltaItem.deltaFromSparkleExecutableSize.unsignedLongLongValue, fileSize.unsignedLongLongValue);
+                            SULog(SULogLevelDefault, @"Expected file size (%llu) of Sparkle's executable does not match actual file size (%llu). Skipping delta update.", deltaItem.deltaFromSparkleExecutableSize.unsignedLongLongValue, fileSize.unsignedLongLongValue);
                         } else {
                             sparkleExecutableIsOK = YES;
                         }

--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -32,6 +32,10 @@ void SULog(SULogLevel level, NSString *format, ...)
     // Note we don't take advantage of info like the source line number because we wrap this macro inside our own function
     // And we don't really leverage of os_log's deferred formatting processing because we format the string before passing it in
     switch (level) {
+#pragma clang diagnostic push
+#if __has_warning("-Wpre-c11-compat")
+#pragma clang diagnostic ignored "-Wpre-c11-compat"
+#endif
         case SULogLevelDefault:
             // See docs for OS_LOG_TYPE_DEFAULT
             // By default, OS_LOG_TYPE_DEFAULT seems to be more noticeable than OS_LOG_TYPE_INFO
@@ -41,5 +45,6 @@ void SULog(SULogLevel level, NSString *format, ...)
             // See docs for OS_LOG_TYPE_ERROR
             os_log_error(logger, "%{public}@", logMessage);
             break;
+#pragma clang diagnostic pop
     }
 }


### PR DESCRIPTION
Fix all compiler warnings for Xcode 16.3. There's still a Xcode-specific dependency scan warning from SparkleLauncher which I'm not sure I can easily fix. Filed FB16984934.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI
