### PR TITLE
Add markdown support for release notes

### DIFF
--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
@@ -58,6 +58,11 @@
             value = "DELTA"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "TEST_MODE"
+            value = "MARKDOWN"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -371,7 +371,7 @@
     
     __weak __typeof__(self) weakSelf = self;
     __weak id<SPUStandardUserDriverDelegate> weakDelegate = delegate;
-    _activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:_host versionDisplayer:versionDisplayer updaterSettings:_updaterSettings completionBlock:^(SPUUserUpdateChoice choice, NSRect windowFrame, BOOL wasKeyWindow) {
+    _activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:_host versionDisplayer:versionDisplayer updaterSettings:_updaterSettings delegate:_delegate completionBlock:^(SPUUserUpdateChoice choice, NSRect windowFrame, BOOL wasKeyWindow) {
         reply(choice);
         
         __typeof__(self) strongSelf = weakSelf;

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -371,7 +371,7 @@
     
     __weak __typeof__(self) weakSelf = self;
     __weak id<SPUStandardUserDriverDelegate> weakDelegate = delegate;
-    _activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:_host versionDisplayer:versionDisplayer updaterSettings:_updaterSettings delegate:_delegate completionBlock:^(SPUUserUpdateChoice choice, NSRect windowFrame, BOOL wasKeyWindow) {
+    _activeUpdateAlert = [[SUUpdateAlert alloc] initWithAppcastItem:appcastItem state:state host:_host versionDisplayer:versionDisplayer updaterSettings:_updaterSettings delegate:delegate completionBlock:^(SPUUserUpdateChoice choice, NSRect windowFrame, BOOL wasKeyWindow) {
         reply(choice);
         
         __typeof__(self) strongSelf = weakSelf;

--- a/Sparkle/SPUStandardUserDriverDelegate.h
+++ b/Sparkle/SPUStandardUserDriverDelegate.h
@@ -188,6 +188,22 @@ SU_EXPORT @protocol SPUStandardUserDriverDelegate <NSObject>
  */
 - (void)standardUserDriverWillFinishUpdateSession;
 
+/**
+ Called before the standard user driver shows plain-text or markdown release notes text to the user.
+ 
+ The delegate has the opportunity to return a new attributed string for the release notes text that will be shown to the user.
+ The `bundleDisplayVersion` and `bundleVersion` are supplied in case they're useful for creating a new attributed string.
+ 
+ This method will not be invoked for HTML release notes. It is only applicable to plain-text and markdown release notes.
+ 
+ @param releaseNotesAttributedString The release notes text that the standard user driver wants to show to the user.
+ @param update The new update the release notes will be shown for.
+ @param bundleDisplayVersion The current display version  (or `CFBundleShortVersionString`)  of the bundle that is being updated.
+ @param bundleVersion The current version   (or `CFBundleVersion`) of the bundle that is being updated.
+ @return A new attributed string for the release notes text to show, or @c nil if the `releaseNotesAttributedString` should still be used.
+ */
+- (NSAttributedString * _Nullable)standardUserDriverWillShowReleaseNotesText:(NSAttributedString *)releaseNotesAttributedString forUpdate:(SUAppcastItem *)update withBundleDisplayVersion:(NSString *)bundleDisplayVersion bundleVersion:(NSString *)bundleVersion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SUPlainTextReleaseNotesView.h
+++ b/Sparkle/SUPlainTextReleaseNotesView.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUPlainTextReleaseNotesView : NSObject <SUReleaseNotesView>
 
-- (instancetype)initWithFontPointSize:(int)fontPointSize customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
+- (instancetype)initWithFontPointSize:(int)fontPointSize prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
 
 @end
 

--- a/Sparkle/SUPlainTextReleaseNotesView.h
+++ b/Sparkle/SUPlainTextReleaseNotesView.h
@@ -12,11 +12,15 @@
 
 #import "SUReleaseNotesView.h"
 
+@protocol SPUStandardUserDriverDelegate;
+@class SUAppcastItem;
+@class SUHost;
+
 NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUPlainTextReleaseNotesView : NSObject <SUReleaseNotesView>
 
-- (instancetype)initWithFontPointSize:(int)fontPointSize prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
+- (instancetype)initWithFontPointSize:(int)fontPointSize appcastItem:(SUAppcastItem *)appcastItem host:(SUHost *)host delegate:(id<SPUStandardUserDriverDelegate>)delegate prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
 
 @end
 

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -215,7 +215,6 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
                 NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: font}];
                 
                 [outputAttributedSubString appendAttributedString:tabAttributedString];
-                paragraphStyle.defaultTabInterval = font.pointSize * 1.38;
             }
             
             break;
@@ -245,9 +244,12 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             break;
         }
         case NSPresentationIntentKindCodeBlock: {
-            paragraphStyle.headIndent += font.pointSize * 0.6;
-            paragraphStyle.firstLineHeadIndent += font.pointSize * 0.6;
             paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
+            
+            // A parent of a code block could be a block quote or list item
+            // It's more correct to use tab rather than leading paragraph indentation in this case
+            NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: monospacedParagraphFont}];
+            [outputAttributedSubString appendAttributedString:tabAttributedString];
             
             NSMutableAttributedString *blockquoteAttributedString = [fragmentAttributedString mutableCopy];
             [blockquoteAttributedString addAttributes:@{NSFontAttributeName: monospacedParagraphFont, NSForegroundColorAttributeName: NSColor.labelColor} range:NSMakeRange(0, blockquoteAttributedString.length)];
@@ -260,7 +262,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         case NSPresentationIntentKindOrderedList:
         case NSPresentationIntentKindUnorderedList:
         // Note: TextKit 2 doesn't support NSTextTable
-        // Tables also don't show up in release notes often, so not worthwhile supporting
+        // Tables don't show up in release notes often, so they're not that worthwhile supporting
         case NSPresentationIntentKindTable:
         case NSPresentationIntentKindTableHeaderRow:
         case NSPresentationIntentKindTableRow:
@@ -324,7 +326,9 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             paragraphStyle.headIndent = 0;
             paragraphStyle.firstLineHeadIndent = 0;
             
+            // Assume tabs won't be used in headers so we'll just use regular paragraph font size
             paragraphStyle.tabStops = @[];
+            paragraphStyle.defaultTabInterval = paragraphFont.pointSize * 1.38;
             
             NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
             

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -156,8 +156,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             break;
         }
         case NSPresentationIntentKindParagraph: {
-            if (parentIntent != nil) {
-                // If the parent intent is a list item or a blockquote we don't want to apply paragraphSpacingBefore,
+            if (parentIntent != nil && parentIntent.intentKind == NSPresentationIntentKindListItem) {
+                // If the parent intent is a list item we don't want to apply paragraphSpacingBefore,
                 // and we'll apply less spacing
                 paragraphStyle.paragraphSpacing += font.pointSize * 0.3;
             } else {
@@ -213,10 +213,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             // Special rendering via text attachments or decorations is not done because
             // it's complex and may have tradeoffs
             
-            const CGFloat headIndentAdvancement = 10.0;
-            
-            paragraphStyle.firstLineHeadIndent += headIndentAdvancement;
-            paragraphStyle.headIndent += headIndentAdvancement;
+            paragraphStyle.firstLineHeadIndent += paragraphStyle.defaultTabInterval;
+            paragraphStyle.headIndent += paragraphStyle.defaultTabInterval;
 
             break;
         }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -378,13 +378,9 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, NSURL * _Nullable baseURL, CGFloat defaultFontPointSize, NSTextView *textView, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+// Note: this must be called on main thread
+static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *originalAttributedString, CGFloat defaultFontPointSize, NSTextView *textView) API_AVAILABLE(macos(12.0))
 {
-    NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:baseURL error:outError];
-    if (originalAttributedString == nil) {
-        return nil;
-    }
-    
     // Create our fonts and cache some common attributed strings up front (list bullets, newline)
     
     NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize];
@@ -446,26 +442,9 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     return outputAttributedString;
 }
 
-- (void)_loadString:(NSString *)contents baseURL:(nullable NSURL *)baseURL completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
+
+- (void)_loadAttributedString:(NSAttributedString * _Nullable)attributedString completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
 {
-    NSAttributedString *attributedString = nil;
-    if (_prefersMarkdown) {
-        if (@available(macOS 12, *)) {
-            NSError *markdownError = nil;
-            attributedString = makeMarkdownAttributedString(contents, baseURL, (CGFloat)_fontPointSize, _textView, &markdownError);
-            if (attributedString == nil) {
-                SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
-            }
-        } else {
-            SULog(SULogLevelDefault, @"Warning: falling back to plain text because markdown support requires macOS 12 or newer");
-        }
-    }
-    
-    if (attributedString == nil) {
-        // Fall back to plain text
-        attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)_fontPointSize] }];
-    }
-    
     if (attributedString == nil) {
         completionHandler([NSError errorWithDomain:SUSparkleErrorDomain code:SUReleaseNotesError userInfo:@{NSLocalizedDescriptionKey: @"Failed to create attributed string of contents to load"}]);
         return;
@@ -475,7 +454,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     NSAttributedString *finalAttributedString;
     id<SPUStandardUserDriverDelegate> delegate = _delegate;
     if ([(NSObject *)delegate respondsToSelector:@selector(standardUserDriverWillShowReleaseNotesText:forUpdate:withBundleDisplayVersion:bundleVersion:)]) {
-        NSAttributedString *attributedStringFromDelegate = [delegate standardUserDriverWillShowReleaseNotesText:attributedString forUpdate:_updateItem withBundleDisplayVersion:_host.displayVersion bundleVersion:_host.version];
+        NSAttributedString *attributedStringFromDelegate = [delegate standardUserDriverWillShowReleaseNotesText:(NSAttributedString * _Nonnull)attributedString forUpdate:_updateItem withBundleDisplayVersion:_host.displayVersion bundleVersion:_host.version];
         if (attributedStringFromDelegate != nil) {
             finalAttributedString = attributedStringFromDelegate;
         } else {
@@ -487,6 +466,11 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     
     [_textView.textStorage setAttributedString:finalAttributedString];
     
+    completionHandler(nil);
+}
+
+- (void)_loadString:(NSString *)contents baseURL:(nullable NSURL *)baseURL completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
+{
     NSSize contentSize = [_scrollView contentSize];
     [_textView setFrame:NSMakeRect(0, 0, contentSize.width, contentSize.height)];
     [_textView setMinSize:NSMakeSize(0.0, contentSize.height)];
@@ -506,7 +490,42 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     [_scrollView setHasVerticalScroller:YES];
     [_scrollView setHasHorizontalScroller:NO];
     
-    completionHandler(nil);
+    if (_prefersMarkdown) {
+        if (@available(macOS 12, *)) {
+            dispatch_queue_attr_t queuePriority = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
+            
+            dispatch_queue_t markdownDispatchQueue = dispatch_queue_create("org.sparkle-project.markdown-loader", queuePriority);
+            
+            dispatch_async(markdownDispatchQueue, ^{
+                NSError *loadMarkdownError = nil;
+                NSAttributedString *originalMarkdownAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:baseURL error:&loadMarkdownError];
+                
+                if (originalMarkdownAttributedString == nil) {
+                    // Fallback to plain-text
+                    
+                    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)self->_fontPointSize] }];
+                    
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [self _loadAttributedString:attributedString completionHandler:completionHandler];
+                    });
+                } else {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        NSAttributedString *formattedAttributedString = formatMarkdownAttributedString(originalMarkdownAttributedString, (CGFloat)self->_fontPointSize, self->_textView);
+                        
+                        [self _loadAttributedString:formattedAttributedString completionHandler:completionHandler];
+                    });
+                }
+            });
+            
+            return;
+        } else {
+            SULog(SULogLevelDefault, @"Warning: falling back to plain text because markdown support requires macOS 12 or newer");
+        }
+    }
+    
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)_fontPointSize] }];
+    
+    [self _loadAttributedString:attributedString completionHandler:completionHandler];
 }
 
 - (void)loadString:(NSString *)contents baseURL:(NSURL * _Nullable)baseURL completionHandler:(void (^)(NSError * _Nullable))completionHandler

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -21,20 +21,35 @@ API_AVAILABLE(macos(10.14))
 @end
 
 @implementation SPUMarkdownHorizontalDividerAttachmentCell
+{
+    NSTextView *_textView;
+}
+
+- (instancetype)initWithTextView:(NSTextView *)textView
+{
+    self = [super init];
+    if (self != nil) {
+        _textView = textView;
+    }
+    return self;
+}
 
 - (NSSize)cellSize
 {
-    // Minimum width needs to be at least 1
-    return NSMakeSize(1.0, 10.0);
+    return NSMakeSize(CGFLOAT_MAX, 10.0);
 }
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
 {
     CGFloat yPosition = NSMidY(cellFrame);
     
+    NSSize containerInset = _textView.textContainerInset;
+    CGFloat lineFragmentPadding = _textView.textContainer.lineFragmentPadding;
+    CGFloat totalWidthPadding = containerInset.width + lineFragmentPadding;
+    
     NSBezierPath *path = [NSBezierPath bezierPath];
-    [path moveToPoint:NSMakePoint(0.0, yPosition)];
-    [path lineToPoint:NSMakePoint(view.bounds.size.width, yPosition)];
+    [path moveToPoint:NSMakePoint(view.bounds.origin.x + totalWidthPadding, yPosition)];
+    [path lineToPoint:NSMakePoint(view.bounds.origin.x + view.bounds.size.width - totalWidthPadding, yPosition)];
 
     [[NSColor separatorColor] setStroke];
     [path setLineWidth:1.0];
@@ -64,6 +79,7 @@ API_AVAILABLE(macos(12.0))
     NSBezierPath *path = [NSBezierPath bezierPath];
     path.lineCapStyle = NSLineCapStyleButt;
     
+    // In TextKit 2 we can render the entire view bounds and it will be appropriately clamped
     NSPoint beginPoint = NSMakePoint(xPosition, view.bounds.origin.y);
     NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + view.bounds.size.height);
     
@@ -181,7 +197,7 @@ API_AVAILABLE(macos(12.0))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, NSTextView *textView, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -225,7 +241,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, textView, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
     }
     
     // Process the current intent
@@ -297,7 +313,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         }
         case NSPresentationIntentKindThematicBreak: {
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownHorizontalDividerAttachmentCell alloc] init];
+            attachment.attachmentCell = [[SPUMarkdownHorizontalDividerAttachmentCell alloc] initWithTextView:textView];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
@@ -351,7 +367,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSTextView *textView, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
     NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
     if (originalAttributedString == nil) {
@@ -410,7 +426,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             NSUInteger previousOutputLength = outputAttributedString.length;
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, textView, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
             
             [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
         }];
@@ -425,7 +441,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     if (_prefersMarkdown) {
         if (@available(macOS 12, *)) {
             NSError *markdownError = nil;
-            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, &markdownError);
+            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, _textView, &markdownError);
             if (attributedString == nil) {
                 SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
             }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -10,8 +10,10 @@
 
 #import "SUPlainTextReleaseNotesView.h"
 #import "SUReleaseNotesCommon.h"
+#import "SPUStandardUserDriverDelegate.h"
 #import "SULog.h"
 #import "SUErrors.h"
+#import "SUHost.h"
 
 #import <AppKit/AppKit.h>
 
@@ -51,7 +53,7 @@ API_AVAILABLE(macos(10.14))
     [path moveToPoint:NSMakePoint(view.bounds.origin.x + totalWidthPadding, yPosition)];
     [path lineToPoint:NSMakePoint(view.bounds.origin.x + view.bounds.size.width - totalWidthPadding, yPosition)];
 
-    [[NSColor separatorColor] setStroke];
+    [NSColor.separatorColor setStroke];
     [path setLineWidth:1.0];
     [path stroke];
 }
@@ -86,7 +88,7 @@ API_AVAILABLE(macos(12.0))
     [path moveToPoint:NSMakePoint(beginPoint.x, beginPoint.y)];
     [path lineToPoint:NSMakePoint(endPoint.x, endPoint.y)];
 
-    [[NSColor lightGrayColor] setStroke];
+    [NSColor.lightGrayColor setStroke];
     [path setLineWidth:lineWidth];
     [path stroke];
 }
@@ -142,11 +144,15 @@ API_AVAILABLE(macos(12.0))
 #endif
     NSArray<NSString *> *_customAllowedURLSchemes;
     
+    SUAppcastItem *_updateItem;
+    SUHost *_host;
+    __weak id<SPUStandardUserDriverDelegate> _delegate;
+    
     int _fontPointSize;
     BOOL _prefersMarkdown;
 }
 
-- (instancetype)initWithFontPointSize:(int)fontPointSize prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
+- (instancetype)initWithFontPointSize:(int)fontPointSize appcastItem:(SUAppcastItem *)appcastItem host:(SUHost *)host delegate:(id<SPUStandardUserDriverDelegate>)delegate prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
 {
     self = [super init];
     if (self != nil) {
@@ -154,6 +160,11 @@ API_AVAILABLE(macos(12.0))
         _customAllowedURLSchemes = customAllowedURLSchemes;
         _prefersMarkdown = prefersMarkdown;
         _scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+        
+        _updateItem = appcastItem;
+        _host = host;
+        
+        _delegate = delegate;
         
         if (@available(macOS 12, *)) {
             // Create NSTextView using TextKit 2
@@ -460,7 +471,21 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         return;
     }
     
-    [_textView.textStorage setAttributedString:attributedString];
+    // Give delegate a chance to process and modify the attributed string
+    NSAttributedString *finalAttributedString;
+    id<SPUStandardUserDriverDelegate> delegate = _delegate;
+    if ([(NSObject *)delegate respondsToSelector:@selector(standardUserDriverWillShowReleaseNotesText:forUpdate:withBundleDisplayVersion:bundleVersion:)]) {
+        NSAttributedString *attributedStringFromDelegate = [delegate standardUserDriverWillShowReleaseNotesText:attributedString forUpdate:_updateItem withBundleDisplayVersion:_host.displayVersion bundleVersion:_host.version];
+        if (attributedStringFromDelegate != nil) {
+            finalAttributedString = attributedStringFromDelegate;
+        } else {
+            finalAttributedString = attributedString;
+        }
+    } else {
+        finalAttributedString = attributedString;
+    }
+    
+    [_textView.textStorage setAttributedString:finalAttributedString];
     
     NSSize contentSize = [_scrollView contentSize];
     [_textView setFrame:NSMakeRect(0, 0, contentSize.width, contentSize.height)];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -44,20 +44,25 @@ API_AVAILABLE(macos(10.14))
 @end
 
 // Divider attachment cell used for markdown block quotes
-API_AVAILABLE(macos(10.14))
+API_AVAILABLE(macos(12.0))
 @interface SPUMarkdownVerticalAttachmentCell : NSTextAttachmentCell
 @end
 
 @implementation SPUMarkdownVerticalAttachmentCell
 {
+    NSTextContentManager *_textContentManager;
     NSFont *_font;
+    
+    NSInteger _textOffset;
 }
 
-- (instancetype)initWithFont:(NSFont *)font
+- (instancetype)initWithTextContentManager:(NSTextContentManager *)textContentManager textOffset:(NSInteger)textOffset font:(NSFont *)font
 {
     self = [super init];
     if (self != nil) {
+        _textContentManager = textContentManager;
         _font = font;
+        _textOffset = textOffset;
     }
     return self;
 }
@@ -70,12 +75,30 @@ API_AVAILABLE(macos(10.14))
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
 {
+    NSTextLayoutManager *textLayoutManager = _textContentManager.textLayoutManagers.firstObject;
+    
+    id<NSTextLocation> textLocation = [_textContentManager locationFromLocation:_textContentManager.documentRange.location withOffset:_textOffset];
+    
+    NSTextLayoutFragment *textLayoutFragment = [textLayoutManager textLayoutFragmentForLocation:textLocation];
+    CGRect layoutFragmentFrame = textLayoutFragment.layoutFragmentFrame;
+    NSLog(@"Height: %f", layoutFragmentFrame.size.height);
+    
     const CGFloat lineWidth = 2.0;
     CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
     
     NSBezierPath *path = [NSBezierPath bezierPath];
-    [path moveToPoint:NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height - _font.ascender)];
-    [path lineToPoint:NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height + -(_font.descender))];
+    
+    NSPoint beginPoint = NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height - _font.ascender);
+    NSPoint endPoint = NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height + -(_font.descender));
+    
+    //NSLog(@"%f", endPoint.y - beginPoint.y);
+    CGFloat difference = layoutFragmentFrame.size.height - (endPoint.y - beginPoint.y);
+    
+    [path moveToPoint:NSMakePoint(beginPoint.x, beginPoint.y)];
+    [path lineToPoint:NSMakePoint(endPoint.x, endPoint.y)];
+    
+    //[path moveToPoint:NSMakePoint(xPosition, layoutFragmentFrame.origin.y)];
+    //[path lineToPoint:NSMakePoint(xPosition, layoutFragmentFrame.origin.y + layoutFragmentFrame.size.height)];
 
     [[NSColor separatorColor] setStroke];
     [path setLineWidth:lineWidth];
@@ -151,7 +174,7 @@ API_AVAILABLE(macos(10.14))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString, NSTextContentManager *textContentManager) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -195,7 +218,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textContentManager);
     }
     
     // Process the current intent
@@ -270,7 +293,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
             // Each line will get its own preceding vertical line. These lines are not 'connected' which is a limitation for now.
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithFont:font];
+            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextContentManager:textContentManager textOffset:(NSInteger)outputAttributedSubString.length font:font];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
@@ -310,7 +333,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSTextContentManager *textContentManager, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
     NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
     if (originalAttributedString == nil) {
@@ -390,8 +413,11 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     NSAttributedString *attributedString = nil;
     if (_prefersMarkdown) {
         if (@available(macOS 12, *)) {
+            
+            NSTextContentManager *textContentManager = _textView.textLayoutManager.textContentManager;
+            
             NSError *markdownError = nil;
-            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, &markdownError);
+            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, textContentManager, &markdownError);
             if (attributedString == nil) {
                 SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
             }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -98,6 +98,7 @@ API_AVAILABLE(macos(12.0))
 
 @end
 
+// Attachment cell used for unordered list bullets
 @interface SPUMarkdownBulletAttachmentCell : NSTextAttachmentCell
 @end
 

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -310,28 +310,32 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     // Enumerate through every presentation intent fragment and create a new attributed string that we append to the output
     // Foundation handles formatting some things for us already in the attributed string such as bold/itatlics and hyperlinks,
     // but we need to handle formatting paragraphs, headers, lists, block quotes, etc in the attributed string.
-    [originalAttributedString enumerateAttribute:NSPresentationIntentAttributeName inRange:NSMakeRange(0, originalAttributedString.length) options:0 usingBlock:^(NSPresentationIntent *intent, NSRange range, BOOL * _Nonnull __unused stop) {
+    [originalAttributedString enumerateAttribute:NSPresentationIntentAttributeName inRange:NSMakeRange(0, originalAttributedString.length) options:0 usingBlock:^(NSPresentationIntent *intent, NSRange presentationIntentRange, BOOL * _Nonnull __unused stopPresentationIntentEnumeration) {
         
-        NSAttributedString *fragmentAttributedString = [originalAttributedString attributedSubstringFromRange:range];
-        
-        // Properties of the paragraph start as 0 and later get incremented based on what is processed
-        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.paragraphSpacingBefore = 0;
-        paragraphStyle.paragraphSpacing = 0;
-        paragraphStyle.headIndent = 0;
-        paragraphStyle.firstLineHeadIndent = 0;
-        
-        paragraphStyle.tabStops = @[];
-        
-        NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
-        
-        BOOL canProcessListItem = YES;
-        processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
-        
-        [fragmentOutputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, fragmentOutputAttributedString.length)];
-        
-        [outputAttributedString appendAttributedString:fragmentOutputAttributedString];
-        [outputAttributedString appendAttributedString:newlineAttributedString];
+        // Split the presentation intent by lines so we treat every line as a separate paragraph so we present them properly (with correct indentation / tabs)
+        // Normally multiple lines aren't in the same paragraph, but this can happen in some cases like code blocks
+        [originalAttributedString.string enumerateSubstringsInRange:presentationIntentRange options:NSStringEnumerationByLines usingBlock:^(NSString * _Nullable __unused substring, NSRange substringRange, NSRange __unused enclosingRange, BOOL * _Nonnull __unused stopLineEnumeration) {
+            NSAttributedString *fragmentAttributedString = [originalAttributedString attributedSubstringFromRange:substringRange];
+            
+            // Properties of the paragraph start as 0 and later get incremented based on what is processed
+            NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+            paragraphStyle.paragraphSpacingBefore = 0;
+            paragraphStyle.paragraphSpacing = 0;
+            paragraphStyle.headIndent = 0;
+            paragraphStyle.firstLineHeadIndent = 0;
+            
+            paragraphStyle.tabStops = @[];
+            
+            NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
+            
+            BOOL canProcessListItem = YES;
+            processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
+            
+            [fragmentOutputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, fragmentOutputAttributedString.length)];
+            
+            [outputAttributedString appendAttributedString:fragmentOutputAttributedString];
+            [outputAttributedString appendAttributedString:newlineAttributedString];
+        }];
     }];
     
     return outputAttributedString;

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -25,13 +25,16 @@ API_AVAILABLE(macos(10.14))
 @implementation SPUMarkdownHorizontalDividerAttachmentCell
 {
     NSTextView *_textView;
+    
+    CGFloat _headIndent;
 }
 
-- (instancetype)initWithTextView:(NSTextView *)textView
+- (instancetype)initWithTextView:(NSTextView *)textView headIndent:(CGFloat)headIndent
 {
     self = [super init];
     if (self != nil) {
         _textView = textView;
+        _headIndent = headIndent;
     }
     return self;
 }
@@ -47,7 +50,7 @@ API_AVAILABLE(macos(10.14))
     
     NSSize containerInset = _textView.textContainerInset;
     CGFloat lineFragmentPadding = _textView.textContainer.lineFragmentPadding;
-    CGFloat totalWidthPadding = containerInset.width + lineFragmentPadding;
+    CGFloat totalWidthPadding = containerInset.width + lineFragmentPadding + _headIndent;
     
     NSBezierPath *path = [NSBezierPath bezierPath];
     [path moveToPoint:NSMakePoint(view.bounds.origin.x + totalWidthPadding, yPosition)];
@@ -324,7 +327,9 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         }
         case NSPresentationIntentKindThematicBreak: {
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownHorizontalDividerAttachmentCell alloc] initWithTextView:textView];
+            // Account for headIndent if thematic break is inside a blockquote
+            // This may not work well if thematic break is in a list element, oh well
+            attachment.attachmentCell = [[SPUMarkdownHorizontalDividerAttachmentCell alloc] initWithTextView:textView headIndent:paragraphStyle.headIndent];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -15,6 +15,32 @@
 
 #import <AppKit/AppKit.h>
 
+API_AVAILABLE(macos(10.14))
+@interface SPUMarkdownDividerAttachmentCell : NSTextAttachmentCell
+@end
+
+@implementation SPUMarkdownDividerAttachmentCell
+
+- (NSSize)cellSize
+{
+    return NSMakeSize(0, 10);
+}
+
+- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+{
+    CGFloat midY = NSMidY(cellFrame);
+
+    NSBezierPath *path = [NSBezierPath bezierPath];
+    [path moveToPoint:NSMakePoint(0, midY)];
+    [path lineToPoint:NSMakePoint(controlView.bounds.size.width, midY)];
+
+    [[NSColor separatorColor] setStroke];
+    [path setLineWidth:1.0];
+    [path stroke];
+}
+
+@end
+
 @interface SUPlainTextReleaseNotesView () <NSTextViewDelegate>
 @end
 
@@ -24,9 +50,11 @@
     NSTextView *_textView;
     NSArray<NSString *> *_customAllowedURLSchemes;
     int _fontPointSize;
+    
+    BOOL _prefersMarkdown;
 }
 
-- (instancetype)initWithFontPointSize:(int)fontPointSize customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
+- (instancetype)initWithFontPointSize:(int)fontPointSize prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes
 {
     self = [super init];
     if (self != nil) {
@@ -36,6 +64,7 @@
         _scrollView.documentView = _textView;
         _fontPointSize = fontPointSize;
         _customAllowedURLSchemes = customAllowedURLSchemes;
+        _prefersMarkdown = prefersMarkdown;
     }
     return self;
 }
@@ -45,9 +74,161 @@
     return _scrollView;
 }
 
+static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+{
+    NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize];
+    NSFont *monospacedParagraphFont = [NSFont monospacedSystemFontOfSize:defaultFontPointSize weight:NSFontWeightRegular];
+    
+    NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
+    
+    NSMutableAttributedString *newAttributedString = [[NSMutableAttributedString alloc] init];
+    
+    NSAttributedString *newlineAttributedString = [[NSAttributedString alloc] initWithString:@"\n"];
+    
+    [originalAttributedString enumerateAttribute:NSPresentationIntentAttributeName inRange:NSMakeRange(0, originalAttributedString.length) options:0 usingBlock:^(NSPresentationIntent *intent, NSRange range, BOOL * _Nonnull __unused stop) {
+        
+        NSAttributedString *subAttributedString = [originalAttributedString attributedSubstringFromRange:range];
+        
+        NSLog(@"Parent intent: %@", intent.parentIntent);
+        
+        NSLog(@"Subattributed string: %@", subAttributedString);
+        
+        switch (intent.intentKind) {
+            case NSPresentationIntentKindHeader: {
+                NSInteger level = intent.headerLevel;
+                NSFont *font;
+                switch (level) {
+                    case 1:
+                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 7.0];
+                        break;
+                    case 2:
+                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 4.0];
+                        break;
+                    case 3:
+                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 2.0];
+                        break;
+                    default:
+                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 1.0];
+                        break;
+                }
+                
+                NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+                paragraphStyle.paragraphSpacingBefore = 4.0;
+                paragraphStyle.paragraphSpacing = 8.0;
+                
+                NSMutableAttributedString *headerAttributedString = [subAttributedString mutableCopy];
+                
+                [headerAttributedString addAttributes:@{NSFontAttributeName: font, NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, headerAttributedString.length)];
+                
+                [newAttributedString appendAttributedString:headerAttributedString];
+                [newAttributedString appendAttributedString:newlineAttributedString];
+                
+                break;
+            }
+            case NSPresentationIntentKindParagraph: {
+                NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+                paragraphStyle.paragraphSpacing = 4.0;
+                
+                NSMutableAttributedString *paragraphAttributedString = [[NSMutableAttributedString alloc] init];
+                
+                NSPresentationIntent *parentIntent = intent.parentIntent;
+                if (parentIntent != nil) {
+                    switch (parentIntent.intentKind) {
+                        case NSPresentationIntentKindListItem: {
+                            paragraphStyle.firstLineHeadIndent = 20.0 * parentIntent.indentationLevel;
+                            paragraphStyle.headIndent = 20.0 * parentIntent.indentationLevel;
+                            
+                            NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
+                            
+                            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+                            attachment.image = bulletSymbol;
+                            
+                            const CGFloat imageScale = 0.4;
+                            const CGFloat yBoundsScaleOffset = 0.1;
+                            attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
+                            
+                            NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
+                            
+                            [finalBulletAttributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@"  "]];
+                            
+                            [finalBulletAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, finalBulletAttributedString.length)];
+                            
+                            [paragraphAttributedString appendAttributedString:finalBulletAttributedString];
+                            
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                }
+                
+                NSMutableAttributedString *contentAttributedString = [subAttributedString mutableCopy];
+                [contentAttributedString addAttributes:@{NSFontAttributeName: paragraphFont, NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, contentAttributedString.length)];
+                
+                [paragraphAttributedString appendAttributedString:contentAttributedString];
+                
+                [newAttributedString appendAttributedString:paragraphAttributedString];
+                [newAttributedString appendAttributedString:newlineAttributedString];
+                
+                break;
+            }
+            case NSPresentationIntentKindThematicBreak: {
+                NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+                attachment.attachmentCell = [[SPUMarkdownDividerAttachmentCell alloc] init];
+
+                NSAttributedString *dividerAttributedString =
+                    [NSAttributedString attributedStringWithAttachment:attachment];
+                
+                [newAttributedString appendAttributedString:dividerAttributedString];
+                [newAttributedString appendAttributedString:newlineAttributedString];
+                break;
+            }
+            case NSPresentationIntentKindCodeBlock: {
+                NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+                style.headIndent = 6;
+                style.firstLineHeadIndent = 6;
+                style.paragraphSpacing = 2;
+                style.paragraphSpacingBefore = 4;
+
+                NSDictionary *attrs = @{
+                    NSFontAttributeName: monospacedParagraphFont,
+                    NSParagraphStyleAttributeName: style,
+                    NSForegroundColorAttributeName: NSColor.labelColor
+                };
+                
+                NSMutableAttributedString *blockquoteAttributedString = [subAttributedString mutableCopy];
+                [blockquoteAttributedString addAttributes:attrs range:NSMakeRange(0, blockquoteAttributedString.length)];
+                
+                [newAttributedString appendAttributedString:blockquoteAttributedString];
+                [newAttributedString appendAttributedString:newlineAttributedString];
+                
+                break;
+            }
+            default:
+                break;
+        }
+    }];
+    
+    return newAttributedString;
+}
+
 - (void)_loadString:(NSString *)contents completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
 {
-    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)_fontPointSize] }];
+    NSAttributedString *attributedString = nil;
+    if (_prefersMarkdown) {
+        if (@available(macOS 12, *)) {
+            NSError *markdownError = nil;
+            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, &markdownError);
+            if (attributedString == nil) {
+                SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
+            }
+        }
+    }
+    
+    if (attributedString == nil) {
+        // Fall back to plain text
+        attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)_fontPointSize] }];
+    }
     
     if (attributedString == nil) {
         completionHandler([NSError errorWithDomain:SUSparkleErrorDomain code:SUReleaseNotesError userInfo:@{NSLocalizedDescriptionKey: @"Failed to create attributed string of contents to load"}]);

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -371,14 +371,13 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             paragraphStyle.tabStops = @[];
             paragraphStyle.defaultTabInterval = paragraphFont.pointSize * 1.38;
             
-            NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
+            NSUInteger previousOutputLength = outputAttributedString.length;
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textContentManager);
             
-            [fragmentOutputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, fragmentOutputAttributedString.length)];
+            [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
             
-            [outputAttributedString appendAttributedString:fragmentOutputAttributedString];
             [outputAttributedString appendAttributedString:newlineAttributedString];
         }];
     }];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -203,14 +203,19 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
                     if (insertUnorderedBullet) {
                         [outputAttributedSubString appendAttributedString:listBulletAttributedString];
                     } else {
-                        NSString *ordinalStringWithSpacing = [NSString stringWithFormat:@"%ld. ", intent.ordinal];
-                        NSAttributedString *listItemAttributedString = [[NSAttributedString alloc] initWithString:ordinalStringWithSpacing attributes:@{NSFontAttributeName: monospacedParagraphFont}];
+                        NSString *ordinalStringWithSpacing = [NSString stringWithFormat:@"%ld.", intent.ordinal];
+                        NSAttributedString *listItemAttributedString = [[NSAttributedString alloc] initWithString:ordinalStringWithSpacing attributes:@{NSFontAttributeName: font}];
                         
                         [outputAttributedSubString appendAttributedString:listItemAttributedString];
                     }
                     
                     [previousVisitedListItemIntents addObject:intent];
                 }
+                
+                NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: font}];
+                
+                [outputAttributedSubString appendAttributedString:tabAttributedString];
+                paragraphStyle.defaultTabInterval = font.pointSize * 1.38;
             }
             
             break;
@@ -254,6 +259,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         
         case NSPresentationIntentKindOrderedList:
         case NSPresentationIntentKindUnorderedList:
+        // Note: TextKit 2 doesn't support NSTextTable
+        // Tables also don't show up in release notes often, so not worthwhile supporting
         case NSPresentationIntentKindTable:
         case NSPresentationIntentKindTableHeaderRow:
         case NSPresentationIntentKindTableRow:
@@ -295,13 +302,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
         attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
         
-        NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
-        
-        NSAttributedString *spaceAttributedString = [[NSAttributedString alloc] initWithString:@"  " attributes:@{NSFontAttributeName: paragraphFont}];
-        
-        [finalBulletAttributedString appendAttributedString:spaceAttributedString];
-        
-        listBulletAttributedString = [finalBulletAttributedString copy];
+        listBulletAttributedString = [NSAttributedString attributedStringWithAttachment:attachment];
     }
     
     NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents = [[NSMutableSet alloc] init];
@@ -319,6 +320,8 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         paragraphStyle.paragraphSpacing = 0;
         paragraphStyle.headIndent = 0;
         paragraphStyle.firstLineHeadIndent = 0;
+        
+        paragraphStyle.tabStops = @[];
         
         NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
         

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -367,9 +367,9 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSTextView *textView, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, NSURL * _Nullable baseURL, CGFloat defaultFontPointSize, NSTextView *textView, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
-    NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
+    NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:baseURL error:outError];
     if (originalAttributedString == nil) {
         return nil;
     }
@@ -435,13 +435,13 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     return outputAttributedString;
 }
 
-- (void)_loadString:(NSString *)contents completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
+- (void)_loadString:(NSString *)contents baseURL:(nullable NSURL *)baseURL completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
 {
     NSAttributedString *attributedString = nil;
     if (_prefersMarkdown) {
         if (@available(macOS 12, *)) {
             NSError *markdownError = nil;
-            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, _textView, &markdownError);
+            attributedString = makeMarkdownAttributedString(contents, baseURL, (CGFloat)_fontPointSize, _textView, &markdownError);
             if (attributedString == nil) {
                 SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
             }
@@ -486,7 +486,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
 
 - (void)loadString:(NSString *)contents baseURL:(NSURL * _Nullable)baseURL completionHandler:(void (^)(NSError * _Nullable))completionHandler
 {
-    [self _loadString:contents completionHandler:completionHandler];
+    [self _loadString:contents baseURL:baseURL completionHandler:completionHandler];
 }
 
 - (void)loadData:(NSData *)data MIMEType:(NSString *)MIMEType textEncodingName:(NSString *)textEncodingName baseURL:(NSURL *)baseURL completionHandler:(void (^)(NSError * _Nullable))completionHandler
@@ -507,7 +507,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         return;
     }
     
-    [self _loadString:contents completionHandler:completionHandler];
+    [self _loadString:contents baseURL:baseURL completionHandler:completionHandler];
 }
 
 - (void)stopLoading

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -101,13 +101,31 @@ API_AVAILABLE(macos(10.14))
 {
     self = [super init];
     if (self != nil) {
-        _scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
-        _textView = [[NSTextView alloc] initWithFrame:NSZeroRect];
-        _textView.delegate = self;
-        _scrollView.documentView = _textView;
         _fontPointSize = fontPointSize;
         _customAllowedURLSchemes = customAllowedURLSchemes;
         _prefersMarkdown = prefersMarkdown;
+        _scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+        
+        if (@available(macOS 12, *)) {
+            // Create NSTextView using TextKit 2
+            // https://developer.apple.com/documentation/appkit/nstextview/1449347-initwithframe
+            
+            NSTextContainer *textContainer = [[NSTextContainer alloc] initWithContainerSize:NSMakeSize(0, (CGFloat)FLT_MAX)];
+            textContainer.widthTracksTextView = YES;
+            
+            NSTextLayoutManager *textLayoutManager = [[NSTextLayoutManager alloc] init];
+            textLayoutManager.textContainer = textContainer;
+            
+            NSTextContentStorage *textContentStorage = [[NSTextContentStorage alloc] init];
+            [textContentStorage addTextLayoutManager:textLayoutManager];
+            
+            _textView = [[NSTextView alloc] initWithFrame:NSZeroRect textContainer:textLayoutManager.textContainer];
+        } else {
+            _textView = [[NSTextView alloc] initWithFrame:NSZeroRect];
+        }
+        
+        _textView.delegate = self;
+        _scrollView.documentView = _textView;
     }
     return self;
 }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -159,8 +159,8 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
     
     switch (intent.intentKind) {
         case NSPresentationIntentKindHeader: {
-            paragraphStyle.paragraphSpacingBefore += 8.0;
-            paragraphStyle.paragraphSpacing += 4.0;
+            paragraphStyle.paragraphSpacingBefore += font.pointSize * 0.16;
+            paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
             
             NSMutableAttributedString *headerAttributedString = [subAttributedString mutableCopy];
             
@@ -171,19 +171,19 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
             break;
         }
         case NSPresentationIntentKindParagraph: {
-            paragraphStyle.paragraphSpacing += 4.0;
+            paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
             
             NSMutableAttributedString *contentAttributedString = [subAttributedString mutableCopy];
             [contentAttributedString addAttributes:@{NSFontAttributeName: font} range:NSMakeRange(0, contentAttributedString.length)];
             
-            [newAttributedSubString appendAttributedString:subAttributedString];
+            [newAttributedSubString appendAttributedString:contentAttributedString];
             
             break;
         }
         case NSPresentationIntentKindListItem: {
             if (canProcessListItem) {
-                paragraphStyle.firstLineHeadIndent += intent.indentationLevel * 20.0;
-                paragraphStyle.headIndent += intent.indentationLevel * 20.0;
+                paragraphStyle.firstLineHeadIndent += intent.indentationLevel * (font.pointSize * 1.5);
+                paragraphStyle.headIndent += intent.indentationLevel * (font.pointSize * 1.5);
                 
                 BOOL insertUnorderedBullet = (parentIntent == nil || parentIntent.intentKind == NSPresentationIntentKindUnorderedList);
                 
@@ -195,9 +195,10 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
                     NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
                     attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
                     
-                    const CGFloat imageScale = 0.4;
-                    const CGFloat yBoundsScaleOffset = 0.1;
-                    attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
+                    const CGFloat imageScale = font.pointSize / 32.5;
+                    const CGFloat yBoundsScaleOffset = 0.25;
+                    
+                    attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
                     
                     NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
                     
@@ -236,10 +237,9 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
             break;
         }
         case NSPresentationIntentKindCodeBlock: {
-            paragraphStyle.headIndent += 8;
-            paragraphStyle.firstLineHeadIndent += 8;
-            paragraphStyle.paragraphSpacing += 2;
-            paragraphStyle.paragraphSpacingBefore += 4;
+            paragraphStyle.headIndent += font.pointSize * 0.6;
+            paragraphStyle.firstLineHeadIndent += font.pointSize * 0.6;
+            paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
             
             NSMutableAttributedString *blockquoteAttributedString = [subAttributedString mutableCopy];
             [blockquoteAttributedString addAttributes:@{NSFontAttributeName: monospacedParagraphFont, NSForegroundColorAttributeName: NSColor.labelColor} range:NSMakeRange(0, blockquoteAttributedString.length)];
@@ -261,7 +261,7 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
 
 static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
-    NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize + 5];
+    NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize];
     NSFont *monospacedParagraphFont = [NSFont monospacedSystemFontOfSize:defaultFontPointSize weight:NSFontWeightRegular];
     
     NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -15,6 +15,7 @@
 
 #import <AppKit/AppKit.h>
 
+// Divider attachment cell used for markdown horizontal line breaks
 API_AVAILABLE(macos(10.14))
 @interface SPUMarkdownHorizontalDividerAttachmentCell : NSTextAttachmentCell
 @end
@@ -42,6 +43,7 @@ API_AVAILABLE(macos(10.14))
 
 @end
 
+// Divider attachment cell used for markdown block quotes
 API_AVAILABLE(macos(10.14))
 @interface SPUMarkdownVerticalAttachmentCell : NSTextAttachmentCell
 @end
@@ -115,8 +117,10 @@ API_AVAILABLE(macos(10.14))
     return _scrollView;
 }
 
-static void processMarkdownAttributedSubString(NSAttributedString *subAttributedString, NSMutableAttributedString *newAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *newlineAttributedString) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
 {
+    // Pre-pass processing of intent
+    // This info must be computed before processing parent intent
     BOOL isListItem = NO;
     NSFont *font = inputParagraphFont;
     switch (intent.intentKind) {
@@ -152,35 +156,41 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
             break;
     }
     
+    // Process parent intent if available
+    // A paragraph's intent may be a list item, or a block quote for example. A header's parent intent could be a block quote.
+    // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownAttributedSubString(subAttributedString, newAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, parentIntent, font, monospacedParagraphFont, newlineAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, parentIntent, font, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
     }
     
+    // Process the current intent
     switch (intent.intentKind) {
         case NSPresentationIntentKindHeader: {
             paragraphStyle.paragraphSpacingBefore += font.pointSize * 0.16;
             paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
             
-            NSMutableAttributedString *headerAttributedString = [subAttributedString mutableCopy];
+            NSMutableAttributedString *headerAttributedString = [fragmentAttributedString mutableCopy];
             
             [headerAttributedString addAttributes:@{NSFontAttributeName: font} range:NSMakeRange(0, headerAttributedString.length)];
             
-            [newAttributedSubString appendAttributedString:headerAttributedString];
+            [outputAttributedSubString appendAttributedString:headerAttributedString];
             
             break;
         }
         case NSPresentationIntentKindParagraph: {
             paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
             
-            NSMutableAttributedString *contentAttributedString = [subAttributedString mutableCopy];
+            NSMutableAttributedString *contentAttributedString = [fragmentAttributedString mutableCopy];
             [contentAttributedString addAttributes:@{NSFontAttributeName: font} range:NSMakeRange(0, contentAttributedString.length)];
             
-            [newAttributedSubString appendAttributedString:contentAttributedString];
+            [outputAttributedSubString appendAttributedString:contentAttributedString];
             
             break;
         }
         case NSPresentationIntentKindListItem: {
+            // We only process (the innermost first) list item once when we encounter nested lists,
+            // to avoid outputting multiple list bullets
             if (canProcessListItem) {
                 paragraphStyle.firstLineHeadIndent += intent.indentationLevel * (font.pointSize * 1.5);
                 paragraphStyle.headIndent += intent.indentationLevel * (font.pointSize * 1.5);
@@ -188,27 +198,11 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
                 BOOL insertUnorderedBullet = (parentIntent == nil || parentIntent.intentKind == NSPresentationIntentKindUnorderedList);
                 
                 if (insertUnorderedBullet) {
-                    NSImageSymbolConfiguration *bulletSymbolConfiguration = [NSImageSymbolConfiguration configurationWithHierarchicalColor:NSColor.textColor];
-                    
-                    NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
-                    
-                    NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-                    attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
-                    
-                    const CGFloat imageScale = font.pointSize / 32.5;
-                    const CGFloat yBoundsScaleOffset = 0.25;
-                    
-                    attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
-                    
-                    NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
-                    
-                    [finalBulletAttributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@"  " attributes:@{NSFontAttributeName: font}]];
-                    
-                    [newAttributedSubString appendAttributedString:finalBulletAttributedString];
+                    [outputAttributedSubString appendAttributedString:listBulletAttributedString];
                 } else {
                     NSAttributedString *listItemAttributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld. ", intent.ordinal] attributes:@{NSFontAttributeName: monospacedParagraphFont}];
                     
-                    [newAttributedSubString appendAttributedString:listItemAttributedString];
+                    [outputAttributedSubString appendAttributedString:listItemAttributedString];
                 }
             }
             
@@ -221,18 +215,20 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
             
-            [newAttributedSubString appendAttributedString:dividerAttributedString];
+            [outputAttributedSubString appendAttributedString:dividerAttributedString];
             
             break;
         }
         case NSPresentationIntentKindBlockQuote: {
+            // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
+            // Each line will get its own preceding vertical line. These lines are not 'connected' which is a limitation for now.
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
             attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithFont:font];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
             
-            [newAttributedSubString appendAttributedString:dividerAttributedString];
+            [outputAttributedSubString appendAttributedString:dividerAttributedString];
 
             break;
         }
@@ -241,10 +237,10 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
             paragraphStyle.firstLineHeadIndent += font.pointSize * 0.6;
             paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
             
-            NSMutableAttributedString *blockquoteAttributedString = [subAttributedString mutableCopy];
+            NSMutableAttributedString *blockquoteAttributedString = [fragmentAttributedString mutableCopy];
             [blockquoteAttributedString addAttributes:@{NSFontAttributeName: monospacedParagraphFont, NSForegroundColorAttributeName: NSColor.labelColor} range:NSMakeRange(0, blockquoteAttributedString.length)];
             
-            [newAttributedSubString appendAttributedString:blockquoteAttributedString];
+            [outputAttributedSubString appendAttributedString:blockquoteAttributedString];
             
             break;
         }
@@ -261,19 +257,52 @@ static void processMarkdownAttributedSubString(NSAttributedString *subAttributed
 
 static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
+    NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
+    if (originalAttributedString == nil) {
+        return nil;
+    }
+    
+    // Create our fonts and cache some common attributed strings up front (list bullets, newline)
+    
     NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize];
     NSFont *monospacedParagraphFont = [NSFont monospacedSystemFontOfSize:defaultFontPointSize weight:NSFontWeightRegular];
     
-    NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
-    
-    NSMutableAttributedString *newAttributedString = [[NSMutableAttributedString alloc] init];
+    NSMutableAttributedString *outputAttributedString = [[NSMutableAttributedString alloc] init];
     
     NSAttributedString *newlineAttributedString = [[NSAttributedString alloc] initWithString:@"\n"];
     
+    NSAttributedString *listBulletAttributedString;
+    {
+        // Create a list bullet by using a SF symbol that uses a dynamic color appropriate for switching between light/dark mode,
+        // and we can scale the image to what we need (regular unicode bullet point characters are scaled too small or too big and may not be offsetted right)
+        // Perhaps we could have created a custom attachment cell class instead, but this works
+        NSImageSymbolConfiguration *bulletSymbolConfiguration = [NSImageSymbolConfiguration configurationWithHierarchicalColor:NSColor.textColor];
+        
+        NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
+        
+        NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+        attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
+        
+        const CGFloat imageScale = paragraphFont.pointSize / 32.5;
+        const CGFloat yBoundsScaleOffset = 0.25;
+        
+        attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
+        
+        NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
+        
+        [finalBulletAttributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@"  " attributes:@{NSFontAttributeName: paragraphFont}]];
+        
+        listBulletAttributedString = [finalBulletAttributedString copy];
+    }
+    
+    // Enumerate through every presentation intent fragment and create a new attributed string that we append to the output
+    // Foundation handles formatting some things for us already in the attributed string such as bold/itatlics and hyperlinks,
+    // but we need to handle formatting paragraphs, headers, lists, block quotes, etc in the attributed string.
     [originalAttributedString enumerateAttribute:NSPresentationIntentAttributeName inRange:NSMakeRange(0, originalAttributedString.length) options:0 usingBlock:^(NSPresentationIntent *intent, NSRange range, BOOL * _Nonnull __unused stop) {
         
-        NSAttributedString *subAttributedString = [originalAttributedString attributedSubstringFromRange:range];
+        NSAttributedString *fragmentAttributedString = [originalAttributedString attributedSubstringFromRange:range];
         
+        // Properties of the paragraph start as 0 and later get incremented based on what is processed
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         paragraphStyle.paragraphSpacingBefore = 0;
         paragraphStyle.paragraphSpacing = 0;
@@ -283,15 +312,15 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         NSMutableAttributedString *newAttributedSubString = [[NSMutableAttributedString alloc] init];
         
         BOOL canProcessListItem = YES;
-        processMarkdownAttributedSubString(subAttributedString, newAttributedSubString, paragraphStyle, canProcessListItem, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, newAttributedSubString, paragraphStyle, canProcessListItem, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
         
         [newAttributedSubString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, newAttributedSubString.length)];
         
-        [newAttributedString appendAttributedString:newAttributedSubString];
-        [newAttributedString appendAttributedString:newlineAttributedString];
+        [outputAttributedString appendAttributedString:newAttributedSubString];
+        [outputAttributedString appendAttributedString:newlineAttributedString];
     }];
     
-    return newAttributedString;
+    return outputAttributedString;
 }
 
 - (void)_loadString:(NSString *)contents completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
@@ -304,6 +333,8 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             if (attributedString == nil) {
                 SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
             }
+        } else {
+            SULog(SULogLevelDefault, @"Warning: falling back to plain text because markdown support requires macOS 12 or newer");
         }
     }
     

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -362,22 +362,11 @@ static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *or
     
     NSAttributedString *listBulletAttributedString;
     {
-        // We use a text attachment for unordered list bullets so we can control the size/offset/padding of the symbol
-        // We don't use a NSTextAttachmentCell because that doesn't work in Catalyst applications
+        // The bullet character looks too small in the system font, so switch to another font where it's bigger at same point size
+        NSFont *listBulletPreferredFont = [NSFont fontWithName:@"Menlo Regular" size:defaultFontPointSize];
+        NSFont *listBulletFont = (listBulletPreferredFont != nil) ? listBulletPreferredFont : paragraphFont;
         
-        NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-        
-        NSImageSymbolConfiguration *bulletSymbolConfiguration = [NSImageSymbolConfiguration configurationWithHierarchicalColor:NSColor.textColor];
-        
-        NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
-        
-        const CGFloat imageScale = paragraphFont.pointSize / 40.0;
-        const CGFloat yBoundsScaleOffset = 0.4;
-        
-        attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
-        attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
-        
-        listBulletAttributedString = [NSAttributedString attributedStringWithAttachment:attachment];
+        listBulletAttributedString = [[NSAttributedString alloc] initWithString:@"•" attributes:@{NSFontAttributeName : listBulletFont}];
     }
     
     NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: paragraphFont}];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -469,7 +469,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     [_textView setVerticallyResizable:YES];
     [_textView setHorizontallyResizable:NO];
     [_textView setAutoresizingMask:NSViewWidthSizable];
-    [_textView setTextContainerInset:NSMakeSize(8, 8)];
+    [_textView setTextContainerInset:NSMakeSize(4, 8)];
     [_textView setContinuousSpellCheckingEnabled:NO];
     _textView.usesFontPanel = NO;
     _textView.editable = NO;

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -80,8 +80,6 @@ API_AVAILABLE(macos(12.0))
     id<NSTextLocation> textLocation = [_textContentManager locationFromLocation:_textContentManager.documentRange.location withOffset:_textOffset];
     
     NSTextLayoutFragment *textLayoutFragment = [textLayoutManager textLayoutFragmentForLocation:textLocation];
-    CGRect layoutFragmentFrame = textLayoutFragment.layoutFragmentFrame;
-    NSLog(@"Height: %f", layoutFragmentFrame.size.height);
     
     const CGFloat lineWidth = 2.0;
     CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
@@ -89,16 +87,10 @@ API_AVAILABLE(macos(12.0))
     NSBezierPath *path = [NSBezierPath bezierPath];
     
     NSPoint beginPoint = NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height - _font.ascender);
-    NSPoint endPoint = NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height + -(_font.descender));
-    
-    //NSLog(@"%f", endPoint.y - beginPoint.y);
-    CGFloat difference = layoutFragmentFrame.size.height - (endPoint.y - beginPoint.y);
+    NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + (_font.ascender + -(_font.descender) + _font.leading) * textLayoutFragment.textLineFragments.count);
     
     [path moveToPoint:NSMakePoint(beginPoint.x, beginPoint.y)];
     [path lineToPoint:NSMakePoint(endPoint.x, endPoint.y)];
-    
-    //[path moveToPoint:NSMakePoint(xPosition, layoutFragmentFrame.origin.y)];
-    //[path lineToPoint:NSMakePoint(xPosition, layoutFragmentFrame.origin.y + layoutFragmentFrame.size.height)];
 
     [[NSColor separatorColor] setStroke];
     [path setLineWidth:lineWidth];
@@ -291,7 +283,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         }
         case NSPresentationIntentKindBlockQuote: {
             // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
-            // Each line will get its own preceding vertical line. These lines are not 'connected' which is a limitation for now.
+            // Each text fragment will get its own preceding vertical line. These lines are not 'connected' which is a limitation for now.
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
             attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextContentManager:textContentManager textOffset:(NSInteger)outputAttributedSubString.length font:font];
 
@@ -381,6 +373,12 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         // Split the presentation intent by lines so we treat every line as a separate paragraph so we present them properly (with correct indentation / tabs)
         // Normally multiple lines aren't in the same paragraph, but this can happen in some cases like code blocks
         [originalAttributedString.string enumerateSubstringsInRange:presentationIntentRange options:NSStringEnumerationByLines usingBlock:^(NSString * _Nullable __unused substring, NSRange substringRange, NSRange __unused enclosingRange, BOOL * _Nonnull __unused stopLineEnumeration) {
+            // Insert newline after outputting previous paragraph
+            // This check ensures an extra newline is not inserted after the last outputted paragraph
+            if (outputAttributedString.length > 0) {
+                [outputAttributedString appendAttributedString:newlineAttributedString];
+            }
+            
             NSAttributedString *fragmentAttributedString = [originalAttributedString attributedSubstringFromRange:substringRange];
             
             // Properties of the paragraph start as 0 and later get incremented based on what is processed
@@ -400,8 +398,6 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textContentManager);
             
             [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
-            
-            [outputAttributedString appendAttributedString:newlineAttributedString];
         }];
     }];
     

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -251,6 +251,11 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
 }
 
 // Note: this function can be called from a background thread and shouldn't use main-thread only APIs
+// More decorative rendering for blockquotes and line breaks (i.e. rendering dividers) was tried out,
+// using a. NSTextAttachmentCell based subclass, or b. NSTextAttachmentViewProvider, or c. adopting custom NSTextViewportLayoutControllerDelegate.
+// This was ultimatily given up on and they all have various tradeoffs. NSCell based text attachments don't work in Catalyst,
+// view based attachments take up additional space, and TextKit2 CALayer decorations are hard to (re)size/position correctly.
+// Also each increases code complexity and risk. In the end, changelogs can can live without these.
 static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *originalAttributedString, CGFloat defaultFontPointSize) API_AVAILABLE(macos(12.0))
 {
     // Create our fonts and cache some common attributed strings up front (list bullets, newline)

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -50,17 +50,17 @@ API_AVAILABLE(macos(12.0))
 
 @implementation SPUMarkdownVerticalAttachmentCell
 {
-    NSTextContentManager *_textContentManager;
+    NSTextLayoutManager *_textLayoutManager;
     NSFont *_font;
     
     NSInteger _textOffset;
 }
 
-- (instancetype)initWithTextContentManager:(NSTextContentManager *)textContentManager textOffset:(NSInteger)textOffset font:(NSFont *)font
+- (instancetype)initWithTextLayoutManager:(NSTextLayoutManager *)textLayoutManager textOffset:(NSInteger)textOffset font:(NSFont *)font
 {
     self = [super init];
     if (self != nil) {
-        _textContentManager = textContentManager;
+        _textLayoutManager = textLayoutManager;
         _font = font;
         _textOffset = textOffset;
     }
@@ -75,11 +75,10 @@ API_AVAILABLE(macos(12.0))
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
 {
-    NSTextLayoutManager *textLayoutManager = _textContentManager.textLayoutManagers.firstObject;
+    NSTextContentManager *textContentManager = _textLayoutManager.textContentManager;
+    id<NSTextLocation> textLocation = [textContentManager locationFromLocation:textContentManager.documentRange.location withOffset:_textOffset];
     
-    id<NSTextLocation> textLocation = [_textContentManager locationFromLocation:_textContentManager.documentRange.location withOffset:_textOffset];
-    
-    NSTextLayoutFragment *textLayoutFragment = [textLayoutManager textLayoutFragmentForLocation:textLocation];
+    NSTextLayoutFragment *textLayoutFragment = [_textLayoutManager textLayoutFragmentForLocation:textLocation];
     
     const CGFloat lineWidth = 2.0;
     CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
@@ -166,7 +165,7 @@ API_AVAILABLE(macos(12.0))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString, NSTextContentManager *textContentManager) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString, NSTextLayoutManager *textLayoutManager) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -210,7 +209,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textContentManager);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
     }
     
     // Process the current intent
@@ -285,7 +284,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
             // Each text fragment will get its own preceding vertical line. These lines are not 'connected' which is a limitation for now.
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextContentManager:textContentManager textOffset:(NSInteger)outputAttributedSubString.length font:font];
+            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextLayoutManager:textLayoutManager textOffset:(NSInteger)outputAttributedSubString.length font:font];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
@@ -325,7 +324,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSTextContentManager *textContentManager, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSTextLayoutManager *textLayoutManager, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
     NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
     if (originalAttributedString == nil) {
@@ -395,7 +394,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             NSUInteger previousOutputLength = outputAttributedString.length;
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textContentManager);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
             
             [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
         }];
@@ -410,10 +409,10 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     if (_prefersMarkdown) {
         if (@available(macOS 12, *)) {
             
-            NSTextContentManager *textContentManager = _textView.textLayoutManager.textContentManager;
+            NSTextLayoutManager *textLayoutManager = _textView.textLayoutManager;
             
             NSError *markdownError = nil;
-            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, textContentManager, &markdownError);
+            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, textLayoutManager, &markdownError);
             if (attributedString == nil) {
                 SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
             }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -18,6 +18,7 @@
 #import <AppKit/AppKit.h>
 
 // Divider attachment cell used for markdown horizontal line breaks
+// Note: this does not work in Catalyst apps as it's NSTextAttachmentCell based
 API_AVAILABLE(macos(10.14))
 @interface SPUMarkdownHorizontalDividerAttachmentCell : NSTextAttachmentCell
 @end
@@ -64,6 +65,7 @@ API_AVAILABLE(macos(10.14))
 @end
 
 // Divider attachment cell used for markdown block quotes
+// Note: this does not work in Catalyst apps as it's NSTextAttachmentCell based
 API_AVAILABLE(macos(12.0))
 @interface SPUMarkdownVerticalAttachmentCell : NSTextAttachmentCell
 @end
@@ -94,44 +96,6 @@ API_AVAILABLE(macos(12.0))
     [NSColor.lightGrayColor setStroke];
     [path setLineWidth:lineWidth];
     [path stroke];
-}
-
-@end
-
-// Attachment cell used for unordered list bullets
-@interface SPUMarkdownBulletAttachmentCell : NSTextAttachmentCell
-@end
-
-@implementation SPUMarkdownBulletAttachmentCell
-{
-    CGFloat _fontPointSize;
-}
-
-- (instancetype)initWithFont:(NSFont *)font
-{
-    self = [super init];
-    if (self != nil) {
-        _fontPointSize = font.pointSize;
-    }
-    return self;
-}
-
-- (NSSize)cellSize
-{
-    CGFloat cellSize = _fontPointSize * 0.65;
-    return NSMakeSize(cellSize, cellSize);
-}
-
-- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
-{
-    CGFloat diameter = cellFrame.size.height * 0.5;
-    CGFloat x = NSMidX(cellFrame) - diameter / 2.0;
-    CGFloat y = NSMidY(cellFrame) - diameter / 2.0;
-
-    NSBezierPath *circlePath = [NSBezierPath bezierPathWithOvalInRect:NSMakeRect(x, y, diameter, diameter)];
-
-    [NSColor.textColor setFill];
-    [circlePath fill];
 }
 
 @end
@@ -398,9 +362,20 @@ static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *or
     
     NSAttributedString *listBulletAttributedString;
     {
+        // We use a text attachment for unordered list bullets so we can control the size/offset/padding of the symbol
+        // We don't use a NSTextAttachmentCell because that doesn't work in Catalyst applications
+        
         NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-        SPUMarkdownBulletAttachmentCell *cell = [[SPUMarkdownBulletAttachmentCell alloc] initWithFont:paragraphFont];
-        attachment.attachmentCell = cell;
+        
+        NSImageSymbolConfiguration *bulletSymbolConfiguration = [NSImageSymbolConfiguration configurationWithHierarchicalColor:NSColor.textColor];
+        
+        NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
+        
+        const CGFloat imageScale = paragraphFont.pointSize / 40.0;
+        const CGFloat yBoundsScaleOffset = 0.4;
+        
+        attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
+        attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
         
         listBulletAttributedString = [NSAttributedString attributedStringWithAttachment:attachment];
     }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -103,16 +103,16 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         case NSPresentationIntentKindHeader:
             switch (intent.headerLevel) {
                 case 1:
-                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 7.0];
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize * 1.5];
                     break;
                 case 2:
-                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 4.0];
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize * 1.3];
                     break;
                 case 3:
-                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 2.0];
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize * 1.2];
                     break;
                 default:
-                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 1.0];
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize * 1.1];
                     break;
             }
             break;

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -231,8 +231,9 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // Process the current intent
     switch (intent.intentKind) {
         case NSPresentationIntentKindHeader: {
-            paragraphStyle.paragraphSpacingBefore += font.pointSize * 0.16;
-            paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
+            CGFloat paragraphSpacing = font.pointSize * 0.8;
+            paragraphStyle.paragraphSpacingBefore += paragraphSpacing;
+            paragraphStyle.paragraphSpacing += paragraphSpacing;
             
             NSMutableAttributedString *headerAttributedString = [fragmentAttributedString mutableCopy];
             
@@ -243,7 +244,15 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             break;
         }
         case NSPresentationIntentKindParagraph: {
-            paragraphStyle.paragraphSpacing += font.pointSize * 0.25;
+            if (parentIntent != nil) {
+                // If the parent intent is a list item or a blockquote we don't want to apply paragraphSpacingBefore,
+                // and we'll apply less spacing
+                paragraphStyle.paragraphSpacing += font.pointSize * 0.3;
+            } else {
+                CGFloat paragraphSpacing = font.pointSize * 0.5;
+                paragraphStyle.paragraphSpacing += paragraphSpacing;
+                paragraphStyle.paragraphSpacingBefore += paragraphSpacing;
+            }
             
             NSMutableAttributedString *contentAttributedString = [fragmentAttributedString mutableCopy];
             [contentAttributedString addAttributes:@{NSFontAttributeName: font} range:NSMakeRange(0, contentAttributedString.length)];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -17,89 +17,6 @@
 
 #import <AppKit/AppKit.h>
 
-// Divider attachment cell used for markdown horizontal line breaks
-// Note: this does not work in Catalyst apps as it's NSTextAttachmentCell based
-API_AVAILABLE(macos(10.14))
-@interface SPUMarkdownHorizontalDividerAttachmentCell : NSTextAttachmentCell
-@end
-
-@implementation SPUMarkdownHorizontalDividerAttachmentCell
-{
-    NSTextView *_textView;
-    
-    CGFloat _headIndent;
-}
-
-- (instancetype)initWithTextView:(NSTextView *)textView headIndent:(CGFloat)headIndent
-{
-    self = [super init];
-    if (self != nil) {
-        _textView = textView;
-        _headIndent = headIndent;
-    }
-    return self;
-}
-
-- (NSSize)cellSize
-{
-    return NSMakeSize(CGFLOAT_MAX, 10.0);
-}
-
-- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
-{
-    CGFloat yPosition = NSMidY(cellFrame);
-    
-    NSSize containerInset = _textView.textContainerInset;
-    CGFloat lineFragmentPadding = _textView.textContainer.lineFragmentPadding;
-    CGFloat totalWidthPadding = containerInset.width + lineFragmentPadding + _headIndent;
-    
-    NSBezierPath *path = [NSBezierPath bezierPath];
-    [path moveToPoint:NSMakePoint(view.bounds.origin.x + totalWidthPadding, yPosition)];
-    [path lineToPoint:NSMakePoint(view.bounds.origin.x + view.bounds.size.width - totalWidthPadding, yPosition)];
-
-    [NSColor.separatorColor setStroke];
-    [path setLineWidth:1.0];
-    [path stroke];
-}
-
-@end
-
-// Divider attachment cell used for markdown block quotes
-// Note: this does not work in Catalyst apps as it's NSTextAttachmentCell based
-API_AVAILABLE(macos(12.0))
-@interface SPUMarkdownVerticalAttachmentCell : NSTextAttachmentCell
-@end
-
-@implementation SPUMarkdownVerticalAttachmentCell
-
-- (NSSize)cellSize
-{
-    // Minimum height needs to be at least 1
-    return NSMakeSize(10.0, 1.0);
-}
-
-- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
-{
-    const CGFloat lineWidth = 3.0;
-    CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
-    
-    NSBezierPath *path = [NSBezierPath bezierPath];
-    path.lineCapStyle = NSLineCapStyleButt;
-    
-    // In TextKit 2 we can render the entire view bounds and it will be appropriately clamped
-    NSPoint beginPoint = NSMakePoint(xPosition, view.bounds.origin.y);
-    NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + view.bounds.size.height);
-    
-    [path moveToPoint:NSMakePoint(beginPoint.x, beginPoint.y)];
-    [path lineToPoint:NSMakePoint(endPoint.x, endPoint.y)];
-
-    [NSColor.lightGrayColor setStroke];
-    [path setLineWidth:lineWidth];
-    [path stroke];
-}
-
-@end
-
 @interface SUPlainTextReleaseNotesView () <NSTextViewDelegate>
 @end
 
@@ -176,7 +93,7 @@ API_AVAILABLE(macos(12.0))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, NSTextView *textView, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -220,7 +137,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, textView, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
     }
     
     // Process the current intent
@@ -290,32 +207,16 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             
             break;
         }
-        case NSPresentationIntentKindThematicBreak: {
-            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            // Account for headIndent if thematic break is inside a blockquote
-            // This may not work well if thematic break is in a list element, oh well
-            attachment.attachmentCell = [[SPUMarkdownHorizontalDividerAttachmentCell alloc] initWithTextView:textView headIndent:paragraphStyle.headIndent];
-
-            NSAttributedString *dividerAttributedString =
-                [NSAttributedString attributedStringWithAttachment:attachment];
-            
-            [outputAttributedSubString appendAttributedString:dividerAttributedString];
-            
-            break;
-        }
         case NSPresentationIntentKindBlockQuote: {
-            // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
-            
-            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] init];
-
-            NSAttributedString *dividerAttributedString =
-                [NSAttributedString attributedStringWithAttachment:attachment];
-            
             // Advance text that wraps to next line by this divider width
-            paragraphStyle.headIndent += dividerAttributedString.size.width;
+            // Multiple levels of block quotes will be advanced mulitiple times
+            // Special rendering via text attachments or decorations is not done because
+            // it's complex and may have tradeoffs
             
-            [outputAttributedSubString appendAttributedString:dividerAttributedString];
+            const CGFloat headIndentAdvancement = 10.0;
+            
+            paragraphStyle.firstLineHeadIndent += headIndentAdvancement;
+            paragraphStyle.headIndent += headIndentAdvancement;
 
             break;
         }
@@ -338,6 +239,9 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         
         case NSPresentationIntentKindOrderedList:
         case NSPresentationIntentKindUnorderedList:
+        // Nothing special is rendered for thematic breaks
+        // Rendering them via text attachments or decorations is complex and has tradeoffs
+        case NSPresentationIntentKindThematicBreak:
         // Note: TextKit 2 doesn't support NSTextTable
         // Tables don't show up in release notes often, so they're not that worthwhile supporting
         case NSPresentationIntentKindTable:
@@ -348,8 +252,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-// Note: this must be called on main thread
-static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *originalAttributedString, CGFloat defaultFontPointSize, NSTextView *textView) API_AVAILABLE(macos(12.0))
+// Note: this function can be called from a background thread and shouldn't use main-thread only APIs
+static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *originalAttributedString, CGFloat defaultFontPointSize) API_AVAILABLE(macos(12.0))
 {
     // Create our fonts and cache some common attributed strings up front (list bullets, newline)
     
@@ -403,7 +307,7 @@ static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *or
             NSUInteger previousOutputLength = outputAttributedString.length;
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, textView, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
             
             [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
         }];
@@ -479,9 +383,9 @@ static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *or
                         [self _loadAttributedString:attributedString completionHandler:completionHandler];
                     });
                 } else {
+                    NSAttributedString *formattedAttributedString = formatMarkdownAttributedString(originalMarkdownAttributedString, (CGFloat)self->_fontPointSize);
+                    
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        NSAttributedString *formattedAttributedString = formatMarkdownAttributedString(originalMarkdownAttributedString, (CGFloat)self->_fontPointSize, self->_textView);
-                        
                         [self _loadAttributedString:formattedAttributedString completionHandler:completionHandler];
                     });
                 }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -49,23 +49,6 @@ API_AVAILABLE(macos(12.0))
 @end
 
 @implementation SPUMarkdownVerticalAttachmentCell
-{
-    NSTextLayoutManager *_textLayoutManager;
-    NSFont *_font;
-    
-    NSMutableOrderedSet<NSNumber *> *_textOffsets;
-}
-
-- (instancetype)initWithTextLayoutManager:(NSTextLayoutManager *)textLayoutManager textOffsets:(NSMutableOrderedSet<NSNumber *> *)textOffsets font:(NSFont *)font
-{
-    self = [super init];
-    if (self != nil) {
-        _textLayoutManager = textLayoutManager;
-        _font = font;
-        _textOffsets = textOffsets;
-    }
-    return self;
-}
 
 - (NSSize)cellSize
 {
@@ -75,33 +58,14 @@ API_AVAILABLE(macos(12.0))
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
 {
-    NSTextContentManager *textContentManager = _textLayoutManager.textContentManager;
-    
-    NSUInteger totalNumberOfTextLineFragments = 0;
-    id<NSTextLocation> textDocumentRangeLocation = textContentManager.documentRange.location;
-    for (NSNumber *textOffset in _textOffsets) {
-        id<NSTextLocation> textLocation = [textContentManager locationFromLocation:textDocumentRangeLocation withOffset:textOffset.integerValue];
-        
-        if (textLocation == nil) {
-            continue;
-        }
-        
-        NSTextLayoutFragment *textLayoutFragment = [_textLayoutManager textLayoutFragmentForLocation:textLocation];
-        if (textLayoutFragment == nil) {
-            continue;
-        }
-        
-        totalNumberOfTextLineFragments += textLayoutFragment.textLineFragments.count;
-    }
-    
     const CGFloat lineWidth = 3.0;
     CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
     
     NSBezierPath *path = [NSBezierPath bezierPath];
     path.lineCapStyle = NSLineCapStyleButt;
     
-    NSPoint beginPoint = NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height - _font.ascender);
-    NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + (_font.ascender + -(_font.descender) + _font.leading) * totalNumberOfTextLineFragments);
+    NSPoint beginPoint = NSMakePoint(xPosition, view.bounds.origin.y);
+    NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + view.bounds.size.height);
     
     [path moveToPoint:NSMakePoint(beginPoint.x, beginPoint.y)];
     [path lineToPoint:NSMakePoint(endPoint.x, endPoint.y)];
@@ -124,8 +88,8 @@ API_AVAILABLE(macos(12.0))
     id _textViewSwitchedToTextKit1Observer;
 #endif
     NSArray<NSString *> *_customAllowedURLSchemes;
-    int _fontPointSize;
     
+    int _fontPointSize;
     BOOL _prefersMarkdown;
 }
 
@@ -180,7 +144,7 @@ API_AVAILABLE(macos(12.0))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSMutableDictionary<NSNumber *, NSMutableOrderedSet<NSNumber *> *> *blockquoteToTextOffsetsTable, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString, NSTextLayoutManager *textLayoutManager) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -224,7 +188,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, blockquoteToTextOffsetsTable, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
     }
     
     // Process the current intent
@@ -299,18 +263,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         case NSPresentationIntentKindBlockQuote: {
             // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
             
-            NSNumber *intentIdentity = @(intent.identity);
-            NSMutableOrderedSet<NSNumber *> *textOffsetsForBlockquote = blockquoteToTextOffsetsTable[intentIdentity];
-            if (textOffsetsForBlockquote == nil) {
-                textOffsetsForBlockquote = [[NSMutableOrderedSet alloc] init];
-                blockquoteToTextOffsetsTable[intentIdentity] = textOffsetsForBlockquote;
-            }
-            
-            NSInteger textOffset = (NSInteger)outputAttributedSubString.length;
-            [textOffsetsForBlockquote addObject:@(textOffset)];
-            
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextLayoutManager:textLayoutManager textOffsets:textOffsetsForBlockquote font:font];
+            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] init];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
@@ -351,7 +305,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     }
 }
 
-static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSTextLayoutManager *textLayoutManager, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
+static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
     NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
     if (originalAttributedString == nil) {
@@ -391,8 +345,6 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     
     NSMutableSet<NSNumber *> *previousVisitedListItemIntents = [[NSMutableSet alloc] init];
     
-    NSMutableDictionary<NSNumber *, NSMutableOrderedSet<NSNumber *> *> *blockquoteToTextOffsetsTable = [[NSMutableDictionary alloc] init];
-    
     // Enumerate through every presentation intent fragment and create a new attributed string that we append to the output
     // Foundation handles formatting some things for us already in the attributed string such as bold/itatlics and hyperlinks,
     // but we need to handle formatting paragraphs, headers, lists, block quotes, etc in the attributed string.
@@ -423,7 +375,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             NSUInteger previousOutputLength = outputAttributedString.length;
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, blockquoteToTextOffsetsTable, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
             
             [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
         }];
@@ -437,11 +389,8 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     NSAttributedString *attributedString = nil;
     if (_prefersMarkdown) {
         if (@available(macOS 12, *)) {
-            
-            NSTextLayoutManager *textLayoutManager = _textView.textLayoutManager;
-            
             NSError *markdownError = nil;
-            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, textLayoutManager, &markdownError);
+            attributedString = makeMarkdownAttributedString(contents, (CGFloat)_fontPointSize, &markdownError);
             if (attributedString == nil) {
                 SULog(SULogLevelError, @"Failed to load markdown contents with error: %@. Falling back to plain text.", markdownError.localizedDescription);
             }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -193,8 +193,12 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             // to avoid outputting multiple list bullets
             // Also avoid processing list items that were processed from previous passes / fragments
             if (canProcessListItem) {
-                paragraphStyle.firstLineHeadIndent += intent.indentationLevel * (font.pointSize * 1.5);
-                paragraphStyle.headIndent += intent.indentationLevel * (font.pointSize * 1.5);
+                CGFloat firstLineIdentation = intent.indentationLevel * (font.pointSize * 1.5);
+                paragraphStyle.firstLineHeadIndent += firstLineIdentation;
+                
+                // Advance subsequent lines and text that wraps to next line by next tab interval past the firstLineIdentation
+                CGFloat defaultTabInterval = paragraphStyle.defaultTabInterval;
+                paragraphStyle.headIndent += ceil(firstLineIdentation / defaultTabInterval) * defaultTabInterval;
                 
                 BOOL didVisitListItemFromPreviousPass = [previousVisitedListItemIntents containsObject:intent];
                 BOOL insertUnorderedBullet = (parentIntent == nil || parentIntent.intentKind == NSPresentationIntentKindUnorderedList);
@@ -238,6 +242,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
                 [NSAttributedString attributedStringWithAttachment:attachment];
             
             [outputAttributedSubString appendAttributedString:dividerAttributedString];
+            // Advance text that wraps to next line by this divider width
+            paragraphStyle.headIndent += dividerAttributedString.size.width;
 
             break;
         }
@@ -247,6 +253,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             // A parent of a code block could be a block quote or list item
             // It's more correct to use tab rather than leading paragraph indentation in this case
             [outputAttributedSubString appendAttributedString:tabAttributedString];
+            // Advance text that wraps to next line by next tab interval
+            paragraphStyle.headIndent += paragraphStyle.defaultTabInterval;
             
             NSMutableAttributedString *blockquoteAttributedString = [fragmentAttributedString mutableCopy];
             [blockquoteAttributedString addAttributes:@{NSFontAttributeName: monospacedParagraphFont, NSForegroundColorAttributeName: NSColor.labelColor} range:NSMakeRange(0, blockquoteAttributedString.length)];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -117,7 +117,7 @@ API_AVAILABLE(macos(10.14))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -161,7 +161,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, parentIntent, font, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
     }
     
     // Process the current intent
@@ -191,18 +191,25 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         case NSPresentationIntentKindListItem: {
             // We only process (the innermost first) list item once when we encounter nested lists,
             // to avoid outputting multiple list bullets
+            // Also avoid processing list items that were processed from previous passes / fragments
             if (canProcessListItem) {
                 paragraphStyle.firstLineHeadIndent += intent.indentationLevel * (font.pointSize * 1.5);
                 paragraphStyle.headIndent += intent.indentationLevel * (font.pointSize * 1.5);
                 
+                BOOL didVisitListItemFromPreviousPass = [previousVisitedListItemIntents containsObject:intent];
                 BOOL insertUnorderedBullet = (parentIntent == nil || parentIntent.intentKind == NSPresentationIntentKindUnorderedList);
                 
-                if (insertUnorderedBullet) {
-                    [outputAttributedSubString appendAttributedString:listBulletAttributedString];
-                } else {
-                    NSAttributedString *listItemAttributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld. ", intent.ordinal] attributes:@{NSFontAttributeName: monospacedParagraphFont}];
+                if (!didVisitListItemFromPreviousPass) {
+                    if (insertUnorderedBullet) {
+                        [outputAttributedSubString appendAttributedString:listBulletAttributedString];
+                    } else {
+                        NSString *ordinalStringWithSpacing = [NSString stringWithFormat:@"%ld. ", intent.ordinal];
+                        NSAttributedString *listItemAttributedString = [[NSAttributedString alloc] initWithString:ordinalStringWithSpacing attributes:@{NSFontAttributeName: monospacedParagraphFont}];
+                        
+                        [outputAttributedSubString appendAttributedString:listItemAttributedString];
+                    }
                     
-                    [outputAttributedSubString appendAttributedString:listItemAttributedString];
+                    [previousVisitedListItemIntents addObject:intent];
                 }
             }
             
@@ -281,19 +288,23 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
         
         NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-        attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
         
         const CGFloat imageScale = paragraphFont.pointSize / 32.5;
         const CGFloat yBoundsScaleOffset = 0.25;
         
         attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
+        attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
         
         NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
         
-        [finalBulletAttributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@"  " attributes:@{NSFontAttributeName: paragraphFont}]];
+        NSAttributedString *spaceAttributedString = [[NSAttributedString alloc] initWithString:@"  " attributes:@{NSFontAttributeName: paragraphFont}];
+        
+        [finalBulletAttributedString appendAttributedString:spaceAttributedString];
         
         listBulletAttributedString = [finalBulletAttributedString copy];
     }
+    
+    NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents = [[NSMutableSet alloc] init];
     
     // Enumerate through every presentation intent fragment and create a new attributed string that we append to the output
     // Foundation handles formatting some things for us already in the attributed string such as bold/itatlics and hyperlinks,
@@ -312,7 +323,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
         
         BOOL canProcessListItem = YES;
-        processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
         
         [fragmentOutputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, fragmentOutputAttributedString.length)];
         

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -77,6 +77,43 @@ API_AVAILABLE(macos(12.0))
 
 @end
 
+@interface SPUMarkdownBulletAttachmentCell : NSTextAttachmentCell
+@end
+
+@implementation SPUMarkdownBulletAttachmentCell
+{
+    CGFloat _fontPointSize;
+}
+
+- (instancetype)initWithFont:(NSFont *)font
+{
+    self = [super init];
+    if (self != nil) {
+        _fontPointSize = font.pointSize;
+    }
+    return self;
+}
+
+- (NSSize)cellSize
+{
+    CGFloat cellSize = _fontPointSize * 0.65;
+    return NSMakeSize(cellSize, cellSize);
+}
+
+- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+{
+    CGFloat diameter = cellFrame.size.height * 0.5;
+    CGFloat x = NSMidX(cellFrame) - diameter / 2.0;
+    CGFloat y = NSMidY(cellFrame) - diameter / 2.0;
+
+    NSBezierPath *circlePath = [NSBezierPath bezierPathWithOvalInRect:NSMakeRect(x, y, diameter, diameter)];
+
+    [NSColor.textColor setFill];
+    [circlePath fill];
+}
+
+@end
+
 @interface SUPlainTextReleaseNotesView () <NSTextViewDelegate>
 @end
 
@@ -323,20 +360,9 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     
     NSAttributedString *listBulletAttributedString;
     {
-        // Create a list bullet by using a SF symbol that uses a dynamic color appropriate for switching between light/dark mode,
-        // and we can scale the image to what we need (regular unicode bullet point characters are scaled too small or too big and may not be offsetted right)
-        // Perhaps we could have created a custom attachment cell class instead, but this works
-        NSImageSymbolConfiguration *bulletSymbolConfiguration = [NSImageSymbolConfiguration configurationWithHierarchicalColor:NSColor.textColor];
-        
-        NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
-        
         NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-        
-        const CGFloat imageScale = paragraphFont.pointSize / 32.5;
-        const CGFloat yBoundsScaleOffset = 0.25;
-        
-        attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * imageScale * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
-        attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
+        SPUMarkdownBulletAttachmentCell *cell = [[SPUMarkdownBulletAttachmentCell alloc] initWithFont:paragraphFont];
+        attachment.attachmentCell = cell;
         
         listBulletAttributedString = [NSAttributedString attributedStringWithAttachment:attachment];
     }

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -117,7 +117,7 @@ API_AVAILABLE(macos(10.14))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -161,7 +161,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
     }
     
     // Process the current intent
@@ -212,8 +212,6 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
                     [previousVisitedListItemIntents addObject:intent];
                 }
                 
-                NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: font}];
-                
                 [outputAttributedSubString appendAttributedString:tabAttributedString];
             }
             
@@ -248,7 +246,6 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
             
             // A parent of a code block could be a block quote or list item
             // It's more correct to use tab rather than leading paragraph indentation in this case
-            NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: monospacedParagraphFont}];
             [outputAttributedSubString appendAttributedString:tabAttributedString];
             
             NSMutableAttributedString *blockquoteAttributedString = [fragmentAttributedString mutableCopy];
@@ -307,6 +304,8 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         listBulletAttributedString = [NSAttributedString attributedStringWithAttachment:attachment];
     }
     
+    NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: paragraphFont}];
+    
     NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents = [[NSMutableSet alloc] init];
     
     // Enumerate through every presentation intent fragment and create a new attributed string that we append to the output
@@ -333,7 +332,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString);
             
             [fragmentOutputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, fragmentOutputAttributedString.length)];
             

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -309,14 +309,14 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         paragraphStyle.headIndent = 0;
         paragraphStyle.firstLineHeadIndent = 0;
         
-        NSMutableAttributedString *newAttributedSubString = [[NSMutableAttributedString alloc] init];
+        NSMutableAttributedString *fragmentOutputAttributedString = [[NSMutableAttributedString alloc] init];
         
         BOOL canProcessListItem = YES;
-        processMarkdownFragmentAttributedString(fragmentAttributedString, newAttributedSubString, paragraphStyle, canProcessListItem, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, fragmentOutputAttributedString, paragraphStyle, canProcessListItem, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString, listBulletAttributedString);
         
-        [newAttributedSubString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, newAttributedSubString.length)];
+        [fragmentOutputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, fragmentOutputAttributedString.length)];
         
-        [outputAttributedString appendAttributedString:newAttributedSubString];
+        [outputAttributedString appendAttributedString:fragmentOutputAttributedString];
         [outputAttributedString appendAttributedString:newlineAttributedString];
     }];
     

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -53,16 +53,16 @@ API_AVAILABLE(macos(12.0))
     NSTextLayoutManager *_textLayoutManager;
     NSFont *_font;
     
-    NSInteger _textOffset;
+    NSMutableOrderedSet<NSNumber *> *_textOffsets;
 }
 
-- (instancetype)initWithTextLayoutManager:(NSTextLayoutManager *)textLayoutManager textOffset:(NSInteger)textOffset font:(NSFont *)font
+- (instancetype)initWithTextLayoutManager:(NSTextLayoutManager *)textLayoutManager textOffsets:(NSMutableOrderedSet<NSNumber *> *)textOffsets font:(NSFont *)font
 {
     self = [super init];
     if (self != nil) {
         _textLayoutManager = textLayoutManager;
         _font = font;
-        _textOffset = textOffset;
+        _textOffsets = textOffsets;
     }
     return self;
 }
@@ -76,22 +76,37 @@ API_AVAILABLE(macos(12.0))
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
 {
     NSTextContentManager *textContentManager = _textLayoutManager.textContentManager;
-    id<NSTextLocation> textLocation = [textContentManager locationFromLocation:textContentManager.documentRange.location withOffset:_textOffset];
     
-    NSTextLayoutFragment *textLayoutFragment = [_textLayoutManager textLayoutFragmentForLocation:textLocation];
+    NSUInteger totalNumberOfTextLineFragments = 0;
+    id<NSTextLocation> textDocumentRangeLocation = textContentManager.documentRange.location;
+    for (NSNumber *textOffset in _textOffsets) {
+        id<NSTextLocation> textLocation = [textContentManager locationFromLocation:textDocumentRangeLocation withOffset:textOffset.integerValue];
+        
+        if (textLocation == nil) {
+            continue;
+        }
+        
+        NSTextLayoutFragment *textLayoutFragment = [_textLayoutManager textLayoutFragmentForLocation:textLocation];
+        if (textLayoutFragment == nil) {
+            continue;
+        }
+        
+        totalNumberOfTextLineFragments += textLayoutFragment.textLineFragments.count;
+    }
     
-    const CGFloat lineWidth = 2.0;
+    const CGFloat lineWidth = 3.0;
     CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
     
     NSBezierPath *path = [NSBezierPath bezierPath];
+    path.lineCapStyle = NSLineCapStyleButt;
     
     NSPoint beginPoint = NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height - _font.ascender);
-    NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + (_font.ascender + -(_font.descender) + _font.leading) * textLayoutFragment.textLineFragments.count);
+    NSPoint endPoint = NSMakePoint(beginPoint.x, beginPoint.y + (_font.ascender + -(_font.descender) + _font.leading) * totalNumberOfTextLineFragments);
     
     [path moveToPoint:NSMakePoint(beginPoint.x, beginPoint.y)];
     [path lineToPoint:NSMakePoint(endPoint.x, endPoint.y)];
 
-    [[NSColor separatorColor] setStroke];
+    [[NSColor lightGrayColor] setStroke];
     [path setLineWidth:lineWidth];
     [path stroke];
 }
@@ -165,7 +180,7 @@ API_AVAILABLE(macos(12.0))
     return _scrollView;
 }
 
-static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString, NSTextLayoutManager *textLayoutManager) API_AVAILABLE(macos(12.0))
+static void processMarkdownFragmentAttributedString(NSAttributedString *fragmentAttributedString, NSMutableAttributedString *outputAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSMutableSet<NSNumber *> *previousVisitedListItemIntents, NSMutableDictionary<NSNumber *, NSMutableOrderedSet<NSNumber *> *> *blockquoteToTextOffsetsTable, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *tabAttributedString, NSAttributedString *newlineAttributedString, NSAttributedString *listBulletAttributedString, NSTextLayoutManager *textLayoutManager) API_AVAILABLE(macos(12.0))
 {
     // Pre-pass processing of intent
     // This info must be computed before processing parent intent
@@ -209,7 +224,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
     // In these cases, we may pre-append attributed string to the output before processing current intent.
     NSPresentationIntent *parentIntent = intent.parentIntent;
     if (parentIntent != nil) {
-        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
+        processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, previousVisitedListItemIntents, blockquoteToTextOffsetsTable, parentIntent, font, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
     }
     
     // Process the current intent
@@ -248,7 +263,8 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
                 CGFloat defaultTabInterval = paragraphStyle.defaultTabInterval;
                 paragraphStyle.headIndent += ceil(firstLineIdentation / defaultTabInterval) * defaultTabInterval;
                 
-                BOOL didVisitListItemFromPreviousPass = [previousVisitedListItemIntents containsObject:intent];
+                NSNumber *intentIdentity = @(intent.identity);
+                BOOL didVisitListItemFromPreviousPass = [previousVisitedListItemIntents containsObject:intentIdentity];
                 BOOL insertUnorderedBullet = (parentIntent == nil || parentIntent.intentKind == NSPresentationIntentKindUnorderedList);
                 
                 if (!didVisitListItemFromPreviousPass) {
@@ -261,7 +277,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
                         [outputAttributedSubString appendAttributedString:listItemAttributedString];
                     }
                     
-                    [previousVisitedListItemIntents addObject:intent];
+                    [previousVisitedListItemIntents addObject:intentIdentity];
                 }
                 
                 [outputAttributedSubString appendAttributedString:tabAttributedString];
@@ -282,16 +298,27 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
         }
         case NSPresentationIntentKindBlockQuote: {
             // Multiple levels of block quotes are handled (e.g. parent intent could be another block quote).
-            // Each text fragment will get its own preceding vertical line. These lines are not 'connected' which is a limitation for now.
+            
+            NSNumber *intentIdentity = @(intent.identity);
+            NSMutableOrderedSet<NSNumber *> *textOffsetsForBlockquote = blockquoteToTextOffsetsTable[intentIdentity];
+            if (textOffsetsForBlockquote == nil) {
+                textOffsetsForBlockquote = [[NSMutableOrderedSet alloc] init];
+                blockquoteToTextOffsetsTable[intentIdentity] = textOffsetsForBlockquote;
+            }
+            
+            NSInteger textOffset = (NSInteger)outputAttributedSubString.length;
+            [textOffsetsForBlockquote addObject:@(textOffset)];
+            
             NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextLayoutManager:textLayoutManager textOffset:(NSInteger)outputAttributedSubString.length font:font];
+            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithTextLayoutManager:textLayoutManager textOffsets:textOffsetsForBlockquote font:font];
 
             NSAttributedString *dividerAttributedString =
                 [NSAttributedString attributedStringWithAttachment:attachment];
             
-            [outputAttributedSubString appendAttributedString:dividerAttributedString];
             // Advance text that wraps to next line by this divider width
             paragraphStyle.headIndent += dividerAttributedString.size.width;
+            
+            [outputAttributedSubString appendAttributedString:dividerAttributedString];
 
             break;
         }
@@ -362,7 +389,9 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
     
     NSAttributedString *tabAttributedString = [[NSAttributedString alloc] initWithString:@"\t" attributes:@{NSFontAttributeName: paragraphFont}];
     
-    NSMutableSet<NSPresentationIntent *> *previousVisitedListItemIntents = [[NSMutableSet alloc] init];
+    NSMutableSet<NSNumber *> *previousVisitedListItemIntents = [[NSMutableSet alloc] init];
+    
+    NSMutableDictionary<NSNumber *, NSMutableOrderedSet<NSNumber *> *> *blockquoteToTextOffsetsTable = [[NSMutableDictionary alloc] init];
     
     // Enumerate through every presentation intent fragment and create a new attributed string that we append to the output
     // Foundation handles formatting some things for us already in the attributed string such as bold/itatlics and hyperlinks,
@@ -394,7 +423,7 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
             NSUInteger previousOutputLength = outputAttributedString.length;
             
             BOOL canProcessListItem = YES;
-            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
+            processMarkdownFragmentAttributedString(fragmentAttributedString, outputAttributedString, paragraphStyle, canProcessListItem, previousVisitedListItemIntents, blockquoteToTextOffsetsTable, intent, paragraphFont, monospacedParagraphFont, tabAttributedString, newlineAttributedString, listBulletAttributedString, textLayoutManager);
             
             [outputAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(previousOutputLength, outputAttributedString.length - previousOutputLength)];
         }];

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -91,6 +91,9 @@ API_AVAILABLE(macos(10.14))
 {
     NSScrollView *_scrollView;
     NSTextView *_textView;
+#if DEBUG
+    id _textViewSwitchedToTextKit1Observer;
+#endif
     NSArray<NSString *> *_customAllowedURLSchemes;
     int _fontPointSize;
     
@@ -120,6 +123,12 @@ API_AVAILABLE(macos(10.14))
             [textContentStorage addTextLayoutManager:textLayoutManager];
             
             _textView = [[NSTextView alloc] initWithFrame:NSZeroRect textContainer:textLayoutManager.textContainer];
+            
+#if DEBUG
+            _textViewSwitchedToTextKit1Observer = [NSNotificationCenter.defaultCenter addObserverForName:NSTextViewDidSwitchToNSLayoutManagerNotification object:_textView queue:nil usingBlock:^(NSNotification * _Nonnull __unused notification) {
+                SULog(SULogLevelError, @"Error: Plain text release notes text view switched to TextKit 1. This should not happen. Was some TextKit 1 API called that is causing this?");
+            }];
+#endif
         } else {
             _textView = [[NSTextView alloc] initWithFrame:NSZeroRect];
         }
@@ -129,6 +138,13 @@ API_AVAILABLE(macos(10.14))
     }
     return self;
 }
+
+#if DEBUG
+- (void)dealloc
+{
+    [NSNotificationCenter.defaultCenter removeObserver:_textViewSwitchedToTextKit1Observer];
+}
+#endif
 
 - (NSView *)view
 {

--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -16,26 +16,67 @@
 #import <AppKit/AppKit.h>
 
 API_AVAILABLE(macos(10.14))
-@interface SPUMarkdownDividerAttachmentCell : NSTextAttachmentCell
+@interface SPUMarkdownHorizontalDividerAttachmentCell : NSTextAttachmentCell
 @end
 
-@implementation SPUMarkdownDividerAttachmentCell
+@implementation SPUMarkdownHorizontalDividerAttachmentCell
 
 - (NSSize)cellSize
 {
-    return NSMakeSize(0, 10);
+    // Minimum width needs to be at least 1
+    return NSMakeSize(1.0, 10.0);
 }
 
-- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
+- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
 {
-    CGFloat midY = NSMidY(cellFrame);
-
+    CGFloat yPosition = NSMidY(cellFrame);
+    
     NSBezierPath *path = [NSBezierPath bezierPath];
-    [path moveToPoint:NSMakePoint(0, midY)];
-    [path lineToPoint:NSMakePoint(controlView.bounds.size.width, midY)];
+    [path moveToPoint:NSMakePoint(0.0, yPosition)];
+    [path lineToPoint:NSMakePoint(view.bounds.size.width, yPosition)];
 
     [[NSColor separatorColor] setStroke];
     [path setLineWidth:1.0];
+    [path stroke];
+}
+
+@end
+
+API_AVAILABLE(macos(10.14))
+@interface SPUMarkdownVerticalAttachmentCell : NSTextAttachmentCell
+@end
+
+@implementation SPUMarkdownVerticalAttachmentCell
+{
+    NSFont *_font;
+}
+
+- (instancetype)initWithFont:(NSFont *)font
+{
+    self = [super init];
+    if (self != nil) {
+        _font = font;
+    }
+    return self;
+}
+
+- (NSSize)cellSize
+{
+    // Minimum height needs to be at least 1
+    return NSMakeSize(10.0, 1.0);
+}
+
+- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)view
+{
+    const CGFloat lineWidth = 2.0;
+    CGFloat xPosition = cellFrame.origin.x + lineWidth / 2.0;
+    
+    NSBezierPath *path = [NSBezierPath bezierPath];
+    [path moveToPoint:NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height - _font.ascender)];
+    [path lineToPoint:NSMakePoint(xPosition, cellFrame.origin.y + cellFrame.size.height + -(_font.descender))];
+
+    [[NSColor separatorColor] setStroke];
+    [path setLineWidth:lineWidth];
     [path stroke];
 }
 
@@ -74,9 +115,153 @@ API_AVAILABLE(macos(10.14))
     return _scrollView;
 }
 
+static void processMarkdownAttributedSubString(NSAttributedString *subAttributedString, NSMutableAttributedString *newAttributedSubString, NSMutableParagraphStyle *paragraphStyle, BOOL canProcessListItem, NSPresentationIntent *intent, NSFont *inputParagraphFont, NSFont *monospacedParagraphFont, NSAttributedString *newlineAttributedString) API_AVAILABLE(macos(12.0))
+{
+    BOOL isListItem = NO;
+    NSFont *font = inputParagraphFont;
+    switch (intent.intentKind) {
+        case NSPresentationIntentKindHeader:
+            switch (intent.headerLevel) {
+                case 1:
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 7.0];
+                    break;
+                case 2:
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 4.0];
+                    break;
+                case 3:
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 2.0];
+                    break;
+                default:
+                    font = [NSFont boldSystemFontOfSize:(CGFloat)inputParagraphFont.pointSize + 1.0];
+                    break;
+            }
+            break;
+        case NSPresentationIntentKindListItem:
+            isListItem = YES;
+            break;
+        case NSPresentationIntentKindParagraph:
+        case NSPresentationIntentKindThematicBreak:
+        case NSPresentationIntentKindBlockQuote:
+        case NSPresentationIntentKindCodeBlock:
+        case NSPresentationIntentKindOrderedList:
+        case NSPresentationIntentKindUnorderedList:
+        case NSPresentationIntentKindTable:
+        case NSPresentationIntentKindTableHeaderRow:
+        case NSPresentationIntentKindTableRow:
+        case NSPresentationIntentKindTableCell:
+            break;
+    }
+    
+    NSPresentationIntent *parentIntent = intent.parentIntent;
+    if (parentIntent != nil) {
+        processMarkdownAttributedSubString(subAttributedString, newAttributedSubString, paragraphStyle, canProcessListItem && !isListItem, parentIntent, font, monospacedParagraphFont, newlineAttributedString);
+    }
+    
+    switch (intent.intentKind) {
+        case NSPresentationIntentKindHeader: {
+            paragraphStyle.paragraphSpacingBefore += 8.0;
+            paragraphStyle.paragraphSpacing += 4.0;
+            
+            NSMutableAttributedString *headerAttributedString = [subAttributedString mutableCopy];
+            
+            [headerAttributedString addAttributes:@{NSFontAttributeName: font} range:NSMakeRange(0, headerAttributedString.length)];
+            
+            [newAttributedSubString appendAttributedString:headerAttributedString];
+            
+            break;
+        }
+        case NSPresentationIntentKindParagraph: {
+            paragraphStyle.paragraphSpacing += 4.0;
+            
+            NSMutableAttributedString *contentAttributedString = [subAttributedString mutableCopy];
+            [contentAttributedString addAttributes:@{NSFontAttributeName: font} range:NSMakeRange(0, contentAttributedString.length)];
+            
+            [newAttributedSubString appendAttributedString:subAttributedString];
+            
+            break;
+        }
+        case NSPresentationIntentKindListItem: {
+            if (canProcessListItem) {
+                paragraphStyle.firstLineHeadIndent += intent.indentationLevel * 20.0;
+                paragraphStyle.headIndent += intent.indentationLevel * 20.0;
+                
+                BOOL insertUnorderedBullet = (parentIntent == nil || parentIntent.intentKind == NSPresentationIntentKindUnorderedList);
+                
+                if (insertUnorderedBullet) {
+                    NSImageSymbolConfiguration *bulletSymbolConfiguration = [NSImageSymbolConfiguration configurationWithHierarchicalColor:NSColor.textColor];
+                    
+                    NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
+                    
+                    NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+                    attachment.image = [bulletSymbol imageWithSymbolConfiguration:bulletSymbolConfiguration];
+                    
+                    const CGFloat imageScale = 0.4;
+                    const CGFloat yBoundsScaleOffset = 0.1;
+                    attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
+                    
+                    NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
+                    
+                    [finalBulletAttributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@"  " attributes:@{NSFontAttributeName: font}]];
+                    
+                    [newAttributedSubString appendAttributedString:finalBulletAttributedString];
+                } else {
+                    NSAttributedString *listItemAttributedString = [[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"%ld. ", intent.ordinal] attributes:@{NSFontAttributeName: monospacedParagraphFont}];
+                    
+                    [newAttributedSubString appendAttributedString:listItemAttributedString];
+                }
+            }
+            
+            break;
+        }
+        case NSPresentationIntentKindThematicBreak: {
+            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+            attachment.attachmentCell = [[SPUMarkdownHorizontalDividerAttachmentCell alloc] init];
+
+            NSAttributedString *dividerAttributedString =
+                [NSAttributedString attributedStringWithAttachment:attachment];
+            
+            [newAttributedSubString appendAttributedString:dividerAttributedString];
+            
+            break;
+        }
+        case NSPresentationIntentKindBlockQuote: {
+            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+            attachment.attachmentCell = [[SPUMarkdownVerticalAttachmentCell alloc] initWithFont:font];
+
+            NSAttributedString *dividerAttributedString =
+                [NSAttributedString attributedStringWithAttachment:attachment];
+            
+            [newAttributedSubString appendAttributedString:dividerAttributedString];
+
+            break;
+        }
+        case NSPresentationIntentKindCodeBlock: {
+            paragraphStyle.headIndent += 8;
+            paragraphStyle.firstLineHeadIndent += 8;
+            paragraphStyle.paragraphSpacing += 2;
+            paragraphStyle.paragraphSpacingBefore += 4;
+            
+            NSMutableAttributedString *blockquoteAttributedString = [subAttributedString mutableCopy];
+            [blockquoteAttributedString addAttributes:@{NSFontAttributeName: monospacedParagraphFont, NSForegroundColorAttributeName: NSColor.labelColor} range:NSMakeRange(0, blockquoteAttributedString.length)];
+            
+            [newAttributedSubString appendAttributedString:blockquoteAttributedString];
+            
+            break;
+        }
+        
+        case NSPresentationIntentKindOrderedList:
+        case NSPresentationIntentKindUnorderedList:
+        case NSPresentationIntentKindTable:
+        case NSPresentationIntentKindTableHeaderRow:
+        case NSPresentationIntentKindTableRow:
+        case NSPresentationIntentKindTableCell:
+            break;
+    }
+}
+
 static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *contents, CGFloat defaultFontPointSize, NSError * __autoreleasing *outError) API_AVAILABLE(macos(12.0))
 {
-    NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize];
+    NSFont *paragraphFont = [NSFont systemFontOfSize:defaultFontPointSize + 5];
     NSFont *monospacedParagraphFont = [NSFont monospacedSystemFontOfSize:defaultFontPointSize weight:NSFontWeightRegular];
     
     NSAttributedString *originalAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:nil error:outError];
@@ -89,124 +274,21 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
         
         NSAttributedString *subAttributedString = [originalAttributedString attributedSubstringFromRange:range];
         
-        NSLog(@"Parent intent: %@", intent.parentIntent);
+        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+        paragraphStyle.paragraphSpacingBefore = 0;
+        paragraphStyle.paragraphSpacing = 0;
+        paragraphStyle.headIndent = 0;
+        paragraphStyle.firstLineHeadIndent = 0;
         
-        NSLog(@"Subattributed string: %@", subAttributedString);
+        NSMutableAttributedString *newAttributedSubString = [[NSMutableAttributedString alloc] init];
         
-        switch (intent.intentKind) {
-            case NSPresentationIntentKindHeader: {
-                NSInteger level = intent.headerLevel;
-                NSFont *font;
-                switch (level) {
-                    case 1:
-                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 7.0];
-                        break;
-                    case 2:
-                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 4.0];
-                        break;
-                    case 3:
-                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 2.0];
-                        break;
-                    default:
-                        font = [NSFont boldSystemFontOfSize:(CGFloat)defaultFontPointSize + 1.0];
-                        break;
-                }
-                
-                NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-                paragraphStyle.paragraphSpacingBefore = 4.0;
-                paragraphStyle.paragraphSpacing = 8.0;
-                
-                NSMutableAttributedString *headerAttributedString = [subAttributedString mutableCopy];
-                
-                [headerAttributedString addAttributes:@{NSFontAttributeName: font, NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, headerAttributedString.length)];
-                
-                [newAttributedString appendAttributedString:headerAttributedString];
-                [newAttributedString appendAttributedString:newlineAttributedString];
-                
-                break;
-            }
-            case NSPresentationIntentKindParagraph: {
-                NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-                paragraphStyle.paragraphSpacing = 4.0;
-                
-                NSMutableAttributedString *paragraphAttributedString = [[NSMutableAttributedString alloc] init];
-                
-                NSPresentationIntent *parentIntent = intent.parentIntent;
-                if (parentIntent != nil) {
-                    switch (parentIntent.intentKind) {
-                        case NSPresentationIntentKindListItem: {
-                            paragraphStyle.firstLineHeadIndent = 20.0 * parentIntent.indentationLevel;
-                            paragraphStyle.headIndent = 20.0 * parentIntent.indentationLevel;
-                            
-                            NSImage *bulletSymbol = [NSImage imageWithSystemSymbolName:@"circle.fill" accessibilityDescription:nil];
-                            
-                            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-                            attachment.image = bulletSymbol;
-                            
-                            const CGFloat imageScale = 0.4;
-                            const CGFloat yBoundsScaleOffset = 0.1;
-                            attachment.bounds = NSMakeRect(0, bulletSymbol.size.height * yBoundsScaleOffset, bulletSymbol.size.width * imageScale, bulletSymbol.size.height * imageScale);
-                            
-                            NSMutableAttributedString *finalBulletAttributedString = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
-                            
-                            [finalBulletAttributedString appendAttributedString:[[NSAttributedString alloc] initWithString:@"  "]];
-                            
-                            [finalBulletAttributedString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, finalBulletAttributedString.length)];
-                            
-                            [paragraphAttributedString appendAttributedString:finalBulletAttributedString];
-                            
-                            break;
-                        }
-                        default:
-                            break;
-                    }
-                }
-                
-                NSMutableAttributedString *contentAttributedString = [subAttributedString mutableCopy];
-                [contentAttributedString addAttributes:@{NSFontAttributeName: paragraphFont, NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, contentAttributedString.length)];
-                
-                [paragraphAttributedString appendAttributedString:contentAttributedString];
-                
-                [newAttributedString appendAttributedString:paragraphAttributedString];
-                [newAttributedString appendAttributedString:newlineAttributedString];
-                
-                break;
-            }
-            case NSPresentationIntentKindThematicBreak: {
-                NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-                attachment.attachmentCell = [[SPUMarkdownDividerAttachmentCell alloc] init];
-
-                NSAttributedString *dividerAttributedString =
-                    [NSAttributedString attributedStringWithAttachment:attachment];
-                
-                [newAttributedString appendAttributedString:dividerAttributedString];
-                [newAttributedString appendAttributedString:newlineAttributedString];
-                break;
-            }
-            case NSPresentationIntentKindCodeBlock: {
-                NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-                style.headIndent = 6;
-                style.firstLineHeadIndent = 6;
-                style.paragraphSpacing = 2;
-                style.paragraphSpacingBefore = 4;
-
-                NSDictionary *attrs = @{
-                    NSFontAttributeName: monospacedParagraphFont,
-                    NSParagraphStyleAttributeName: style,
-                    NSForegroundColorAttributeName: NSColor.labelColor
-                };
-                
-                NSMutableAttributedString *blockquoteAttributedString = [subAttributedString mutableCopy];
-                [blockquoteAttributedString addAttributes:attrs range:NSMakeRange(0, blockquoteAttributedString.length)];
-                
-                [newAttributedString appendAttributedString:blockquoteAttributedString];
-                [newAttributedString appendAttributedString:newlineAttributedString];
-                
-                break;
-            }
-            default:
-                break;
-        }
+        BOOL canProcessListItem = YES;
+        processMarkdownAttributedSubString(subAttributedString, newAttributedSubString, paragraphStyle, canProcessListItem, intent, paragraphFont, monospacedParagraphFont, newlineAttributedString);
+        
+        [newAttributedSubString addAttributes:@{NSParagraphStyleAttributeName: paragraphStyle} range:NSMakeRange(0, newAttributedSubString.length)];
+        
+        [newAttributedString appendAttributedString:newAttributedSubString];
+        [newAttributedString appendAttributedString:newlineAttributedString];
     }];
     
     return newAttributedString;
@@ -293,8 +375,6 @@ static NSAttributedString * _Nullable makeMarkdownAttributedString(NSString *con
 {
 }
 
-// Links are not insertable yet but this is useful in case we support them in the future
-// This is also a defence in case links are somehow insertable
 - (BOOL)textView:(NSTextView *)textView clickedOnLink:(id)link atIndex:(NSUInteger)charIndex
 {
     NSURL *linkURL;

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -16,11 +16,12 @@
 #import "SPUUserUpdateState.h"
 
 @protocol SUUpdateAlertDelegate;
+@protocol SPUStandardUserDriverDelegate;
 
 @class SUAppcastItem, SPUDownloadData, SUHost, SPUUpdaterSettings;
 SPU_OBJC_DIRECT_MEMBERS @interface SUUpdateAlert : NSWindowController
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer updaterSettings:(SPUUpdaterSettings *)updaterSettings completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer updaterSettings:(SPUUpdaterSettings *)updaterSettings delegate:(id<SPUStandardUserDriverDelegate>)delegate completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock;
 
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData;
 - (void)showReleaseNotesFailedToDownload;

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -56,6 +56,8 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
     id<SUReleaseNotesView> _releaseNotesView;
     id<SUVersionDisplay> _versionDisplayer;
     
+    __weak id<SPUStandardUserDriverDelegate> _delegate;
+    
     IBOutlet NSStackView *_stackView;
     IBOutlet NSButton *_installButton;
     IBOutlet NSButton *_laterButton;
@@ -71,7 +73,7 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
     BOOL _windowLoadedAndShowsReleaseNotes;
 }
 
-- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer updaterSettings:(SPUUpdaterSettings *)updaterSettings completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
+- (instancetype)initWithAppcastItem:(SUAppcastItem *)item state:(SPUUserUpdateState *)state host:(SUHost *)aHost versionDisplayer:(id<SUVersionDisplay>)versionDisplayer updaterSettings:(SPUUpdaterSettings *)updaterSettings delegate:(id<SPUStandardUserDriverDelegate>)delegate completionBlock:(void (^)(SPUUserUpdateChoice, NSRect, BOOL))completionBlock didBecomeKeyBlock:(void (^)(void))didBecomeKeyBlock
 {
     self = [super initWithWindowNibName:@"SUUpdateAlert"];
     if (self != nil) {
@@ -80,6 +82,7 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
         _versionDisplayer = versionDisplayer;
         
         _state = state;
+        _delegate = delegate;
         _completionBlock = [completionBlock copy];
         _didBecomeKeyBlock = [didBecomeKeyBlock copy];
         
@@ -321,12 +324,13 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
         customAllowedURLSchemes = [allowedSchemes copy];
     }
     
+    id<SPUStandardUserDriverDelegate> delegate = _delegate;
     switch (usedReleaseNotesFormat) {
         case SUReleaseNotesFormatPlainText:
-            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize prefersMarkdown:NO customAllowedURLSchemes:customAllowedURLSchemes];
+            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize appcastItem:_updateItem host:_host delegate:delegate prefersMarkdown:NO customAllowedURLSchemes:customAllowedURLSchemes];
             break;
         case SUReleaseNotesFormatMarkdown:
-            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize prefersMarkdown:YES customAllowedURLSchemes:customAllowedURLSchemes];
+            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize appcastItem:_updateItem host:_host delegate:delegate prefersMarkdown:YES customAllowedURLSchemes:customAllowedURLSchemes];
             break;
         case SUReleaseNotesFormatHTML:
         {

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -36,6 +36,13 @@ static NSString *const SUAllowsAutomaticUpdatesKeyPath = @"allowsAutomaticUpdate
 
 static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
 
+typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
+{
+    SUReleaseNotesFormatHTML,
+    SUReleaseNotesFormatPlainText,
+    SUReleaseNotesFormatMarkdown
+};
+
 @interface SUUpdateAlert () <NSTouchBarDelegate>
 @end
 
@@ -172,12 +179,17 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
         NSString *itemDescription = _updateItem.itemDescription;
         if (itemDescription != nil) {
             NSString *itemDescriptionFormat = _updateItem.itemDescriptionFormat;
-            // We don't support markdown but prepare for the future in case we support it one day
-            BOOL prefersPlainText =
-                ([itemDescriptionFormat isEqualToString:@"plain-text"] ||
-                 [itemDescriptionFormat isEqualToString:@"markdown"]);
             
-            [self _createReleaseNotesViewPreferringPlainText:prefersPlainText];
+            SUReleaseNotesFormat releaseNotesFormat;
+            if ([itemDescriptionFormat isEqualToString:@"plain-text"]) {
+                releaseNotesFormat = SUReleaseNotesFormatPlainText;
+            } else if ([itemDescriptionFormat isEqualToString:@"markdown"]) {
+                releaseNotesFormat = SUReleaseNotesFormatMarkdown;
+            } else {
+                releaseNotesFormat = SUReleaseNotesFormatHTML;
+            }
+            
+            [self _createReleaseNotesViewPreferringFormat:releaseNotesFormat];
             
             __weak __typeof__(self) weakSelf = self;
             [_releaseNotesView loadString:itemDescription baseURL:nil completionHandler:^(NSError * _Nullable error) {
@@ -213,15 +225,20 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
     
     // We don't support markdown but prepare for the future in case we support it one day
     NSString *pathExtension = releaseNotesURL.pathExtension;
-    BOOL preferringPlainText =
-        ([chosenMIMEType isEqualToString:@"text/plain"] ||
-         [pathExtension caseInsensitiveCompare:@"txt"] == NSOrderedSame ||
-         [chosenMIMEType isEqualToString:@"text/markdown"] ||
-         [chosenMIMEType isEqualToString:@"text/x-markdown"] ||
-         [pathExtension caseInsensitiveCompare:@"md"] == NSOrderedSame ||
-         [pathExtension caseInsensitiveCompare:@"markdown"] == NSOrderedSame);
     
-    [self _createReleaseNotesViewPreferringPlainText:preferringPlainText];
+    SUReleaseNotesFormat releaseNotesFormat;
+    if ([chosenMIMEType isEqualToString:@"text/plain"] || [pathExtension caseInsensitiveCompare:@"txt"] == NSOrderedSame) {
+        releaseNotesFormat = SUReleaseNotesFormatPlainText;
+    } else if ([chosenMIMEType isEqualToString:@"text/markdown"] ||
+               [chosenMIMEType isEqualToString:@"text/x-markdown"] ||
+               [pathExtension caseInsensitiveCompare:@"md"] == NSOrderedSame ||
+               [pathExtension caseInsensitiveCompare:@"markdown"] == NSOrderedSame) {
+        releaseNotesFormat = SUReleaseNotesFormatMarkdown;
+    } else {
+        releaseNotesFormat = SUReleaseNotesFormatHTML;
+    }
+    
+    [self _createReleaseNotesViewPreferringFormat:releaseNotesFormat];
     
     __weak __typeof__(self) weakSelf = self;
     [_releaseNotesView loadData:downloadData.data MIMEType:chosenMIMEType textEncodingName:chosenTextEncodingName baseURL:baseURL completionHandler:^(NSError * _Nullable error) {
@@ -255,26 +272,32 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
         return [shouldShowReleaseNotes boolValue];
 }
 
-- (void)_createReleaseNotesViewPreferringPlainText:(BOOL)preferringPlainText SPU_OBJC_DIRECT
+- (void)_createReleaseNotesViewPreferringFormat:(SUReleaseNotesFormat)preferredReleaseNotesFormat SPU_OBJC_DIRECT
 {
     // "-apple-system-font" is a reference to the system UI font. "-apple-system" is the new recommended token, but for backward compatibility we can't use it.
     NSString *defaultFontFamily = @"-apple-system-font";
     
     int defaultFontSize = (int)[NSFont systemFontSize];
     
-    BOOL usesPlainText;
-    if (preferringPlainText) {
-        usesPlainText = YES;
-    } else {
-        if (@available(macOS 10.15, *)) {
-            usesPlainText = [[NSProcessInfo processInfo] isMacCatalystApp];
-            
-            if (usesPlainText && !preferringPlainText) {
-                SULog(SULogLevelError, @"Error: Showing HTML release notes for Catalyst apps is not supported. The release notes will be interpreted as plain text. Please serve a plain-text (.txt) release notes file. If you are using a <description> element then please specify the %@=\"plain-text\" attribute in that element.", SUAppcastAttributeFormat);
+    SUReleaseNotesFormat usedReleaseNotesFormat;
+    switch (preferredReleaseNotesFormat) {
+        case SUReleaseNotesFormatPlainText:
+        case SUReleaseNotesFormatMarkdown:
+            usedReleaseNotesFormat = preferredReleaseNotesFormat;
+            break;
+        case SUReleaseNotesFormatHTML:
+            if (@available(macOS 10.15, *)) {
+                if ([[NSProcessInfo processInfo] isMacCatalystApp]) {
+                    usedReleaseNotesFormat = SUReleaseNotesFormatPlainText;
+                    
+                    SULog(SULogLevelError, @"Error: Showing HTML release notes for Catalyst apps is not supported. The release notes will be interpreted as plain text. Please serve a plain-text (.txt) or markdown (.md) release notes file. If you are using a <description> element then please specify the %@=\"plain-text\" or %@=\"markdown\" attribute in that element.", SUAppcastAttributeFormat, SUAppcastAttributeFormat);
+                } else {
+                    usedReleaseNotesFormat = preferredReleaseNotesFormat;
+                }
+            } else {
+                usedReleaseNotesFormat = preferredReleaseNotesFormat;
             }
-        } else {
-            usesPlainText = NO;
-        }
+            break;
     }
     
     NSArray<NSString *> *customAllowedURLSchemes;
@@ -297,26 +320,35 @@ static const CGFloat SUUpdateAlertGroupElementSpacing = 12.0;
         customAllowedURLSchemes = [allowedSchemes copy];
     }
     
-    if (usesPlainText) {
-        _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize customAllowedURLSchemes:customAllowedURLSchemes];
-    } else {
-        NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
-        
-        BOOL javaScriptEnabled = [_host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
-        
-#if DOWNLOADER_XPC_SERVICE_EMBEDDED
-        // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
-        // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
-        // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
-        // In this case, fall back to legacy WebKit view.
-        // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
-        BOOL useWKWebView = !SPUXPCServiceIsEnabled(SUEnableDownloaderServiceKey);
-        if (!useWKWebView) {
-            _releaseNotesView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled customAllowedURLSchemes:customAllowedURLSchemes];
-        } else
-#endif
+    switch (usedReleaseNotesFormat) {
+        case SUReleaseNotesFormatPlainText:
+            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize prefersMarkdown:NO customAllowedURLSchemes:customAllowedURLSchemes];
+            break;
+        case SUReleaseNotesFormatMarkdown:
+            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize prefersMarkdown:YES customAllowedURLSchemes:customAllowedURLSchemes];
+            break;
+        case SUReleaseNotesFormatHTML:
         {
-            _releaseNotesView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled customAllowedURLSchemes:customAllowedURLSchemes installedVersion: _host.version];
+            NSURL *colorStyleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"ReleaseNotesColorStyle" withExtension:@"css"];
+            
+            BOOL javaScriptEnabled = [_host boolForInfoDictionaryKey:SUEnableJavaScriptKey];
+            
+#if DOWNLOADER_XPC_SERVICE_EMBEDDED
+            // WKWebView has a bug where it won't work in loading local HTML content in sandboxed apps that do not have an outgoing network entitlement
+            // FB6993802: https://twitter.com/sindresorhus/status/1160577243929878528 | https://github.com/feedback-assistant/reports/issues/1
+            // If the developer is using the downloader XPC service, they are very most likely are a) sandboxed b) do not use outgoing network entitlement.
+            // In this case, fall back to legacy WebKit view.
+            // (In theory it is possible for a non-sandboxed app or sandboxed app with outgoing network entitlement to use the XPC service, it's just pretty unlikely. And falling back to a legacy web view would not be too harmful in those cases).
+            BOOL useWKWebView = !SPUXPCServiceIsEnabled(SUEnableDownloaderServiceKey);
+            if (!useWKWebView) {
+                _releaseNotesView = [[SULegacyWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled customAllowedURLSchemes:customAllowedURLSchemes];
+            } else
+#endif
+            {
+                _releaseNotesView = [[SUWKWebView alloc] initWithColorStyleSheetLocation:colorStyleURL fontFamily:defaultFontFamily fontPointSize:defaultFontSize javaScriptEnabled:javaScriptEnabled customAllowedURLSchemes:customAllowedURLSchemes installedVersion: _host.version];
+            }
+            
+            break;
         }
     }
     

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -227,13 +227,14 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
     NSString *pathExtension = releaseNotesURL.pathExtension;
     
     SUReleaseNotesFormat releaseNotesFormat;
-    if ([chosenMIMEType isEqualToString:@"text/plain"] || [pathExtension caseInsensitiveCompare:@"txt"] == NSOrderedSame) {
-        releaseNotesFormat = SUReleaseNotesFormatPlainText;
-    } else if ([chosenMIMEType isEqualToString:@"text/markdown"] ||
+    // Make sure we test for markdown first because text/plain may be used for MIME type
+    if ([chosenMIMEType isEqualToString:@"text/markdown"] ||
                [chosenMIMEType isEqualToString:@"text/x-markdown"] ||
                [pathExtension caseInsensitiveCompare:@"md"] == NSOrderedSame ||
                [pathExtension caseInsensitiveCompare:@"markdown"] == NSOrderedSame) {
         releaseNotesFormat = SUReleaseNotesFormatMarkdown;
+    } else if ([chosenMIMEType isEqualToString:@"text/plain"] || [pathExtension caseInsensitiveCompare:@"txt"] == NSOrderedSame) {
+        releaseNotesFormat = SUReleaseNotesFormatPlainText;
     } else {
         releaseNotesFormat = SUReleaseNotesFormatHTML;
     }

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -110,6 +110,8 @@
     NSString *finalUpdatedVersion;
     if ([testMode isEqualToString:@"REGULAR"]) {
         finalUpdatedVersion = @"2.0";
+    } else if ([testMode isEqualToString:@"MARKDOWN"]) {
+        finalUpdatedVersion = @"2.0.1";
     } else if ([testMode isEqualToString:@"DELTA"]) {
         finalUpdatedVersion = @"2.1";
     } else if ([testMode isEqualToString:@"AUTOMATIC"]) {
@@ -250,10 +252,10 @@
                 }
                 
                 NSUInteger numberOfLengthReplacements = [appcastContents replaceOccurrencesOfString:@"$INSERT_ARCHIVE_LENGTH" withString:[NSString stringWithFormat:@"%llu", archiveFileAttributes.fileSize] options:NSLiteralSearch range:NSMakeRange(0, appcastContents.length)];
-                assert(numberOfLengthReplacements == 2);
+                assert(numberOfLengthReplacements == 3);
                 
                 NSUInteger numberOfSignatureReplacements = [appcastContents replaceOccurrencesOfString:@"$INSERT_EDDSA_SIGNATURE" withString:signatureString options:NSLiteralSearch range:NSMakeRange(0, appcastContents.length)];
-                assert(numberOfSignatureReplacements == 2);
+                assert(numberOfSignatureReplacements == 3);
                 
                 NSError *writeAppcastError = nil;
                 if (![appcastContents writeToURL:appcastDestinationURL atomically:NO encoding:NSUTF8StringEncoding error:&writeAppcastError]) {
@@ -320,6 +322,8 @@
         return [NSSet setWithObject:@"delta"];
     } else if ([_testMode isEqualToString:@"AUTOMATIC"]) {
         return [NSSet setWithObject:@"automatic"];
+    } else if ([_testMode isEqualToString:@"MARKDOWN"]) {
+        return [NSSet setWithObject:@"markdown"];
     } else {
         return [NSSet set];
     }

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -102,9 +102,9 @@ Note though, Sparkle's markdown support does not support tables or images. It ne
 
 ### Version 2.0
 
-* *Redesigned Interface*: Enjoy a refreshed, modern UI that improves navigation and streamlines workflows across the app.
-* *Cloud Sync Support*: Projects and settings can now be synced securely across multiple devices using your account.
-* *Customizable Shortcuts*: Create and manage keyboard shortcuts for almost any action.
+* **Redesigned Interface**: Enjoy a refreshed, modern UI that improves navigation and streamlines workflows across the app.
+* **Cloud Sync Support**: Projects and settings can now be synced securely across multiple devices using your account.
+* **Customizable Shortcuts**: Create and manage keyboard shortcuts for almost any action.
 * Improved launch performance and reduced memory usage during startup.
 * Fixed an issue where notifications could appear twice in some cases.
 * Addressed several minor visual glitches in dark mode.]]>

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -84,19 +84,11 @@ From a good friend:
 >> And that is how nested quotes can work. A known limitation is properly styling lists in blockquotes so I'd suggest to avoid that.
 >
 
-After this paragraph, you should see a horizontal thematic line break.
+After this paragraph, you should see extra spacing from using a line break.
 
 ---
 
-> Even quotes can have thematic line breaks
->
-> ---
->
-> There you have it.
-
----
-
-Even code blocks are supported:
+Code blocks from markdown are also supported using a monospace font:
 
 ```sh
 me@Compy ~/D/P/Sparkle> ls

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -55,7 +55,7 @@
         <sparkle:fullReleaseNotesLink>releasenotes.html</sparkle:fullReleaseNotesLink>
         <sparkle:channel>markdown</sparkle:channel>
         <description sparkle:format="markdown">
-<![CDATA[### Version 2.0.1
+<![CDATA[## Version 2.0.1
 
 * Added `markdown` support to release notes.
 * Upgraded text kit system to use *improved* TextKit 2.
@@ -100,7 +100,7 @@ build/               common_cli/          Downloader/          InstallerConnecti
 
 Note though, Sparkle's markdown support does not support tables or images. It needs to work without loading additional resources and without switching to TextKit 1.
 
-### Version 2.0
+## Version 2.0
 
 * **Redesigned Interface**: Enjoy a refreshed, modern UI that improves navigation and streamlines workflows across the app.
 * **Cloud Sync Support**: Projects and settings can now be synced securely across multiple devices using your account.

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -55,8 +55,7 @@
         <sparkle:fullReleaseNotesLink>releasenotes.html</sparkle:fullReleaseNotesLink>
         <sparkle:channel>markdown</sparkle:channel>
         <description sparkle:format="markdown">
-<![CDATA[
-### Version 2.0.1
+<![CDATA[### Version 2.0.1
 
 * Added `markdown` support to release notes.
 * Upgraded text kit system to use *improved* TextKit 2.
@@ -86,6 +85,14 @@ From a good friend:
 >
 
 After this paragraph, you should see a horizontal thematic line break.
+
+---
+
+> Even quotes can have thematic line breaks
+>
+> ---
+>
+> There you have it.
 
 ---
 

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -49,6 +49,72 @@
         </item>
         
         <item>
+        <title>Version 2.0.1</title>
+        <sparkle:version>2.0.1</sparkle:version>
+        <link>https://sparkle-project.org</link>
+        <sparkle:fullReleaseNotesLink>releasenotes.html</sparkle:fullReleaseNotesLink>
+        <sparkle:channel>markdown</sparkle:channel>
+        <description sparkle:format="markdown">
+<![CDATA[
+### Version 2.0.1
+
+* Added `markdown` support to release notes.
+* Upgraded text kit system to use *improved* TextKit 2.
+* Lists in markdown can contain multiple paragraphs
+  
+  These paragraphs can even span multiple lines if they are long and wide enough to pass over the next line. These paragraphs can also contain useful information.
+
+  * Multiple levels of lists can also exist in Markdown
+  * Indented list items can contain information that are related to a parent list point. For example this could contain information about writing long paragraphs.
+
+1. Markdown also supports numbered lists.
+2. This is an example of a numbered list.
+    1. Even numbered lists can have multiple levels.
+    2. This is an example of numbered lists having multiple levels.
+
+Markdown also allows writing standalone paragraphs that don't belong to any list or other associated element (such as blockquotes). This can be a powerful and normal used feature.
+
+[Writers like markdown](https://daringfireball.net/projects/markdown/) because it allows them to blog or write text without having to write all the opening/closing HTML tags. This makes blogging or writing software release notes with markdown a pleasant experience.
+
+From a good friend:
+
+> Markdown is also useful for applications that cannot embed WKWebView directly, such as apps without a download client entitlement, or Catalyst applications.
+>
+>> In quotes you can also have nested quotes, and the lines in nested quotes can be long enough to span over the next few lines, assuming that the lines are long enough.
+>>
+>> And that is how nested quotes can work. A known limitation is properly styling lists in blockquotes so I'd suggest to avoid that.
+>
+
+After this paragraph, you should see a horizontal thematic line break.
+
+---
+
+Even code blocks are supported:
+
+```sh
+me@Compy ~/D/P/Sparkle> ls
+Autoupdate/          Carthage-dev.json    Configurations/      generate_appcast/    InstallerLauncher/   Package.swift        Sparkle/             TestAppHelper/       Vendor/
+bin/                 CHANGELOG            DerivedData/         generate_keys/       InstallerStatus/     README.markdown      sparkle-cli/         TestApplication/
+BinaryDelta/         CODE_OF_CONDUCT.md   Documentation/       INSTALL              LICENSE              Resources/           Sparkle.podspec      Tests/
+build/               common_cli/          Downloader/          InstallerConnection/ Makefile             sign_update/         Sparkle.xcodeproj/   UITests/
+```
+
+Note though, Sparkle's markdown support does not support tables or images. It needs to work without loading additional resources and without switching to TextKit 1.
+
+### Version 2.0
+
+* *Redesigned Interface*: Enjoy a refreshed, modern UI that improves navigation and streamlines workflows across the app.
+* *Cloud Sync Support*: Projects and settings can now be synced securely across multiple devices using your account.
+* *Customizable Shortcuts*: Create and manage keyboard shortcuts for almost any action.
+* Improved launch performance and reduced memory usage during startup.
+* Fixed an issue where notifications could appear twice in some cases.
+* Addressed several minor visual glitches in dark mode.]]>
+        </description>
+        <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="$INSERT_ARCHIVE_LENGTH" type="application/octet-stream" sparkle:edSignature="$INSERT_EDDSA_SIGNATURE" />
+        </item>
+        
+        <item>
         <title>Version 2.0</title>
         <sparkle:version>2.0</sparkle:version>
         <link>https://sparkle-project.org</link>

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -464,12 +464,18 @@ func moveOldUpdatesFromAppcasts(archivesSourceDir: URL, oldFilesDirectory: URL, 
             
             let htmlReleaseNotesFile = archivePath.deletingPathExtension().appendingPathExtension("html")
             let plainTextReleaseNotesFile = archivePath.deletingPathExtension().appendingPathExtension("txt")
+            let markdownReleaseNotesFile = archivePath.deletingPathExtension().appendingPathExtension("md")
+            let markdownSecondaryReleaseNotesFile = archivePath.deletingPathExtension().appendingPathExtension("markdown")
             
             let releaseNotesFile: URL?
             if fileManager.fileExists(atPath: htmlReleaseNotesFile.path) {
                 releaseNotesFile = htmlReleaseNotesFile
             } else if fileManager.fileExists(atPath: plainTextReleaseNotesFile.path) {
                 releaseNotesFile = plainTextReleaseNotesFile
+            } else if fileManager.fileExists(atPath: markdownReleaseNotesFile.path) {
+                releaseNotesFile = markdownReleaseNotesFile
+            } else if fileManager.fileExists(atPath: markdownSecondaryReleaseNotesFile.path) {
+                releaseNotesFile = markdownSecondaryReleaseNotesFile
             } else {
                 releaseNotesFile = nil
             }

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -420,6 +420,16 @@ class ArchiveItem: CustomStringConvertible {
             return plainTextReleaseNotes
         }
         
+        let markdownReleaseNotes = basename.appendingPathExtension("md")
+        if FileManager.default.fileExists(atPath: markdownReleaseNotes.path) {
+            return markdownReleaseNotes
+        }
+        
+        let markdownSecondaryReleaseNotes = basename.appendingPathExtension("markdown")
+        if FileManager.default.fileExists(atPath: markdownSecondaryReleaseNotes.path) {
+            return markdownSecondaryReleaseNotes
+        }
+        
         return nil
     }
 
@@ -428,7 +438,16 @@ class ArchiveItem: CustomStringConvertible {
             return nil
         }
         
-        let format = (path.pathExtension.caseInsensitiveCompare("txt") == .orderedSame) ? "plain-text" : "html"
+        let format: String
+        let pathExtension = path.pathExtension
+        switch pathExtension {
+        case "txt":
+            format = "plain-text"
+        case "md", "markdown":
+            format = "markdown"
+        default:
+            format = "html"
+        }
         
         if embedReleaseNotesAlways {
             return (content, format)

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -183,7 +183,7 @@ struct GenerateAppcast: ParsableCommand {
         Use the --versions option if you need to insert an update that is older than the latest update in your feed, or
         if you need to insert only a specific new version with certain parameters.
         
-        .html or .txt files that have the same filename as an archive (except for the file extension) will be used for release notes for that item.
+        .html, .md, or .txt files that have the same filename as an archive (except for the file extension) will be used for release notes for that item.
         For HTML release notes, if the contents of these files do not include a DOCTYPE or body tags, they will be treated as embedded CDATA release notes.
         Release notes for new items can be forced to be embedded by passing --embed-release-notes
         


### PR DESCRIPTION
This adds markdown support to Sparkle's release notes. Similar to plain-text release notes, this allows using releasing notes in applications that aren't able to use WKWebView (e.g. Catalyst apps and apps without an outgoing network client entitlement which use the Downloader XPC Service). Other apps may also adopt markdown due to simplicity, although note it's not _as_ expressive as HTML/CSS.

Other details:

* Supports Markdown ordered/unordered lists, paragraphs, headers, code blocks, inline styling. Block quotes and thematic breaks are handled in simple manner through indentation and extra newline respectively. Tables are not supported. HTML isn't supported.
* Requires macOS 12 or later due to leveraging Foundation / presentation intents for markdown processing. Older OS's and older Sparkle versions >= 2.4.0 will fall back to plain-text interpretation. Additionally, TextKit 2 is now adopted for macOS 12+, and TextKit 1 only code is to be avoided.
* Adds delegate method to allow formatting / modifying the presented text before it will be shown for plain-text and markdown release notes. This, for example, can be used to adapting release notes based on currently installed version, but it could also open up styling release notes in other ways.
* Adds `sparkle:format="markdown"` option to `<description>` element for embedded release notes (in addition to already existing`sparkle:format="plain-text"` option)
* Adds support for generate_appcast to handle markdown release note files and embedded release notes.
* Adds a MARKDOWN test mode to Sparkle Test App.

Decorative rendering for block quotes and thematic breaks was experimented through three ways (NSTextAttachmentCell, NSTextAttachmentViewProvider,  NSTextViewportLayoutControllerDelegate). In the end I decided the complexity, risk, compatibility tradeoffs of these were not worthwhile enough, and I figure these are not critical to many change logs.

<img width="698" height="527" alt="Screenshot 2025-12-16 at 8 43 48 PM" src="https://github.com/user-attachments/assets/397a5288-5000-4a73-9d77-c03e8b933138" />

Fixes #2319

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tested markdown support in Sparkle Test App, in other app using macOS Catalyst.

macOS version tested:
26.2 (25C56)
12.0 VM (at an earlier revision, I'll test this again at a later point).

