### PR TITLE
Add private module map

### DIFF
--- a/Configurations/ConfigFramework.xcconfig
+++ b/Configurations/ConfigFramework.xcconfig
@@ -24,3 +24,6 @@ STRINGS_FILE_OUTPUT_ENCODING = binary
 // with Application Extensions, then we should allow frameworks that require
 // compatibility to be able to link with us.
 APPLICATION_EXTENSION_API_ONLY = YES
+
+ENABLE_MODULE_VERIFIER = YES
+MODULEMAP_PRIVATE_FILE = Sparkle/Sparkle.private.modulemap

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -1093,6 +1093,7 @@
 		72316BD11E0DA8430039EFD9 /* SUUnarchiverNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SUUnarchiverNotifier.h; path = Autoupdate/SUUnarchiverNotifier.h; sourceTree = SOURCE_ROOT; };
 		72316BD21E0DA8430039EFD9 /* SUUnarchiverNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SUUnarchiverNotifier.m; path = Autoupdate/SUUnarchiverNotifier.m; sourceTree = SOURCE_ROOT; };
 		7235B75E29DFC0120081FE4E /* make-xcframework.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "make-xcframework.sh"; sourceTree = "<group>"; };
+		72366CCC2DC2D1FC003CE62B /* Sparkle.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Sparkle.private.modulemap; sourceTree = "<group>"; };
 		723ABCD7259A9A9D00BDB4FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		723ABD37259A9BA500BDB4FA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/SUUpdateAlert.xib; sourceTree = "<group>"; };
 		723ABD4C259A9BB900BDB4FA /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/SUUpdateAlert.strings; sourceTree = "<group>"; };
@@ -1845,6 +1846,7 @@
 			isa = PBXGroup;
 			children = (
 				720767D11E2EB86200F9A850 /* AppKitPrevention.h */,
+				72366CCC2DC2D1FC003CE62B /* Sparkle.private.modulemap */,
 				61299B3909CB055000B7442F /* Appcast Support */,
 				55C14BD5136EEFD000649790 /* Autoupdate */,
 				72F9EBE41D519425004AC8B6 /* Deprecated */,

--- a/Sparkle/Sparkle.private.modulemap
+++ b/Sparkle/Sparkle.private.modulemap
@@ -1,0 +1,19 @@
+//
+//  Sparkle.private.modulemap
+//  Sparkle
+//
+//  Created on 4/30/25.
+//  Copyright © 2025 Sparkle Project. All rights reserved.
+//
+
+framework module Sparkle_Private {
+    header "SPUStandardUserDriver+Private.h"
+    header "SPUGentleUserDriverReminders.h"
+    header "SPUUserAgent+Private.h"
+    header "SPUInstallationType.h"
+    header "SPUAppcastItemStateResolver.h"
+    header "SUAppcastItem+Private.h"
+    header "SUInstallerLauncher+Private.h"
+    
+    export *
+}

--- a/Sparkle/Sparkle.private.modulemap
+++ b/Sparkle/Sparkle.private.modulemap
@@ -7,13 +7,32 @@
 //
 
 framework module Sparkle_Private {
+    // Nothing exported here
+}
+
+explicit module Sparkle_Private.SPUStandardUserDriver {
     header "SPUStandardUserDriver+Private.h"
+    export *
+}
+
+explicit module Sparkle_Private.SPUGentleUserDriverReminders {
     header "SPUGentleUserDriverReminders.h"
+    export *
+}
+
+explicit module Sparkle_Private.SPUUserAgent {
     header "SPUUserAgent+Private.h"
-    header "SPUInstallationType.h"
-    header "SPUAppcastItemStateResolver.h"
+    export *
+}
+
+explicit module Sparkle_Private.SUAppcastItem {
     header "SUAppcastItem+Private.h"
+    header "SPUAppcastItemStateResolver.h"
+    export *
+}
+
+explicit module Sparkle_Private.SUInstallerLauncher {
     header "SUInstallerLauncher+Private.h"
-    
+    header "SPUInstallationType.h"
     export *
 }


### PR DESCRIPTION
Adds a private module map so private headers are importable from Swift, and enables module verifier for the framework.

Fixes #2710

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested importing private submodules from `Sparkle_Private` from Swift using the framework.

macOS version tested: 15.4 (24E248)
