### PR TITLE
Remove NSAppTransportSecurity from the Sparkle Test App

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -318,7 +318,7 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             
             if (foundATSPersistentIssue || foundATSMainBundleIssue) {
                 // Just log a warning. Don't outright fail in case we are wrong (eg: app is linked on an old SDK where ATS doesn't take effect)
-                SULog(SULogLevelDefault, @"The feed URL (%@) may need to change to use HTTPS.\nFor more information: https://sparkle-project.org/documentation/app-transport-security", [feedURL absoluteString]);
+                SULog(SULogLevelDefault, @"The feed URL (%@) may need to change to use HTTPS. If the feed URL is using local networking for testing, this warning may be incorrect and ignored however.\nFor more information: https://sparkle-project.org/documentation/app-transport-security", [feedURL absoluteString]);
                 
                 _loggedATSWarning = YES;
             }

--- a/TestApplication/TestApplication-Info.plist
+++ b/TestApplication/TestApplication-Info.plist
@@ -34,10 +34,5 @@
 	<string>eRFPLZuNM6m8bltmtpPX4fzKbufI1z6rKJHtgIIsllk=</string>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
NSAllowsLocalNetworking is enabled by default these days since 10.12.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Ran test app and worked with warning. Testing CI here.

macOS version tested: 26.0.1 (25A362)
