### PR TITLE
Wait after checking for updates for UI tests

### DIFF
--- a/UITests/SUTestApplicationTest.swift
+++ b/UITests/SUTestApplicationTest.swift
@@ -52,6 +52,9 @@ class SUTestApplicationTest: XCTestCase
         let checkForUpdatesMenuItem = menuBarsQuery.menuItems["Check for Updates…"]
         if checkForUpdatesMenuItem.isEnabled {
             checkForUpdatesMenuItem.click()
+            
+            // Give some time to wait for window to show up
+            sleep(5)
         } else {
             // We haven't checked for updates in a while so an automatic check was already done
             // in this case click the main menu again to deactivate it


### PR DESCRIPTION
I was seeing some issues with window not showing up in time for the UI tests for the last automatic update test. Maybe this will help.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Testing in CI
