### PR TITLE
Fix testParseAppcast failing on macOS 26

### DIFF
--- a/Tests/Resources/testappcast.xml
+++ b/Tests/Resources/testappcast.xml
@@ -39,7 +39,7 @@
         <sparkle:version>4.0</sparkle:version>
         <pubDate>Sat, 26 Jul 2014 15:20:13 +0000</pubDate>
         <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
-        <sparkle:minimumSystemVersion>17.0.0</sparkle:minimumSystemVersion>
+        <sparkle:minimumSystemVersion>9999.0.0</sparkle:minimumSystemVersion>
     </item>
     <!-- A joke release testing maximumSystemVersion -->
     <item>


### PR DESCRIPTION
In the appcast there is an item with minimum OS requirement set to 17.0, which was never meant to be satisfied (originally written around when OS X was 10.12). This is just purely a test issue.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Re-ran failed test.

macOS version tested: macOS 26 RC
