### PR TITLE
Update Sparkle 1 for macOS Tahoe

### DIFF
--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -75,7 +75,7 @@
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="fKC-QA-GZa" userLabel="Container to hide release notes">
                         <rect key="frame" x="108" y="73" width="492" height="235"/>
                         <subviews>
-                            <box boxType="oldStyle" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="89">
+                            <box borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="89">
                                 <rect key="frame" x="0.0" y="0.0" width="492" height="215"/>
                                 <view key="contentView" id="hbB-V1-Bf6">
                                     <rect key="frame" x="1" y="1" width="490" height="213"/>

--- a/Sparkle/Base.lproj/SUUpdateAlert.xib
+++ b/Sparkle/Base.lproj/SUUpdateAlert.xib
@@ -75,7 +75,7 @@
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="fKC-QA-GZa" userLabel="Container to hide release notes">
                         <rect key="frame" x="108" y="73" width="492" height="235"/>
                         <subviews>
-                            <box borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="89">
+                            <box boxType="custom" borderType="line" cornerRadius="5" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="89">
                                 <rect key="frame" x="0.0" y="0.0" width="492" height="215"/>
                                 <view key="contentView" id="hbB-V1-Bf6">
                                     <rect key="frame" x="1" y="1" width="490" height="213"/>
@@ -84,6 +84,8 @@
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="pvn-8k-9Ev"/>
                                 </constraints>
+                                <color key="borderColor" name="separatorColor" catalog="System" colorSpace="catalog"/>
+                                <color key="fillColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <font key="titleFont" size="11" name="LucidaGrande"/>
                                 <connections>
                                     <binding destination="-2" name="hidden" keyPath="showsReleaseNotes" id="164">

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -303,6 +303,15 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         
         self.webView.view.frame = boxContentView.bounds;
         self.webView.view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+        
+        /// Prevent webview from spilling out of the box
+        ///     Note: [Jul 2025] ]The box around the webview is of type `NSBoxPrimary` (defined in IB). We're using it just for its border. Its fill is never visible, since the box's background is covered by the `webView`s background (in lightmode) or the `darkBackgroundView` (in darkmode)
+        ({
+            const double boxCornerRadius = 5.0, boxBorderWidth = 1.0; /// [Jul 2025] Hardcoded values. Matches `NSBoxPrimary` on macOS 26.0 Beta 2 || Tip: If you ever need to change these hardcoded values for new macOS versions, you might have to turn on "Increase Contrast" in System Settings.
+            boxContentView.wantsLayer = YES;
+            boxContentView.layer.masksToBounds = YES;
+            boxContentView.layer.cornerRadius = boxCornerRadius - boxBorderWidth;
+        });
     }
 
     [self.window setFrameAutosaveName: showReleaseNotes ? @"SUUpdateAlert" : @"SUUpdateAlertSmall" ];

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -305,12 +305,11 @@ static NSString *const SUUpdateAlertTouchBarIndentifier = @"" SPARKLE_BUNDLE_IDE
         self.webView.view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         
         /// Prevent webview from spilling out of the box
-        ///     Note: [Jul 2025] ]The box around the webview is of type `NSBoxPrimary` (defined in IB). We're using it just for its border. Its fill is never visible, since the box's background is covered by the `webView`s background (in lightmode) or the `darkBackgroundView` (in darkmode)
+        ///     Note: [Jul 2025] The box around the webview is of type `NSBoxCustom` (defined in IB). We're using it just for its border. Its fill is never visible, since the box's background is covered by the `webView`s background (in lightmode) or the `darkBackgroundView` (in darkmode)
         ({
-            const double boxCornerRadius = 5.0, boxBorderWidth = 1.0; /// [Jul 2025] Hardcoded values. Matches `NSBoxPrimary` on macOS 26.0 Beta 2 || Tip: If you ever need to change these hardcoded values for new macOS versions, you might have to turn on "Increase Contrast" in System Settings.
             boxContentView.wantsLayer = YES;
             boxContentView.layer.masksToBounds = YES;
-            boxContentView.layer.cornerRadius = boxCornerRadius - boxBorderWidth;
+            boxContentView.layer.cornerRadius = self.releaseNotesBoxView.cornerRadius - self.releaseNotesBoxView.borderWidth;
         });
     }
 


### PR DESCRIPTION
This improves the border style of the release notes on SUUpdateAlert in Sparkle 1.

This is supposed to be a minimal set of changes to Sparkle 1 to make it not look out-of-place on macOS Tahoe – But it also happens to slightly improve the look in older macOS versions.

Also see #2737.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: macOS 10.14 Mojave, macOS 15 Sequoia, and macOS 26 Tahoe

Screenshots:

### Mojave 

<details>
<summary> Light </summary>

- Before
    <img width="632" alt="Screenshot 2025-07-03 at 22 27 05" src="https://github.com/user-attachments/assets/fee6ce9c-750d-4520-bfb3-e7547fc54b6a" />
- After
    <img width="596" alt="Screenshot 2025-07-04 at 02 50 51" src="https://github.com/user-attachments/assets/01ff05ba-49c8-47f6-87db-512361482b42" />
</details>

<details>
<summary> Dark </summary>

- Before
    <img width="633" alt="Screenshot 2025-07-03 at 22 27 40" src="https://github.com/user-attachments/assets/9a9e18ee-f503-4111-9545-a0b0f6d096a2" />
- After:
    <img width="595" alt="Screenshot 2025-07-04 at 02 51 16" src="https://github.com/user-attachments/assets/c201ef9c-eeb8-4b3d-b811-63a9b8dac8fe" />

</details>

### Sequoia

<details>
<summary> Light </summary>

- Before:
    <img width="632" alt="Screenshot 2025-07-03 at 23 11 07" src="https://github.com/user-attachments/assets/bf1e3aba-74a9-41f0-9f1c-637da48c8a9d" />
- After:
    <img width="631" alt="Screenshot 2025-07-04 at 02 59 27" src="https://github.com/user-attachments/assets/727e8ac0-4415-4925-b0a9-a3387f15f1bd" />

</details>

<details>
<summary> Dark </summary>

- Before:
    <img width="634" alt="Screenshot 2025-07-03 at 23 10 53" src="https://github.com/user-attachments/assets/a47888ce-085f-41f6-91f8-482c590d6d45" />
- After
    <img width="629" alt="Screenshot 2025-07-04 at 02 59 39" src="https://github.com/user-attachments/assets/ded8f19d-a4ad-41b4-884e-d979607d267f" />

</details>

### Tahoe 

<details>
<summary> Light </summary>

- Before:
    <img width="628" alt="Screenshot 2025-07-03 at 23 18 32" src="https://github.com/user-attachments/assets/b1fd3474-4def-4889-ab3d-46b834246984" />
- After:
    <img width="630" alt="Screenshot 2025-07-04 at 03 01 27" src="https://github.com/user-attachments/assets/64d74a61-0bd1-4739-9f22-d82f7f4de2a9" />

</details>

<details>
<summary> Dark </summary>

- Before:
    <img width="629" alt="Screenshot 2025-07-03 at 23 18 04" src="https://github.com/user-attachments/assets/78f4825d-bbf0-4a53-9d2b-61918be3e08e" />
- After
    <img width="629" alt="Screenshot 2025-07-04 at 03 02 02" src="https://github.com/user-attachments/assets/6c8f37ca-c370-4d29-b02f-68f5b787cede" />

</details>

