### PR TITLE
Make -[SPUUserDriver showUpdateInFocus] optional

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -96,7 +96,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  
  If an update hasn't started, the user may be shown that a new check for updates is occurring.
  If an update has already been downloaded or begun installing from a previous session, the user may be presented to install that update.
- If the user is already being presented with an update, that update will be shown to the user in active focus.
+ If the user is already being presented with an update or update permission prompt, that notice may be shown to the user in active focus
+ (as long as the user driver is the standard `SPUStandardUserDriver` or if it implements `-[SPUUserDriver showUpdateInFocus]`).
  
  This will find updates that the user has previously opted into skipping.
  
@@ -150,7 +151,10 @@ SU_EXPORT @interface SPUUpdater : NSObject
 /**
  A property indicating whether or not updates can be checked by the user.
  
- An update check can be made by the user when an update session isn't in progress, or when an update or its progress is being shown to the user.
+ An update check can be made by the user when an update session isn't in progress.
+ An update check can also be made when an update or its progress is being shown to the user
+ (as long as the user driver is the standard `SPUStandardUserDriver` or if it implements `-[SPUUserDriver showUpdateInFocus]`).
+ 
  A user cannot check for updates when data (such as the feed or an update) is still being downloaded automatically in the background.
  
  This property is suitable to use for menu item validation for seeing if `-checkForUpdates` can be invoked.

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -257,14 +257,6 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
 - (void)showUpdateInstalledAndRelaunched:(BOOL)relaunched acknowledgement:(void (^)(void))acknowledgement;
 
 /**
- * Show the user the current presented update or its progress in utmost focus
- *
- * The user wishes to check for updates while the user is being shown update progress.
- * Bring whatever is on screen to frontmost focus (permission request, update information, downloading or extraction status, choice to install update, etc).
- */
-- (void)showUpdateInFocus;
-
-/**
  * Dismiss the current update installation
  *
  * Stop and tear down everything.
@@ -273,12 +265,22 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  */
 - (void)dismissUpdateInstallation;
 
+@optional
+
+/**
+ * Show the user the current presented update or its progress in utmost focus
+ *
+ * The user wishes to check for updates while the user is being shown update progress.
+ * Bring whatever is on screen to frontmost focus (permission request, update information, downloading or extraction status, choice to install update, etc).
+ * Implementing this method is optional.
+ */
+- (void)showUpdateInFocus;
+
 /*
  * Below are deprecated methods that have been replaced by better alternatives.
  * The deprecated methods will be used if the alternatives have not been implemented yet.
  * In the future support for using these deprecated methods may be removed however.
  */
-@optional
 
 // Clients should move to non-deprecated methods
 // Deprecated methods are only (temporarily) kept around for compatibility reasons

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -121,10 +121,6 @@
     }
 }
 
-- (void)showUpdateInFocus
-{
-}
-
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
 {
     if (_verbose) {


### PR DESCRIPTION
When this method is not implemented, the updater assumes already presented updates cannot be brought in utmost focus again.

Fixes #2704

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested not implementing showUpdateInFocus in standard user driver with test app, and keeping it implemented.
Tested update notice and permission prompt, and not being able to check for updates when showUpdateInFocus is not implemented.
Tested update notice and permission prompt, and not being able to check for updates when showUpdateInFocus is not implemented and canCheckForUpdates is not checked (with appropriate error message logged).

macOS version tested: 15.4 (24E248)
