### PR TITLE
Add missing executable bit permission warnings

### DIFF
--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -186,9 +186,19 @@
             if (strongSelf != nil && strongSelf->_installerConnection != nil && !strongSelf->_aborted) {
                 NSString *impactedTools = usingInstallerService ? (@SPARKLE_RELAUNCH_TOOL_NAME" and "@INSTALLER_LAUNCHER_NAME) : @SPARKLE_RELAUNCH_TOOL_NAME;
                 
+                NSString *additionalFailureReason;
+                {
+                    NSString *executableFailureReason;
+                    if (!SPUHelperHasExecutablePermission(@SPARKLE_RELAUNCH_TOOL_NAME, &executableFailureReason) || !SPUHelperHasExecutablePermission(@SPARKLE_INSTALLER_PROGRESS_TOOL_NAME@".app/Contents/MacOS/Updater", &executableFailureReason)) {
+                        additionalFailureReason = executableFailureReason;
+                    } else {
+                        additionalFailureReason = [NSString stringWithFormat:@"If your application is sandboxed, please ensure Installer Connection & Status entitlements are correctly set up: https://sparkle-project.org/documentation/sandboxing/ . Otherwise if %@ %@ not adhoc signed, your app must be signed with a matching team ID", impactedTools, (usingInstallerService ? @"are" : @"is")];
+                    }
+                }
+                
                 NSDictionary *genericUserInfo = @{
                     NSLocalizedDescriptionKey: SULocalizedStringFromTableInBundle(@"An error occurred while running the updater. Please try again later.", SPARKLE_TABLE, SUSparkleBundle(), nil),
-                    NSLocalizedFailureReasonErrorKey:[NSString stringWithFormat:@"The remote port connection was invalidated from the updater. If your application is sandboxed, please ensure Installer Connection & Status entitlements are correctly set up: https://sparkle-project.org/documentation/sandboxing/ . Otherwise if %@ %@ not adhoc signed, your app must be signed with a matching team ID. For additional details, check Console logs for %@", impactedTools, (usingInstallerService ? @"are" : @"is"), impactedTools]
+                    NSLocalizedFailureReasonErrorKey:[NSString stringWithFormat:@"The remote port connection was invalidated from the updater. %@. For additional details, check Console logs for %@", additionalFailureReason, impactedTools]
                 };
                 
                 [strongSelf _reportInstallerError:strongSelf->_installerError genericErrorCode:SUInstallationError genericUserInfo:genericUserInfo];
@@ -412,9 +422,19 @@
 #endif
                 if (!retrievedLaunchStatus) {
 #pragma clang diagnostic pop
+                    NSString *additionalFailureReason;
+                    {
+                        NSString *executableFailureReason;
+                        if (!SPUXPCServiceHasExecutablePermission(@INSTALLER_LAUNCHER_NAME, &executableFailureReason)) {
+                            additionalFailureReason = [NSString stringWithFormat:@" %@", executableFailureReason];
+                        } else {
+                            additionalFailureReason = @"";
+                        }
+                    }
+                    
                     NSError *error =
                     [NSError errorWithDomain:SUSparkleErrorDomain code:SUInstallationError userInfo:@{ NSLocalizedDescriptionKey:SULocalizedStringFromTableInBundle(@"An error occurred while connecting to the installer. Please try again later.", SPARKLE_TABLE, SUSparkleBundle(), nil),
-                        NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"If your app is not sandboxed, please remove or disable %@ in your app's Info.plist. Otherwise please check Console logs for "@INSTALLER_LAUNCHER_NAME" and "@SPARKLE_RELAUNCH_TOOL_NAME" processes if there are additional details.", SUEnableInstallerLauncherServiceKey]}];
+                        NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"If your app is not sandboxed, please remove or disable %@ in your app's Info.plist. Please also check Console logs for "@INSTALLER_LAUNCHER_NAME" and "@SPARKLE_RELAUNCH_TOOL_NAME" processes if there are additional details.%@", SUEnableInstallerLauncherServiceKey, additionalFailureReason]}];
                     
                     completionHandler(error);
                     

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -189,7 +189,7 @@
                 NSString *additionalFailureReason;
                 {
                     NSString *executableFailureReason;
-                    if (!SPUHelperHasExecutablePermission(@SPARKLE_RELAUNCH_TOOL_NAME, &executableFailureReason) || !SPUHelperHasExecutablePermission(@SPARKLE_INSTALLER_PROGRESS_TOOL_NAME@".app/Contents/MacOS/Updater", &executableFailureReason)) {
+                    if (!SPUHelperHasExecutablePermission(@SPARKLE_RELAUNCH_TOOL_NAME, &executableFailureReason) || !SPUHelperHasExecutablePermission(@SPARKLE_INSTALLER_PROGRESS_TOOL_NAME@".app/Contents/MacOS/"@SPARKLE_INSTALLER_PROGRESS_TOOL_NAME, &executableFailureReason)) {
                         additionalFailureReason = executableFailureReason;
                     } else {
                         additionalFailureReason = [NSString stringWithFormat:@"If your application is sandboxed, please ensure Installer Connection & Status entitlements are correctly set up: https://sparkle-project.org/documentation/sandboxing/ . Otherwise if %@ %@ not adhoc signed, your app must be signed with a matching team ID", impactedTools, (usingInstallerService ? @"are" : @"is")];

--- a/Sparkle/SPUXPCServiceInfo.h
+++ b/Sparkle/SPUXPCServiceInfo.h
@@ -12,4 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 BOOL SPUXPCServiceIsEnabled(NSString *enabledKey);
 
+BOOL SPUHelperHasExecutablePermission(NSString *component, NSString * _Nullable __autoreleasing * _Nullable failureReason);
+
+BOOL SPUXPCServiceHasExecutablePermission(NSString *serviceName, NSString * _Nullable __autoreleasing * _Nullable failureReason);
+
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUXPCServiceInfo.m
+++ b/Sparkle/SPUXPCServiceInfo.m
@@ -20,3 +20,36 @@ BOOL SPUXPCServiceIsEnabled(NSString *enabledKey)
     
     return [mainBundleHost boolForInfoDictionaryKey:enabledKey];
 }
+
+BOOL SPUHelperHasExecutablePermission(NSString *component, NSString * _Nullable __autoreleasing * _Nullable failureReason)
+{
+    NSBundle *sparkleBundle = [NSBundle bundleWithIdentifier:SUBundleIdentifier];
+    NSURL *helperURL = [[sparkleBundle.bundleURL URLByAppendingPathComponent:component isDirectory:NO] URLByResolvingSymlinksInPath];
+    
+    NSNumber *isExecutableFile = nil;
+    NSError *getResourceError = nil;
+    if (![helperURL getResourceValue:&isExecutableFile forKey:NSURLIsExecutableKey error:&getResourceError]) {
+        if (failureReason != NULL) {
+            *failureReason = [NSString stringWithFormat:@"Failed to fetch info from file '%@' -- does this helper exist? %@", helperURL.path, getResourceError.localizedDescription];
+        }
+        
+        return NO;
+    }
+    
+    if (!isExecutableFile.boolValue) {
+        if (failureReason != NULL) {
+            *failureReason = [NSString stringWithFormat:@"The file '%@' is not considered an executable -- were the executable permissions lost during a bad file copy? Please ensure file permissions and symbolic links for Sparkle framework are preserved.", helperURL.path];
+        }
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
+BOOL SPUXPCServiceHasExecutablePermission(NSString *serviceName, NSString * _Nullable __autoreleasing * _Nullable failureReason)
+{
+    NSString *componentName = [NSString stringWithFormat:@"XPCServices/%@.xpc/Contents/MacOS/%@", serviceName, serviceName];
+    
+    return SPUHelperHasExecutablePermission(componentName, failureReason);
+}

--- a/Sparkle/SPUXPCServiceInfo.m
+++ b/Sparkle/SPUXPCServiceInfo.m
@@ -26,22 +26,30 @@ BOOL SPUHelperHasExecutablePermission(NSString *component, NSString * _Nullable 
     NSBundle *sparkleBundle = [NSBundle bundleWithIdentifier:SUBundleIdentifier];
     NSURL *helperURL = [[sparkleBundle.bundleURL URLByAppendingPathComponent:component isDirectory:NO] URLByResolvingSymlinksInPath];
     
-    NSNumber *isExecutableFile = nil;
-    NSError *getResourceError = nil;
-    if (![helperURL getResourceValue:&isExecutableFile forKey:NSURLIsExecutableKey error:&getResourceError]) {
+    NSString *helperPath = helperURL.path;
+    
+    NSError *attributesError = nil;
+    NSDictionary<NSFileAttributeKey, id> *attributes = [NSFileManager.defaultManager attributesOfItemAtPath:helperPath error:&attributesError];
+    
+    if (attributes == nil) {
         if (failureReason != NULL) {
-            *failureReason = [NSString stringWithFormat:@"Failed to fetch info from file '%@' -- does this helper exist? %@", helperURL.path, getResourceError.localizedDescription];
+            *failureReason = [NSString stringWithFormat:@"Failed to fetch info from file '%@' -- does this helper exist? %@", helperPath, attributesError.localizedDescription];
         }
         
         return NO;
     }
     
-    if (!isExecutableFile.boolValue) {
-        if (failureReason != NULL) {
-            *failureReason = [NSString stringWithFormat:@"The file '%@' is not considered an executable -- were the executable permissions lost during a bad file copy? Please ensure file permissions and symbolic links for Sparkle framework are preserved.", helperURL.path];
+    NSNumber *posixPermissions = attributes[NSFilePosixPermissions];
+    
+    if (posixPermissions != nil) {
+        mode_t mode = posixPermissions.unsignedShortValue;
+        if (((mode & S_IXUSR) == 0 || (mode & S_IXGRP) == 0 || (mode & S_IXOTH) == 0)) {
+            if (failureReason != NULL) {
+                *failureReason = [NSString stringWithFormat:@"The file '%@' may not have executable permissions -- were they lost during a bad file copy? Please ensure file permissions and symbolic links for Sparkle framework are preserved.", helperPath];
+            }
+            
+            return NO;
         }
-        
-        return NO;
     }
     
     return YES;


### PR DESCRIPTION
These warnings are logged after failing to connect to XPC and launchd helpers and indicate the helpers likely did not launch at all.

This error happens when developers incorrectly copy Sparkle framework not preserving executable permissions, and is sadly somewhat common.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested making Autoupdate, Updater, Installer, Downloader all missing executable bits (via chmod 0644 ..) and verified appropriate error is logged after failing to connect / timeout to helper.

macOS version tested: 26.0.1 (25A362)
