### PR TITLE
Include app name in startUpdater: failure in SPUStandardUpdaterController

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -158,7 +158,7 @@
 "The installation failed due to not having permission to write the new update." = "The installation failed due to not having permission to write the new update.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version.";
+"The updater failed to start. Please verify you have the latest version of %@ and contact the app developer if the issue still persists. Check the Console logs for more information." = "The updater failed to start. Please verify you have the latest version of %@ and contact the app developer if the issue still persists. Check the Console logs for more information.";
 
 /* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "The update is improperly signed and could not be validated. Please try again later or contact the app developer.";

--- a/Sparkle/cs.lproj/Sparkle.strings
+++ b/Sparkle/cs.lproj/Sparkle.strings
@@ -119,9 +119,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Přejete si, aby aplikace %1$@ automaticky vyhledávala aktualizace? Tuto volbu můžete kdykoliv změnit v nabídce %1$@.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "Nepodařilo se správně spustit update checker. Kontaktujte prosím vývojáře, nahlašte tento problém a ujistěte se, že používáte nejnovější verzi.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "Tato aktualizace není správně podepsaná a nelze ji ověřit. Zkuste to prosím později nebo kontaktujte vývojáře aplikace.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/de.lproj/Sparkle.strings
+++ b/Sparkle/de.lproj/Sparkle.strings
@@ -158,9 +158,6 @@
 "The installation failed due to not having permission to write the new update." = "Die Installation ist fehlgeschlagen aufgrund fehlender Berechtigung zum Schreiben des neuen Updates.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "Das Aktualisierungsprogramm wurde nicht richtig gestartet. Du solltest den App-Entwickler kontaktieren, um diesen Fehler zu melden und zu prüfen, ob du die neueste Version hast.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "Das Update ist nicht ordnungsgemäß signiert und konnte nicht überprüft werden. Bitte versuche es später erneut oder kontaktiere den App-Entwickler.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/he.lproj/Sparkle.strings
+++ b/Sparkle/he.lproj/Sparkle.strings
@@ -119,9 +119,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "האם %1$@ צריך לבדוק באופן אוטומטי אם יש עדכונים? תוכל תמיד לחפש עדכונים באופן ידני מהתפריט של %1$@.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "בודק העדכונים לא הצליח לפעול כראוי. עליך ליצור קשר עם מפתח היישום כדי לדווח על בעיה זו ולוודא שיש לך את הגרסה העדכנית ביותר.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "העדכון חתום בצורה לא נכונה ולא ניתן היה לאמת אותו. נסה שוב מאוחר יותר או צור קשר עם מפתח היישום.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/it.lproj/Sparkle.strings
+++ b/Sparkle/it.lproj/Sparkle.strings
@@ -119,9 +119,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Desideri che %1$@ verifichi gli aggiornamenti automaticamente? Puoi effettuare la verifica manualmente dal menu di %1$@.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "Il controllo degli aggiornamenti non è stato avviato correttamente. È necessario contattare lo sviluppatore dell’app per segnalare questo problema e verificare di disporre della versione più recente.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "L’aggiornamento è firmato in modo errato e non può essere convalidato. Riprova in seguito o contatta lo sviluppatore dell’app.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/ja.lproj/Sparkle.strings
+++ b/Sparkle/ja.lproj/Sparkle.strings
@@ -158,9 +158,6 @@
 "The installation failed due to not having permission to write the new update." = "新しいアップデートを書き込むアクセス権がないためインストールできませんでした。";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "アップデートチェッカーが正しくスタートできませんでした。アプリケーション開発者に連絡をしてこの不具合を報告し、最新バージョンであることを確認してください。";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "アップデートの署名が不適切で認証できませんでした。あとでやり直すかアプリケーション開発者に連絡してください。";
 
 /* No comment provided by engineer. */

--- a/Sparkle/ko.lproj/Sparkle.strings
+++ b/Sparkle/ko.lproj/Sparkle.strings
@@ -119,9 +119,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "%1$@ 업데이트 확인을 자동으로 할까요? %1$@ 메뉴에서 수동으로 변경 할 수 있습니다.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "업데이트 확인 도구가 올바르게 시작되지 않았습니다. 이 문제를 앱 개발자에게 알려주고 사용 중인 버전이 최신 버전인지 확인해주세요.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "업데이트가 잘못 서명되어 유효성 검사를 할 수 없습니다. 나중에 다시 시도하거나 앱 개발자에게 문의해주세요.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/nl.lproj/Sparkle.strings
+++ b/Sparkle/nl.lproj/Sparkle.strings
@@ -158,9 +158,6 @@
 "The installation failed due to not having permission to write the new update." = "De installatie is mislukt omdat je geen bevoegdheden hebt om de nieuwe update te schrijven.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "De updatezoeker is niet goed gestart. Je kunt wellicht met de app-ontwikkelaar contact opnemen om de fout te melden en te controleren dat je de nieuwste versie hebt.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "De update is onjuist gesigneerd en kan niet worden gecontroleerd. Probeer het later opnieuw of neem contact op met de app-ontwikkelaar.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/pt-BR.lproj/Sparkle.strings
+++ b/Sparkle/pt-BR.lproj/Sparkle.strings
@@ -116,9 +116,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "Deseja que o app %1$@ busque atualizações automaticamente? Você também pode buscar atualizações manualmente no menu %1$@.";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "Houve uma falha ao iniciar a busca de atualizações. Contate o desenvolvedor do app para comunicar esse problema e verifique se você tem a versão mais recente.";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "A atualização foi assinada incorretamente e não pôde ser validada. Tente novamente mais tarde ou contate o desenvolvedor do app.";
 
 /* No comment provided by engineer. */

--- a/Sparkle/zh_HK.lproj/Sparkle.strings
+++ b/Sparkle/zh_HK.lproj/Sparkle.strings
@@ -119,9 +119,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "%1$@ 是否應自動檢查更新？你可隨時從 %1$@ 選單手動檢查更新。";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "更新檢查程式未能正確啓動。你應聯絡軟體開發者以回報此問題並驗證你是否已有最新版本。";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "此更新並未正確簽署且無法驗證。請稍後再試或聯絡軟體開發者。";
 
 /* No comment provided by engineer. */

--- a/Sparkle/zh_TW.lproj/Sparkle.strings
+++ b/Sparkle/zh_TW.lproj/Sparkle.strings
@@ -119,9 +119,6 @@
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "%1$@ 是否應自動檢查更新項目？您可隨時從 %1$@ 選單手動檢查更新項目。";
 
 /* No comment provided by engineer. */
-"The update checker failed to start correctly. You should contact the app developer to report this issue and verify that you have the latest version." = "更新檢查程式未能正確啟動。您應聯絡軟體開發者以回報此問題並驗證您是否已有最新版本。";
-
-/* No comment provided by engineer. */
 "The update is improperly signed and could not be validated. Please try again later or contact the app developer." = "此更新並未正確簽署且無法驗證。請稍後再試一次或聯絡軟體開發者。";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Include app name in startUpdater: failure in SPUStandardUpdaterController.

The localizations for this are stale now, but I don't consider it a huge issue as ideally this message should not occur in production (unless the user corrupted an app or developer didn't test their app).

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested modified version of test app that uses SPUStandardUpdaterController and removes Ed key in plist

macOS version tested: 26.0.1 (25A362)
