### PR TITLE
Document and better enforce main thread only requirement for using Sparkle methods

### DIFF
--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
  It also allows hooking up the updater's and user driver's delegates.
  
  If you need more control over what bundle you want to update, or you want to provide a custom user interface (via `SPUUserDriver`), please use `SPUUpdater` directly instead.
+ 
+ This class must be used on the main thread.
   */
 SU_EXPORT @interface SPUStandardUpdaterController : NSObject
 {

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
  - `feedURL`
  
  Please view the documentation on each of these properties for more detail if you are to configure them dynamically.
+ 
+ This class must be used on the main thread.
  */
 SU_EXPORT @interface SPUUpdater : NSObject
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -350,6 +350,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  For testing purposes, the last update check is stored in the `SULastCheckTime` key in the host bundle's user defaults.
  For example, `defaults delete my-bundle-id SULastCheckTime` can be invoked to clear the last update check time and test
  if update checks are automatically scheduled.
+ 
+ This property must be called on the main thread.
  */
 @property (nonatomic, readonly, copy, nullable) NSDate *lastUpdateCheckDate;
 
@@ -361,6 +363,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  If the `updateCheckInterval` or `automaticallyChecksForUpdates` properties are changed, this method is automatically invoked after a short delay using `-resetUpdateCycleAfterShortDelay`. In these cases, manually resetting the update cycle is not necessary.
  
  See also `-resetUpdateCycleAfterShortDelay` which gives the user a short delay before triggering a cycle reset.
+ 
+ This must be called on the main thread.
  */
 - (void)resetUpdateCycle;
 
@@ -374,6 +378,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  no cycle reset will be done.
  
  If the `updateCheckInterval` or `automaticallyChecksForUpdates` properties are changed, this method is automatically invoked. In these cases, manually resetting the update cycle is not necessary.
+ 
+ This must be called on the main thread.
  */
 - (void)resetUpdateCycleAfterShortDelay;
 

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -100,8 +100,9 @@ SU_EXPORT @interface SPUUpdater : NSObject
  (as long as the user driver is the standard `SPUStandardUserDriver` or if it implements `-[SPUUserDriver showUpdateInFocus]`).
  
  This will find updates that the user has previously opted into skipping.
- 
  See `canCheckForUpdates` property which can determine when this method may be invoked.
+
+ This must be called on the main thread.
  */
 - (void)checkForUpdates;
 
@@ -127,6 +128,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  This will not find updates that the user has opted into skipping.
  
  This method does not do anything if there is a `sessionInProgress`.
+
+ This must be called on the main thread.
  */
 - (void)checkForUpdatesInBackground;
 
@@ -145,6 +148,8 @@ SU_EXPORT @interface SPUUpdater : NSObject
  Updates that have been skipped by the user will not be found.
  
  This method does not do anything if there is a `sessionInProgress`.
+
+ This must be called on the main thread.
  */
 - (void)checkForUpdateInformation;
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -156,6 +156,13 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (BOOL)startUpdater:(NSError * __autoreleasing *)error
 {
+    if (![NSThread isMainThread]) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidUpdaterError userInfo:@{ NSLocalizedDescriptionKey: @"-[SPUUpdater must be called on the main thread]"}];
+        }
+        return NO;
+    }
+    
     if (_startedUpdater) {
         return YES;
     }
@@ -627,7 +634,12 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 - (void)checkForUpdatesInBackground
 {
     if (![NSThread isMainThread]) {
-        SULog(SULogLevelError, @"Error: -checkForUpdatesInBackground can only be called on the main thread");
+        SULog(SULogLevelError, @"Error: -[SPUUpdater checkForUpdatesInBackground] can only be called on the main thread");
+        
+        // Try to be nice and dispatch on main thread anyway
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self checkForUpdatesInBackground];
+        });
         return;
     }
 
@@ -659,7 +671,13 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 - (void)checkForUpdates
 {
     if (![NSThread isMainThread]) {
-        SULog(SULogLevelError, @"Error: -checkForUpdates can only be called on the main thread");
+        SULog(SULogLevelError, @"Error: -[SPUUpdater checkForUpdates] can only be called on the main thread");
+        
+        // Try to be nice and dispatch on main thread anyway
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self checkForUpdates];
+        });
+        
         return;
     }
 
@@ -710,7 +728,13 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 - (void)checkForUpdateInformation
 {
     if (![NSThread isMainThread]) {
-        SULog(SULogLevelError, @"Error: -checkForUpdateInformation can only be called on the main thread");
+        SULog(SULogLevelError, @"Error: -[SPUUpdater checkForUpdateInformation] can only be called on the main thread");
+        
+        // Try to be nice and dispatch on main thread anyway
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self checkForUpdateInformation];
+        });
+        
         return;
     }
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -626,6 +626,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 // Sparkle internally uses _checkForUpdatesInBackground
 - (void)checkForUpdatesInBackground
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -checkForUpdatesInBackground can only be called on the main thread");
+        return;
+    }
+
     if (!_startedUpdater) {
         SULog(SULogLevelError, @"Error: checkForUpdatesInBackground - updater hasn't been started yet. Please call -startUpdater: first");
         return;
@@ -653,6 +658,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)checkForUpdates
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -checkForUpdates can only be called on the main thread");
+        return;
+    }
+
     if (_showingPermissionRequest || _driver.showingUpdate) {
         if ([_userDriver respondsToSelector:@selector(showUpdateInFocus)]) {
             [_userDriver showUpdateInFocus];
@@ -699,6 +709,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)checkForUpdateInformation
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -checkForUpdateInformation can only be called on the main thread");
+        return;
+    }
+
     __weak __typeof__(self) weakSelf = self;
     if (!_startedUpdater) {
         SULog(SULogLevelError, @"Error: checkForUpdateInformation - updater hasn't been started yet. Please call -startUpdater: first");

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -474,6 +474,10 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (NSDate *)lastUpdateCheckDate
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater lastUpdateCheckDate] must be called on the main thread.");
+    }
+    
     if (_updateLastCheckedDate == nil)
     {
         _updateLastCheckedDate = [_host objectForUserDefaultsKey:SULastCheckTimeKey];
@@ -927,6 +931,16 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)resetUpdateCycle
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater resetUpdateCycle] must be called on the main thread.");
+        
+        // Try to be nice and dispatch on main thread anyway
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self resetUpdateCycle];
+        });
+        return;
+    }
+    
     if (!_startedUpdater) {
         SULog(SULogLevelError, @"Error: resetUpdateCycle - updater hasn't been started yet. Please call -startUpdater: first");
         return; // not even ready yet
@@ -965,17 +979,35 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)resetUpdateCycleAfterShortDelay
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater resetUpdateCycleAfterShortDelay] must be called on the main thread.");
+        
+        // Try to be nice and dispatch on main thread anyway
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self resetUpdateCycleAfterShortDelay];
+        });
+        return;
+    }
+    
     [self cancelNextUpdateCycle];
     [_updaterCycle resetUpdateCycleAfterDelay];
 }
 
 - (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyCheckForUpdates
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater setAutomaticallyChecksForUpdates:] must be called on the main thread.");
+    }
+    
     _updaterSettings.automaticallyChecksForUpdates = automaticallyCheckForUpdates;
 }
 
 - (BOOL)automaticallyChecksForUpdates
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater automaticallyChecksForUpdates] must be called on the main thread.");
+    }
+    
     return [_updaterSettings automaticallyChecksForUpdates];
 }
 
@@ -1004,11 +1036,19 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyUpdates
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater setAutomaticallyDownloadsUpdates:] must be called on the main thread.");
+    }
+    
     _updaterSettings.automaticallyDownloadsUpdates = automaticallyUpdates;
 }
 
 - (BOOL)automaticallyDownloadsUpdates
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater automaticallyDownloadsUpdates] must be called on the main thread.");
+    }
+    
     return [_updaterSettings automaticallyDownloadsUpdates];
 }
 
@@ -1136,11 +1176,19 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 
 - (void)setSendsSystemProfile:(BOOL)sendsSystemProfile
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater setSendsSystemProfile:] must be called on the main thread.");
+    }
+    
     _updaterSettings.sendsSystemProfile = sendsSystemProfile;
 }
 
 - (BOOL)sendsSystemProfile
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater sendsSystemProfile] must be called on the main thread.");
+    }
+    
     return [_updaterSettings sendsSystemProfile];
 }
 
@@ -1241,11 +1289,19 @@ static NSString *escapeURLComponent(NSString *str) {
 
 - (void)setUpdateCheckInterval:(NSTimeInterval)updateCheckInterval
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater setUpdateCheckInterval:] must be called on the main thread.");
+    }
+    
     _updaterSettings.updateCheckInterval = updateCheckInterval;
 }
 
 - (NSTimeInterval)updateCheckInterval
 {
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater updateCheckInterval] must be called on the main thread.");
+    }
+    
     return [_updaterSettings updateCheckInterval];
 }
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -158,7 +158,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 {
     if (![NSThread isMainThread]) {
         if (error != NULL) {
-            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidUpdaterError userInfo:@{ NSLocalizedDescriptionKey: @"-[SPUUpdater must be called on the main thread]"}];
+            *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInvalidUpdaterError userInfo:@{ NSLocalizedDescriptionKey: @"-[SPUUpdater startUpdater:] must be called on the main thread]"}];
         }
         return NO;
     }


### PR DESCRIPTION
Document and better enforce main thread only requirement for using Sparkle methods.

In general, Sparkle usage should be constrained to main thread only.

Continuation of #2746.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Code review, tested test app. No errors should be logged in normal cases.

macOS version tested: 15.5 (24F74)
