### PR TITLE
Fix an issue while searching a cloneable file

### DIFF
--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -115,9 +115,9 @@ uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersio
         case SUBinaryDeltaMajorVersion2:
             return 5;
         case SUBinaryDeltaMajorVersion3:
-            return 2;
+            return 3;
         case SUBinaryDeltaMajorVersion4:
-            return 1;
+            return 2;
     }
     return 0;
 }

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -345,7 +345,12 @@ static NSString *cloneableRelativePath(NSDictionary<NSString *, NSData *> *after
         if (oldCloneInfo == nil) {
             continue;
         }
-        
+
+        // The old file must have the same type as the new one
+        if ([(NSNumber *)oldCloneInfo[INFO_TYPE_KEY] unsignedShortValue] != FTS_F) {
+            continue;
+        }
+
         NSNumber *newPermissions = newInfo[INFO_PERMISSIONS_KEY];
         if (outNewPermissions != NULL) {
             *outNewPermissions = newPermissions;


### PR DESCRIPTION
Hi !

Thank you for this amazing project that I've been using for years now !
I'm the developer of a program called "Hopper Disassembler." I have been using an old version of Sparkle (1.27.1), which worked perfectly fine for years. My CI compiles the new versions of my application and builds 3 delta updates for each variant (demo, full, etc.). Everything was fine, until I upgraded to Sparkle 2.7.1 for my upcoming version 6.x.

When building delta updates between my old version (which uses Sparkle 1.27.1) and my new version (using Sparkle 2.7.1), BinaryDelta fails to create the patch between the two versions of the embedded Sparkle framework because a file named `SUUpdateAlert.nib` is compared to a directory with the same name and path (after the `.framework/Versions/{A -> B}` substitution)  in the old version.

## Fixes

The fixe is trivial: in the `cloneableRelativePath` function, in the part which handled the `.framework/Versions/{A -> B}` substitution, I check that the candidate is also a file.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [X] My own app
- [ ] Other (please specify)

macOS version tested: 15.6
