### PR TITLE
Document the thread safety requirement of SPUUpdater

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -100,8 +100,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
  (as long as the user driver is the standard `SPUStandardUserDriver` or if it implements `-[SPUUserDriver showUpdateInFocus]`).
  
  This will find updates that the user has previously opted into skipping.
- 
  See `canCheckForUpdates` property which can determine when this method may be invoked.
+
+ This must be called on the main thread.
  */
 - (void)checkForUpdates;
 
@@ -127,6 +128,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  This will not find updates that the user has opted into skipping.
  
  This method does not do anything if there is a `sessionInProgress`.
+
+ This must be called on the main thread.
  */
 - (void)checkForUpdatesInBackground;
 
@@ -145,6 +148,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Updates that have been skipped by the user will not be found.
  
  This method does not do anything if there is a `sessionInProgress`.
+
+ This must be called on the main thread.
  */
 - (void)checkForUpdateInformation;
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -626,6 +626,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 // Sparkle internally uses _checkForUpdatesInBackground
 - (void)checkForUpdatesInBackground
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -checkForUpdatesInBackground can only be called on the main thread");
+        return;
+    }
+
     if (!_startedUpdater) {
         SULog(SULogLevelError, @"Error: checkForUpdatesInBackground - updater hasn't been started yet. Please call -startUpdater: first");
         return;
@@ -653,6 +658,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)checkForUpdates
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -checkForUpdates can only be called on the main thread");
+        return;
+    }
+
     if (_showingPermissionRequest || _driver.showingUpdate) {
         if ([_userDriver respondsToSelector:@selector(showUpdateInFocus)]) {
             [_userDriver showUpdateInFocus];
@@ -699,6 +709,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)checkForUpdateInformation
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -checkForUpdateInformation can only be called on the main thread");
+        return;
+    }
+
     __weak __typeof__(self) weakSelf = self;
     if (!_startedUpdater) {
         SULog(SULogLevelError, @"Error: checkForUpdateInformation - updater hasn't been started yet. Please call -startUpdater: first");


### PR DESCRIPTION
This adds some documentation and some runtime checks to the APIs of SPUUpdater to ensure that they only gets used from the main thread as they're not thread safe.

Fixes # 2745

## Misc Checklist

- [X ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ X] My own app
- [ ] Other (please specify)

I ensured that the code was not crashing because of the new checks.

macOS version tested: 15.5
