### PR TITLE
Fix reserved identifier warnings for Xcode 26

### DIFF
--- a/Autoupdate/SPUSparkleDeltaArchive.m
+++ b/Autoupdate/SPUSparkleDeltaArchive.m
@@ -216,7 +216,7 @@ typedef struct
     }
 }
 
-static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMode compressionMode)
+static compression_algorithm compressionAlgorithmForMode(SPUDeltaCompressionMode compressionMode)
 {
     switch (compressionMode) {
     case SPUDeltaCompressionModeLZMA:
@@ -310,7 +310,7 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
         case SPUDeltaCompressionModeLZFSE:
         case SPUDeltaCompressionModeLZ4:
         case SPUDeltaCompressionModeZLIB: {
-            if (compression_stream_init(&_compressionStream, COMPRESSION_STREAM_DECODE, _compressionAlgorithmForMode(compression)) != COMPRESSION_STATUS_OK) {
+            if (compression_stream_init(&_compressionStream, COMPRESSION_STREAM_DECODE, compressionAlgorithmForMode(compression)) != COMPRESSION_STATUS_OK) {
                 _error = [NSError errorWithDomain:SPARKLE_COMPRESSION_ERROR_DOMAIN code:COMPRESSION_STATUS_ERROR userInfo:@{ NSLocalizedDescriptionKey: @"Failed to open compression stream for reading" }];
                 return nil;
             }
@@ -844,7 +844,7 @@ static compression_algorithm _compressionAlgorithmForMode(SPUDeltaCompressionMod
         case SPUDeltaCompressionModeLZFSE:
         case SPUDeltaCompressionModeLZ4:
         case SPUDeltaCompressionModeZLIB: {
-            if (compression_stream_init(&_compressionStream, COMPRESSION_STREAM_ENCODE, _compressionAlgorithmForMode(compression)) != COMPRESSION_STATUS_OK) {
+            if (compression_stream_init(&_compressionStream, COMPRESSION_STREAM_ENCODE, compressionAlgorithmForMode(compression)) != COMPRESSION_STATUS_OK) {
                 _error = [NSError errorWithDomain:SPARKLE_COMPRESSION_ERROR_DOMAIN code:COMPRESSION_STATUS_ERROR userInfo:@{ NSLocalizedDescriptionKey: @"Failed to open compression stream for writing" }];
                 
                 return;

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -228,7 +228,7 @@ extern char *xar_get_safe_path(xar_file_t f) __attribute__((weak_import));
     xar_subdoc_prop_set(attributes, AFTER_TREE_SHA1_KEY, [displayHashFromRawHash(header.afterTreeHash) UTF8String]);
 }
 
-static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTable, xar_t x, NSString *relativePath, NSString *filePath)
+static xar_file_t xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTable, xar_t x, NSString *relativePath, NSString *filePath)
 {
     NSArray<NSString *> *rootRelativePathComponents = relativePath.pathComponents;
     // Relative path must at least have starting "/" component and one more path component
@@ -285,7 +285,7 @@ static xar_file_t _xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTa
     SPUDeltaItemCommands commands = item.commands;
     uint16_t mode = item.mode;
     
-    xar_file_t newFile = _xarAddFile(_fileTable, _x, relativeFilePath, filePath);
+    xar_file_t newFile = xarAddFile(_fileTable, _x, relativeFilePath, filePath);
     if (newFile == NULL) {
         _error = [NSError errorWithDomain:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_DOMAIN code:SPARKLE_DELTA_XAR_ARCHIVE_ERROR_CODE_ADD_FAILURE userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to add xar file entry: %@", relativeFilePath] }];
         return;

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -159,7 +159,7 @@ NSString *temporaryDirectory(NSString *base)
     return stringWithFileSystemRepresentation(templateResult);
 }
 
-static void _sha1HashOfBuffer(unsigned char *hash, const char *buffer, ssize_t bufferLength)
+static void sha1HashOfBuffer(unsigned char *hash, const char *buffer, ssize_t bufferLength)
 {
     assert(bufferLength >= 0 && bufferLength <= UINT32_MAX);
     CC_SHA1_CTX hashContext;
@@ -168,7 +168,7 @@ static void _sha1HashOfBuffer(unsigned char *hash, const char *buffer, ssize_t b
     CC_SHA1_Final(hash, &hashContext);
 }
 
-static BOOL _crc32HashOfFileContents(uLong *outChecksum, FTSENT *ent, void *tempBuffer, size_t tempBufferSize)
+static BOOL crc32HashOfFileContents(uLong *outChecksum, FTSENT *ent, void *tempBuffer, size_t tempBufferSize)
 {
     uLong checksum = *outChecksum;
     
@@ -220,7 +220,7 @@ static BOOL _crc32HashOfFileContents(uLong *outChecksum, FTSENT *ent, void *temp
     return YES;
 }
 
-static BOOL _sha1HashOfFileContents(unsigned char *hash, FTSENT *ent, void *tempBuffer, size_t tempBufferSize)
+static BOOL sha1HashOfFileContents(unsigned char *hash, FTSENT *ent, void *tempBuffer, size_t tempBufferSize)
 {
     if (ent->fts_info == FTS_SL) {
         char linkDestination[MAXPATHLEN + 1];
@@ -230,11 +230,11 @@ static BOOL _sha1HashOfFileContents(unsigned char *hash, FTSENT *ent, void *temp
             return NO;
         }
 
-        _sha1HashOfBuffer(hash, linkDestination, linkDestinationLength);
+        sha1HashOfBuffer(hash, linkDestination, linkDestinationLength);
     } else if (ent->fts_info == FTS_F) {
         ssize_t fileSize = ent->fts_statp->st_size;
         if (fileSize <= 0) {
-            _sha1HashOfBuffer(hash, NULL, 0);
+            sha1HashOfBuffer(hash, NULL, 0);
         } else {
             FILE *file = fopen(ent->fts_path, "rb");
             if (file == NULL) {
@@ -329,7 +329,7 @@ BOOL getRawHashOfTreeAndFileTablesWithVersion(void *hashBuffer, NSString *path, 
                 fileHashKey = nil;
             } else {
                 uLong fileContentsChecksum = initialCrc32Value;
-                if (!_crc32HashOfFileContents(&fileContentsChecksum, ent, tempBuffer, tempBufferSize)) {
+                if (!crc32HashOfFileContents(&fileContentsChecksum, ent, tempBuffer, tempBufferSize)) {
                     fts_close(fts);
                     free(tempBuffer);
                     return NO;
@@ -347,7 +347,7 @@ BOOL getRawHashOfTreeAndFileTablesWithVersion(void *hashBuffer, NSString *path, 
             }
         } else {
             unsigned char fileHash[CC_SHA1_DIGEST_LENGTH];
-            if (!_sha1HashOfFileContents(fileHash, ent, tempBuffer, tempBufferSize)) {
+            if (!sha1HashOfFileContents(fileHash, ent, tempBuffer, tempBufferSize)) {
                 fts_close(fts);
                 free(tempBuffer);
                 return NO;

--- a/Autoupdate/SUPipedUnarchiver.m
+++ b/Autoupdate/SUPipedUnarchiver.m
@@ -21,7 +21,7 @@
 }
 
 // pipingData == NO is only supported for zip archives
-static NSArray<NSString *> * _Nullable _argumentsConformingToTypeOfPath(NSString *path, BOOL pipingData, NSString * __autoreleasing *outCommand)
+static NSArray<NSString *> * _Nullable argumentsConformingToTypeOfPath(NSString *path, BOOL pipingData, NSString * __autoreleasing *outCommand)
 {
     NSArray <NSString *> *extractTGZ = @[@"/usr/bin/tar", @"-zxC"];
     NSArray <NSString *> *extractTBZ = @[@"/usr/bin/tar", @"-jxC"];
@@ -78,7 +78,7 @@ static NSArray<NSString *> * _Nullable _argumentsConformingToTypeOfPath(NSString
 
 + (BOOL)canUnarchivePath:(NSString *)path
 {
-    return _argumentsConformingToTypeOfPath(path, YES, NULL) != nil;
+    return argumentsConformingToTypeOfPath(path, YES, NULL) != nil;
 }
 
 + (BOOL)mustValidateBeforeExtraction
@@ -104,7 +104,7 @@ static NSArray<NSString *> * _Nullable _argumentsConformingToTypeOfPath(NSString
 - (void)unarchiveWithCompletionBlock:(void (^)(NSError * _Nullable))completionBlock progressBlock:(void (^ _Nullable)(double))progressBlock waitForCleanup:(BOOL)__unused waitForCleanup
 {
     NSString *command = nil;
-    NSArray<NSString *> *arguments = _argumentsConformingToTypeOfPath(_archivePath, YES, &command);
+    NSArray<NSString *> *arguments = argumentsConformingToTypeOfPath(_archivePath, YES, &command);
     assert(arguments != nil);
     assert(command != nil);
     
@@ -153,7 +153,7 @@ static NSArray<NSString *> * _Nullable _argumentsConformingToTypeOfPath(NSString
                             [notifier notifyFailureWithError:extractError];
                         } else {
                             // The ditto command will be the same so no need to fetch it again
-                            NSArray<NSString *> *nonPipingArguments = _argumentsConformingToTypeOfPath(self->_archivePath, NO, NULL);
+                            NSArray<NSString *> *nonPipingArguments = argumentsConformingToTypeOfPath(self->_archivePath, NO, NULL);
                             assert(nonPipingArguments != nil);
                             
                             NSError *nonPipingExtractError = nil;

--- a/Sparkle/SULog+NSError.m
+++ b/Sparkle/SULog+NSError.m
@@ -11,7 +11,7 @@
 
 #include "AppKitPrevention.h"
 
-static void _SULogErrors(NSArray<NSError *> *errors, int recursionLimit)
+static void SULogErrors(NSArray<NSError *> *errors, int recursionLimit)
 {
     if (recursionLimit == 0) {
         return;
@@ -25,14 +25,14 @@ static void _SULogErrors(NSArray<NSError *> *errors, int recursionLimit)
         if (@available(macOS 11.3, *)) {
             NSArray<NSError *> *underlyingErrors = userInfo[NSMultipleUnderlyingErrorsKey];
             if (underlyingErrors != nil) {
-                _SULogErrors(underlyingErrors, recursionLimit - 1);
+                SULogErrors(underlyingErrors, recursionLimit - 1);
                 continue;
             }
         }
         
         NSError *underlyingError = userInfo[NSUnderlyingErrorKey];
         if (underlyingError != nil) {
-            _SULogErrors(@[underlyingError], recursionLimit - 1);
+            SULogErrors(@[underlyingError], recursionLimit - 1);
         }
     }
 }
@@ -43,5 +43,5 @@ void SULogError(NSError *error)
         return;
     }
     
-    _SULogErrors(@[error], 7);
+    SULogErrors(@[error], 7);
 }

--- a/Sparkle/SUWKWebView.m
+++ b/Sparkle/SUWKWebView.m
@@ -35,7 +35,7 @@
     BOOL _drawsWebViewBackground;
 }
 
-static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
+static WKUserScript *makeUserScriptWithInjectedStyleSource(NSString *styleSource)
 {
     // We must remove newlines when inserting the style source in this interpolated string below
     NSString *strippedStyleSource = [styleSource stringByReplacingOccurrencesOfString:@"\n" withString:@""];
@@ -53,7 +53,7 @@ static WKUserScript *_userScriptWithInjectedStyleSource(NSString *styleSource)
     return [[WKUserScript alloc] initWithSource:scriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];
 }
 
-static WKUserScript *_userScriptForExposingCurrentRelease(NSString *releaseString)
+static WKUserScript *makeUserScriptForExposingCurrentRelease(NSString *releaseString)
 {
     // Check that release string can be safely injected
     NSMutableCharacterSet *allowedCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
@@ -112,14 +112,14 @@ static WKUserScript *_userScriptForExposingCurrentRelease(NSString *releaseStrin
         // In fact, we must execute javascript to properly inject our default CSS style into the DOM
         // Legacy WebView has exposed methods for custom stylesheets and default fonts,
         // but WKWebView seems to forgo that type of API surface in favor of user scripts like this
-        WKUserScript *userScriptWithInjectedStyleSource = _userScriptWithInjectedStyleSource(finalStyleContents);
+        WKUserScript *userScriptWithInjectedStyleSource = makeUserScriptWithInjectedStyleSource(finalStyleContents);
         if (userScriptWithInjectedStyleSource == nil) {
             SULog(SULogLevelError, @"Failed to create script for injecting style");
         } else {
             [userContentController addUserScript:userScriptWithInjectedStyleSource];
         }
         
-        WKUserScript *userScriptForExposingCurrentRelease = _userScriptForExposingCurrentRelease(installedVersion);
+        WKUserScript *userScriptForExposingCurrentRelease = makeUserScriptForExposingCurrentRelease(installedVersion);
         if (userScriptForExposingCurrentRelease == nil) {
             SULog(SULogLevelDefault, @"warning: Failed to create script for injecting version %@", installedVersion);
         } else {


### PR DESCRIPTION
Fix reserved identifier warnings for Xcode 26 particularly for static functions.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing here in CI, tested test app on macOS 26 beta 1.
