### PR TITLE
Update CI to use Xcode 26.1 and macOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: ['xcode26', 'xcode16.4']
+        xcode: ['xcode26.1', 'xcode16.4']
         include:
             - xcode: 'xcode16.4'
               xcode-path: '/Applications/Xcode_16.4.app/Contents/Developer'
               upload-dist: true
               run-analyzer: true
               macos: 'macos-15'
-            - xcode: 'xcode26'
-              xcode-path: '/Applications/Xcode_26.0.app'
+            - xcode: 'xcode26.1'
+              xcode-path: '/Applications/Xcode_26.1.app'
               upload-dist: false
               run-analyzer: false
-              macos: 'macos-15'
+              macos: 'macos-26'
             
     name: Build and Test Sparkle
     runs-on: ${{ matrix.macos }}


### PR DESCRIPTION
Update CI to use Xcode 26.1 and macOS 26.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI.
