### PR TITLE
Enforce RunAtLoad and remove KeepAlive

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -86,8 +86,7 @@
         jobDictionary[@"Label"] = label;
         jobDictionary[@"ProgramArguments"] = arguments;
         jobDictionary[@"EnableTransactions"] = @NO;
-        jobDictionary[@"KeepAlive"] = @{@"SuccessfulExit" : @NO};
-        jobDictionary[@"RunAtLoad"] = @NO;
+        jobDictionary[@"RunAtLoad"] = @YES;
         jobDictionary[@"Nice"] = @0;
         jobDictionary[@"ProcessType"] = @"Interactive";
         jobDictionary[@"LaunchOnlyOnce"] = @YES;
@@ -284,7 +283,7 @@
             }
         }
         
-        NSDictionary *jobDictionary = @{@"Label" : label, @"ProgramArguments" : arguments, @"EnableTransactions" : @NO, @"KeepAlive" : @{@"SuccessfulExit" : @NO}, @"RunAtLoad" : @NO, @"Nice" : @0, @"ProcessType": @"Interactive", @"LaunchOnlyOnce": @YES, @"MachServices" : @{SPUInstallerServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES, SPUProgressAgentServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES}};
+        NSDictionary *jobDictionary = @{@"Label" : label, @"ProgramArguments" : arguments, @"EnableTransactions" : @NO, @"RunAtLoad" : @YES, @"Nice" : @0, @"ProcessType": @"Interactive", @"LaunchOnlyOnce": @YES, @"MachServices" : @{SPUInstallerServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES, SPUProgressAgentServiceNameForBundleIdentifier(hostBundleIdentifier) : @YES}};
         
         CFErrorRef submitError = NULL;
 #pragma clang diagnostic push


### PR DESCRIPTION
Overriding KeepAlive before actually implies RunAtLoad is true but we were setting RunAtLoad to false which is conflicting. In any case we don't want to restart the job if it crashes, and we want to run Updater when the job is loaded.

Regarding discussion https://github.com/sparkle-project/Sparkle/discussions/2794

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

* Tested updating app on several OS versions.
* Confirmed RunAtLoad is needed (without KeepAlive) otherwise Updater job won't start

macOS version tested: 26.0.1 (25A362)
macOS 12 VM
macOS 10.14 VM
