### PR TITLE
Set STRINGS_FILE_OUTPUT_ENCODING = binary in xcconfig

### DIFF
--- a/Configurations/ConfigFramework.xcconfig
+++ b/Configurations/ConfigFramework.xcconfig
@@ -18,6 +18,7 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) BUILDING_SPARKLE=1
 SKIP_INSTALL = YES
 DEFINES_MODULE = YES
 PRODUCT_BUNDLE_IDENTIFIER = ${SPARKLE_BUNDLE_IDENTIFIER}
+STRINGS_FILE_OUTPUT_ENCODING = binary
 
 // As long as we don't ourselves depend upon any Frameworks that are incompatible
 // with Application Extensions, then we should allow frameworks that require

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -4165,7 +4165,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 149B78631B7D3A0C00D7D62C /* ConfigCommonCoverage.xcconfig */;
 			buildSettings = {
-				STRINGS_FILE_OUTPUT_ENCODING = binary;
 			};
 			name = Coverage;
 		};
@@ -4227,7 +4226,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA1941CF0D94A70100DD942E /* ConfigCommonDebug.xcconfig */;
 			buildSettings = {
-				STRINGS_FILE_OUTPUT_ENCODING = binary;
 			};
 			name = Debug;
 		};
@@ -4235,7 +4233,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA1941CC0D94A70100DD942E /* ConfigCommonRelease.xcconfig */;
 			buildSettings = {
-				STRINGS_FILE_OUTPUT_ENCODING = binary;
 			};
 			name = Release;
 		};


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Verifying localizations in Sparkle framework output are still binary.
