### PR TITLE
Remove unused connection validation options

### DIFF
--- a/Autoupdate/AgentConnection.m
+++ b/Autoupdate/AgentConnection.m
@@ -71,7 +71,7 @@
     
     // Hardening but not critical for security
     NSError *validationError = nil;
-    SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionDefault error:&validationError];
+    SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection error:&validationError];
     switch (validationStatus) {
         case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
             break;

--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -147,7 +147,7 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         if (!_performedStage1Installation) {
             BOOL passesValidation;
             NSError *validationError = nil;
-            SUValidateConnectionStatus status = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionDefault error:&validationError];
+            SUValidateConnectionStatus status = [SUCodeSigningVerifier validateConnection:newConnection error:&validationError];
             switch (status) {
                 case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                     passesValidation = YES;

--- a/Autoupdate/SUCodeSigningVerifier.h
+++ b/Autoupdate/SUCodeSigningVerifier.h
@@ -27,14 +27,6 @@ typedef NS_ENUM(NSUInteger, SUValidateConnectionStatus) {
     SUValidateConectionNoSupportedValidationMethodFailure,
 };
 
-typedef NS_OPTIONS(NSUInteger, SUValidateConnectionOptions) {
-    // Default validation behavior (matches against Team ID from main executable if available)
-    SUValidateConnectionOptionDefault = 0,
-    
-    // Require that the connecting client has the app sandbox entitlement
-    SUValidateConnectionOptionRequireSandboxEntitlement = 1 << 0,
-};
-
 SUCodeSigningVerifierDefinitionAttribute
 @interface SUCodeSigningVerifier : NSObject
 
@@ -52,7 +44,7 @@ SUCodeSigningVerifierDefinitionAttribute
 + (NSString * _Nullable)teamIdentifierAtURL:(NSURL *)url;
 + (NSString * _Nullable)teamIdentifierFromMainExecutable;
 
-+ (SUValidateConnectionStatus)validateConnection:(NSXPCConnection *)connection options:(SUValidateConnectionOptions)options error:(NSError * __autoreleasing *)error;
++ (SUValidateConnectionStatus)validateConnection:(NSXPCConnection *)connection error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/Autoupdate/SUCodeSigningVerifier.m
+++ b/Autoupdate/SUCodeSigningVerifier.m
@@ -443,30 +443,16 @@ finally:
     return (resultError == nil);
 }
 
-+ (SUValidateConnectionStatus)validateConnection:(NSXPCConnection *)connection options:(SUValidateConnectionOptions)options error:(NSError * __autoreleasing *)error
++ (SUValidateConnectionStatus)validateConnection:(NSXPCConnection *)connection error:(NSError * __autoreleasing *)error
 {
-    NSMutableArray<NSString *> *codeSigningRequirementComponents = [NSMutableArray array];
-    
-    // Build the default team ID signing requirement
+    // Check if code signing requirement is required
     NSString *hostTeamIdentifier = [self teamIdentifierFromMainExecutable];
-    if (hostTeamIdentifier != nil) {
-        NSString *teamIdentifierRequirement = [NSString stringWithFormat:@"(anchor apple generic and certificate leaf[subject.OU] = \"%@\")", hostTeamIdentifier];
-        [codeSigningRequirementComponents addObject:teamIdentifierRequirement];
-    }
-    
-    // Build the sandboxing requirement
-    if ((options & SUValidateConnectionOptionRequireSandboxEntitlement) != 0) {
-        // This ensures the entitlement is set to true too
-        NSString *sandboxingRequirement = @"(entitlement [\"com.apple.security.app-sandbox\"] exists)";
-        [codeSigningRequirementComponents addObject:sandboxingRequirement];
-    }
-    
-    // Check if no requirement is required
-    if (codeSigningRequirementComponents.count == 0) {
+    if (hostTeamIdentifier == nil) {
         return SUValidateConnectionStatusSetNoRequirementSuccess;
     }
     
-    NSString *codeSigningRequirement = [codeSigningRequirementComponents componentsJoinedByString:@" and "];
+    // Build the default team ID signing requirement
+    NSString *codeSigningRequirement = [NSString stringWithFormat:@"(anchor apple generic and certificate leaf[subject.OU] = \"%@\")", hostTeamIdentifier];
     
     if (@available(macOS 13.0, *)) {
         [connection setCodeSigningRequirement:codeSigningRequirement];

--- a/Downloader/main.m
+++ b/Downloader/main.m
@@ -26,7 +26,7 @@
     // This is a policy, not a security critical enforcement.
     {
         NSError *validationError = nil;
-        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options:SUValidateConnectionOptionDefault error:&validationError];
+        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection error:&validationError];
         switch (validationStatus) {
             case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                 break;

--- a/InstallerLauncher/main.m
+++ b/InstallerLauncher/main.m
@@ -23,7 +23,7 @@
     // This is a policy, not a security critical enforcement.
     {
         NSError *validationError = nil;
-        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection options: SUValidateConnectionOptionDefault error:&validationError];
+        SUValidateConnectionStatus validationStatus = [SUCodeSigningVerifier validateConnection:newConnection error:&validationError];
         switch (validationStatus) {
             case SUValidateConnectionStatusSetCodeSigningRequirementSuccess:
                 break;


### PR DESCRIPTION
Remove unused connection validation options

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested everything adhoc signed works
Tested everything apple code signed with same team id works
Tested XPC Services / Autoupdate apple code signed and Test App not code signed, and ensure it failed.

macOS version tested: 26.0.1 (25A362)
