### PR TITLE
Don't ignore dependency scan warning anymore in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           DEVELOPER_DIR: ${{ matrix.xcode-path }}
         run: |
-            if grep "warning:" analyze_output.txt | grep -q -v "dependency scan of"; then
+            if grep -q "warning:" analyze_output.txt; then
                 echo "analyzestatus=0" >> $GITHUB_OUTPUT
             else
                 echo "analyzestatus=1" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Don't ignore dependency scan warning anymore in CI since we have silenced this warning.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI
