### PR TITLE
Add allowsAutomaticUpdates property

### DIFF
--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -252,6 +252,18 @@ SU_EXPORT @interface SPUUpdater : NSObject
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
 
 /**
+ A property indicating whether or not the *option* to automatically download updates in the background can be turned on.
+ 
+ This property can be used to determine whether an option to automatically download/install updates should be enabled.
+ 
+ Its value depends  on `automaticallyChecksForUpdates`, or the `SUAllowsAutomaticUpdates`in the host bundle's Info.plist if specified.
+ Don't set `SUAllowsAutomaticUpdates` in the Info.plist unless you need custom behavior.
+ 
+ This property is KVO compliant. This property must be called on the main thread.
+ */
+@property (nonatomic, readonly) BOOL allowsAutomaticUpdates;
+
+/**
  The URL of the appcast used to download update information.
  
  If the updater's delegate implements `-[SPUUpdaterDelegate feedURLStringForUpdater:]`, this will return that feed URL.

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -1056,6 +1056,25 @@ NSString *const SUUpdaterAppcastNotificationKey = @"SUUpdaterAppCastNotification
     return NO;
 }
 
+- (BOOL)allowsAutomaticUpdates
+{
+    if (![NSThread isMainThread]) {
+        SULog(SULogLevelError, @"Error: -[SPUUpdater allowsAutomaticUpdates] must be called on the main thread.");
+    }
+    
+    return [_updaterSettings allowsAutomaticUpdates];
+}
+
++ (NSSet<NSString *> *)keyPathsForValuesAffectingAllowsAutomaticUpdates
+{
+    return [NSSet setWithObject:@"updaterSettings.allowsAutomaticUpdates"];
+}
+
++ (BOOL)automaticallyNotifiesObserversOfAllowsAutomaticUpdates
+{
+    return NO;
+}
+
 - (void)setFeedURL:(NSURL * _Nullable)feedURL
 {
     if (![NSThread isMainThread]) {

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -49,24 +49,11 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
 @property (nonatomic) NSTimeInterval updateCheckInterval;
 
 /**
- * The impatient update check interval.
- *
- * If an update has already been downloaded automatically in the background, Sparkle may not notify users of the update immediately,
- * and tries to install the update siliently on quit without notifying the user.
- *
- * Sparkle uses this long impatient update check interval to decide when to notify the user of the update if they haven't quit the app for a long time.
- * By default this check interval is set to 604800 seconds (which is 1 week). This interval must be bigger than the `updateCheckInterval`.
- */
-@property (nonatomic, readonly) NSTimeInterval impatientUpdateCheckInterval;
-
-/**
  * Indicates whether or not automatically downloading updates is allowed to be turned on by the user.
- * If this value is nil, the developer has not explicitly specified this option.
- */
-@property (readonly, nonatomic, nullable) NSNumber *allowsAutomaticUpdatesOption;
-
-/**
- * Indicates whether or not automatically downloading updates is allowed to be turned on by the user.
+ *
+ * This property is determined by checking `automaticallyChecksForUpdates` and `allowsAutomaticUpdatesOption`.
+ *
+ * This property is KVO compliant. This property must be called on the main thread.
  */
 @property (readonly, nonatomic) BOOL allowsAutomaticUpdates;
 
@@ -79,6 +66,25 @@ SU_EXPORT @interface SPUUpdaterSettings : NSObject
  * This property is KVO compliant. This property must be called on the main thread.
  */
 @property (nonatomic) BOOL automaticallyDownloadsUpdates;
+
+/**
+ * Indicates whether or not the developer allows turning on updates being automatically downloaded and installed.
+ * If this value is nil, the developer has not explicitly specified this option (which is the default).
+ *
+ * Please prefer to use `allowsAutomaticUpdates` instead.
+ */
+@property (readonly, nonatomic, nullable) NSNumber *allowsAutomaticUpdatesOption;
+
+/**
+ * The impatient update check interval.
+ *
+ * If an update has already been downloaded automatically in the background, Sparkle may not notify users of the update immediately,
+ * and tries to install the update siliently on quit without notifying the user.
+ *
+ * Sparkle uses this long impatient update check interval to decide when to notify the user of the update if they haven't quit the app for a long time.
+ * By default this check interval is set to 604800 seconds (which is 1 week). This interval must be bigger than the `updateCheckInterval`.
+ */
+@property (nonatomic, readonly) NSTimeInterval impatientUpdateCheckInterval;
 
 /**
  * Indicates whether or not anonymous system profile information is sent when checking for updates.

--- a/Sparkle/SPUUpdaterSettings.m
+++ b/Sparkle/SPUUpdaterSettings.m
@@ -19,6 +19,8 @@ static NSString *SUUpdateCheckIntervalKeyPath = @"updateCheckInterval";
 static NSString *SUImpatientUpdateCheckIntervalKeyPath = @"impatientUpdateCheckInterval";
 static NSString *SUAutomaticallyDownloadsUpdatesKeyPath = @"automaticallyDownloadsUpdates";
 static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
+static NSString *SUAllowsAutomaticUpdatesOptionKeyPath = @"allowsAutomaticUpdatesOption";
+static NSString *SUAllowsAutomaticUpdatesKeyPath = @"allowsAutomaticUpdates";
 
 @implementation SPUUpdaterSettings
 {
@@ -34,6 +36,8 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
 @synthesize impatientUpdateCheckInterval = _impatientUpdateCheckInterval;
 @synthesize automaticallyDownloadsUpdates = _automaticallyDownloadsUpdates;
 @synthesize sendsSystemProfile = _sendsSystemProfile;
+@synthesize allowsAutomaticUpdatesOption = _allowsAutomaticUpdatesOption;
+@synthesize allowsAutomaticUpdates = _allowsAutomaticUpdates;
 
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle
 {
@@ -50,6 +54,8 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
         _automaticallyChecksForUpdates = [self currentAutomaticallyChecksForUpdates];
         _updateCheckInterval = [self currentUpdateCheckInterval];
         _impatientUpdateCheckInterval = [self currentImpatientUpdateCheckInterval];
+        _allowsAutomaticUpdatesOption = [self currentAllowsAutomaticUpdatesOption];
+        _allowsAutomaticUpdates = [self currentAllowsAutomaticUpdates];
         _automaticallyDownloadsUpdates = [self currentAutomaticallyDownloadsUpdates];
         _sendsSystemProfile = [self currentSendsSystemProfile];
         
@@ -93,6 +99,9 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
         _automaticallyChecksForUpdates = currentValue;
         
         [self didChangeValueForKey:updatedKeyPath];
+        
+        [self processAllowsAutomaticUpdates];
+        [self processAutomaticallyDownloadsUpdates];
     }
 }
 
@@ -121,6 +130,36 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
         [self willChangeValueForKey:updatedKeyPath];
         
         _impatientUpdateCheckInterval = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
+}
+
+- (void)processAllowsAutomaticUpdatesOption SPU_OBJC_DIRECT
+{
+    NSNumber *currentValue = [self currentAllowsAutomaticUpdatesOption];
+    
+    if (((currentValue != nil) != (_allowsAutomaticUpdatesOption != nil)) || (currentValue.boolValue != _allowsAutomaticUpdatesOption.boolValue)) {
+        NSString *updatedKeyPath = SUAllowsAutomaticUpdatesOptionKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _allowsAutomaticUpdatesOption = currentValue;
+        
+        [self didChangeValueForKey:updatedKeyPath];
+    }
+}
+
+- (void)processAllowsAutomaticUpdates SPU_OBJC_DIRECT
+{
+    BOOL currentValue = [self currentAllowsAutomaticUpdates];
+    
+    if (currentValue != _allowsAutomaticUpdates) {
+        NSString *updatedKeyPath = SUAllowsAutomaticUpdatesKeyPath;
+        
+        [self willChangeValueForKey:updatedKeyPath];
+        
+        _allowsAutomaticUpdates = currentValue;
         
         [self didChangeValueForKey:updatedKeyPath];
     }
@@ -172,6 +211,8 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     [self processCurrentAutomaticallyChecksForUpdates];
     [self processUpdateCheckInterval];
     [self processImpatientUpdateCheckInterval];
+    [self processAllowsAutomaticUpdatesOption];
+    [self processAllowsAutomaticUpdates];
     [self processAutomaticallyDownloadsUpdates];
     [self processSendsSystemProfile];
 }
@@ -201,6 +242,9 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     } else {
         [NSNotificationCenter.defaultCenter postNotificationName:SUUpdateAutomaticCheckSettingChangedNotification object:nil userInfo:@{SUUpdateBundlePathUserInfoKey: _host.bundlePath}];
     }
+    
+    [self processAllowsAutomaticUpdates];
+    [self processAutomaticallyDownloadsUpdates];
 }
 
 + (BOOL)automaticallyNotifiesObserversOfAutomaticallyChecksForUpdates
@@ -255,22 +299,32 @@ static NSString *SUSendsSystemProfileKeyPath = @"sendsSystemProfile";
     return NO;
 }
 
-// For allowing automatic downloaded updates to be turned on or off
-- (NSNumber * _Nullable)allowsAutomaticUpdatesOption
+- (NSNumber * _Nullable)currentAllowsAutomaticUpdatesOption SPU_OBJC_DIRECT
 {
     NSNumber *developerAllowsAutomaticUpdates = [_host boolNumberForInfoDictionaryKey:SUAllowsAutomaticUpdatesKey];
     return developerAllowsAutomaticUpdates;
 }
 
-- (BOOL)allowsAutomaticUpdates
++ (BOOL)automaticallyNotifiesObserversOfAllowsAutomaticUpdatesOption
 {
-    NSNumber *developerAllowsAutomaticUpdates = [self allowsAutomaticUpdatesOption];
-    return (developerAllowsAutomaticUpdates == nil || developerAllowsAutomaticUpdates.boolValue);
+    return NO;
 }
 
+// This depends on currentAllowsAutomaticUpdatesOption and currentAutomaticallyChecksForUpdates and must be processed afterwards
+- (BOOL)currentAllowsAutomaticUpdates
+{
+    return (_allowsAutomaticUpdatesOption == nil) ? _automaticallyChecksForUpdates : _allowsAutomaticUpdatesOption.boolValue;
+}
+
++ (BOOL)automaticallyNotifiesObserversOfAllowsAutomaticUpdates
+{
+    return NO;
+}
+
+// This depends on currentAllowsAutomaticUpdates and must be processed afterwards
 - (BOOL)currentAutomaticallyDownloadsUpdates SPU_OBJC_DIRECT
 {
-    return [self allowsAutomaticUpdates] && [_host boolForKey:SUAutomaticallyUpdateKey];
+    return _allowsAutomaticUpdates && [_host boolForKey:SUAutomaticallyUpdateKey];
 }
 
 - (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyDownloadsUpdates

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -32,6 +32,7 @@
 #import "SPUUserUpdateState.h"
 
 static NSString *const SUUpdateAlertTouchBarIdentifier = @"" SPARKLE_BUNDLE_IDENTIFIER ".SUUpdateAlert";
+static NSString *const SUAllowsAutomaticUpdatesKeyPath = @"allowsAutomaticUpdates";
 
 static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
 
@@ -60,7 +61,6 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
     void (^_didBecomeKeyBlock)(void);
     void(^_completionBlock)(SPUUserUpdateChoice, NSRect, BOOL);
     
-    BOOL _allowsAutomaticUpdates;
     BOOL _windowLoadedAndShowsReleaseNotes;
 }
 
@@ -78,22 +78,18 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
         
         _updaterSettings = updaterSettings;
         
-        BOOL allowsAutomaticUpdates;
-        NSNumber *allowsAutomaticUpdatesOption = _updaterSettings.allowsAutomaticUpdatesOption;
-        if (item.informationOnlyUpdate) {
-            allowsAutomaticUpdates = NO;
-        } else if (allowsAutomaticUpdatesOption == nil) {
-            allowsAutomaticUpdates = _updaterSettings.automaticallyChecksForUpdates;
-        } else {
-            allowsAutomaticUpdates = allowsAutomaticUpdatesOption.boolValue;
-        }
-        _allowsAutomaticUpdates = allowsAutomaticUpdates;
-        
         [self setShouldCascadeWindows:NO];
     } else {
         assert(false);
     }
     return self;
+}
+
+- (void)dealloc
+{
+    if (self.windowLoaded) {
+        [_updaterSettings removeObserver:self forKeyPath:SUAllowsAutomaticUpdatesKeyPath];
+    }
 }
 
 - (NSString *)description
@@ -338,6 +334,15 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
     }
 }
 
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context
+{
+    if ([keyPath isEqualToString:SUAllowsAutomaticUpdatesKeyPath]) {
+        _automaticallyInstallUpdatesButton.superview.hidden = !_updaterSettings.allowsAutomaticUpdates;
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
+}
+
 - (void)windowDidLoad
 {
     NSWindow *window = self.window;
@@ -395,8 +400,6 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
         [_installButton setTitle:SULocalizedStringFromTableInBundle(@"Learn More…", SPARKLE_TABLE, sparkleBundle, @"Alternate title for 'Install Update' button when there's no download in RSS feed.")];
         [_installButton setAction:@selector(openInfoURL:)];
     }
-
-    BOOL allowsAutomaticUpdates = _allowsAutomaticUpdates;
     
     if (showReleaseNotes) {
         [self displayReleaseNotesSpinner];
@@ -409,9 +412,7 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
     
     // NOTE: The code below for deciding what buttons to hide is complex! Due to array of feature configurations :)
     
-    if (!allowsAutomaticUpdates) {
-        _automaticallyInstallUpdatesButton.superview.hidden = YES;
-    }
+    [_updaterSettings addObserver:self forKeyPath:SUAllowsAutomaticUpdatesKeyPath options:(NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew) context:NULL];
     
     if (_state.stage == SPUUserUpdateStageInstalling) {
         // We're going to be relaunching pretty instantaneously

--- a/Sparkle/SUUpdateAlert.xib
+++ b/Sparkle/SUUpdateAlert.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24118.1" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24412" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24118.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24412"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,17 +26,17 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="746" y="229" width="532" height="370"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1470" height="918"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1470" height="922"/>
             <value key="minSize" type="size" width="462" height="150"/>
             <view key="contentView" misplaced="YES" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="532" height="370"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="61v-5k-OXp">
-                        <rect key="frame" x="0.0" y="0.0" width="680" height="377"/>
+                        <rect key="frame" x="0.0" y="0.0" width="680" height="381"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="cGD-9V-Gym" userLabel="Title View">
-                                <rect key="frame" x="0.0" y="313" width="680" height="64"/>
+                                <rect key="frame" x="0.0" y="317" width="680" height="64"/>
                                 <subviews>
                                     <imageView translatesAutoresizingMaskIntoConstraints="NO" id="F1L-zh-U8Z" userLabel="Program icon">
                                         <rect key="frame" x="20" y="0.0" width="64" height="64"/>
@@ -96,7 +96,7 @@
                                 </constraints>
                             </customView>
                             <box boxType="custom" cornerRadius="4" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="ikY-gb-bgB" userLabel="Release Notes Box">
-                                <rect key="frame" x="20" y="70" width="640" height="235"/>
+                                <rect key="frame" x="20" y="74" width="640" height="235"/>
                                 <view key="contentView" id="YbC-Ky-Aam" userLabel="Release Notes Content View">
                                     <rect key="frame" x="1" y="1" width="638" height="233"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -107,10 +107,10 @@
                                 </constraints>
                             </box>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Dg5-0U-d14" userLabel="Options view">
-                                <rect key="frame" x="0.0" y="48" width="680" height="14"/>
+                                <rect key="frame" x="0.0" y="52" width="680" height="14"/>
                                 <subviews>
                                     <button verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xYY-q8-ZyN">
-                                        <rect key="frame" x="19" y="-1" width="316" height="16"/>
+                                        <rect key="frame" x="20" y="0.0" width="313" height="14"/>
                                         <buttonCell key="cell" type="check" title="Automatically download and install updates in the future" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="fPh-Q9-vLr">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -128,10 +128,10 @@
                                 </constraints>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="iUh-Md-dRX" userLabel="Choices view">
-                                <rect key="frame" x="0.0" y="0.0" width="680" height="40"/>
+                                <rect key="frame" x="0.0" y="0.0" width="680" height="44"/>
                                 <subviews>
                                     <button horizontalHuggingPriority="150" verticalHuggingPriority="750" horizontalCompressionResistancePriority="997" translatesAutoresizingMaskIntoConstraints="NO" id="uGk-Ks-HQR">
-                                        <rect key="frame" x="395" y="13" width="137" height="32"/>
+                                        <rect key="frame" x="395" y="20" width="127" height="24"/>
                                         <buttonCell key="cell" type="push" title="Remind Me Later" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="G8s-oM-9gf">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -148,7 +148,7 @@ Gw
                                         </connections>
                                     </button>
                                     <button horizontalHuggingPriority="20" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="sUq-y0-gA3">
-                                        <rect key="frame" x="530" y="13" width="137" height="32"/>
+                                        <rect key="frame" x="534" y="20" width="126" height="24"/>
                                         <buttonCell key="cell" type="push" title="Install Update" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" inset="2" id="IIY-s3-hkz">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -165,7 +165,7 @@ DQ
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="998" translatesAutoresizingMaskIntoConstraints="NO" id="nRH-TL-zdL">
-                                        <rect key="frame" x="13" y="13" width="139" height="32"/>
+                                        <rect key="frame" x="20" y="20" width="129" height="24"/>
                                         <buttonCell key="cell" type="push" title="Skip This Version" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="kVE-pO-gl0">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>

--- a/TestApplication/SUUpdateSettingsWindowController.xib
+++ b/TestApplication/SUUpdateSettingsWindowController.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24412" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24412"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdateSettingsWindowController">
@@ -17,7 +18,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES"/>
             <rect key="contentRect" x="543" y="572" width="314" height="149"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1366" height="745"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1470" height="922"/>
             <value key="minSize" type="size" width="213" height="107"/>
             <view key="contentView" id="0o9-QI-P26">
                 <rect key="frame" x="0.0" y="0.0" width="314" height="149"/>
@@ -25,6 +26,7 @@
                 <subviews>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ztb-OP-JVc">
                         <rect key="frame" x="22" y="88" width="225" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="tLK-9z-r4H">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
@@ -35,16 +37,19 @@
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z6k-h3-dCv">
                         <rect key="frame" x="22" y="68" width="228" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Automatically download updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="lEd-7a-Fwr">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
+                            <binding destination="-2" name="enabled" keyPath="self.updater.allowsAutomaticUpdates" id="rpK-8V-5hr"/>
                             <binding destination="-2" name="value" keyPath="self.updater.automaticallyDownloadsUpdates" id="JjR-6W-VVm"/>
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wFV-vU-Dle">
                         <rect key="frame" x="22" y="48" width="224" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Send system profile information" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="vXw-Wi-ZkC">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
@@ -53,35 +58,39 @@
                             <binding destination="-2" name="value" keyPath="self.updater.sendsSystemProfile" id="neZ-PW-Ps7"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mU2-vs-cVn">
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mU2-vs-cVn">
                         <rect key="frame" x="21" y="112" width="106" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Debug options:" id="GIS-sb-n98">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Is-To-hSg">
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Is-To-hSg">
                         <rect key="frame" x="18" y="22" width="157" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Check for updates every" id="ObK-Ox-eAR">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XCP-rZ-MyN">
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XCP-rZ-MyN">
                         <rect key="frame" x="241" y="22" width="63" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="seconds" id="Cng-TF-emj">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ajc-nf-0sD">
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ajc-nf-0sD">
                         <rect key="frame" x="180" y="20" width="56" height="22"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="gV9-qi-vv1">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <connections>


### PR DESCRIPTION
This allows us to determine if automatic downloading/installing of updates option (typically a checkbox) should be enabled or not. This property is based on whether or not automatically checking of updates is enabled, or the SUAllowsAutomaticUpdates option (if specified by developer for custom needs).

The update alert now updates hiding/unhiding the automatic downloading checkbox if the automatic update checking option changes.

The test application is now updated to use `-[SPUUpdater allowsAutomaticUpdates]` for enabling/disabling the automatic downloads update checkbox.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested enabling/disabling automatic checking and automatic downloading options in the test app settings window, by defaults CLI, and from changing latter option from the update alert window.

macOS version tested: 26.1 (25B78)
