### PR TITLE
Work around the display of warnings about dependency scan analysis

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -165,3 +165,6 @@ GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
 WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Werror=undef
+
+// Prevents spurious warnings based on dependency scan considering Sparkle itself a dependency
+DIAGNOSE_MISSING_TARGET_DEPENDENCIES = NO


### PR DESCRIPTION
Work around the display of warnings about dependency scan analysis discovering a dependency of SparkleInstallerLauncher on Sparkle.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other: Manual building with and without the pertinent build setting.

macOS version tested: macOS 26 beta with Xcode 25 beta.

