### PR TITLE
Synchronize updater settings with user defaults

### DIFF
--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,7 +25,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="746" y="229" width="620" height="370"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1470" height="918"/>
             <value key="minSize" type="size" width="550" height="150"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="620" height="370"/>
@@ -43,7 +43,7 @@
                             <binding destination="-2" name="value" keyPath="applicationIcon" id="9"/>
                         </connections>
                     </imageView>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="10" userLabel="Version text field">
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="10" userLabel="Version text field">
                         <rect key="frame" x="106" y="338" width="494" height="17"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="777" constant="17" id="n8w-DR-XEM"/>
@@ -57,7 +57,7 @@
                             <binding destination="-2" name="value" keyPath="titleText" id="11"/>
                         </connections>
                     </textField>
-                    <textField horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" preferredMaxLayoutWidth="490" translatesAutoresizingMaskIntoConstraints="NO" id="101" userLabel="Question text field">
+                    <textField focusRingType="none" horizontalHuggingPriority="350" verticalHuggingPriority="999" horizontalCompressionResistancePriority="100" verticalCompressionResistancePriority="1000" preferredMaxLayoutWidth="490" translatesAutoresizingMaskIntoConstraints="NO" id="101" userLabel="Question text field">
                         <rect key="frame" x="106" y="316" width="494" height="14"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="lessThanOrEqual" priority="300" constant="28" id="H6E-te-Fog"/>
@@ -93,7 +93,7 @@
                                     </binding>
                                 </connections>
                             </box>
-                            <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="17">
+                            <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="17">
                                 <rect key="frame" x="-2" y="221" width="88" height="14"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="100" constant="100" id="gkn-FW-9aC"/>
@@ -124,9 +124,6 @@
                     </customView>
                     <button horizontalHuggingPriority="150" verticalHuggingPriority="750" horizontalCompressionResistancePriority="997" translatesAutoresizingMaskIntoConstraints="NO" id="22">
                         <rect key="frame" x="338" y="12" width="137" height="32"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="222" constant="90" id="2Zy-5G-GBj"/>
-                        </constraints>
                         <buttonCell key="cell" type="push" title="Remind Me Later" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="171">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -134,6 +131,9 @@
 Gw
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="222" constant="90" id="2Zy-5G-GBj"/>
+                        </constraints>
                         <connections>
                             <action selector="remindMeLater:" target="-2" id="34"/>
                         </connections>
@@ -150,9 +150,6 @@ Gw
                     </button>
                     <button horizontalHuggingPriority="20" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="76">
                         <rect key="frame" x="473" y="12" width="134" height="32"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="222" constant="120" id="N94-uf-6oP"/>
-                        </constraints>
                         <buttonCell key="cell" type="push" title="Install Update" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" inset="2" id="173">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -160,22 +157,25 @@ Gw
 DQ
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="222" constant="120" id="N94-uf-6oP"/>
+                        </constraints>
                         <connections>
                             <action selector="installUpdate:" target="-2" id="77"/>
                         </connections>
                     </button>
                     <button translatesAutoresizingMaskIntoConstraints="NO" id="117">
                         <rect key="frame" x="108" y="50" width="491" height="16"/>
-                        <constraints>
-                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="28" id="0AI-ue-a0r"/>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="yM1-TA-HfP"/>
-                        </constraints>
                         <buttonCell key="cell" type="check" title="Automatically download and install updates in the future" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="175">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="28" id="0AI-ue-a0r"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="yM1-TA-HfP"/>
+                        </constraints>
                         <connections>
-                            <binding destination="93" name="value" keyPath="values.SUAutomaticallyUpdate" id="135"/>
+                            <binding destination="-2" name="value" keyPath="self.updaterSettings.automaticallyDownloadsUpdates" id="kdq-kt-v6U"/>
                         </connections>
                     </button>
                 </subviews>

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -200,7 +200,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  The update schedule cycle will be reset in a short delay after the property's new value is set.
  This is to allow reverting this property without kicking off a schedule change immediately.
  
- This property is KVO compliant.
+ This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL automaticallyChecksForUpdates;
 
@@ -217,7 +217,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  The update schedule cycle will be reset in a short delay after the property's new value is set.
  This is to allow reverting this property without kicking off a schedule change immediately.
  
- This property is KVO compliant.
+ This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) NSTimeInterval updateCheckInterval;
 
@@ -240,7 +240,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Only set this property if the user wants to change the default via a user settings option.
  Do not always set it on launch unless you want to ignore the user's preference.
  
- This property is KVO compliant.
+ This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
@@ -333,7 +333,7 @@ SU_EXPORT @interface SPUUpdater : NSObject
 
  Setting this property will persist in the host bundle's user defaults.
  
- This property is KVO compliant.
+ This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL sendsSystemProfile;
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -198,7 +198,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
  to your app's command line arguments instead of setting this property.
  
  The update schedule cycle will be reset in a short delay after the property's new value is set.
- This is to allow reverting this property without kicking off a schedule change immediately
+ This is to allow reverting this property without kicking off a schedule change immediately.
+ 
+ This property is KVO compliant.
  */
 @property (nonatomic) BOOL automaticallyChecksForUpdates;
 
@@ -213,7 +215,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Do not always set it on launch unless you want to ignore the user's preference.
  
  The update schedule cycle will be reset in a short delay after the property's new value is set.
- This is to allow reverting this property without kicking off a schedule change immediately
+ This is to allow reverting this property without kicking off a schedule change immediately.
+ 
+ This property is KVO compliant.
  */
 @property (nonatomic) NSTimeInterval updateCheckInterval;
 
@@ -235,6 +239,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Hence developers shouldn't maintain an additional user default for this property.
  Only set this property if the user wants to change the default via a user settings option.
  Do not always set it on launch unless you want to ignore the user's preference.
+ 
+ This property is KVO compliant.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
@@ -326,6 +332,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  A property indicating whether or not the user's system profile information is sent when checking for updates.
 
  Setting this property will persist in the host bundle's user defaults.
+ 
+ This property is KVO compliant.
  */
 @property (nonatomic) BOOL sendsSystemProfile;
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -825,8 +825,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             [strongSelf setSessionInProgress:NO];
             [strongSelf setCanCheckForUpdates:YES];
             
-            if (!strongSelf->_updatingMainBundle && error == nil && !shouldShowUpdateImmediately) {
-                // If we're not updating the main bundle, a potentially new bundle may have different info
+            if (!strongSelf->_updatingMainBundle && error == nil && !shouldShowUpdateImmediately && resumableUpdate == nil) {
+                // If we're not updating the main bundle, a potentially new installed bundle may have different info
                 [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateSettingsNeedsSynchronizationNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: strongSelf->_host.bundlePath}];
             }
             

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -825,7 +825,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             [strongSelf setSessionInProgress:NO];
             [strongSelf setCanCheckForUpdates:YES];
             
-            if (!strongSelf->_updatingMainBundle && error == nil) {
+            if (!strongSelf->_updatingMainBundle && error == nil && !shouldShowUpdateImmediately) {
                 // If we're not updating the main bundle, a potentially new bundle may have different info
                 [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateSettingsNeedsSynchronizationNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: strongSelf->_host.bundlePath}];
             }

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -171,6 +171,8 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     _startedUpdater = YES;
     [self setCanCheckForUpdates:YES];
     
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(updateAutomaticCheckSettingChanged:) name:SUUpdateAutomaticCheckSettingChangedNotification object:nil];
+    
     // Start updater on next update cycle so we make sure the application invoking the updater is ready
     // This also gives the developer a cycle to check for updates before Sparkle's update cycle scheduler kicks in
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -823,6 +825,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             [strongSelf setSessionInProgress:NO];
             [strongSelf setCanCheckForUpdates:YES];
             
+            if (!strongSelf->_updatingMainBundle && error == nil) {
+                // If we're not updating the main bundle, a potentially new bundle may have different info
+                [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateSettingsNeedsSynchronizationNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: strongSelf->_host.bundlePath}];
+            }
+            
             notifyDelegateOfDriverCompletion(error, shouldShowUpdateImmediately);
             
             // Ensure the delegate doesn't start a new session when being notified of the previous one ending
@@ -925,17 +932,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyCheckForUpdates
 {
-    [_host setBool:automaticallyCheckForUpdates forUserDefaultsKey:SUEnableAutomaticChecksKey];
-    // Hack to support backwards compatibility with older Sparkle versions, which supported
-    // disabling updates by setting the check interval to 0.
-    if (automaticallyCheckForUpdates && (NSInteger)[self updateCheckInterval] == 0) {
-        [self setUpdateCheckInterval:SUDefaultUpdateCheckInterval];
-    }
-    
-    if (_startedUpdater) {
-        // Provide a small delay in case multiple preferences are being updated simultaneously.
-        [self resetUpdateCycleAfterShortDelay];
-    }
+    _updaterSettings.automaticallyChecksForUpdates = automaticallyCheckForUpdates;
 }
 
 - (BOOL)automaticallyChecksForUpdates
@@ -943,14 +940,37 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     return [_updaterSettings automaticallyChecksForUpdates];
 }
 
+- (void)updateAutomaticCheckSettingChanged:(NSNotification *)notification
+{
+    NSString *bundlePath = notification.userInfo[SUUpdateBundlePathUserInfoKey];
+    if (![bundlePath isEqualToString:_host.bundlePath]) {
+        return;
+    }
+    
+    if (_startedUpdater && !_sessionInProgress) {
+        // Provide a small delay in case multiple preferences are being updated simultaneously.
+        [self resetUpdateCycleAfterShortDelay];
+    }
+}
+
++ (NSSet<NSString *> *)keyPathsForValuesAffectingAutomaticallyChecksForUpdates
+{
+    return [NSSet setWithObject:@"updaterSettings.automaticallyChecksForUpdates"];
+}
+
 - (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyUpdates
 {
-    [_host setBool:automaticallyUpdates forUserDefaultsKey:SUAutomaticallyUpdateKey];
+    _updaterSettings.automaticallyDownloadsUpdates = automaticallyUpdates;
 }
 
 - (BOOL)automaticallyDownloadsUpdates
 {
-    return [_updaterSettings allowsAutomaticUpdates] && [_updaterSettings automaticallyDownloadsUpdates];
+    return [_updaterSettings automaticallyDownloadsUpdates];
+}
+
++ (NSSet<NSString *> *)keyPathsForValuesAffectingAutomaticallyDownloadsUpdates
+{
+    return [NSSet setWithObject:@"updaterSettings.automaticallyDownloadsUpdates"];
 }
 
 - (void)setFeedURL:(NSURL * _Nullable)feedURL
@@ -1067,12 +1087,17 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)setSendsSystemProfile:(BOOL)sendsSystemProfile
 {
-    [_host setBool:sendsSystemProfile forUserDefaultsKey:SUSendProfileInfoKey];
+    _updaterSettings.sendsSystemProfile = sendsSystemProfile;
 }
 
 - (BOOL)sendsSystemProfile
 {
     return [_updaterSettings sendsSystemProfile];
+}
+
++ (NSSet<NSString *> *)keyPathsForValuesAffectingSendsSystemProfile
+{
+    return [NSSet setWithObject:@"updaterSettings.sendsSystemProfile"];
 }
 
 static NSString *escapeURLComponent(NSString *str) {
@@ -1162,15 +1187,7 @@ static NSString *escapeURLComponent(NSString *str) {
 
 - (void)setUpdateCheckInterval:(NSTimeInterval)updateCheckInterval
 {
-    [_host setObject:@(updateCheckInterval) forUserDefaultsKey:SUScheduledCheckIntervalKey];
-    if ((NSInteger)updateCheckInterval == 0) { // For compatibility with 1.1's settings.
-        [self setAutomaticallyChecksForUpdates:NO];
-    }
-    
-    if (_startedUpdater) {
-        // Provide a small delay in case multiple preferences are being updated simultaneously.
-        [self resetUpdateCycleAfterShortDelay];
-    }
+    _updaterSettings.updateCheckInterval = updateCheckInterval;
 }
 
 - (NSTimeInterval)updateCheckInterval
@@ -1178,8 +1195,15 @@ static NSString *escapeURLComponent(NSString *str) {
     return [_updaterSettings updateCheckInterval];
 }
 
++ (NSSet<NSString *> *)keyPathsForValuesAffectingUpdateCheckInterval
+{
+    return [NSSet setWithObject:@"updaterSettings.updateCheckInterval"];
+}
+
 - (void)dealloc
 {
+    [NSNotificationCenter.defaultCenter removeObserver:self name:SUUpdateAutomaticCheckSettingChangedNotification object:nil];
+    
     // Stop checking for updates
     [self cancelNextUpdateCycle];
     [_updaterTimer invalidate];

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -1202,7 +1202,9 @@ static NSString *escapeURLComponent(NSString *str) {
 
 - (void)dealloc
 {
-    [NSNotificationCenter.defaultCenter removeObserver:self name:SUUpdateAutomaticCheckSettingChangedNotification object:nil];
+    if (_startedUpdater) {
+        [NSNotificationCenter.defaultCenter removeObserver:self name:SUUpdateAutomaticCheckSettingChangedNotification object:nil];
+    }
     
     // Stop checking for updates
     [self cancelNextUpdateCycle];

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -958,6 +958,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     return [NSSet setWithObject:@"updaterSettings.automaticallyChecksForUpdates"];
 }
 
++ (BOOL)automaticallyNotifiesObserversOfAutomaticallyChecksForUpdates
+{
+    return NO;
+}
+
 - (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyUpdates
 {
     _updaterSettings.automaticallyDownloadsUpdates = automaticallyUpdates;
@@ -971,6 +976,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 + (NSSet<NSString *> *)keyPathsForValuesAffectingAutomaticallyDownloadsUpdates
 {
     return [NSSet setWithObject:@"updaterSettings.automaticallyDownloadsUpdates"];
+}
+
++ (BOOL)automaticallyNotifiesObserversOfAutomaticallyDownloadsUpdates
+{
+    return NO;
 }
 
 - (void)setFeedURL:(NSURL * _Nullable)feedURL
@@ -1100,6 +1110,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     return [NSSet setWithObject:@"updaterSettings.sendsSystemProfile"];
 }
 
++ (BOOL)automaticallyNotifiesObserversOfSendsSystemProfile
+{
+    return NO;
+}
+
 static NSString *escapeURLComponent(NSString *str) {
     NSString *escapedString = [str stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
     
@@ -1198,6 +1213,11 @@ static NSString *escapeURLComponent(NSString *str) {
 + (NSSet<NSString *> *)keyPathsForValuesAffectingUpdateCheckInterval
 {
     return [NSSet setWithObject:@"updaterSettings.updateCheckInterval"];
+}
+
++ (BOOL)automaticallyNotifiesObserversOfUpdateCheckInterval
+{
+    return NO;
 }
 
 - (void)dealloc

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -33,14 +33,14 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
 /**
  * Indicates whether or not automatic update checks are enabled.
  *
- * This property is KVO observable.
+ * This property is KVO compliant.
  */
 @property (nonatomic) BOOL automaticallyChecksForUpdates;
 
 /**
  * The regular update check interval.
  *
- * This property is KVO observable.
+ * This property is KVO compliant.
  */
 @property (nonatomic) NSTimeInterval updateCheckInterval;
 
@@ -61,14 +61,14 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  * Note this does not indicate whether or not automatic downloading of updates is allowable.
  * See `-allowsAutomaticUpdates` property for that.
  *
- * This property is KVO observable.
+ * This property is KVO compliant.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
 /**
  * Indicates whether or not anonymous system profile information is sent when checking for updates.
  *
- * This property is KVO observable.
+ * This property is KVO compliant.
  */
 @property (nonatomic) BOOL sendsSystemProfile;
 

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  It retrieves the settings by first looking into the host's user defaults.
  If the setting is not found in there, then the host's Info.plist file is looked at.
+ 
+ For updating updater settings, changes are made in the host's user defaults.
  */
 SU_EXPORT @interface SPUUpdaterSettings : NSObject
 

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -21,7 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- This class can be used for reading certain updater settings.
+ This class can be used for reading and updating updater settings.
  
  It retrieves the settings by first looking into the host's user defaults.
  If the setting is not found in there, then the host's Info.plist file is looked at.
@@ -32,13 +32,17 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
 
 /**
  * Indicates whether or not automatic update checks are enabled.
+ *
+ * This property is KVO observable.
  */
-@property (readonly, nonatomic) BOOL automaticallyChecksForUpdates;
+@property (nonatomic) BOOL automaticallyChecksForUpdates;
 
 /**
  * The regular update check interval.
+ *
+ * This property is KVO observable.
  */
-@property (readonly, nonatomic) NSTimeInterval updateCheckInterval;
+@property (nonatomic) NSTimeInterval updateCheckInterval;
 
 /**
  * Indicates whether or not automatically downloading updates is allowed to be turned on by the user.
@@ -56,13 +60,17 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  *
  * Note this does not indicate whether or not automatic downloading of updates is allowable.
  * See `-allowsAutomaticUpdates` property for that.
+ *
+ * This property is KVO observable.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
 /**
  * Indicates whether or not anonymous system profile information is sent when checking for updates.
+ *
+ * This property is KVO observable.
  */
-@property (readonly, nonatomic) BOOL sendsSystemProfile;
+@property (nonatomic) BOOL sendsSystemProfile;
 
 @end
 

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -57,7 +57,7 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  * Note this does not indicate whether or not automatic downloading of updates is allowable.
  * See `-allowsAutomaticUpdates` property for that.
  */
-@property (readonly, nonatomic) BOOL automaticallyDownloadsUpdates;
+@property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
 /**
  * Indicates whether or not anonymous system profile information is sent when checking for updates.

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -35,14 +35,14 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
 /**
  * Indicates whether or not automatic update checks are enabled.
  *
- * This property is KVO compliant.
+ * This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL automaticallyChecksForUpdates;
 
 /**
  * The regular update check interval.
  *
- * This property is KVO compliant.
+ * This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) NSTimeInterval updateCheckInterval;
 
@@ -63,14 +63,14 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  * Note this does not indicate whether or not automatic downloading of updates is allowable.
  * See `-allowsAutomaticUpdates` property for that.
  *
- * This property is KVO compliant.
+ * This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
 /**
  * Indicates whether or not anonymous system profile information is sent when checking for updates.
  *
- * This property is KVO compliant.
+ * This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL sendsSystemProfile;
 

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -13,30 +13,157 @@
 
 #include "AppKitPrevention.h"
 
+static NSString *SUAutomaticallyChecksForUpdatesKeyPath = @"automaticallyChecksForUpdates";
+static NSString *SUUpdateCheckIntervalKeyPath = @"updateCheckInterval";
+static NSString *SUAutomaticallyDownloadsUpdatesKeyPath = @"automaticallyDownloadsUpdates";
+static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
+
 @implementation SPUUpdaterSettings
 {
     SUHost *_host;
 }
+
+@synthesize automaticallyChecksForUpdates = _automaticallyChecksForUpdates;
+@synthesize updateCheckInterval = _updateCheckInterval;
+@synthesize automaticallyDownloadsUpdates = _automaticallyDownloadsUpdates;
+@synthesize sendsSystemProfile = _sendsSystemProfile;
 
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle
 {
     self = [super init];
     if (self != nil) {
         _host = [[SUHost alloc] initWithBundle:hostBundle];
+        
+        _automaticallyChecksForUpdates = [self currentAutomaticallyChecksForUpdates];
+        _updateCheckInterval = [self currentUpdateCheckInterval];
+        _automaticallyDownloadsUpdates = [self currentAutomaticallyDownloadsUpdates];
+        _sendsSystemProfile = [self currentSendsSystemProfile];
+        
+        [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(synchronize:) name:SUUpdateSettingsNeedsSynchronizationNotification object:nil];
+        
+        __weak __typeof__(self) weakSelf = self;
+        [_host observeChangesFromUserDefaultKeys:[NSSet setWithArray:@[SUEnableAutomaticChecksKey, SUScheduledCheckIntervalKey, SUAutomaticallyUpdateKey, SUSendProfileInfoKey]] changeHandler:^(NSString *keyPath) {
+            __typeof(self) strongSelf = weakSelf;
+            if (strongSelf == nil) {
+                return;
+            }
+            
+            if ([keyPath isEqualToString:SUEnableAutomaticChecksKey]) {
+                [strongSelf processCurrentAutomaticallyChecksForUpdates];
+            } else if ([keyPath isEqualToString:SUScheduledCheckIntervalKey]) {
+                [strongSelf processUpdateCheckInterval];
+            } else if ([keyPath isEqualToString:SUAutomaticallyUpdateKey]) {
+                [strongSelf processAutomaticallyDownloadsUpdates];
+            } else if ([keyPath isEqualToString:SUSendProfileInfoKey]) {
+                [strongSelf processSendsSystemProfile];
+            }
+        }];
     }
     return self;
 }
 
-- (BOOL)automaticallyChecksForUpdates
+- (void)dealloc
+{
+    [NSNotificationCenter.defaultCenter removeObserver:self name:SUUpdateSettingsNeedsSynchronizationNotification object:_host.bundlePath];
+}
+
+- (void)processCurrentAutomaticallyChecksForUpdates SPU_OBJC_DIRECT
+{
+    BOOL currentValue = [self currentAutomaticallyChecksForUpdates];
+    
+    if (currentValue != _automaticallyChecksForUpdates) {
+        NSString *updatedKeyPath = SUAutomaticallyChecksForUpdatesKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _automaticallyChecksForUpdates = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
+}
+
+- (void)processUpdateCheckInterval SPU_OBJC_DIRECT
+{
+    NSString *updatedKeyPath = SUUpdateCheckIntervalKeyPath;
+    
+    [self willChangeValueForKey:updatedKeyPath];
+    
+    _updateCheckInterval = [self currentUpdateCheckInterval];
+    
+    [self didChangeValueForKey:updatedKeyPath];
+}
+
+- (void)processAutomaticallyDownloadsUpdates SPU_OBJC_DIRECT
+{
+    BOOL currentValue = [self currentAutomaticallyDownloadsUpdates];
+    
+    if (currentValue != _automaticallyDownloadsUpdates) {
+        NSString *updatedKeyPath = SUAutomaticallyDownloadsUpdatesKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _automaticallyDownloadsUpdates = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
+}
+
+- (void)processSendsSystemProfile SPU_OBJC_DIRECT
+{
+    BOOL currentValue = [self currentSendsSystemProfile];
+    
+    if (currentValue != _sendsSystemProfile) {
+        NSString *updatedKeyPath = SUSendsSystemProfileKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _sendsSystemProfile = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
+}
+
+- (void)synchronize:(NSNotification *)notification
+{
+    NSString *bundlePath = notification.userInfo[SUUpdateBundlePathUserInfoKey];
+    if (![bundlePath isEqualToString:_host.bundlePath]) {
+        return;
+    }
+    
+    [self processCurrentAutomaticallyChecksForUpdates];
+    [self processUpdateCheckInterval];
+    [self processAutomaticallyDownloadsUpdates];
+    [self processSendsSystemProfile];
+}
+
+- (BOOL)currentAutomaticallyChecksForUpdates SPU_OBJC_DIRECT
 {
     // Don't automatically update when the check interval is 0, to be compatible with 1.1 settings.
-    if ((NSInteger)[self updateCheckInterval] == 0) {
+    if ((NSInteger)[self currentUpdateCheckInterval] == 0) {
         return NO;
     }
     return [_host boolForKey:SUEnableAutomaticChecksKey];
 }
 
-- (NSTimeInterval)updateCheckInterval
+- (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyCheckForUpdates
+{
+    [self willChangeValueForKey:SUAutomaticallyChecksForUpdatesKeyPath];
+    
+    _automaticallyChecksForUpdates = automaticallyCheckForUpdates;
+    [_host setBool:automaticallyCheckForUpdates forUserDefaultsKey:SUEnableAutomaticChecksKey];
+    
+    [self didChangeValueForKey:SUAutomaticallyChecksForUpdatesKeyPath];
+    
+    // Hack to support backwards compatibility with older Sparkle versions, which supported
+    // disabling updates by setting the check interval to 0.
+    if (automaticallyCheckForUpdates && (NSInteger)[self currentUpdateCheckInterval] == 0) {
+        [self setUpdateCheckInterval:SUDefaultUpdateCheckInterval];
+    } else {
+        [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateAutomaticCheckSettingChangedNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: _host.bundlePath}];
+    }
+}
+
+- (NSTimeInterval)currentUpdateCheckInterval SPU_OBJC_DIRECT
 {
     // Find the stored check interval. User defaults override Info.plist.
     NSNumber *intervalValue = [_host objectForKey:SUScheduledCheckIntervalKey];
@@ -44,6 +171,22 @@
         return [intervalValue doubleValue];
     else
         return SUDefaultUpdateCheckInterval;
+}
+
+- (void)setUpdateCheckInterval:(NSTimeInterval)updateCheckInterval
+{
+    [self willChangeValueForKey:SUUpdateCheckIntervalKeyPath];
+    
+    _updateCheckInterval = updateCheckInterval;
+    [_host setObject:@(updateCheckInterval) forUserDefaultsKey:SUScheduledCheckIntervalKey];
+    
+    [self didChangeValueForKey:SUUpdateCheckIntervalKeyPath];
+    
+    if ((NSInteger)updateCheckInterval == 0) { // For compatibility with 1.1's settings.
+        [self setAutomaticallyChecksForUpdates:NO];
+    } else {
+        [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateAutomaticCheckSettingChangedNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: _host.bundlePath}];
+    }
 }
 
 // For allowing automatic downloaded updates to be turned on or off
@@ -59,19 +202,38 @@
     return (developerAllowsAutomaticUpdates == nil || developerAllowsAutomaticUpdates.boolValue);
 }
 
-- (BOOL)automaticallyDownloadsUpdates
+- (BOOL)currentAutomaticallyDownloadsUpdates SPU_OBJC_DIRECT
 {
-    return [_host boolForKey:SUAutomaticallyUpdateKey];
+    return [self allowsAutomaticUpdates] && [_host boolForKey:SUAutomaticallyUpdateKey];
 }
 
 - (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyDownloadsUpdates
 {
+    if (![self allowsAutomaticUpdates]) {
+        return;
+    }
+    
+    [self willChangeValueForKey:SUAutomaticallyDownloadsUpdatesKeyPath];
+    
+    _automaticallyDownloadsUpdates = automaticallyDownloadsUpdates;
     [_host setBool:automaticallyDownloadsUpdates forUserDefaultsKey:SUAutomaticallyUpdateKey];
+    
+    [self didChangeValueForKey:SUAutomaticallyDownloadsUpdatesKeyPath];
 }
 
-- (BOOL)sendsSystemProfile
+- (BOOL)currentSendsSystemProfile SPU_OBJC_DIRECT
 {
     return [_host boolForKey:SUSendProfileInfoKey];
+}
+
+- (void)setSendsSystemProfile:(BOOL)sendsSystemProfile
+{
+    [self willChangeValueForKey:SUSendsSystemProfileKeyPath];
+    
+    _sendsSystemProfile = sendsSystemProfile;
+    [_host setBool:sendsSystemProfile forUserDefaultsKey:SUSendProfileInfoKey];
+    
+    [self didChangeValueForKey:SUSendsSystemProfileKeyPath];
 }
 
 @end

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -84,6 +84,9 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 
 - (void)processUpdateCheckInterval SPU_OBJC_DIRECT
 {
+    // Note: not doing a check to see if the time interval differs from the current one
+    // due to avoiding comparisons with floating-point
+    
     NSString *updatedKeyPath = SUUpdateCheckIntervalKeyPath;
     
     [self willChangeValueForKey:updatedKeyPath];

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -84,16 +84,17 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 
 - (void)processUpdateCheckInterval SPU_OBJC_DIRECT
 {
-    // Note: not doing a check to see if the time interval differs from the current one
-    // due to avoiding comparisons with floating-point
+    NSTimeInterval currentValue = [self currentUpdateCheckInterval];
     
-    NSString *updatedKeyPath = SUUpdateCheckIntervalKeyPath;
-    
-    [self willChangeValueForKey:updatedKeyPath];
-    
-    _updateCheckInterval = [self currentUpdateCheckInterval];
-    
-    [self didChangeValueForKey:updatedKeyPath];
+    if (fabs(currentValue - _updateCheckInterval) >= 0.001) {
+        NSString *updatedKeyPath = SUUpdateCheckIntervalKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _updateCheckInterval = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
 }
 
 - (void)processAutomaticallyDownloadsUpdates SPU_OBJC_DIRECT
@@ -174,11 +175,12 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 - (NSTimeInterval)currentUpdateCheckInterval SPU_OBJC_DIRECT
 {
     // Find the stored check interval. User defaults override Info.plist.
-    NSNumber *intervalValue = [_host objectForKey:SUScheduledCheckIntervalKey];
-    if (intervalValue)
-        return [intervalValue doubleValue];
-    else
+    id intervalValue = [_host objectForKey:SUScheduledCheckIntervalKey];
+    if (intervalValue == nil || ![(NSObject *)intervalValue isKindOfClass:[NSNumber class]]) {
         return SUDefaultUpdateCheckInterval;
+    }
+    
+    return [(NSNumber *)intervalValue doubleValue];
 }
 
 - (void)setUpdateCheckInterval:(NSTimeInterval)updateCheckInterval

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -64,6 +64,11 @@
     return [_host boolForKey:SUAutomaticallyUpdateKey];
 }
 
+- (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyDownloadsUpdates
+{
+    [_host setBool:automaticallyDownloadsUpdates forUserDefaultsKey:SUAutomaticallyUpdateKey];
+}
+
 - (BOOL)sendsSystemProfile
 {
     return [_host boolForKey:SUSendProfileInfoKey];

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -163,6 +163,11 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     }
 }
 
++ (BOOL)automaticallyNotifiesObserversOfAutomaticallyChecksForUpdates
+{
+    return NO;
+}
+
 - (NSTimeInterval)currentUpdateCheckInterval SPU_OBJC_DIRECT
 {
     // Find the stored check interval. User defaults override Info.plist.
@@ -187,6 +192,11 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     } else {
         [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateAutomaticCheckSettingChangedNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: _host.bundlePath}];
     }
+}
+
++ (BOOL)automaticallyNotifiesObserversOfUpdateCheckInterval
+{
+    return NO;
 }
 
 // For allowing automatic downloaded updates to be turned on or off
@@ -221,6 +231,11 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     [self didChangeValueForKey:SUAutomaticallyDownloadsUpdatesKeyPath];
 }
 
++ (BOOL)automaticallyNotifiesObserversOfAutomaticallyDownloadsUpdates
+{
+    return NO;
+}
+
 - (BOOL)currentSendsSystemProfile SPU_OBJC_DIRECT
 {
     return [_host boolForKey:SUSendProfileInfoKey];
@@ -234,6 +249,11 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     [_host setBool:sendsSystemProfile forUserDefaultsKey:SUSendProfileInfoKey];
     
     [self didChangeValueForKey:SUSendsSystemProfileKeyPath];
+}
+
++ (BOOL)automaticallyNotifiesObserversOfSendsSystemProfile
+{
+    return NO;
 }
 
 @end

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -31,6 +31,9 @@ extern NSString *const SUAppcastAttributeValueMacOS;
 // -----------------------------------------------------------------------------
 
 extern NSString *const SUTechnicalErrorInformationKey;
+extern NSString *const SUUpdateAutomaticCheckSettingChangedNotification;
+extern NSString *const SUUpdateSettingsNeedsSynchronizationNotification;
+extern NSString *const SUUpdateBundlePathUserInfoKey;
 
 // -----------------------------------------------------------------------------
 //	PList keys::

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -31,6 +31,9 @@ NSString *const SUBundleIdentifier = @SPARKLE_BUNDLE_IDENTIFIER;
 NSString *const SUAppcastAttributeValueMacOS = @"macos";
 
 NSString *const SUTechnicalErrorInformationKey = @"SUTechnicalErrorInformation";
+NSString *const SUUpdateAutomaticCheckSettingChangedNotification = @"SUUpdateAutomaticCheckSettingChanged";
+NSString *const SUUpdateSettingsNeedsSynchronizationNotification = @"SUUpdateSettingsNeedsSynchronization";
+NSString *const SUUpdateBundlePathUserInfoKey = @"SUBundlePath";
 
 NSString *const SUFeedURLKey = @"SUFeedURL";
 NSString *const SUHasLaunchedBeforeKey = @"SUHasLaunchedBefore";

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -47,6 +47,9 @@ SUHostDefinitionAttribute
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName;
 - (nullable id)objectForKey:(NSString *)key;
 - (BOOL)boolForKey:(NSString *)key;
+
+- (void)observeChangesFromUserDefaultKeys:(NSSet<NSString *> *)keyPaths changeHandler:(void (^)(NSString *))changeHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 // if the process is sandboxed or not; eg: finding the user's caches directory. Or code that depends
 // on compilation flags and if other files exist relative to the host bundle.
 
+static void *SUHostObservableContext = &SUHostObservableContext;
+
 @implementation SUHost
 {
     NSUserDefaults *_userDefaults;
@@ -72,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
     _modifyingKeyPaths = [NSMutableSet set];
     
     for (NSString *keyPath in keyPaths) {
-        [_userDefaults addObserver:self forKeyPath:keyPath options:NSKeyValueObservingOptionNew context:NULL];
+        [_userDefaults addObserver:self forKeyPath:keyPath options:NSKeyValueObservingOptionNew context:SUHostObservableContext];
     }
     
     _observedUserDefaultKeyPaths = keyPaths;
@@ -81,6 +83,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary<NSKeyValueChangeKey,id> *)change context:(nullable void *)context
 {
+    if (context != SUHostObservableContext)
+    {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+        return;
+    }
+    
     if (keyPath == nil || [_modifyingKeyPaths containsObject:(NSString * _Nonnull)keyPath]) {
         return;
     }

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -25,9 +25,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SUHost
 {
-    NSString *_defaultsDomain;
+    NSUserDefaults *_userDefaults;
+    NSSet<NSString *> *_observedUserDefaultKeyPaths;
+    NSMutableSet<NSString *> *_modifyingKeyPaths;
     
-    BOOL _usesStandardUserDefaults;
+    void (^_changeObservationHandler)(NSString *);
+    
     BOOL _isMainBundle;
 }
 
@@ -45,16 +48,48 @@ NS_ASSUME_NONNULL_BEGIN
         
         _isMainBundle = [aBundle isEqualTo:[NSBundle mainBundle]];
 
-        _defaultsDomain = [self objectForInfoDictionaryKey:SUDefaultsDomainKey];
-        if (_defaultsDomain == nil) {
-            _defaultsDomain = [_bundle bundleIdentifier];
+        NSString *defaultsDomain = [self objectForInfoDictionaryKey:SUDefaultsDomainKey];
+        if (defaultsDomain == nil) {
+            _userDefaults = [NSUserDefaults standardUserDefaults];
+        } else {
+            _userDefaults = [[NSUserDefaults alloc] initWithSuiteName:defaultsDomain];
         }
-
-        // If we're using the main bundle's defaults we'll use the standard user defaults mechanism, otherwise we have to get CF-y.
-        NSString *mainBundleIdentifier = NSBundle.mainBundle.bundleIdentifier;
-        _usesStandardUserDefaults = _defaultsDomain == nil || [_defaultsDomain isEqualToString:mainBundleIdentifier];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    if (_observedUserDefaultKeyPaths != nil) {
+        for (NSString *keyPath in _observedUserDefaultKeyPaths) {
+            [_userDefaults removeObserver:self forKeyPath:keyPath];
+        }
+    }
+}
+
+- (void)observeChangesFromUserDefaultKeys:(NSSet<NSString *> *)keyPaths changeHandler:(void (^)(NSString *))changeHandler
+{
+    _modifyingKeyPaths = [NSMutableSet set];
+    
+    for (NSString *keyPath in keyPaths) {
+        [_userDefaults addObserver:self forKeyPath:keyPath options:NSKeyValueObservingOptionNew context:NULL];
+    }
+    
+    _observedUserDefaultKeyPaths = keyPaths;
+    _changeObservationHandler = [changeHandler copy];
+}
+
+- (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary<NSKeyValueChangeKey,id> *)change context:(nullable void *)context
+{
+    if (keyPath == nil || [_modifyingKeyPaths containsObject:(NSString * _Nonnull)keyPath]) {
+        return;
+    }
+    
+    if (_changeObservationHandler == nil) {
+        return;
+    }
+    
+    _changeObservationHandler((NSString * _Nonnull)keyPath);
 }
 
 - (NSString *)description { return [NSString stringWithFormat:@"%@ <%@>", [self class], [self bundlePath]]; }
@@ -120,7 +155,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isRunningOnReadOnlyVolume
 {
     struct statfs statfs_info;
-    statfs(_bundle.bundlePath.fileSystemRepresentation, &statfs_info);
+    if (statfs(_bundle.bundlePath.fileSystemRepresentation, &statfs_info) != 0)
+    {
+        return NO;
+    }
+    
     return (statfs_info.f_flags & MNT_RDONLY) != 0;
 }
 
@@ -205,65 +244,35 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable id)objectForUserDefaultsKey:(NSString *)defaultName
 {
-    if (!defaultName || _defaultsDomain == nil) {
+    if (defaultName == nil || _userDefaults == nil) {
         return nil;
     }
 
-    // Under Tiger, CFPreferencesCopyAppValue doesn't get values from NSRegistrationDomain, so anything
-    // passed into -[NSUserDefaults registerDefaults:] is ignored.  The following line falls
-    // back to using NSUserDefaults, but only if the host bundle is the main bundle.
-    if (_usesStandardUserDefaults) {
-        return [[NSUserDefaults standardUserDefaults] objectForKey:defaultName];
-    }
-
-    CFPropertyListRef obj = CFPreferencesCopyAppValue((__bridge CFStringRef)defaultName, (__bridge CFStringRef)_defaultsDomain);
-    return CFBridgingRelease(obj);
+    return [_userDefaults objectForKey:defaultName];
 }
 
 // Note this handles nil being passed for defaultName, in which case the user default will be removed
 - (void)setObject:(nullable id)value forUserDefaultsKey:(NSString *)defaultName
 {
-	if (_usesStandardUserDefaults)
-	{
-        [[NSUserDefaults standardUserDefaults] setObject:value forKey:defaultName];
-	}
-	else
-	{
-        CFPreferencesSetValue((__bridge CFStringRef)defaultName, (__bridge CFPropertyListRef)(value), (__bridge CFStringRef)_defaultsDomain, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-        CFPreferencesSynchronize((__bridge CFStringRef)_defaultsDomain, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    }
+    [_modifyingKeyPaths addObject:defaultName];
+    
+    [_userDefaults setObject:value forKey:defaultName];
+    
+    [_modifyingKeyPaths removeObject:defaultName];
 }
 
 - (BOOL)boolForUserDefaultsKey:(NSString *)defaultName
 {
-    if (_usesStandardUserDefaults) {
-        return [[NSUserDefaults standardUserDefaults] boolForKey:defaultName];
-    }
-
-    BOOL value;
-    CFPropertyListRef plr = CFPreferencesCopyAppValue((__bridge CFStringRef)defaultName, (__bridge CFStringRef)_defaultsDomain);
-    if (plr == NULL) {
-        value = NO;
-	}
-	else
-	{
-        value = CFBooleanGetValue((CFBooleanRef)plr) ? YES : NO;
-        CFRelease(plr);
-    }
-    return value;
+    return [_userDefaults boolForKey:defaultName];
 }
 
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName
 {
-	if (_usesStandardUserDefaults)
-	{
-        [[NSUserDefaults standardUserDefaults] setBool:value forKey:defaultName];
-	}
-	else
-	{
-        CFPreferencesSetValue((__bridge CFStringRef)defaultName, (__bridge CFBooleanRef) @(value), (__bridge CFStringRef)_defaultsDomain, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-        CFPreferencesSynchronize((__bridge CFStringRef)_defaultsDomain, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    }
+    [_modifyingKeyPaths addObject:defaultName];
+    
+    [_userDefaults setBool:value forKey:defaultName];
+    
+    [_modifyingKeyPaths removeObject:defaultName];
 }
 
 - (nullable id)objectForKey:(NSString *)key {

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -50,11 +50,22 @@ static void *SUHostObservableContext = &SUHostObservableContext;
         
         _isMainBundle = [aBundle isEqualTo:[NSBundle mainBundle]];
 
-        NSString *defaultsDomain = [self objectForInfoDictionaryKey:SUDefaultsDomainKey];
-        if (defaultsDomain == nil) {
+        NSString *domainIdentifier;
+        {
+            NSString *defaultsDomain = [self objectForInfoDictionaryKey:SUDefaultsDomainKey];
+            if (defaultsDomain != nil) {
+                domainIdentifier = defaultsDomain;
+            } else if (!_isMainBundle) {
+                domainIdentifier = aBundle.bundleIdentifier;
+            } else {
+                domainIdentifier = nil;
+            }
+        }
+        
+        if (domainIdentifier == nil) {
             _userDefaults = [NSUserDefaults standardUserDefaults];
         } else {
-            _userDefaults = [[NSUserDefaults alloc] initWithSuiteName:defaultsDomain];
+            _userDefaults = [[NSUserDefaults alloc] initWithSuiteName:domainIdentifier];
         }
     }
     return self;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -38,6 +38,7 @@ static NSString *const SUUpdateAlertTouchBarIdentifier = @"" SPARKLE_BUNDLE_IDEN
 
 @implementation SUUpdateAlert
 {
+    SPUUpdaterSettings *_updaterSettings;
     SUAppcastItem *_updateItem;
     SUHost *_host;
     SPUUserUpdateState *_state;
@@ -73,14 +74,14 @@ static NSString *const SUUpdateAlertTouchBarIdentifier = @"" SPARKLE_BUNDLE_IDEN
         _completionBlock = [completionBlock copy];
         _didBecomeKeyBlock = [didBecomeKeyBlock copy];
         
-        SPUUpdaterSettings *updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:aHost.bundle];
+        _updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:aHost.bundle];
         
         BOOL allowsAutomaticUpdates;
-        NSNumber *allowsAutomaticUpdatesOption = updaterSettings.allowsAutomaticUpdatesOption;
+        NSNumber *allowsAutomaticUpdatesOption = _updaterSettings.allowsAutomaticUpdatesOption;
         if (item.informationOnlyUpdate) {
             allowsAutomaticUpdates = NO;
         } else if (allowsAutomaticUpdatesOption == nil) {
-            allowsAutomaticUpdates = updaterSettings.automaticallyChecksForUpdates;
+            allowsAutomaticUpdates = _updaterSettings.automaticallyChecksForUpdates;
         } else {
             allowsAutomaticUpdates = allowsAutomaticUpdatesOption.boolValue;
         }


### PR DESCRIPTION
Synchronize updater settings with user defaults so multiple components in an app can better synchronize state -- like the automatically downloads/installs update in the release notes.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

* Tested changing automatically download updates checkbox synchronizes between release notes window and test app window
* Tested user default changes from CLI synchronize with UI in Sparkle (e.g. automatically downloads updates and updates check interval)
* Tested updating another bundle (by modifying test app) re-synchronizes updater settings after successful update installation
* Tested using KVO on SPUUpdater properties fires notifications on changes to properties as expected

macOS version tested: 15.5 (24F74)
macOS 10.14 VM
macOS 26 Beta 1
