### PR TITLE
Make Debug builds use same time interval settings as Release

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		723C8A561E2D60DB00C14942 /* SUTouchBarButtonGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 723C8A531E2D60DB00C14942 /* SUTouchBarButtonGroup.m */; };
 		723EDC3F26885A8E000BCBA4 /* testappcast_channels.xml in Resources */ = {isa = PBXBuildFile; fileRef = 723EDC3E26885A8E000BCBA4 /* testappcast_channels.xml */; };
 		7240852E2CA11C1400ED2FCD /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7240852D2CA11C1400ED2FCD /* libz.tbd */; };
+		7245495C2ECA648000ABA991 /* SPUUpdaterSettings+Debug.h in Headers */ = {isa = PBXBuildFile; fileRef = 7245495B2ECA648000ABA991 /* SPUUpdaterSettings+Debug.h */; };
 		72464F701E1F31E000FB341C /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		72464F7C1E2097F600FB341C /* SUOperatingSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 726F2CE41BC9C33D001971A4 /* SUOperatingSystem.m */; };
 		72464F7E1E21ED8C00FB341C /* SUHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 61EF67550E25B58D00F754E0 /* SUHost.m */; };
@@ -1139,6 +1140,7 @@
 		723DFF962B3DFF6E00628E6C /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		723EDC3E26885A8E000BCBA4 /* testappcast_channels.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = testappcast_channels.xml; sourceTree = "<group>"; };
 		7240852D2CA11C1400ED2FCD /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		7245495B2ECA648000ABA991 /* SPUUpdaterSettings+Debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SPUUpdaterSettings+Debug.h"; sourceTree = "<group>"; };
 		7246E0A11C83B685003B4E75 /* SPUStandardUpdaterController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUStandardUpdaterController.h; sourceTree = "<group>"; };
 		7246E0A21C83B685003B4E75 /* SPUStandardUpdaterController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUStandardUpdaterController.m; sourceTree = "<group>"; };
 		724BB36C1D31D0B7005D534A /* InstallerConnection.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = InstallerConnection.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2098,6 +2100,7 @@
 				72F9EC471D5EA7D3004AC8B6 /* SPUUpdaterDelegate.h */,
 				72EE181826DAE6E100C58B19 /* SPUUpdateCheck.h */,
 				726E078B1CA891E9001A286B /* SPUUpdaterSettings.h */,
+				7245495B2ECA648000ABA991 /* SPUUpdaterSettings+Debug.h */,
 				726E078C1CA891E9001A286B /* SPUUpdaterSettings.m */,
 				72F9EC3D1D5E823F004AC8B6 /* SPUUpdaterTimer.h */,
 				72F9EC3E1D5E823F004AC8B6 /* SPUUpdaterTimer.m */,
@@ -2482,6 +2485,7 @@
 				7229E1BD1C98EFF200CB50D0 /* SPUDownloadDriver.h in Headers */,
 				7267E5FD1D3DD1B700D1BF90 /* SPUResumableUpdate.h in Headers */,
 				7267E5B61D3D8AEE00D1BF90 /* SPUInstallationInfo.h in Headers */,
+				7245495C2ECA648000ABA991 /* SPUUpdaterSettings+Debug.h in Headers */,
 				72EE181926DAE70900C58B19 /* SPUUpdateCheck.h in Headers */,
 				72B767CE1C9B924900A07552 /* SPUInstallerDriver.h in Headers */,
 				723ABF30259D062F00BDB4FA /* SULegacyWebView.h in Headers */,

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -25,6 +25,9 @@
 #import "SPUStandardVersionDisplay.h"
 #import "SULog.h"
 #import "SPUNoUpdateFoundInfo.h"
+#import "SPUUpdaterSettings.h"
+#import "SPUUpdaterSettings+Debug.h"
+
 #include <time.h>
 #include <mach/mach_time.h>
 #import <IOKit/pwr_mgt/IOPMLib.h>
@@ -37,9 +40,6 @@
 - (void)activate;
 @end
 #endif
-
-// The amount of time the app is allowed to be idle for us to consider showing an update prompt right away when the app is active
-static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 30.0 : 5 * 60.0;
 
 @interface SPUStandardUserDriver () <SPUGentleUserDriverReminders>
 
@@ -65,6 +65,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     SUStatusController *_checkingController;
     
     SUUpdateAlert *_activeUpdateAlert;
+    SPUUpdaterSettings *_updaterSettings;
     
     SUStatusController *_statusController;
     SUUpdatePermissionPrompt *_permissionPrompt;
@@ -92,6 +93,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     self = [super init];
     if (self != nil) {
         _host = [[SUHost alloc] initWithBundle:hostBundle];
+        _updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:hostBundle];
         _oldHostName = _host.name;
         _oldHostBundleURL = hostBundle.bundleURL;
         _delegate = delegate;
@@ -218,7 +220,9 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
                 if (!appNearUpdaterInitialization && !backgroundApp) {
                     timeSinceLastEvent = CGEventSourceSecondsSinceLastEventType(kCGEventSourceStateHIDSystemState, kCGAnyInputEventType);
                     
-                    if (timeSinceLastEvent >= SUScheduledUpdateIdleEventLeewayInterval) {
+                    NSTimeInterval scheduledUpdateIdleEventLeewayInterval = _updaterSettings.standardUIScheduledUpdateIdleEventLeewayInterval;
+                    
+                    if (timeSinceLastEvent >= scheduledUpdateIdleEventLeewayInterval) {
                         // Make sure there's no active power management assertions preventing
                         // the display from sleeping by the current application.
                         // If there is, then the app may still actively be in use
@@ -367,7 +371,7 @@ static const NSTimeInterval SUScheduledUpdateIdleEventLeewayInterval = DEBUG ? 3
     
     __weak __typeof__(self) weakSelf = self;
     __weak id<SPUStandardUserDriverDelegate> weakDelegate = delegate;
-    _activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:_host versionDisplayer:versionDisplayer completionBlock:^(SPUUserUpdateChoice choice, NSRect windowFrame, BOOL wasKeyWindow) {
+    _activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:_host versionDisplayer:versionDisplayer updaterSettings:_updaterSettings completionBlock:^(SPUUserUpdateChoice choice, NSRect windowFrame, BOOL wasKeyWindow) {
         reply(choice);
         
         __typeof__(self) strongSelf = weakSelf;

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -9,6 +9,7 @@
 #import "SPUUpdater.h"
 #import "SPUUpdaterDelegate.h"
 #import "SPUUpdaterSettings.h"
+#import "SPUUpdaterSettings+Debug.h"
 #import "SUHost.h"
 #import "SPUUpdatePermissionRequest.h"
 #import "SUUpdatePermissionResponse.h"
@@ -84,18 +85,6 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
 @synthesize httpHeaders = _httpHeaders;
 @synthesize sessionInProgress = _sessionInProgress;
 @synthesize canCheckForUpdates = _canCheckForUpdates;
-
-#if DEBUG
-+ (void)initialize
-{
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        // We're using NSLog instead of SULog here because we don't want to start Sparkle's logger here,
-        // and because this is not really an error, just a warning notice
-        NSLog(@"WARNING: This is running a Debug build of Sparkle 2; don't use this in production!");
-    });
-}
-#endif
 
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle applicationBundle:(NSBundle *)applicationBundle userDriver:(id <SPUUserDriver>)userDriver delegate:(id<SPUUpdaterDelegate> _Nullable)delegate
 {
@@ -561,9 +550,11 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                 intervalSinceCheck = 0;
             }
             
+            NSTimeInterval minimumUpdateCheckInterval = self->_updaterSettings.minimumUpdateCheckInterval;
+            
             // Now we want to figure out how long until we check again.
-            if (updateCheckInterval < SUMinimumUpdateCheckInterval)
-                updateCheckInterval = SUMinimumUpdateCheckInterval;
+            if (updateCheckInterval < minimumUpdateCheckInterval)
+                updateCheckInterval = minimumUpdateCheckInterval;
             if (intervalSinceCheck < updateCheckInterval) {
                 NSTimeInterval delayUntilCheck = (updateCheckInterval - intervalSinceCheck); // It hasn't been long enough.
                 if ([delegate respondsToSelector:@selector(updater:willScheduleUpdateCheckAfterDelay:)]) {
@@ -574,7 +565,9 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
                     [(id<SPUGentleUserDriverReminders>)self->_userDriver logGentleScheduledUpdateReminderWarningIfNeeded];
                 }
                 
-                [self->_updaterTimer startAndFireAfterDelay:delayUntilCheck];
+                uint64_t leewayUpdateCheckInterval = self->_updaterSettings.leewayUpdateCheckInterval;
+                
+                [self->_updaterTimer startAndFireAfterDelay:delayUntilCheck leewayUpdateCheckInterval:leewayUpdateCheckInterval];
             } else {
                 // We're overdue! Run one now.
                 [self _checkForUpdatesInBackground];

--- a/Sparkle/SPUUpdaterSettings+Debug.h
+++ b/Sparkle/SPUUpdaterSettings+Debug.h
@@ -1,0 +1,33 @@
+//
+//  SPUUpdaterSettings+Debug.h
+//  Sparkle
+//
+//  Created on 11/16/25.
+//  Copyright © 2025 Sparkle Project. All rights reserved.
+//
+
+#import "SPUUpdaterSettings.h"
+
+/**
+ * Private settings which may be debug gated for the Sparkle Test App under DEBUG
+ */
+@interface SPUUpdaterSettings (Debug)
+
+/**
+ * The minimum update check interval
+ */
+@property (nonatomic, readonly) NSTimeInterval minimumUpdateCheckInterval;
+
+/**
+ * The amount of time the system can defer our update check (for improved performance)
+ */
+@property (nonatomic, readonly) uint64_t leewayUpdateCheckInterval;
+
+/**
+ * The amount of time the app is allowed to be idle for us to consider showing an update prompt right away when the app is active.
+ *
+ * This is for the standard user driver.
+ */
+@property (nonatomic, readonly) NSTimeInterval standardUIScheduledUpdateIdleEventLeewayInterval;
+
+@end

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 SU_EXPORT @interface SPUUpdaterSettings : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle;
 
 /**

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -7,6 +7,7 @@
 //
 
 #import "SPUUpdaterSettings.h"
+#import "SPUUpdaterSettings+Debug.h"
 #import "SUHost.h"
 #import "SUConstants.h"
 
@@ -22,6 +23,10 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 @implementation SPUUpdaterSettings
 {
     SUHost *_host;
+    
+#if DEBUG
+    BOOL _enableDebugUpdateCheckIntervals;
+#endif
 }
 
 @synthesize automaticallyChecksForUpdates = _automaticallyChecksForUpdates;
@@ -35,6 +40,12 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     self = [super init];
     if (self != nil) {
         _host = [[SUHost alloc] initWithBundle:hostBundle];
+        
+#if DEBUG
+        // This one must be checked first, before checking the other settings,
+        // since the others may rely on this
+        _enableDebugUpdateCheckIntervals = [self currentEnableDebugUpdateCheckIntervals];
+#endif
         
         _automaticallyChecksForUpdates = [self currentAutomaticallyChecksForUpdates];
         _updateCheckInterval = [self currentUpdateCheckInterval];
@@ -152,6 +163,12 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
         return;
     }
     
+#if DEBUG
+    // This one must be checked first, before checking the other settings,
+    // since the others may rely on this
+    _enableDebugUpdateCheckIntervals = [self currentEnableDebugUpdateCheckIntervals];
+#endif
+    
     [self processCurrentAutomaticallyChecksForUpdates];
     [self processUpdateCheckInterval];
     [self processImpatientUpdateCheckInterval];
@@ -180,7 +197,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     // Hack to support backwards compatibility with older Sparkle versions, which supported
     // disabling updates by setting the check interval to 0.
     if (automaticallyCheckForUpdates && (NSInteger)[self currentUpdateCheckInterval] == 0) {
-        [self setUpdateCheckInterval:SUDefaultUpdateCheckInterval];
+        [self setUpdateCheckInterval:[self defaultUpdateCheckInterval]];
     } else {
         [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateAutomaticCheckSettingChangedNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: _host.bundlePath}];
     }
@@ -196,7 +213,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     // Find the stored check interval. User defaults override Info.plist.
     NSNumber *intervalValue = [_host doubleNumberForKey:SUScheduledCheckIntervalKey];
     if (intervalValue == nil) {
-        return SUDefaultUpdateCheckInterval;
+        return [self defaultUpdateCheckInterval];
     }
     
     return intervalValue.doubleValue;
@@ -222,7 +239,7 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 {
     NSNumber *intervalValue = [_host doubleNumberForInfoDictionaryKey:SUScheduledImpatientCheckIntervalKey];
     if (intervalValue == nil) {
-        return SUDefaultImpatientUpdateCheckInterval;
+        return [self defaultImpatientUpdateCheckInterval];
     }
     
     return intervalValue.doubleValue;
@@ -293,6 +310,81 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 + (BOOL)automaticallyNotifiesObserversOfSendsSystemProfile
 {
     return NO;
+}
+
+#if DEBUG
+// This is only used in DEBUG and is meant for the Sparkle Test App
+- (BOOL)currentEnableDebugUpdateCheckIntervals
+{
+    return [_host boolForInfoDictionaryKey:@"_SUEnableDebugUpdateCheckIntervals"];
+}
+#endif
+
+- (NSTimeInterval)minimumUpdateCheckInterval
+{
+#if DEBUG
+    if (_enableDebugUpdateCheckIntervals) {
+        // 1 minute
+        return 60;
+    }
+#endif
+    
+    // 1 hour
+    return (60 * 60);
+}
+
+- (uint64_t)leewayUpdateCheckInterval
+{
+#if DEBUG
+    if (_enableDebugUpdateCheckIntervals) {
+        // 1 second
+        return 1;
+    }
+#endif
+    
+    // 15 seconds
+    return 15;
+}
+
+- (NSTimeInterval)defaultUpdateCheckInterval SPU_OBJC_DIRECT
+{
+#if DEBUG
+    if (_enableDebugUpdateCheckIntervals) {
+        // 1 minute
+        return 60;
+    }
+#endif
+    
+    // 1 day
+    return (60 * 60 * 24);
+}
+
+// If the update has already been automatically downloaded, we normally don't want to bug the user about the update
+// However if the user has gone a very long time without quitting an application, we will notify them
+- (NSTimeInterval)defaultImpatientUpdateCheckInterval SPU_OBJC_DIRECT
+{
+#if DEBUG
+    if (_enableDebugUpdateCheckIntervals) {
+        // 2 minutes
+        return (60 * 2);
+    }
+#endif
+    
+    // 1 week
+    return (60 * 60 * 24 * 7);
+}
+
+- (NSTimeInterval)standardUIScheduledUpdateIdleEventLeewayInterval
+{
+#if DEBUG
+    if (_enableDebugUpdateCheckIntervals) {
+        // 30 seconds
+        return 30.0;
+    }
+#endif
+    
+    // 5 minutes
+    return (5 * 60.0);
 }
 
 @end

--- a/Sparkle/SPUUpdaterTimer.h
+++ b/Sparkle/SPUUpdaterTimer.h
@@ -22,7 +22,7 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPUUpdaterTimer : NSObject
 
 - (instancetype)initWithDelegate:(id<SPUUpdaterTimerDelegate>)delegate;
 
-- (void)startAndFireAfterDelay:(NSTimeInterval)delay;
+- (void)startAndFireAfterDelay:(NSTimeInterval)delay leewayUpdateCheckInterval:(uint64_t)leewayUpdateCheckInterval;
 
 - (void)invalidate;
 

--- a/Sparkle/SPUUpdaterTimer.m
+++ b/Sparkle/SPUUpdaterTimer.m
@@ -28,14 +28,14 @@
     return self;
 }
 
-- (void)startAndFireAfterDelay:(NSTimeInterval)delay
+- (void)startAndFireAfterDelay:(NSTimeInterval)delay leewayUpdateCheckInterval:(uint64_t)leewayUpdateCheckInterval
 {
     _source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
     
     // We use the wall time instead of cpu time for our dispatch timer
     // So eg if the computer sleeps we want to include that time spent in our timer
     dispatch_time_t timeToFire = dispatch_walltime(NULL, (int64_t)(delay * NSEC_PER_SEC));
-    dispatch_source_set_timer(_source, timeToFire, DISPATCH_TIME_FOREVER, SULeewayUpdateCheckInterval * NSEC_PER_SEC);
+    dispatch_source_set_timer(_source, timeToFire, DISPATCH_TIME_FOREVER, leewayUpdateCheckInterval * NSEC_PER_SEC);
     
     __weak __typeof__(self) weakSelf = self;
     dispatch_source_set_event_handler(_source, ^{

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -16,12 +16,6 @@
 //	Misc:
 // -----------------------------------------------------------------------------
 
-extern const NSTimeInterval SUDefaultUpdatePermissionPromptInterval;
-extern const NSTimeInterval SUMinimumUpdateCheckInterval;
-extern const NSTimeInterval SUDefaultUpdateCheckInterval;
-extern const uint64_t SULeewayUpdateCheckInterval;
-extern const NSTimeInterval SUDefaultImpatientUpdateCheckInterval;
-
 extern NSString *const SUBundleIdentifier;
 
 extern NSString *const SUAppcastAttributeValueMacOS;
@@ -30,7 +24,6 @@ extern NSString *const SUAppcastAttributeValueMacOS;
 //	Notifications:
 // -----------------------------------------------------------------------------
 
-extern NSString *const SUTechnicalErrorInformationKey;
 extern NSString *const SUUpdateAutomaticCheckSettingChangedNotification;
 extern NSString *const SUUpdateSettingsNeedsSynchronizationNotification;
 extern NSString *const SUUpdateBundlePathUserInfoKey;
@@ -68,11 +61,6 @@ extern NSString *const SUPromptUserOnFirstLaunchKey;
 extern NSString *const SUDefaultsDomainKey;
 extern NSString *const SUEnableJavaScriptKey;
 extern NSString *const SUAllowedURLSchemesKey;
-extern NSString *const SUFixedHTMLDisplaySizeKey __attribute__((deprecated("This key is obsolete and has no effect.")));
-extern NSString *const SUAppendVersionNumberKey __attribute__((deprecated("This key is obsolete. See SPARKLE_APPEND_VERSION_NUMBER.")));
-extern NSString *const SUEnableAutomatedDowngradesKey __attribute__((deprecated("This key is obsolete. See SPARKLE_AUTOMATED_DOWNGRADES.")));
-extern NSString *const SUNormalizeInstalledApplicationNameKey __attribute__((deprecated("This key is obsolete. SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME.")));
-extern NSString *const SURelaunchToolNameKey __attribute__((deprecated("This key is obsolete. SPARKLE_RELAUNCH_TOOL_NAME.")));
 
 // -----------------------------------------------------------------------------
 //	Appcast keys::

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -9,28 +9,12 @@
 #import "SUConstants.h"
 #import "SUErrors.h"
 
-#ifndef DEBUG
-#define DEBUG 0
-#endif
-
 #include "AppKitPrevention.h"
-
-// Define some minimum intervals to avoid DoS-like checking attacks
-const NSTimeInterval SUMinimumUpdateCheckInterval = DEBUG ? 60 : (60 * 60);
-const NSTimeInterval SUDefaultUpdateCheckInterval = DEBUG ? 60 : (60 * 60 * 24);
-// The amount of time the system can defer our update check (for improved performance)
-const uint64_t SULeewayUpdateCheckInterval = DEBUG ? 1 : 15;
-
-// If the update has already been automatically downloaded, we normally don't want to bug the user about the update
-// However if the user has gone a very long time without quitting an application, we will notify them
-// By default this is the time interval for a week
-const NSTimeInterval SUDefaultImpatientUpdateCheckInterval = DEBUG ? (60 * 2) : (60 * 60 * 24 * 7);
 
 NSString *const SUBundleIdentifier = @SPARKLE_BUNDLE_IDENTIFIER;
 
 NSString *const SUAppcastAttributeValueMacOS = @"macos";
 
-NSString *const SUTechnicalErrorInformationKey = @"SUTechnicalErrorInformation";
 NSString *const SUUpdateAutomaticCheckSettingChangedNotification = @"SUUpdateAutomaticCheckSettingChanged";
 NSString *const SUUpdateSettingsNeedsSynchronizationNotification = @"SUUpdateSettingsNeedsSynchronization";
 NSString *const SUUpdateBundlePathUserInfoKey = @"SUBundlePath";
@@ -63,17 +47,11 @@ NSString *const SULastProfileSubmitDateKey = @"SULastProfileSubmissionDate";
 NSString *const SUPromptUserOnFirstLaunchKey = @"SUPromptUserOnFirstLaunch";
 NSString *const SUEnableJavaScriptKey = @"SUEnableJavaScript";
 NSString *const SUAllowedURLSchemesKey = @"SUAllowedURLSchemes";
-NSString *const SUFixedHTMLDisplaySizeKey = @"SUFixedHTMLDisplaySize";
 NSString *const SUDefaultsDomainKey = @"SUDefaultsDomain";
 NSString *const SUSparkleErrorDomain = @"SUSparkleErrorDomain";
 NSString *const SPUNoUpdateFoundReasonKey = @"SUNoUpdateFoundReason";
 NSString *const SPUNoUpdateFoundUserInitiatedKey = @"SPUNoUpdateUserInitiated";
 NSString *const SPULatestAppcastItemFoundKey = @"SULatestAppcastItemFound";
-
-NSString *const SUAppendVersionNumberKey = @"SUAppendVersionNumber";
-NSString *const SUEnableAutomatedDowngradesKey = @"SUEnableAutomatedDowngrades";
-NSString *const SUNormalizeInstalledApplicationNameKey = @"SUNormalizeInstalledApplicationName";
-NSString *const SURelaunchToolNameKey = @"SURelaunchToolName";
 
 NSString *const SUAppcastAttributeDeltaFrom = @"sparkle:deltaFrom";
 NSString *const SUAppcastAttributeDeltaFromSparkleExecutableSize = @"sparkle:deltaFromSparkleExecutableSize";

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -17,10 +17,10 @@
 
 @protocol SUUpdateAlertDelegate;
 
-@class SUAppcastItem, SPUDownloadData, SUHost;
+@class SUAppcastItem, SPUDownloadData, SUHost, SPUUpdaterSettings;
 SPU_OBJC_DIRECT_MEMBERS @interface SUUpdateAlert : NSWindowController
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer updaterSettings:(SPUUpdaterSettings *)updaterSettings completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData;
 - (void)showReleaseNotesFailedToDownload;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -64,7 +64,7 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
     BOOL _windowLoadedAndShowsReleaseNotes;
 }
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer updaterSettings:(SPUUpdaterSettings *)updaterSettings completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
 {
     self = [super initWithWindowNibName:@"SUUpdateAlert"];
     if (self != nil) {
@@ -76,7 +76,7 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
         _completionBlock = [completionBlock copy];
         _didBecomeKeyBlock = [didBecomeKeyBlock copy];
         
-        _updaterSettings = [[SPUUpdaterSettings alloc] initWithHostBundle:aHost.bundle];
+        _updaterSettings = updaterSettings;
         
         BOOL allowsAutomaticUpdates;
         NSNumber *allowsAutomaticUpdatesOption = _updaterSettings.allowsAutomaticUpdatesOption;

--- a/TestApplication/TestApplication-Info.plist
+++ b/TestApplication/TestApplication-Info.plist
@@ -34,5 +34,7 @@
 	<string>eRFPLZuNM6m8bltmtpPX4fzKbufI1z6rKJHtgIIsllk=</string>
 	<key>SUEnableInstallerLauncherService</key>
 	<true/>
+	<key>_SUEnableDebugUpdateCheckIntervals</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The Sparkle Test App will opt into a private setting that changes some of the default and minimum values for DEBUG builds.

This also removes the `WARNING: This is running a Debug build of Sparkle 2; don't use this in production!` log in DEBUG builds, and removes some unused constants internal to Sparkle.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app and update check intervals with the private key option specified and with it not specified in Info.plist.
Confirmed release builds use production settings even with private key option.

macOS version tested: 26.1 (25B78)
