### PR TITLE
Add main thread / reentrancy safety checks for showing feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-logs
-          path: build/Logs
+          path: |
+            build/Logs
+            ~/Library/Logs/DiagnosticReports
       - name: Upload Distribution
         if: ${{ success() && matrix.upload-dist }}
         uses: actions/upload-artifact@v4

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -150,6 +150,8 @@
 
 - (void)downloadFile
 {
+    assert(NSThread.isMainThread);
+    
     id<SPUDownloadDriverDelegate> delegate = _delegate;
     if ([delegate respondsToSelector:@selector(downloadDriverWillBeginDownload)]) {
         [delegate downloadDriverWillBeginDownload];

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -350,6 +350,10 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     
     [self closeCheckingWindow];
     
+    if (_activeUpdateAlert != nil) {
+        SULog(SULogLevelError, @"Error: -[%@ %@] should not be called when _activeUpdateAlert != nil:\n%@", NSStringFromClass([self class]), NSStringFromSelector(_cmd), NSThread.callStackSymbols);
+    }
+    
     id<SPUStandardUserDriverDelegate> delegate = _delegate;
     id<SUVersionDisplay> customVersionDisplayer = nil;
     

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -57,6 +57,8 @@
 
 - (void)loadAppcastFromURL:(NSURL *)appcastURL userAgent:(NSString *)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background
 {
+    assert(NSThread.isMainThread);
+    
     NSMutableDictionary *requestHTTPHeaders = [NSMutableDictionary dictionary];
     if (httpHeaders != nil) {
         [requestHTTPHeaders addEntriesFromDictionary:(NSDictionary * _Nonnull)httpHeaders];


### PR DESCRIPTION
More additions to #2754

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested test app, and own app with downloader service in use or off.

macOS version tested: 15.5 (24F74)
