### PR TITLE
Double quote team identifiers in designated requirement strings

### DIFF
--- a/Autoupdate/SUCodeSigningVerifier.m
+++ b/Autoupdate/SUCodeSigningVerifier.m
@@ -359,7 +359,7 @@ static NSString * _Nullable SUTeamIdentifierFromCode(SecStaticCodeRef staticCode
     // LeafIsDeveloperIDApp = certificate leaf[field.1.2.840.113635.100.6.1.13]
     // DeveloperIDTeamID = certificate leaf[subject.OU]
     // https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements#Xcode-designated-requirement-for-Developer-ID-code
-    requirementString = [NSString stringWithFormat:@"anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = %@", teamIdentifier];
+    requirementString = [NSString stringWithFormat:@"anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = \"%@\"", teamIdentifier];
     
     result = SecRequirementCreateWithString((__bridge CFStringRef)requirementString, kSecCSDefaultFlags, &requirement);
     if (result != errSecSuccess) {
@@ -450,7 +450,7 @@ finally:
     // Build the default team ID signing requirement
     NSString *hostTeamIdentifier = [self teamIdentifierFromMainExecutable];
     if (hostTeamIdentifier != nil) {
-        NSString *teamIdentifierRequirement = [NSString stringWithFormat:@"(anchor apple generic and certificate leaf[subject.OU] = %@)", hostTeamIdentifier];
+        NSString *teamIdentifierRequirement = [NSString stringWithFormat:@"(anchor apple generic and certificate leaf[subject.OU] = \"%@\")", hostTeamIdentifier];
         [codeSigningRequirementComponents addObject:teamIdentifierRequirement];
     }
     


### PR DESCRIPTION
Fixes #2765

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Verified update process works in my notarized test app (I don't have a team ID that starts with a number so testing is limited). Verified newer and legacy code signing requirement paths are still hit. This fix has also been tested by reporter in #2765.

macOS version tested:
15.5 (24F74)
10.14.6 VM
