### PR TITLE
Disable pre-c11-compat globally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
             {
                 echo 'content<<EOF'
-                cat analyze_output.txt
+                head -c 4096 analyze_output.txt
                 echo 'EOF'
             } >> $GITHUB_OUTPUT
       

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -164,4 +164,4 @@ GCC_WARN_UNUSED_PARAMETER = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Werror=undef
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Wno-pre-c11-compat -Werror=undef

--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -164,4 +164,4 @@ GCC_WARN_UNUSED_PARAMETER = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Wno-pre-c11-compat -Werror=undef
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Werror=undef

--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -32,10 +32,6 @@ void SULog(SULogLevel level, NSString *format, ...)
     // Note we don't take advantage of info like the source line number because we wrap this macro inside our own function
     // And we don't really leverage of os_log's deferred formatting processing because we format the string before passing it in
     switch (level) {
-#pragma clang diagnostic push
-#if __has_warning("-Wpre-c11-compat")
-#pragma clang diagnostic ignored "-Wpre-c11-compat"
-#endif
         case SULogLevelDefault:
             // See docs for OS_LOG_TYPE_DEFAULT
             // By default, OS_LOG_TYPE_DEFAULT seems to be more noticeable than OS_LOG_TYPE_INFO
@@ -45,6 +41,5 @@ void SULog(SULogLevel level, NSString *format, ...)
             // See docs for OS_LOG_TYPE_ERROR
             os_log_error(logger, "%{public}@", logMessage);
             break;
-#pragma clang diagnostic pop
     }
 }

--- a/Sparkle/SULog.m
+++ b/Sparkle/SULog.m
@@ -32,6 +32,10 @@ void SULog(SULogLevel level, NSString *format, ...)
     // Note we don't take advantage of info like the source line number because we wrap this macro inside our own function
     // And we don't really leverage of os_log's deferred formatting processing because we format the string before passing it in
     switch (level) {
+#pragma clang diagnostic push
+#if __has_warning("-Wpre-c11-compat")
+#pragma clang diagnostic ignored "-Wpre-c11-compat"
+#endif
         case SULogLevelDefault:
             // See docs for OS_LOG_TYPE_DEFAULT
             // By default, OS_LOG_TYPE_DEFAULT seems to be more noticeable than OS_LOG_TYPE_INFO
@@ -41,5 +45,6 @@ void SULog(SULogLevel level, NSString *format, ...)
             // See docs for OS_LOG_TYPE_ERROR
             os_log_error(logger, "%{public}@", logMessage);
             break;
+#pragma clang diagnostic pop
     }
 }


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Just tested project builds without issues.

macOS version tested: 15.4 (24E248)
