### PR TITLE
Harden policy on what operations clients are allowed to take

### DIFF
--- a/Autoupdate/AgentConnection.m
+++ b/Autoupdate/AgentConnection.m
@@ -10,6 +10,8 @@
 #import "SPUMessageTypes.h"
 #import "SPUInstallerAgentProtocol.h"
 #import "SUInstallerAgentInitiationProtocol.h"
+#import "SUCodeSigningVerifier.h"
+#import "SULog.h"
 
 
 #include "AppKitPrevention.h"
@@ -52,7 +54,7 @@
     _delegate = nil;
     
     [_activeConnection invalidate];
-    _activeConnection = nil;
+    // Don't need to set _activeConnection to nil, we don't expect new connections
     
     [_xpcListener invalidate];
     _xpcListener = nil;
@@ -61,8 +63,27 @@
 - (BOOL)listener:(NSXPCListener *)__unused listener shouldAcceptNewConnection:(NSXPCConnection *)newConnection
 {
     if (_activeConnection != nil) {
+        SULog(SULogLevelError, @"Error: Rejecting new connection for agent due already having an active connection");
+        
         [newConnection invalidate];
         return NO;
+    }
+    
+    // Hardening but not critical for security
+    NSError *validationError = nil;
+    SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionDefault error:&validationError];
+    switch (validationStatus) {
+        case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
+            break;
+        case SUValidateConnectionStatusSetNoRequirementSuccess:
+            break;
+        case SUValidateConnectionStatusAPIFailure:
+        case SUValidateConnectionStatusCodeSigningRequirementFailure:
+        case SUValidateConectionNoSupportedValidationMethodFailure:
+            SULog(SULogLevelError, @"Error: Rejecting new connection for agent due to failing validation of XPC connection with status %lu and error: %@", validationStatus, validationError.localizedDescription);
+            
+            [newConnection invalidate];
+            return NO;
     }
     
     newConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SUInstallerAgentInitiationProtocol)];
@@ -91,9 +112,8 @@
         });
     };
     
-    [newConnection resume];
-    
     _agent = newConnection.remoteObjectProxy;
+    [newConnection resume];
     
     return YES;
 }
@@ -106,7 +126,9 @@
         [self->_delegate agentConnectionDidInitiate];
     });
     
-    acknowledgement();
+    if (acknowledgement != NULL) {
+        acknowledgement();
+    }
 }
 
 - (void)connectionWillInvalidateWithError:(NSError *)error

--- a/Autoupdate/SUCodeSigningVerifier.h
+++ b/Autoupdate/SUCodeSigningVerifier.h
@@ -19,6 +19,22 @@ NS_ASSUME_NONNULL_BEGIN
 #define SUCodeSigningVerifierDefinitionAttribute __attribute__((objc_runtime_name("SUTestCodeSigningVerifier")))
 #endif
 
+typedef NS_ENUM(NSUInteger, SUValidateConnectionStatus) {
+    SUValidateConnectionStatusSetCodeSigningRequirementSuccess = 0,
+    SUValidateConnectionStatusSetNoRequirementSuccess,
+    SUValidateConnectionStatusAPIFailure,
+    SUValidateConnectionStatusCodeSigningRequirementFailure,
+    SUValidateConectionNoSupportedValidationMethodFailure,
+};
+
+typedef NS_OPTIONS(NSUInteger, SUValidateConnectionOptions) {
+    // Default validation behavior (matches against Team ID from main executable if available)
+    SUValidateConnectionOptionDefault = 0,
+    
+    // Require that the connecting client has the app sandbox entitlement
+    SUValidateConnectionOptionRequireSandboxEntitlement = 1 << 0,
+};
+
 SUCodeSigningVerifierDefinitionAttribute
 @interface SUCodeSigningVerifier : NSObject
 
@@ -34,6 +50,9 @@ SUCodeSigningVerifierDefinitionAttribute
 + (BOOL)bundleAtURLIsCodeSigned:(NSURL *)bundleURL;
 
 + (NSString * _Nullable)teamIdentifierAtURL:(NSURL *)url;
++ (NSString * _Nullable)teamIdentifierFromMainExecutable;
+
++ (SUValidateConnectionStatus)validateConnection:(NSXPCConnection *)connection options:(SUValidateConnectionOptions)options error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/Autoupdate/SUInstaller.h
+++ b/Autoupdate/SUInstaller.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUInstaller : NSObject
 
-+ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host expectedInstallationType:(NSString *)expectedInstallationType updateDirectory:(NSString *)updateDirectory homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName error:(NSError **)error;
++ (nullable id<SUInstallerProtocol>)installerForHost:(SUHost *)host expectedInstallationType:(NSString *)expectedInstallationType updateDirectory:(NSString *)updateDirectory connectionCodeSigningValidationSkipped:(BOOL)connectionCodeSigningValidationSkipped homeDirectory:(NSString *)homeDirectory userName:(NSString *)userName error:(NSError **)error;
 
 + (nullable NSString *)installSourcePathInUpdateFolder:(NSString *)inUpdateFolder forHost:(SUHost *)host
 #if SPARKLE_BUILD_PACKAGE_SUPPORT

--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -353,22 +353,16 @@
         // If the update has a custom update security policy, the same team ID policy may not apply,
         // so in that case we will also skip performing an atomic swap
         
-        NSURL *mainExecutableURL = NSBundle.mainBundle.executableURL;
-        if (mainExecutableURL == nil) {
-            // This shouldn't happen
+        updateHasCustomUpdateSecurityPolicy = updateHost.hasUpdateSecurityPolicy;
+        if (updateHasCustomUpdateSecurityPolicy) {
+            // We don't handle working around a custom update security policy
             _canPerformSafeAtomicSwap = NO;
         } else {
-            updateHasCustomUpdateSecurityPolicy = updateHost.hasUpdateSecurityPolicy;
-            if (updateHasCustomUpdateSecurityPolicy) {
-                // We don't handle working around a custom update security policy
-                _canPerformSafeAtomicSwap = NO;
-            } else {
-                NSString *installerTeamIdentifier = [SUCodeSigningVerifier teamIdentifierAtURL:mainExecutableURL];
-                NSString *bundleTeamIdentifier = [SUCodeSigningVerifier teamIdentifierAtURL:bundle.bundleURL];
-                
-                // If bundleTeamIdentifier is nil, then the update isn't code signed so atomic swap is okay
-                _canPerformSafeAtomicSwap = (bundleTeamIdentifier == nil || (installerTeamIdentifier != nil && [installerTeamIdentifier isEqualToString:bundleTeamIdentifier]));
-            }
+            NSString *installerTeamIdentifier = [SUCodeSigningVerifier teamIdentifierFromMainExecutable];
+            NSString *bundleTeamIdentifier = [SUCodeSigningVerifier teamIdentifierAtURL:bundle.bundleURL];
+            
+            // If bundleTeamIdentifier is nil, then the update isn't code signed so atomic swap is okay
+            _canPerformSafeAtomicSwap = (bundleTeamIdentifier == nil || (installerTeamIdentifier != nil && [installerTeamIdentifier isEqualToString:bundleTeamIdentifier]));
         }
     } else {
         _canPerformSafeAtomicSwap = YES;

--- a/Downloader/main.m
+++ b/Downloader/main.m
@@ -26,7 +26,7 @@
     // This is a policy, not a security critical enforcement.
     {
         NSError *validationError = nil;
-        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionRequireSandboxEntitlement error:&validationError];
+        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionDefault error:&validationError];
         switch (validationStatus) {
             case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                 break;

--- a/Downloader/main.m
+++ b/Downloader/main.m
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "SPUDownloader.h"
 #import "SPUDownloaderDelegate.h"
+#import "SULog.h"
+#import "SUCodeSigningVerifier.h"
 
 @interface ServiceDelegate : NSObject <NSXPCListenerDelegate>
 @end
@@ -17,6 +19,30 @@
 
 - (BOOL)listener:(NSXPCListener *)__unused listener shouldAcceptNewConnection:(NSXPCConnection *)newConnection {
     // This method is where the NSXPCListener configures, accepts, and resumes a new incoming NSXPCConnection.
+    
+    // Validate connection of clients to avoid any client from using the service.
+    // Ideally we would also prevent clients connecting that have an outgoing network connection enabled,
+    // but this is not easy to enforce.
+    // This is a policy, not a security critical enforcement.
+    {
+        NSError *validationError = nil;
+        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionRequireSandboxEntitlement error:&validationError];
+        switch (validationStatus) {
+            case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
+                break;
+            case SUValidateConnectionStatusSetNoRequirementSuccess:
+                assert(false);
+                break;
+            case SUValidateConnectionStatusAPIFailure:
+            case SUValidateConnectionStatusCodeSigningRequirementFailure:
+            case SUValidateConectionNoSupportedValidationMethodFailure:
+                SULog(SULogLevelError, @"Error: Downloader XPC Service is rejecting new connection due to failing validation of XPC connection with status %lu and error: %@", validationStatus, validationError.localizedDescription);
+                
+                [newConnection invalidate];
+                
+                return NO;
+        }
+    }
     
     // Configure the connection.
     // First, set the interface that the exported object implements.

--- a/Downloader/main.m
+++ b/Downloader/main.m
@@ -31,7 +31,6 @@
             case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                 break;
             case SUValidateConnectionStatusSetNoRequirementSuccess:
-                assert(false);
                 break;
             case SUValidateConnectionStatusAPIFailure:
             case SUValidateConnectionStatusCodeSigningRequirementFailure:

--- a/InstallerLauncher/SUInstallerLauncherProtocol.h
+++ b/InstallerLauncher/SUInstallerLauncherProtocol.h
@@ -11,6 +11,6 @@
 
 @protocol SUInstallerLauncherProtocol
 
-- (void)launchInstallerWithHostBundlePath:(NSString *)hostBundlePath iconBundlePath:(NSString *)iconBundlePath updaterIdentifier:(NSString *)updaterBundleIdentifier authorizationPrompt:(NSString *)authorizationPrompt installationType:(NSString *)installationType allowingDriverInteraction:(BOOL)allowingDriverInteraction completion:(void (^)(SUInstallerLauncherStatus, BOOL))completionHandler;
+- (void)launchInstallerWithHostBundlePath:(NSString *)hostBundlePath mainBundlePath:(NSString *)mainBundlePath installationType:(NSString *)installationType allowingDriverInteraction:(BOOL)allowingDriverInteraction completion:(void (^)(SUInstallerLauncherStatus, BOOL))completionHandler;
     
 @end

--- a/InstallerLauncher/main.m
+++ b/InstallerLauncher/main.m
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 #import "SUInstallerLauncher.h"
+#import "SULog.h"
+#import "SUCodeSigningVerifier.h"
 
 @interface ServiceDelegate : NSObject <NSXPCListenerDelegate>
 @end
@@ -16,6 +18,28 @@
 
 - (BOOL)listener:(NSXPCListener *)__unused listener shouldAcceptNewConnection:(NSXPCConnection *)newConnection {
     // This method is where the NSXPCListener configures, accepts, and resumes a new incoming NSXPCConnection.
+    
+    // Validate connection of clients to avoid any client from using the service.
+    // This is a policy, not a security critical enforcement.
+    {
+        NSError *validationError = nil;
+        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options: SUValidateConnectionOptionRequireSandboxEntitlement error:&validationError];
+        switch (validationStatus) {
+            case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
+                break;
+            case SUValidateConnectionStatusSetNoRequirementSuccess:
+                assert(false);
+                break;
+            case SUValidateConnectionStatusAPIFailure:
+            case SUValidateConnectionStatusCodeSigningRequirementFailure:
+            case SUValidateConectionNoSupportedValidationMethodFailure:
+                SULog(SULogLevelError, @"Error: Installer XPC Service is rejecting new connection due to failing validation of XPC connection with status %lu and error: %@", validationStatus, validationError.localizedDescription);
+                
+                [newConnection invalidate];
+                
+                return NO;
+        }
+    }
     
     // Configure the connection.
     // First, set the interface that the exported object implements.

--- a/InstallerLauncher/main.m
+++ b/InstallerLauncher/main.m
@@ -23,7 +23,7 @@
     // This is a policy, not a security critical enforcement.
     {
         NSError *validationError = nil;
-        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options: SUValidateConnectionOptionRequireSandboxEntitlement error:&validationError];
+        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options: SUValidateConnectionOptionDefault error:&validationError];
         switch (validationStatus) {
             case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                 break;

--- a/InstallerLauncher/main.m
+++ b/InstallerLauncher/main.m
@@ -28,7 +28,6 @@
             case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                 break;
             case SUValidateConnectionStatusSetNoRequirementSuccess:
-                assert(false);
                 break;
             case SUValidateConnectionStatusAPIFailure:
             case SUValidateConnectionStatusCodeSigningRequirementFailure:

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -347,6 +347,9 @@
 		728ED34C277DA23400D9238F /* SPUSparkleDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 728ED349277DA23400D9238F /* SPUSparkleDeltaArchive.m */; };
 		728ED34D277DA23400D9238F /* SPUSparkleDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 728ED349277DA23400D9238F /* SPUSparkleDeltaArchive.m */; };
 		729051E41DC82AC0003DEA7F /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
+		7290BF2F2E5A5AFA00D75022 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
+		7290BF302E5A5B0F00D75022 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
+		7290BF312E5A5B2F00D75022 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		729743AB279D1BD2009910B2 /* SUCodeSigningVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */; };
 		729924941DF4A45000DBCDF5 /* SUUpdateValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 729924931DF4A45000DBCDF5 /* SUUpdateValidator.m */; };
 		729C51282E58015600D7365A /* SUUpdatePermissionPrompt.xib in Resources */ = {isa = PBXBuildFile; fileRef = 729C51272E58015600D7365A /* SUUpdatePermissionPrompt.xib */; };
@@ -1546,6 +1549,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7290BF312E5A5B2F00D75022 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3462,6 +3466,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7290BF302E5A5B0F00D75022 /* SUCodeSigningVerifier.m in Sources */,
 				72464F7E1E21ED8C00FB341C /* SUHost.m in Sources */,
 				726E07B41CAF08D6001A286B /* main.m in Sources */,
 				721D8A7B1D4963190032E472 /* SPULocalCacheDirectory.m in Sources */,
@@ -3478,6 +3483,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7290BF2F2E5A5AFA00D75022 /* SUCodeSigningVerifier.m in Sources */,
 				723B5DA71CF7AB0100365F95 /* main.m in Sources */,
 				72E539121D68C3FA0092CE5E /* SPUDownloadData.m in Sources */,
 				723B5DA91CF7AB0100365F95 /* SPUDownloader.m in Sources */,

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -320,7 +320,9 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
             NSRunningApplication *firstRunningApplication = runningApplications.firstObject;
             
             BOOL targetDead = (firstRunningApplication == nil || firstRunningApplication.terminated);
-            reply(targetDead);
+            if (reply != NULL) {
+                reply(targetDead);
+            }
             
             self->_repliedToRegistration = YES;
             self->_applicationBundle = applicationBundle;
@@ -358,7 +360,9 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
 #endif
         if (self->_targetRunningApplication != nil && self->_terminationCompletionHandler == nil) {
             if (self->_targetRunningApplication.terminated) {
-                completionHandler();
+                if (completionHandler != NULL) {
+                    completionHandler();
+                }
             } else {
                 self->_terminationCompletionHandler = [completionHandler copy];
                 

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -81,7 +81,9 @@
                     if (strongSelf != nil && !strongSelf->_retrievedDownloadResult && !strongSelf->_cleaningUp) {
                         strongSelf->_downloader = nil;
                         
-                        SULog(SULogLevelError, @"Connection to update downloader was invalidated");
+                        // We can't enforce com.apple.security.network.client == NO or it being absent for sandboxed clients,
+                        // but we should warn about it anyway
+                        SULog(SULogLevelError, @"Error: Connection to update downloader was invalidated. If your app is not sandboxed or has com.apple.security.network.client set to YES, please remove %@ from your Info.plist. Otherwise please check Console logs for "@DOWNLOADER_NAME" if there are any additional details.", SUEnableDownloaderServiceKey);
                         
                         NSDictionary *userInfo =
                         @{

--- a/Tests/SUInstallerTest.m
+++ b/Tests/SUInstallerTest.m
@@ -56,7 +56,7 @@
     NSError *installerError = nil;
     // Note: we may not be using the "correct" home directory or user name (they will be root) but our test pkg does not have
     // pre/post install scripts so it doesn't matter
-    id<SUInstallerProtocol> installer = [SUInstaller installerForHost:host expectedInstallationType:SPUInstallationTypeGuidedPackage updateDirectory:[path stringByDeletingLastPathComponent] homeDirectory:NSHomeDirectory() userName:NSUserName() error:&installerError];
+    id<SUInstallerProtocol> installer = [SUInstaller installerForHost:host expectedInstallationType:SPUInstallationTypeGuidedPackage updateDirectory:[path stringByDeletingLastPathComponent] connectionCodeSigningValidationSkipped:NO homeDirectory:NSHomeDirectory() userName:NSUserName() error:&installerError];
     
     if (installer == nil) {
         XCTFail(@"Installer is nil with error: %@", installerError);


### PR DESCRIPTION
* For the Installer and Downloader XPC Services, if these executables are code signed with an Apple issued Team ID, then the connecting client must also be code signed with a matching Team ID.
* For the Downloader XPC Service, the request URL must be http/https
* For Autoupdate, if stage 1 of installation hasn't been completed yet and this executable is code signed with an Apple issued Team ID, then the connecting client must also be code signed with a matching Team ID. As before, multiple simultaneous connections are still disallowed.
* For Autoupdate, if it's not signed with Apple issued certificate, when installing package updates the bundle being updated must be itself and owned by root on disk (as one expects from a PKG installation)
* The authorization prompt message in the Installer Service is more computed inside the service so the client can't pass a completely arbitrary message
* Add extra nullable checking of parameters coming from XPC endpoints
* Add more thread-safe synchronization for Autoupdate installer
* Add logs for more failure points

This change is back ported to 2.7.2 over here fc4f8cb75337520edfc1504dfac58cd25fa68e92

The in depth security details of this change are [discussed here](https://github.com/sparkle-project/Sparkle/discussions/2764).

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [x] Other (please specify)

Tested:
* Running sparkle test app in debug
* Production app using sandboxing and no sandboxing, 
* Production app with using pkg update

macOS version tested:
15.5 (24F74)
10.14.6
