### PR TITLE
Allow impatient update check interval to be configured

### DIFF
--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -520,14 +520,15 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
             [SPUProbeInstallStatus probeInstallerUpdateItemForHostBundleIdentifier:hostBundleIdentifier completion:^(SPUInstallationInfo * _Nullable installationInfo) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     NSTimeInterval regularCheckInterval = [self updateCheckInterval];
+                    NSTimeInterval impatientCheckInterval = [self->_updaterSettings impatientUpdateCheckInterval];
                     if (installationInfo == nil) {
                         // Proceed as normal if there's no resumable updates
                         completionHandler(regularCheckInterval);
                     } else {
                         if ([installationInfo.appcastItem isCriticalUpdate] || [installationInfo.appcastItem isInformationOnlyUpdate]) {
-                            completionHandler(MIN(regularCheckInterval, SUImpatientUpdateCheckInterval));
+                            completionHandler(MIN(regularCheckInterval, impatientCheckInterval));
                         } else {
-                            completionHandler(MAX(regularCheckInterval, SUImpatientUpdateCheckInterval));
+                            completionHandler(MAX(regularCheckInterval, impatientCheckInterval));
                         }
                     }
                 });

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -47,6 +47,17 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
 @property (nonatomic) NSTimeInterval updateCheckInterval;
 
 /**
+ * The impatient update check interval.
+ *
+ * If an update has already been downloaded automatically in the background, Sparkle may not notify users of the update immediately,
+ * and tries to install the update siliently on quit without notifying the user.
+ *
+ * Sparkle uses this long impatient update check interval to decide when to notify the user of the update if they haven't quit the app for a long time.
+ * By default this check interval is set to 1 week (in seconds).
+ */
+@property (nonatomic, readonly) NSTimeInterval impatientUpdateCheckInterval;
+
+/**
  * Indicates whether or not automatically downloading updates is allowed to be turned on by the user.
  * If this value is nil, the developer has not explicitly specified this option.
  */

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -53,7 +53,7 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  * and tries to install the update siliently on quit without notifying the user.
  *
  * Sparkle uses this long impatient update check interval to decide when to notify the user of the update if they haven't quit the app for a long time.
- * By default this check interval is set to 1 week (in seconds).
+ * By default this check interval is set to 604800 seconds (which is 1 week).
  */
 @property (nonatomic, readonly) NSTimeInterval impatientUpdateCheckInterval;
 

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -53,7 +53,7 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  * and tries to install the update siliently on quit without notifying the user.
  *
  * Sparkle uses this long impatient update check interval to decide when to notify the user of the update if they haven't quit the app for a long time.
- * By default this check interval is set to 604800 seconds (which is 1 week).
+ * By default this check interval is set to 604800 seconds (which is 1 week). This interval must be bigger than the `updateCheckInterval`.
  */
 @property (nonatomic, readonly) NSTimeInterval impatientUpdateCheckInterval;
 

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -15,6 +15,7 @@
 
 static NSString *SUAutomaticallyChecksForUpdatesKeyPath = @"automaticallyChecksForUpdates";
 static NSString *SUUpdateCheckIntervalKeyPath = @"updateCheckInterval";
+static NSString *SUImpatientUpdateCheckIntervalKeyPath = @"impatientUpdateCheckInterval";
 static NSString *SUAutomaticallyDownloadsUpdatesKeyPath = @"automaticallyDownloadsUpdates";
 static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 
@@ -25,6 +26,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 
 @synthesize automaticallyChecksForUpdates = _automaticallyChecksForUpdates;
 @synthesize updateCheckInterval = _updateCheckInterval;
+@synthesize impatientUpdateCheckInterval = _impatientUpdateCheckInterval;
 @synthesize automaticallyDownloadsUpdates = _automaticallyDownloadsUpdates;
 @synthesize sendsSystemProfile = _sendsSystemProfile;
 
@@ -36,6 +38,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
         
         _automaticallyChecksForUpdates = [self currentAutomaticallyChecksForUpdates];
         _updateCheckInterval = [self currentUpdateCheckInterval];
+        _impatientUpdateCheckInterval = [self currentImpatientUpdateCheckInterval];
         _automaticallyDownloadsUpdates = [self currentAutomaticallyDownloadsUpdates];
         _sendsSystemProfile = [self currentSendsSystemProfile];
         
@@ -97,6 +100,21 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     }
 }
 
+- (void)processImpatientUpdateCheckInterval SPU_OBJC_DIRECT
+{
+    NSTimeInterval currentValue = [self currentImpatientUpdateCheckInterval];
+    
+    if (fabs(currentValue - _impatientUpdateCheckInterval) >= 0.001) {
+        NSString *updatedKeyPath = SUImpatientUpdateCheckIntervalKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _impatientUpdateCheckInterval = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
+}
+
 - (void)processAutomaticallyDownloadsUpdates SPU_OBJC_DIRECT
 {
     BOOL currentValue = [self currentAutomaticallyDownloadsUpdates];
@@ -136,6 +154,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     
     [self processCurrentAutomaticallyChecksForUpdates];
     [self processUpdateCheckInterval];
+    [self processImpatientUpdateCheckInterval];
     [self processAutomaticallyDownloadsUpdates];
     [self processSendsSystemProfile];
 }
@@ -199,7 +218,22 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     }
 }
 
+- (NSTimeInterval)currentImpatientUpdateCheckInterval SPU_OBJC_DIRECT
+{
+    NSNumber *intervalValue = [_host doubleNumberForInfoDictionaryKey:SUScheduledImpatientCheckIntervalKey];
+    if (intervalValue == nil) {
+        return SUDefaultImpatientUpdateCheckInterval;
+    }
+    
+    return intervalValue.doubleValue;
+}
+
 + (BOOL)automaticallyNotifiesObserversOfUpdateCheckInterval
+{
+    return NO;
+}
+
++ (BOOL)automaticallyNotifiesObserversOfImpatientUpdateCheckInterval
 {
     return NO;
 }

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -20,7 +20,7 @@ extern const NSTimeInterval SUDefaultUpdatePermissionPromptInterval;
 extern const NSTimeInterval SUMinimumUpdateCheckInterval;
 extern const NSTimeInterval SUDefaultUpdateCheckInterval;
 extern const uint64_t SULeewayUpdateCheckInterval;
-extern const NSTimeInterval SUImpatientUpdateCheckInterval;
+extern const NSTimeInterval SUDefaultImpatientUpdateCheckInterval;
 
 extern NSString *const SUBundleIdentifier;
 
@@ -47,6 +47,7 @@ extern NSString *const SUSkippedMinorVersionKey;
 extern NSString *const SUSkippedMajorVersionKey;
 extern NSString *const SUSkippedMajorSubreleaseVersionKey;
 extern NSString *const SUScheduledCheckIntervalKey;
+extern NSString *const SUScheduledImpatientCheckIntervalKey;
 extern NSString *const SULastCheckTimeKey;
 extern NSString *const SUPublicDSAKeyKey;
 extern NSString *const SUPublicDSAKeyFileKey;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -22,9 +22,9 @@ const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);
 const uint64_t SULeewayUpdateCheckInterval = DEBUG ? 1 : 15;
 
 // If the update has already been automatically downloaded, we normally don't want to bug the user about the update
-// However if the user has gone a very long time without quitting an application, we will bug them
-// This is the time interval for a "week"; it doesn't matter that this measure is imprecise.
-const NSTimeInterval SUImpatientUpdateCheckInterval = DEBUG ? (60 * 2) : (60 * 60 * 24 * 7);
+// However if the user has gone a very long time without quitting an application, we will notify them
+// By default this is the time interval for a week
+const NSTimeInterval SUDefaultImpatientUpdateCheckInterval = DEBUG ? (60 * 2) : (60 * 60 * 24 * 7);
 
 NSString *const SUBundleIdentifier = @SPARKLE_BUNDLE_IDENTIFIER;
 
@@ -43,6 +43,7 @@ NSString *const SUSkippedMinorVersionKey = @"SUSkippedVersion";
 NSString *const SUSkippedMajorVersionKey = @"SUSkippedMajorVersion";
 NSString *const SUSkippedMajorSubreleaseVersionKey = @"SUSkippedMajorSubreleaseVersion";
 NSString *const SUScheduledCheckIntervalKey = @"SUScheduledCheckInterval";
+NSString *const SUScheduledImpatientCheckIntervalKey = @"SUScheduledImpatientCheckInterval";
 NSString *const SULastCheckTimeKey = @"SULastCheckTime";
 NSString *const SUPublicDSAKeyKey = @"SUPublicDSAKey";
 NSString *const SUPublicDSAKeyFileKey = @"SUPublicDSAKeyFile";


### PR DESCRIPTION
The impatient update check interval is used after an update has been downloaded/staged to be installed automatically in the background when the app has quit. By default this is 1 week (in seconds) but this change now allows it to be configured in the Info.plist (with the `SUScheduledImpatientCheckInterval` key).

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested default impatient update check interval and configuring it in debug build of Sparkle Test App.
Tested updating another bundle while keeping the updater alive and getting notified of change in this new key.

macOS version tested: 26.1 (25B78)
