### PR TITLE
Add support for relative URLs for delta updates

### DIFF
--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -335,7 +335,7 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
 // Initializer used for making delta items
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dict relativeToURL:(NSURL * _Nullable)appcastURL state:(SPUAppcastItemState * _Nullable)state SPU_OBJC_DIRECT
 {
-    return [self initWithDictionary:dict relativeToURL:nil stateResolver:nil resolvedState:state failureReason:nil];
+    return [self initWithDictionary:dict relativeToURL:appcastURL stateResolver:nil resolvedState:state failureReason:nil];
 }
 
 // Exported public initializer

--- a/Tests/Resources/test-relative-urls.xml
+++ b/Tests/Resources/test-relative-urls.xml
@@ -7,6 +7,10 @@
         <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
         <sparkle:releaseNotesLink>notes/relnote-3.0.txt</sparkle:releaseNotesLink>
         <enclosure url="release-3.0.zip" sparkle:version="3.0" length="1346234" />
+        <sparkle:deltas>
+            <enclosure url="3.0_from_2.0.delta" sparkle:deltaFrom="2.0" length="1235" type="application/octet-stream" />
+            <enclosure url="3.0_from_1.0.delta" sparkle:deltaFrom="1.0" length="5222" type="application/octet-stream" />
+        </sparkle:deltas>
     </item>
     <item>
         <title>Version 2.0</title>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -998,6 +998,11 @@ class SUAppcastTest: XCTestCase {
             XCTAssertEqual("https://fake.sparkle-project.org/updates/release-3.0.zip", items[0].fileURL?.absoluteString)
             XCTAssertEqual("https://fake.sparkle-project.org/updates/notes/relnote-3.0.txt", items[0].releaseNotesURL?.absoluteString)
 
+            XCTAssertEqual(2, items[0].deltaUpdates!.count)
+
+            XCTAssertEqual("https://fake.sparkle-project.org/updates/3.0_from_2.0.delta", items[0].deltaUpdates!["2.0"]!.fileURL?.absoluteString)
+            XCTAssertEqual("https://fake.sparkle-project.org/updates/3.0_from_1.0.delta", items[0].deltaUpdates!["1.0"]!.fileURL?.absoluteString)
+
             XCTAssertEqual("https://fake.sparkle-project.org/info/info-2.0.txt", items[1].infoURL?.absoluteString)
             
             XCTAssertEqual("https://fake.sparkle-project.org/updates/notes/fullnotes.txt", items[2].fullReleaseNotesURL?.absoluteString)


### PR DESCRIPTION
Relative URL support for appcasts was added in #1617, but `relativeToURL` was not passed down by the constructor used to create delta appcast items, meaning when the updater tried to download a delta from a relative path, it resulted in the following error being logged:
```
Failed to download delta update. Falling back to regular update...
Error: An error occurred while downloading the update. Please try again later. (null) (URL assets/<snip>.delta)
Error: unsupported URL (null) (URL assets/<snip>.delta)
```

This PR fixes it so that deltas can also have relative URLs.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

See unit test update. Pipeline without the change [here](https://github.com/dumbmoron/Sparkle/actions/runs/16221626759/job/45803316472#step:4:101) to show that the problem did exist, and was resolved by this change.

macOS version tested: 26.0 and 16.4