### PR TITLE
Validate Obj-C class when reading objects from user defaults / plists

### DIFF
--- a/Autoupdate/SUPlainInstaller.m
+++ b/Autoupdate/SUPlainInstaller.m
@@ -328,7 +328,7 @@
     
     NSBundle *bundle = [NSBundle bundleWithPath:_bundlePath];
     SUHost *updateHost = [[SUHost alloc] initWithBundle:bundle];
-    NSString *updateVersion = [updateHost objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
+    NSString *updateVersion = [updateHost objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey ofClass:NSString.class];
     
     id<SUVersionComparison> comparator = [[SUStandardVersionComparator alloc] init];
     if (!updateVersion || [comparator compareVersion:hostVersion toVersion:updateVersion] == NSOrderedDescending) {

--- a/Sparkle/SPUSkippedUpdate.m
+++ b/Sparkle/SPUSkippedUpdate.m
@@ -35,9 +35,9 @@
 
 + (nullable SPUSkippedUpdate *)skippedUpdateForHost:(SUHost *)host
 {
-    NSString *minorVersion = [host objectForUserDefaultsKey:SUSkippedMinorVersionKey];
-    NSString *majorVersion = [host objectForUserDefaultsKey:SUSkippedMajorVersionKey];
-    NSString *majorSubreleaseVersion = [host objectForUserDefaultsKey:SUSkippedMajorSubreleaseVersionKey];
+    NSString *minorVersion = [host objectForUserDefaultsKey:SUSkippedMinorVersionKey ofClass:NSString.class];
+    NSString *majorVersion = [host objectForUserDefaultsKey:SUSkippedMajorVersionKey ofClass:NSString.class];
+    NSString *majorSubreleaseVersion = [host objectForUserDefaultsKey:SUSkippedMajorSubreleaseVersionKey ofClass:NSString.class];
     
     if (minorVersion != nil || majorVersion != nil) {
         return [[SPUSkippedUpdate alloc] initWithMinorVersion:minorVersion majorVersion:majorVersion majorSubreleaseVersion:majorSubreleaseVersion];

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -400,7 +400,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     // If the user has been asked about automatic checks or the developer has overridden the setting, don't bother prompting
     // When the user answers to the permission prompt, this will be set to either @YES or @NO instead of nil
-    if ([_host objectForKey:SUEnableAutomaticChecksKey ofClass:NSNumber.class] != nil) {
+    if ([_host boolNumberForKey:SUEnableAutomaticChecksKey] != nil) {
         shouldPrompt = NO;
     }
     // Does the delegate want to take care of the logic for when we should ask permission to update?
@@ -659,7 +659,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (_updatingMainBundle) {
         // Check if Sparkle is configured to ask the user's permission to enable automatic update checks
-        NSNumber *automaticChecksInInfoPlist = [_host objectForInfoDictionaryKey:SUEnableAutomaticChecksKey ofClass:NSNumber.class];
+        NSNumber *automaticChecksInInfoPlist = [_host boolNumberForInfoDictionaryKey:SUEnableAutomaticChecksKey];
         if (automaticChecksInInfoPlist == nil) {
             // Check if automatic update checking is disabled or if the user hasn't given permission for Sparkle to check
             BOOL automaticChecksInDefaults = [self automaticallyChecksForUpdates];

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -187,7 +187,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         // We perform this check one runloop cycle after starting the updater to give the developer
         // a chance to call -clearFeedURLFromUserDefaults before this warning can show up
         if (self->_updatingMainBundle) {
-            NSString *appcastUserDefaultsString = [self->_host objectForUserDefaultsKey:SUFeedURLKey];
+            NSString *appcastUserDefaultsString = [self->_host objectForUserDefaultsKey:SUFeedURLKey ofClass:NSString.class];
             if (appcastUserDefaultsString != nil) {
                 SULog(SULogLevelError, @"Warning: A feed URL was found stored in user defaults for %@. This was likely set using -[SPUUpdater setFeedURL:] which is deprecated. Please migrate away from using this API and call -[SPUUpdater clearFeedURLFromUserDefaults] to remove any stored defaults, otherwise Sparkle may continue to use the feed stored from the defaults. If the feed url was set via a defaults write command for testing purposes, then please ignore this warning.", self->_host.name);
             }
@@ -307,7 +307,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             
             BOOL foundATSMainBundleIssue = NO;
             if (!foundATSPersistentIssue && !foundXPCDownloaderService) {
-                BOOL foundATSIssue = ([mainBundleHost objectForInfoDictionaryKey:@"NSAppTransportSecurity"] == nil);
+                BOOL foundATSIssue = ([mainBundleHost objectForInfoDictionaryKey:@"NSAppTransportSecurity" ofClass:NSDictionary.class] == nil);
                 
                 if (_updatingMainBundle) {
                     // The only way we'll know for sure if there is an issue is if the main bundle is the same as the one we're updating
@@ -400,7 +400,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     // If the user has been asked about automatic checks or the developer has overridden the setting, don't bother prompting
     // When the user answers to the permission prompt, this will be set to either @YES or @NO instead of nil
-    if ([_host objectForKey:SUEnableAutomaticChecksKey] != nil) {
+    if ([_host objectForKey:SUEnableAutomaticChecksKey ofClass:NSNumber.class] != nil) {
         shouldPrompt = NO;
     }
     // Does the delegate want to take care of the logic for when we should ask permission to update?
@@ -480,7 +480,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (_updateLastCheckedDate == nil)
     {
-        _updateLastCheckedDate = [_host objectForUserDefaultsKey:SULastCheckTimeKey];
+        _updateLastCheckedDate = [_host objectForUserDefaultsKey:SULastCheckTimeKey ofClass:NSDate.class];
     }
     
     return _updateLastCheckedDate;
@@ -659,7 +659,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     
     if (_updatingMainBundle) {
         // Check if Sparkle is configured to ask the user's permission to enable automatic update checks
-        NSNumber *automaticChecksInInfoPlist = [_host objectForInfoDictionaryKey:SUEnableAutomaticChecksKey];
+        NSNumber *automaticChecksInInfoPlist = [_host objectForInfoDictionaryKey:SUEnableAutomaticChecksKey ofClass:NSNumber.class];
         if (automaticChecksInInfoPlist == nil) {
             // Check if automatic update checking is disabled or if the user hasn't given permission for Sparkle to check
             BOOL automaticChecksInDefaults = [self automaticallyChecksForUpdates];
@@ -1080,7 +1080,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
         SULog(SULogLevelError, @"Error: -[SPUUpdater clearFeedURLFromUserDefaults] must be called on the main thread.");
     }
     
-    NSString *appcastString = [_host objectForUserDefaultsKey:SUFeedURLKey];
+    NSString *appcastString = [_host objectForUserDefaultsKey:SUFeedURLKey ofClass:NSString.class];
     
     [_host setObject:nil forUserDefaultsKey:SUFeedURLKey];
     
@@ -1124,7 +1124,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     }
     
     // Delegate gets first priority for determining the feed URL
-    NSString *appcastString = [_host objectForKey:SUFeedURLKey];
+    NSString *appcastString = [_host objectForKey:SUFeedURLKey ofClass:NSString.class];
     id<SPUUpdaterDelegate> delegate = _delegate;
     if ([delegate respondsToSelector:@selector((feedURLStringForUpdater:))]) {
         NSString *delegateAppcastString = [delegate feedURLStringForUpdater:self];
@@ -1136,7 +1136,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     // A value in the user defaults overrides one in the Info.plist
     // (as this used to be used for setting alternative feed URLs but is now deprecated)
     if (appcastString == nil) {
-        appcastString = [_host objectForKey:SUFeedURLKey];
+        appcastString = [_host objectForKey:SUFeedURLKey ofClass:NSString.class];
     }
     
     if (appcastString == nil) { // Can't find an appcast string!
@@ -1222,7 +1222,7 @@ static NSString *escapeURLComponent(NSString *str) {
 
     // Let's only send the system profiling information once per week at most, so we normalize daily-checkers vs. biweekly-checkers and the such.
     if (sendingSystemProfile) {
-        NSDate *lastSubmitDate = [_host objectForUserDefaultsKey:SULastProfileSubmitDateKey];
+        NSDate *lastSubmitDate = [_host objectForUserDefaultsKey:SULastProfileSubmitDateKey ofClass:NSDate.class];
         if (!lastSubmitDate) {
             lastSubmitDate = [NSDate distantPast];
         }

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -175,12 +175,12 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 - (NSTimeInterval)currentUpdateCheckInterval SPU_OBJC_DIRECT
 {
     // Find the stored check interval. User defaults override Info.plist.
-    id intervalValue = [_host objectForKey:SUScheduledCheckIntervalKey];
-    if (intervalValue == nil || ![(NSObject *)intervalValue isKindOfClass:[NSNumber class]]) {
+    NSNumber *intervalValue = [_host objectForKey:SUScheduledCheckIntervalKey ofClass:NSNumber.class];
+    if (intervalValue == nil) {
         return SUDefaultUpdateCheckInterval;
     }
     
-    return [(NSNumber *)intervalValue doubleValue];
+    return intervalValue.doubleValue;
 }
 
 - (void)setUpdateCheckInterval:(NSTimeInterval)updateCheckInterval
@@ -207,8 +207,8 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 // For allowing automatic downloaded updates to be turned on or off
 - (NSNumber * _Nullable)allowsAutomaticUpdatesOption
 {
-    NSNumber *developerAllowsAutomaticUpdates = [_host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
-    return [developerAllowsAutomaticUpdates isKindOfClass:[NSNumber class]] ? developerAllowsAutomaticUpdates : nil;
+    NSNumber *developerAllowsAutomaticUpdates = [_host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey ofClass:NSNumber.class];
+    return developerAllowsAutomaticUpdates;
 }
 
 - (BOOL)allowsAutomaticUpdates

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -175,7 +175,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 - (NSTimeInterval)currentUpdateCheckInterval SPU_OBJC_DIRECT
 {
     // Find the stored check interval. User defaults override Info.plist.
-    NSNumber *intervalValue = [_host objectForKey:SUScheduledCheckIntervalKey ofClass:NSNumber.class];
+    NSNumber *intervalValue = [_host doubleNumberForKey:SUScheduledCheckIntervalKey];
     if (intervalValue == nil) {
         return SUDefaultUpdateCheckInterval;
     }
@@ -207,7 +207,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 // For allowing automatic downloaded updates to be turned on or off
 - (NSNumber * _Nullable)allowsAutomaticUpdatesOption
 {
-    NSNumber *developerAllowsAutomaticUpdates = [_host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey ofClass:NSNumber.class];
+    NSNumber *developerAllowsAutomaticUpdates = [_host boolNumberForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
     return developerAllowsAutomaticUpdates;
 }
 

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -39,13 +39,13 @@ SUHostDefinitionAttribute
 
 @property (nonatomic, readonly) BOOL hasUpdateSecurityPolicy;
 
-- (nullable id)objectForInfoDictionaryKey:(NSString *)key;
+- (nullable id)objectForInfoDictionaryKey:(NSString *)key ofClass:(Class)aClass;
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key;
-- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName;
+- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName ofClass:(Class)aClass;
 - (void)setObject:(nullable id)value forUserDefaultsKey:(NSString *)defaultName;
 - (BOOL)boolForUserDefaultsKey:(NSString *)defaultName;
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName;
-- (nullable id)objectForKey:(NSString *)key;
+- (nullable id)objectForKey:(NSString *)key ofClass:(Class)aClass;
 - (BOOL)boolForKey:(NSString *)key;
 
 - (void)observeChangesFromUserDefaultKeys:(NSSet<NSString *> *)keyPaths changeHandler:(void (^)(NSString *))changeHandler;

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -40,13 +40,21 @@ SUHostDefinitionAttribute
 @property (nonatomic, readonly) BOOL hasUpdateSecurityPolicy;
 
 - (nullable id)objectForInfoDictionaryKey:(NSString *)key ofClass:(Class)aClass;
+- (nullable NSNumber *)boolNumberForInfoDictionaryKey:(NSString *)key;
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key;
+- (nullable NSNumber *)doubleNumberForInfoDictionaryKey:(NSString *)key;
+
 - (nullable id)objectForUserDefaultsKey:(NSString *)defaultName ofClass:(Class)aClass;
 - (void)setObject:(nullable id)value forUserDefaultsKey:(NSString *)defaultName;
+- (nullable NSNumber *)boolNumberForUserDefaultsKey:(NSString *)key;
 - (BOOL)boolForUserDefaultsKey:(NSString *)defaultName;
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName;
+- (nullable NSNumber *)doubleNumberForUserDefaultsKey:(NSString *)key;
+
 - (nullable id)objectForKey:(NSString *)key ofClass:(Class)aClass;
+- (nullable NSNumber *)boolNumberForKey:(NSString *)key;
 - (BOOL)boolForKey:(NSString *)key;
+- (nullable NSNumber *)doubleNumberForKey:(NSString *)key;
 
 - (void)observeChangesFromUserDefaultKeys:(NSSet<NSString *> *)keyPaths changeHandler:(void (^)(NSString *))changeHandler;
 

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -52,7 +52,7 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
         NSString *domainIdentifier;
         {
-            NSString *defaultsDomain = [self objectForInfoDictionaryKey:SUDefaultsDomainKey];
+            NSString *defaultsDomain = [self objectForInfoDictionaryKey:SUDefaultsDomainKey ofClass:NSString.class];
             if (defaultsDomain != nil) {
                 domainIdentifier = defaultsDomain;
             } else if (!_isMainBundle) {
@@ -123,13 +123,13 @@ static void *SUHostObservableContext = &SUHostObservableContext;
     NSString *name;
 
     // Allow host bundle to provide a custom name
-    name = [self objectForInfoDictionaryKey:@"SUBundleName"];
+    name = [self objectForInfoDictionaryKey:@"SUBundleName" ofClass:NSString.class];
     if (name && name.length > 0) return name;
 
-    name = [self objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    name = [self objectForInfoDictionaryKey:@"CFBundleDisplayName" ofClass:NSString.class];
 	if (name && name.length > 0) return name;
 
-    name = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
+    name = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey ofClass:NSString.class];
 	if (name && name.length > 0) return name;
 
     return [[[NSFileManager defaultManager] displayNameAtPath:[self bundlePath]] stringByDeletingPathExtension];
@@ -147,7 +147,7 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
 - (NSString * _Nullable)_version SPU_OBJC_DIRECT
 {
-    NSString *version = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
+    NSString *version = [self objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey ofClass:NSString.class];
     return ([self isValidVersion:version] ? version : nil);
 }
 
@@ -164,7 +164,7 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
 - (NSString * _Nonnull)displayVersion
 {
-    NSString *shortVersionString = [self objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *shortVersionString = [self objectForInfoDictionaryKey:@"CFBundleShortVersionString" ofClass:NSString.class];
     if (shortVersionString)
         return shortVersionString;
     else
@@ -190,13 +190,13 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
 - (NSString *_Nullable)publicEDKey SPU_OBJC_DIRECT
 {
-    return [self objectForInfoDictionaryKey:SUPublicEDKeyKey];
+    return [self objectForInfoDictionaryKey:SUPublicEDKeyKey ofClass:NSString.class];
 }
 
 - (NSString *_Nullable)publicDSAKey SPU_OBJC_DIRECT
 {
     // Maybe the key is just a string in the Info.plist.
-    NSString *key = [self objectForInfoDictionaryKey:SUPublicDSAKeyKey];
+    NSString *key = [self objectForInfoDictionaryKey:SUPublicDSAKeyKey ofClass:NSString.class];
 	if (key) {
         return key;
     }
@@ -221,7 +221,7 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
 - (BOOL)hasUpdateSecurityPolicy
 {
-    NSDictionary<NSString *, id> *updateSecurityPolicy = [self objectForInfoDictionaryKey:@"NSUpdateSecurityPolicy"];
+    NSDictionary<NSString *, id> *updateSecurityPolicy = [self objectForInfoDictionaryKey:@"NSUpdateSecurityPolicy" ofClass:NSDictionary.class];
     
     return (updateSecurityPolicy != nil);
 }
@@ -234,16 +234,17 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
 - (NSString * _Nullable)publicDSAKeyFileKey
 {
-    return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey];
+    return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey ofClass:NSString.class];
 }
 
-- (nullable id)objectForInfoDictionaryKey:(NSString *)key
+- (nullable id)objectForInfoDictionaryKey:(NSString *)key ofClass:(Class)aClass
 {
+    id object;
     if (_isMainBundle) {
         // Common fast path - if we're updating the main bundle, that means our updater and host bundle's lifetime is the same
         // If the bundle happens to be updated or change, that means our updater process needs to be terminated first to do it safely
         // Thus we can rely on the cached Info dictionary
-        return [_bundle objectForInfoDictionaryKey:key];
+        object = [_bundle objectForInfoDictionaryKey:key];
     } else {
         // Slow path - if we're updating another bundle, we should read in the most up to date Info dictionary because
         // the bundle can be replaced externally or even by us.
@@ -252,22 +253,44 @@ static void *SUHostObservableContext = &SUHostObservableContext;
         CFDictionaryRef cfInfoDictionary = CFBundleCopyInfoDictionaryInDirectory((CFURLRef)_bundle.bundleURL);
         NSDictionary *infoDictionary = CFBridgingRelease(cfInfoDictionary);
         
-        return [infoDictionary objectForKey:key];
+        object = [infoDictionary objectForKey:key];
     }
+    
+    if (object == nil) {
+        return nil;
+    }
+    
+    if (![(NSObject *)object isKindOfClass:aClass]) {
+        SULog(SULogLevelError, @"Error: Reading info dictionary key %@ with expected class %@ but instead found %@", key, aClass.className, ((NSObject *)object).className);
+        return nil;
+    }
+    
+    return object;
 }
 
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key
 {
-    return [(NSNumber *)[self objectForInfoDictionaryKey:key] boolValue];
+    return [(NSNumber *)[self objectForInfoDictionaryKey:key ofClass:NSNumber.class] boolValue];
 }
 
-- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName
+- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName ofClass:(Class)aClass
 {
     if (defaultName == nil || _userDefaults == nil) {
         return nil;
     }
 
-    return [_userDefaults objectForKey:defaultName];
+    id object = [_userDefaults objectForKey:defaultName];
+    
+    if (object == nil) {
+        return nil;
+    }
+    
+    if (![(NSObject *)object isKindOfClass:aClass]) {
+        SULog(SULogLevelError, @"Error: Reading user defaults key %@ with expected class %@ but instead found %@", defaultName, aClass.className, ((NSObject *)object).className);
+        return nil;
+    }
+    
+    return object;
 }
 
 // Note this handles nil being passed for defaultName, in which case the user default will be removed
@@ -294,12 +317,13 @@ static void *SUHostObservableContext = &SUHostObservableContext;
     [_modifyingKeyPaths removeObject:defaultName];
 }
 
-- (nullable id)objectForKey:(NSString *)key {
-    return [self objectForUserDefaultsKey:key] ? [self objectForUserDefaultsKey:key] : [self objectForInfoDictionaryKey:key];
+- (nullable id)objectForKey:(NSString *)key ofClass:(Class)aClass {
+    id userDefaultsObject = [self objectForUserDefaultsKey:key ofClass:aClass];
+    return userDefaultsObject != nil ? userDefaultsObject : [self objectForInfoDictionaryKey:key ofClass:aClass];
 }
 
 - (BOOL)boolForKey:(NSString *)key {
-    return [self objectForUserDefaultsKey:key] ? [self boolForUserDefaultsKey:key] : [self boolForInfoDictionaryKey:key];
+    return [self objectForUserDefaultsKey:key ofClass:NSNumber.class] != nil ? [self boolForUserDefaultsKey:key] : [self boolForInfoDictionaryKey:key];
 }
 
 @end

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -237,7 +237,24 @@ static void *SUHostObservableContext = &SUHostObservableContext;
     return [self objectForInfoDictionaryKey:SUPublicDSAKeyFileKey ofClass:NSString.class];
 }
 
-- (nullable id)objectForInfoDictionaryKey:(NSString *)key ofClass:(Class)aClass
+static _Nullable id validateObject(id _Nullable object, NSSet<Class> * classes, NSString *key, NSString *keyType)
+{
+    if (object == nil) {
+        return nil;
+    }
+    
+    for (Class aClass in classes) {
+        if ([(NSObject *)object isKindOfClass:aClass]) {
+            return object;
+        }
+    }
+    
+    SULog(SULogLevelError, @"Error: Reading %@ key %@ with expected classes %@ but instead found %@", keyType, key, classes, ((NSObject *)object).className);
+    
+    return nil;
+}
+
+- (nullable id)objectForInfoDictionaryKey:(NSString *)key ofClasses:(NSSet<Class> *)classes SPU_OBJC_DIRECT
 {
     id object;
     if (_isMainBundle) {
@@ -256,41 +273,82 @@ static void *SUHostObservableContext = &SUHostObservableContext;
         object = [infoDictionary objectForKey:key];
     }
     
+    return validateObject(object, classes, key, @"info dictionary");
+}
+
+- (nullable id)objectForInfoDictionaryKey:(NSString *)key ofClass:(Class)aClass
+{
+    return [self objectForInfoDictionaryKey:key ofClasses:[NSSet setWithObject:aClass]];
+}
+
+static NSNumber * _Nullable convertObjectToBoolNumber(NSObject * _Nullable object, NSString *key, NSString *keyType)
+{
     if (object == nil) {
         return nil;
     }
     
-    if (![(NSObject *)object isKindOfClass:aClass]) {
-        SULog(SULogLevelError, @"Error: Reading info dictionary key %@ with expected class %@ but instead found %@", key, aClass.className, ((NSObject *)object).className);
+    if ([object isKindOfClass:NSNumber.class]) {
+        return (NSNumber *)object;
+    }
+    
+    if ([object isKindOfClass:NSString.class]) {
+        return @(((NSString *)object).boolValue);
+    }
+    
+    SULog(SULogLevelError, @"Error: Reading %@ key %@ expecting convertible bool but instead found class %@", keyType, key, ((NSObject *)object).className);
+    
+    return nil;
+}
+
+static NSNumber * _Nullable convertObjectToDoubleNumber(NSObject * _Nullable object, NSString *key, NSString *keyType)
+{
+    if (object == nil) {
         return nil;
     }
     
-    return object;
+    if ([object isKindOfClass:NSNumber.class]) {
+        return (NSNumber *)object;
+    }
+    
+    if ([object isKindOfClass:NSString.class]) {
+        return @(((NSString *)object).doubleValue);
+    }
+    
+    SULog(SULogLevelError, @"Error: Reading %@ key %@ expecting convertible double but instead found class %@", keyType, key, ((NSObject *)object).className);
+    
+    return nil;
+}
+
+- (nullable NSNumber *)boolNumberForInfoDictionaryKey:(NSString *)key
+{
+    NSObject *object = [self objectForInfoDictionaryKey:key ofClasses:[NSSet setWithArray:@[NSNumber.class, NSString.class]]];
+    return convertObjectToBoolNumber(object, key, @"info dictionary");
 }
 
 - (BOOL)boolForInfoDictionaryKey:(NSString *)key
 {
-    return [(NSNumber *)[self objectForInfoDictionaryKey:key ofClass:NSNumber.class] boolValue];
+    return [[self boolNumberForInfoDictionaryKey:key] boolValue];
 }
 
-- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName ofClass:(Class)aClass
+- (nullable NSNumber *)doubleNumberForInfoDictionaryKey:(NSString *)key
+{
+    NSObject *object = [self objectForInfoDictionaryKey:key ofClasses:[NSSet setWithArray:@[NSNumber.class, NSString.class]]];
+    return convertObjectToDoubleNumber(object, key, @"info dictionary");
+}
+
+- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName ofClasses:(NSSet<Class> *)classes SPU_OBJC_DIRECT
 {
     if (defaultName == nil || _userDefaults == nil) {
         return nil;
     }
 
     id object = [_userDefaults objectForKey:defaultName];
-    
-    if (object == nil) {
-        return nil;
-    }
-    
-    if (![(NSObject *)object isKindOfClass:aClass]) {
-        SULog(SULogLevelError, @"Error: Reading user defaults key %@ with expected class %@ but instead found %@", defaultName, aClass.className, ((NSObject *)object).className);
-        return nil;
-    }
-    
-    return object;
+    return validateObject(object, classes, defaultName, @"user default");
+}
+
+- (nullable id)objectForUserDefaultsKey:(NSString *)defaultName ofClass:(Class)aClass
+{
+    return [self objectForUserDefaultsKey:defaultName ofClasses:[NSSet setWithObject:aClass]];
 }
 
 // Note this handles nil being passed for defaultName, in which case the user default will be removed
@@ -303,9 +361,15 @@ static void *SUHostObservableContext = &SUHostObservableContext;
     [_modifyingKeyPaths removeObject:defaultName];
 }
 
+- (nullable NSNumber *)boolNumberForUserDefaultsKey:(NSString *)key;
+{
+    NSObject *object = [self objectForUserDefaultsKey:key ofClasses:[NSSet setWithArray:@[NSNumber.class, NSString.class]]];
+    return convertObjectToBoolNumber(object, key, @"user default");
+}
+
 - (BOOL)boolForUserDefaultsKey:(NSString *)defaultName
 {
-    return [_userDefaults boolForKey:defaultName];
+    return [[self boolNumberForUserDefaultsKey:defaultName] boolValue];
 }
 
 - (void)setBool:(BOOL)value forUserDefaultsKey:(NSString *)defaultName
@@ -317,13 +381,32 @@ static void *SUHostObservableContext = &SUHostObservableContext;
     [_modifyingKeyPaths removeObject:defaultName];
 }
 
+- (nullable NSNumber *)doubleNumberForUserDefaultsKey:(NSString *)key
+{
+    NSObject *object = [self objectForUserDefaultsKey:key ofClasses:[NSSet setWithArray:@[NSNumber.class, NSString.class]]];
+    return convertObjectToDoubleNumber(object, key, @"user default");
+}
+
 - (nullable id)objectForKey:(NSString *)key ofClass:(Class)aClass {
     id userDefaultsObject = [self objectForUserDefaultsKey:key ofClass:aClass];
     return userDefaultsObject != nil ? userDefaultsObject : [self objectForInfoDictionaryKey:key ofClass:aClass];
 }
 
-- (BOOL)boolForKey:(NSString *)key {
-    return [self objectForUserDefaultsKey:key ofClass:NSNumber.class] != nil ? [self boolForUserDefaultsKey:key] : [self boolForInfoDictionaryKey:key];
+- (nullable NSNumber *)boolNumberForKey:(NSString *)key
+{
+    NSNumber *boolFromUserDefaults = [self boolNumberForUserDefaultsKey:key];
+    return (boolFromUserDefaults != nil) ? boolFromUserDefaults : [self boolNumberForInfoDictionaryKey:key];
+}
+
+- (BOOL)boolForKey:(NSString *)key
+{
+    return [[self boolNumberForKey:key] boolValue];
+}
+
+- (nullable NSNumber *)doubleNumberForKey:(NSString *)key
+{
+    NSNumber *doubleFromUserDefaults = [self doubleNumberForUserDefaultsKey:key];
+    return (doubleFromUserDefaults != nil) ? doubleFromUserDefaults : [self doubleNumberForInfoDictionaryKey:key];
 }
 
 @end

--- a/Sparkle/SUNormalization.m
+++ b/Sparkle/SUNormalization.m
@@ -16,10 +16,10 @@ NSString *SUNormalizedInstallationPath(SUHost *host)
     NSBundle *bundle = host.bundle;
     assert(bundle != nil);
    
-    NSString * baseBundleName = [host objectForInfoDictionaryKey:@"SUBundleName"];
+    NSString * baseBundleName = [host objectForInfoDictionaryKey:@"SUBundleName" ofClass:NSString.class];
    
     if (baseBundleName == nil) {
-        baseBundleName = [host objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey];
+        baseBundleName = [host objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleNameKey ofClass:NSString.class];
     }
     
     NSString *normalizedAppPath = [[[bundle bundlePath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", baseBundleName, [[bundle bundlePath] pathExtension]]];

--- a/Sparkle/SUPhasedUpdateGroupInfo.m
+++ b/Sparkle/SUPhasedUpdateGroupInfo.m
@@ -24,6 +24,8 @@
 
 + (NSNumber*)updateGroupIdentifierForHost:(SUHost*)host SPU_OBJC_DIRECT
 {
+    // Only Sparkle should set this user default, so we don't need to convert NSString -> integer number
+    // We can just require NSNumber class.
     NSNumber* updateGroupIdentifier = [host objectForUserDefaultsKey:SUUpdateGroupIdentifierKey ofClass:NSNumber.class];
     if(updateGroupIdentifier == nil) {
         updateGroupIdentifier = [self setNewUpdateGroupIdentifierForHost:host];
@@ -34,7 +36,7 @@
 
 + (NSNumber*)setNewUpdateGroupIdentifierForHost:(SUHost*)host
 {
-    unsigned int r = arc4random_uniform(UINT_MAX);
+    uint32_t r = arc4random_uniform(UINT_MAX);
     NSNumber* updateGroupIdentifier = @(r);
 
     [host setObject:updateGroupIdentifier forUserDefaultsKey:SUUpdateGroupIdentifierKey];

--- a/Sparkle/SUPhasedUpdateGroupInfo.m
+++ b/Sparkle/SUPhasedUpdateGroupInfo.m
@@ -24,7 +24,7 @@
 
 + (NSNumber*)updateGroupIdentifierForHost:(SUHost*)host SPU_OBJC_DIRECT
 {
-    NSNumber* updateGroupIdentifier = [host objectForUserDefaultsKey:SUUpdateGroupIdentifierKey];
+    NSNumber* updateGroupIdentifier = [host objectForUserDefaultsKey:SUUpdateGroupIdentifierKey ofClass:NSNumber.class];
     if(updateGroupIdentifier == nil) {
         updateGroupIdentifier = [self setNewUpdateGroupIdentifierForHost:host];
     }

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -248,7 +248,7 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
 
 - (BOOL)showsReleaseNotes
 {
-    NSNumber *shouldShowReleaseNotes = [_host objectForInfoDictionaryKey:SUShowReleaseNotesKey];
+    NSNumber *shouldShowReleaseNotes = [_host objectForInfoDictionaryKey:SUShowReleaseNotesKey ofClass:NSNumber.class];
     if (shouldShowReleaseNotes == nil) {
         // Don't show release notes if RSS item contains no description and no release notes URL:
         return (([_updateItem itemDescription] != nil
@@ -284,9 +284,9 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
     NSArray<NSString *> *customAllowedURLSchemes;
     {
         NSMutableArray<NSString *> *allowedSchemes = [NSMutableArray array];
-        id hostAllowedURLSchemes = [_host objectForInfoDictionaryKey:SUAllowedURLSchemesKey];
-        if ([(NSObject *)hostAllowedURLSchemes isKindOfClass:[NSArray class]]) {
-            for (id urlScheme in (NSArray *)hostAllowedURLSchemes) {
+        NSArray *hostAllowedURLSchemes = [_host objectForInfoDictionaryKey:SUAllowedURLSchemesKey ofClass:NSArray.class];
+        if (hostAllowedURLSchemes != nil) {
+            for (id urlScheme in hostAllowedURLSchemes) {
                 if ([(NSObject *)urlScheme isKindOfClass:[NSString class]]) {
                     NSString *allowedURLScheme = [(NSString *)urlScheme lowercaseString];
                     if (![allowedURLScheme isEqualToString:@"file"]) {

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -248,7 +248,7 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
 
 - (BOOL)showsReleaseNotes
 {
-    NSNumber *shouldShowReleaseNotes = [_host objectForInfoDictionaryKey:SUShowReleaseNotesKey ofClass:NSNumber.class];
+    NSNumber *shouldShowReleaseNotes = [_host boolNumberForInfoDictionaryKey:SUShowReleaseNotesKey];
     if (shouldShowReleaseNotes == nil) {
         // Don't show release notes if RSS item contains no description and no release notes URL:
         return (([_updateItem itemDescription] != nil

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -80,7 +80,7 @@ static NSString *const SUUpdatePermissionPromptTouchBarIdentifier = @"" SPARKLE_
 
 - (BOOL)allowsAutomaticUpdates
 {
-    NSNumber *allowsAutomaticUpdates = [_host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey ofClass:NSNumber.class];
+    NSNumber *allowsAutomaticUpdates = [_host boolNumberForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
     return (allowsAutomaticUpdates == nil || allowsAutomaticUpdates.boolValue);
 }
 

--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -75,12 +75,12 @@ static NSString *const SUUpdatePermissionPromptTouchBarIdentifier = @"" SPARKLE_
 
 - (BOOL)shouldAskAboutProfile
 {
-    return [(NSNumber *)[_host objectForInfoDictionaryKey:SUEnableSystemProfilingKey] boolValue];
+    return [_host boolForInfoDictionaryKey:SUEnableSystemProfilingKey];
 }
 
 - (BOOL)allowsAutomaticUpdates
 {
-    NSNumber *allowsAutomaticUpdates = [_host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
+    NSNumber *allowsAutomaticUpdates = [_host objectForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey ofClass:NSNumber.class];
     return (allowsAutomaticUpdates == nil || allowsAutomaticUpdates.boolValue);
 }
 


### PR DESCRIPTION
Fixes #2770

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Validated info and user default keys are still read correctly.
Validated string keys for bool/double fields are still interpreted correctly (via UI tests).

macOS version tested: 26.0.1 (25A362)
