### PR TITLE
Add sparkle:minimumUpdateVersion element

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		724BB3AA1D3347C2005D534A /* SUInstallerStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 724BB3971D333832005D534A /* SUInstallerStatus.m */; };
 		724BB3B71D35ABA8005D534A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		724F76F91D6EAD0D00ECD062 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 525A278F133D6AE900FD8D70 /* Cocoa.framework */; };
+		72526BE62EF3349D005791ED /* testappcast_minimumUpdateVersion.xml in Resources */ = {isa = PBXBuildFile; fileRef = 72526BE52EF3349D005791ED /* testappcast_minimumUpdateVersion.xml */; };
 		725453552C04DB3700362123 /* SparkleTestCodeSign_apfs_lzma_aux_files_adhoc.dmg in Resources */ = {isa = PBXBuildFile; fileRef = 725453542C04DB3700362123 /* SparkleTestCodeSign_apfs_lzma_aux_files_adhoc.dmg */; };
 		725602D51C83551C00DAA70E /* SUApplicationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 725602D31C83551C00DAA70E /* SUApplicationInfo.h */; };
 		725602D61C83551C00DAA70E /* SUApplicationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 725602D41C83551C00DAA70E /* SUApplicationInfo.m */; };
@@ -1165,6 +1166,7 @@
 		724BB3A61D33461B005D534A /* SUXPCInstallerStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUXPCInstallerStatus.h; sourceTree = "<group>"; };
 		724BB3A71D33461B005D534A /* SUXPCInstallerStatus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUXPCInstallerStatus.m; sourceTree = "<group>"; };
 		724BB3B51D35AAC3005D534A /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
+		72526BE52EF3349D005791ED /* testappcast_minimumUpdateVersion.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = testappcast_minimumUpdateVersion.xml; sourceTree = "<group>"; };
 		725453542C04DB3700362123 /* SparkleTestCodeSign_apfs_lzma_aux_files_adhoc.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSign_apfs_lzma_aux_files_adhoc.dmg; sourceTree = "<group>"; };
 		725602D31C83551C00DAA70E /* SUApplicationInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUApplicationInfo.h; sourceTree = "<group>"; };
 		725602D41C83551C00DAA70E /* SUApplicationInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUApplicationInfo.m; sourceTree = "<group>"; };
@@ -1815,6 +1817,7 @@
 				5AF6C74E1AEA46D10014A3AB /* test.pkg */,
 				5AD0FA7E1C73F2E2004BCEFF /* testappcast.xml */,
 				723EDC3E26885A8E000BCBA4 /* testappcast_channels.xml */,
+				72526BE52EF3349D005791ED /* testappcast_minimumUpdateVersion.xml */,
 				725B3A81263FBF0C0041AB8E /* testappcast_minimumAutoupdateVersion.xml */,
 				720DC50327A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml */,
 				720DC50527A62CDC00DFF3EC /* testappcast_minimumAutoupdateVersionSkipping2.xml */,
@@ -3114,6 +3117,7 @@
 				723EDC3F26885A8E000BCBA4 /* testappcast_channels.xml in Resources */,
 				720DC50427A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml in Resources */,
 				72E6D9712C04DE1A005496E4 /* SparkleTestCodeSign_pkg.dmg in Resources */,
+				72526BE62EF3349D005791ED /* testappcast_minimumUpdateVersion.xml in Resources */,
 				72AC6B2E1B9B218C00F62325 /* SparkleTestCodeSignApp.dmg in Resources */,
 				C23E885B1BE7B24F0050BB73 /* SparkleTestCodeSignApp.enc.dmg in Resources */,
 				72AC6B281B9AAD6700F62325 /* SparkleTestCodeSignApp.tar in Resources */,

--- a/Sparkle/SPUAppcastItemState.h
+++ b/Sparkle/SPUAppcastItemState.h
@@ -15,11 +15,12 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPUAppcastItemState : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithMajorUpgrade:(BOOL)majorUpgrade criticalUpdate:(BOOL)criticalUpdate informationalUpdate:(BOOL)informationalUpdate minimumOperatingSystemVersionIsOK:(BOOL)minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:(BOOL)maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:(BOOL)arm64HardwareRequirementIsOK;
+- (instancetype)initWithMajorUpgrade:(BOOL)majorUpgrade criticalUpdate:(BOOL)criticalUpdate informationalUpdate:(BOOL)informationalUpdate minimumUpdateVersionIsOK:(BOOL)minimumUpdateVersionIsOK minimumOperatingSystemVersionIsOK:(BOOL)minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:(BOOL)maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:(BOOL)arm64HardwareRequirementIsOK;
 
 @property (nonatomic, readonly) BOOL majorUpgrade;
 @property (nonatomic, readonly) BOOL criticalUpdate;
 @property (nonatomic, readonly) BOOL informationalUpdate;
+@property (nonatomic, readonly) BOOL minimumUpdateVersionIsOK;
 @property (nonatomic, readonly) BOOL minimumOperatingSystemVersionIsOK;
 @property (nonatomic, readonly) BOOL maximumOperatingSystemVersionIsOK;
 @property (nonatomic, readonly) BOOL arm64HardwareRequirementIsOK;

--- a/Sparkle/SPUAppcastItemState.m
+++ b/Sparkle/SPUAppcastItemState.m
@@ -14,6 +14,7 @@
 #define SPUAppcastItemStateMajorUpgradeKey @"SPUAppcastItemStateMajorUpgrade"
 #define SPUAppcastItemStateCriticalUpdateKey @"SPUAppcastItemStateCriticalUpdate"
 #define SPUAppcastItemStateInformationalUpdateKey @"SPUAppcastItemStateInformationalUpdate"
+#define SPUAppcastItemStateUpdateMinimumVersionIsOKKey @"SPUAppcastItemStateMinimumUpdateVersionIsOK"
 #define SPUAppcastItemStateMinimumOperatingSystemVersionIsOKKey @"SPUAppcastItemStateMinimumOperatingSystemVersionIsOK"
 #define SPUAppcastItemStateMaximumOperatingSystemVersionIsOKKey @"SPUAppcastItemStateMaximumOperatingSystemVersionIsOK"
 #define SPUAppcastItemStateArm64HardwareRequirementIsOKKey @"SPUAppcastItemStateArm64HardwareRequirementIsOK"
@@ -26,17 +27,19 @@
 @synthesize majorUpgrade = _majorUpgrade;
 @synthesize criticalUpdate = _criticalUpdate;
 @synthesize informationalUpdate = _informationalUpdate;
+@synthesize minimumUpdateVersionIsOK = _minimumUpdateVersionIsOK;
 @synthesize minimumOperatingSystemVersionIsOK = _minimumOperatingSystemVersionIsOK;
 @synthesize maximumOperatingSystemVersionIsOK = _maximumOperatingSystemVersionIsOK;
 @synthesize arm64HardwareRequirementIsOK = _arm64HardwareRequirementIsOK;
 
-- (instancetype)initWithMajorUpgrade:(BOOL)majorUpgrade criticalUpdate:(BOOL)criticalUpdate informationalUpdate:(BOOL)informationalUpdate minimumOperatingSystemVersionIsOK:(BOOL)minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:(BOOL)maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:(BOOL)arm64HardwareRequirementIsOK
+- (instancetype)initWithMajorUpgrade:(BOOL)majorUpgrade criticalUpdate:(BOOL)criticalUpdate informationalUpdate:(BOOL)informationalUpdate minimumUpdateVersionIsOK:(BOOL)minimumUpdateVersionIsOK minimumOperatingSystemVersionIsOK:(BOOL)minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:(BOOL)maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:(BOOL)arm64HardwareRequirementIsOK
 {
     self = [super init];
     if (self != nil) {
         _majorUpgrade = majorUpgrade;
         _criticalUpdate = criticalUpdate;
         _informationalUpdate = informationalUpdate;
+        _minimumUpdateVersionIsOK = minimumUpdateVersionIsOK;
         _minimumOperatingSystemVersionIsOK = minimumOperatingSystemVersionIsOK;
         _maximumOperatingSystemVersionIsOK = maximumOperatingSystemVersionIsOK;
         _arm64HardwareRequirementIsOK = arm64HardwareRequirementIsOK;
@@ -54,6 +57,7 @@
     [encoder encodeBool:_majorUpgrade forKey:SPUAppcastItemStateMajorUpgradeKey];
     [encoder encodeBool:_criticalUpdate forKey:SPUAppcastItemStateCriticalUpdateKey];
     [encoder encodeBool:_informationalUpdate forKey:SPUAppcastItemStateInformationalUpdateKey];
+    [encoder encodeBool:_minimumUpdateVersionIsOK forKey:SPUAppcastItemStateUpdateMinimumVersionIsOKKey];
     [encoder encodeBool:_minimumOperatingSystemVersionIsOK forKey:SPUAppcastItemStateMinimumOperatingSystemVersionIsOKKey];
     [encoder encodeBool:_maximumOperatingSystemVersionIsOK forKey:SPUAppcastItemStateMaximumOperatingSystemVersionIsOKKey];
     [encoder encodeBool:_arm64HardwareRequirementIsOK forKey:SPUAppcastItemStateArm64HardwareRequirementIsOKKey];
@@ -64,11 +68,12 @@
     BOOL majorUpgrade = [decoder decodeBoolForKey:SPUAppcastItemStateMajorUpgradeKey];
     BOOL criticalUpdate = [decoder decodeBoolForKey:SPUAppcastItemStateCriticalUpdateKey];
     BOOL informationalUpdate = [decoder decodeBoolForKey:SPUAppcastItemStateInformationalUpdateKey];
+    BOOL minimumUpdateVersionIsOK = [decoder decodeBoolForKey:SPUAppcastItemStateUpdateMinimumVersionIsOKKey];
     BOOL minimumOperatingSystemVersionIsOK = [decoder decodeBoolForKey:SPUAppcastItemStateMinimumOperatingSystemVersionIsOKKey];
     BOOL maximumOperatingSystemVersionIsOK = [decoder decodeBoolForKey:SPUAppcastItemStateMaximumOperatingSystemVersionIsOKKey];
     BOOL arm64HardwareRequirementIsOK = [decoder decodeBoolForKey:SPUAppcastItemStateArm64HardwareRequirementIsOKKey];
     
-    return [self initWithMajorUpgrade:majorUpgrade criticalUpdate:criticalUpdate informationalUpdate:informationalUpdate minimumOperatingSystemVersionIsOK:minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:arm64HardwareRequirementIsOK];
+    return [self initWithMajorUpgrade:majorUpgrade criticalUpdate:criticalUpdate informationalUpdate:informationalUpdate minimumUpdateVersionIsOK:minimumUpdateVersionIsOK minimumOperatingSystemVersionIsOK:minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:arm64HardwareRequirementIsOK];
 }
 
 @end

--- a/Sparkle/SPUAppcastItemStateResolver+Private.h
+++ b/Sparkle/SPUAppcastItemStateResolver+Private.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPUAppcastItemStateResolver ()
 
-- (SPUAppcastItemState *)resolveStateWithInformationalUpdateVersions:(NSSet<NSString *> * _Nullable)informationalUpdateVersions minimumOperatingSystemVersion:(NSString * _Nullable)minimumOperatingSystemVersion maximumOperatingSystemVersion:(NSString * _Nullable)maximumOperatingSystemVersion minimumAutoupdateVersion:(NSString * _Nullable)minimumAutoupdateVersion criticalUpdateDictionary:(NSDictionary * _Nullable)criticalUpdateDictionary hardwareRequirements:(NSSet<NSString *> *)hardwareRequirements;
+- (SPUAppcastItemState *)resolveStateWithInformationalUpdateVersions:(NSSet<NSString *> * _Nullable)informationalUpdateVersions minimumUpdateVersion:(NSString * _Nullable)minimumUpdateVersion minimumOperatingSystemVersion:(NSString * _Nullable)minimumOperatingSystemVersion maximumOperatingSystemVersion:(NSString * _Nullable)maximumOperatingSystemVersion minimumAutoupdateVersion:(NSString * _Nullable)minimumAutoupdateVersion criticalUpdateDictionary:(NSDictionary * _Nullable)criticalUpdateDictionary hardwareRequirements:(NSSet<NSString *> *)hardwareRequirements;
 
 + (BOOL)isMinimumAutoupdateVersionOK:(NSString * _Nullable)minimumAutoupdateVersion hostVersion:(NSString *)hostVersion versionComparator:(id<SUVersionComparison>)versionComparator;
 

--- a/Sparkle/SPUAppcastItemStateResolver.m
+++ b/Sparkle/SPUAppcastItemStateResolver.m
@@ -39,6 +39,17 @@
     return self;
 }
 
+- (BOOL)isMinimumUpdateVersionOK:(NSString * _Nullable)minimumUpdateVersion SPU_OBJC_DIRECT
+{
+    NSString *hostVersion = _hostVersion;
+    
+    BOOL minimumVersionOK = YES;
+    if (minimumUpdateVersion != nil && ![minimumUpdateVersion isEqualToString:@""]) {
+        minimumVersionOK = [_applicationVersionComparator compareVersion:(NSString * _Nonnull)minimumUpdateVersion toVersion:hostVersion] != NSOrderedDescending;
+    }
+    return minimumVersionOK;
+}
+
 - (BOOL)isMinimumOperatingSystemVersionOK:(NSString * _Nullable)minimumSystemVersion SPU_OBJC_DIRECT
 {
     BOOL minimumVersionOK = YES;
@@ -149,9 +160,11 @@
 #endif
 }
 
-- (SPUAppcastItemState *)resolveStateWithInformationalUpdateVersions:(NSSet<NSString *> * _Nullable)informationalUpdateVersions minimumOperatingSystemVersion:(NSString * _Nullable)minimumOperatingSystemVersion maximumOperatingSystemVersion:(NSString * _Nullable)maximumOperatingSystemVersion minimumAutoupdateVersion:(NSString * _Nullable)minimumAutoupdateVersion criticalUpdateDictionary:(NSDictionary * _Nullable)criticalUpdateDictionary hardwareRequirements:(NSSet<NSString *> *)hardwareRequirements
+- (SPUAppcastItemState *)resolveStateWithInformationalUpdateVersions:(NSSet<NSString *> * _Nullable)informationalUpdateVersions minimumUpdateVersion:(NSString * _Nullable)minimumUpdateVersion minimumOperatingSystemVersion:(NSString * _Nullable)minimumOperatingSystemVersion maximumOperatingSystemVersion:(NSString * _Nullable)maximumOperatingSystemVersion minimumAutoupdateVersion:(NSString * _Nullable)minimumAutoupdateVersion criticalUpdateDictionary:(NSDictionary * _Nullable)criticalUpdateDictionary hardwareRequirements:(NSSet<NSString *> *)hardwareRequirements
 {
     BOOL informationalUpdate = [self isInformationalUpdateWithInformationalUpdateVersions:informationalUpdateVersions];
+    
+    BOOL minimumUpdateVersionIsOK = [self isMinimumUpdateVersionOK:minimumUpdateVersion];
     
     BOOL minimumOperatingSystemVersionIsOK = [self isMinimumOperatingSystemVersionOK:minimumOperatingSystemVersion];
     
@@ -163,7 +176,7 @@
     
     BOOL arm64HardwareRequirementIsOK = [self isArm64HardwareRequirementOK:hardwareRequirements minimumSystemVersion:minimumOperatingSystemVersion];
     
-    return [[SPUAppcastItemState alloc] initWithMajorUpgrade:majorUpgrade criticalUpdate:criticalUpdate informationalUpdate:informationalUpdate minimumOperatingSystemVersionIsOK:minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:arm64HardwareRequirementIsOK];
+    return [[SPUAppcastItemState alloc] initWithMajorUpgrade:majorUpgrade criticalUpdate:criticalUpdate informationalUpdate:informationalUpdate minimumUpdateVersionIsOK:minimumUpdateVersionIsOK minimumOperatingSystemVersionIsOK:minimumOperatingSystemVersionIsOK maximumOperatingSystemVersionIsOK:maximumOperatingSystemVersionIsOK arm64HardwareRequirementIsOK:arm64HardwareRequirementIsOK];
 }
 
 @end

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -365,6 +365,12 @@ SPU_OBJC_DIRECT
             return NO;
         }
         
+        // We should never be interested in the update if it doesn't pass the minimum update version
+        BOOL passesUpdateVersion = item.minimumUpdateVersionIsOK;
+        if (!passesUpdateVersion) {
+            return NO;
+        }
+        
         NSString *channel = item.channel;
         if (channel == nil) {
             // Item is on the default channel

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -200,6 +200,24 @@ SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
 @property (nonatomic, readonly) BOOL minimumOperatingSystemVersionIsOK;
 
 /**
+ This update will be ignored if the application's version precedes this update's minimum version.
+ 
+ This application's version corresponds to the bundle's @c CFBundleVersion
+ 
+ The minimum update version is extracted from the @c <sparkle:minimumUpdateVersion> element.
+ 
+ Use `minimumUpdateVersionIsOK` property to test if the current bundle passes this requirement.
+ 
+ Old applications must be using Sparkle 2.9 or later, otherwise this property will be ignored.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *minimumUpdateVersion;
+
+/**
+ Indicates whether or not the current bundle passes the `minimumUpdateVersion` requirement.
+ */
+@property (nonatomic, readonly) BOOL minimumUpdateVersionIsOK;
+
+/**
  The required maximum system operating version string for this update if provided.
  
  A maximum system operating version requirement should only be made in unusual scenarios.

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -83,6 +83,7 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
 @synthesize installationType = _installationType;
 @synthesize minimumAutoupdateVersion = _minimumAutoupdateVersion;
 @synthesize ignoreSkippedUpgradesBelowVersion = _ignoreSkippedUpgradesBelowVersion;
+@synthesize minimumUpdateVersion = _minimumUpdateVersion;
 @synthesize phasedRolloutInterval = _phasedRolloutInterval;
 @synthesize channel = _channel;
 @synthesize deltaFromSparkleExecutableSize = _deltaFromSparkleExecutableSize;
@@ -133,6 +134,7 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
         
         _hardwareRequirements = (hardwareRequirements != nil) ? hardwareRequirements : [NSSet set];
         
+        _minimumUpdateVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastElementMinimumUpdateVersion] copy];
         _ignoreSkippedUpgradesBelowVersion = [(NSString *)[decoder decodeObjectOfClass:[NSString class] forKey:SUAppcastElementIgnoreSkippedUpgradesBelowVersion] copy];
         _releaseNotesURL = [decoder decodeObjectOfClass:[NSURL class] forKey:SUAppcastItemReleaseNotesURLKey];
         _fullReleaseNotesURL = [decoder decodeObjectOfClass:[NSURL class] forKey:SUAppcastItemFullReleaseNotesURLKey];
@@ -222,6 +224,10 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
         [encoder encodeObject:_ignoreSkippedUpgradesBelowVersion forKey:SUAppcastElementIgnoreSkippedUpgradesBelowVersion];
     }
     
+    if (_minimumUpdateVersion != nil) {
+        [encoder encodeObject:_minimumUpdateVersion forKey:SUAppcastElementMinimumUpdateVersion];
+    }
+    
     if (_state != nil) {
         [encoder encodeObject:_state forKey:SUAppcastItemStateKey];
     }
@@ -300,6 +306,15 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
 {
     if (_state != nil) {
         return _state.maximumOperatingSystemVersionIsOK;
+    } else {
+        return YES;
+    }
+}
+
+- (BOOL)minimumUpdateVersionIsOK
+{
+    if (_state != nil) {
+        return _state.minimumUpdateVersionIsOK;
     } else {
         return YES;
     }
@@ -584,6 +599,8 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
             }
         }
         
+        _minimumUpdateVersion = [(NSString *)[dict objectForKey:SUAppcastElementMinimumUpdateVersion] copy];
+        
         _ignoreSkippedUpgradesBelowVersion = [(NSString *)[dict objectForKey:SUAppcastElementIgnoreSkippedUpgradesBelowVersion] copy];
         
         NSString *channel = [dict objectForKey:SUAppcastElementChannel];
@@ -622,7 +639,7 @@ static NSString *SUAppcastItemDeltaFromSparkleLocalesKey = @"SUAppcastItemDeltaF
         _hasCriticalInformation = (criticalUpdateDictionary != nil);
         
         if (stateResolver != nil) {
-            _state = [(SPUAppcastItemStateResolver * _Nonnull)stateResolver resolveStateWithInformationalUpdateVersions:_informationalUpdateVersions minimumOperatingSystemVersion:_minimumSystemVersion maximumOperatingSystemVersion:_maximumSystemVersion minimumAutoupdateVersion:_minimumAutoupdateVersion criticalUpdateDictionary:criticalUpdateDictionary hardwareRequirements:_hardwareRequirements];
+            _state = [(SPUAppcastItemStateResolver * _Nonnull)stateResolver resolveStateWithInformationalUpdateVersions:_informationalUpdateVersions minimumUpdateVersion:_minimumUpdateVersion minimumOperatingSystemVersion:_minimumSystemVersion maximumOperatingSystemVersion:_maximumSystemVersion minimumAutoupdateVersion:_minimumAutoupdateVersion criticalUpdateDictionary:criticalUpdateDictionary hardwareRequirements:_hardwareRequirements];
         } else {
             // Note state still may be nil if a deprecated initializer is used
             _state = resolvedState;

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -84,6 +84,7 @@ extern NSString *const SUAppcastElementDeltas;
 extern NSString *const SUAppcastElementMinimumAutoupdateVersion;
 extern NSString *const SUAppcastElementMinimumSystemVersion;
 extern NSString *const SUAppcastElementMaximumSystemVersion;
+extern NSString *const SUAppcastElementMinimumUpdateVersion;
 extern NSString *const SUAppcastElementHardwareRequirements;
 extern NSString *const SUAppcastElementHardwareRequirementARM64;
 extern NSString *const SUAppcastElementReleaseNotesLink;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -73,6 +73,7 @@ NSString *const SUAppcastElementDeltas = @"sparkle:deltas";
 NSString *const SUAppcastElementMinimumAutoupdateVersion = @"sparkle:minimumAutoupdateVersion";
 NSString *const SUAppcastElementMinimumSystemVersion = @"sparkle:minimumSystemVersion";
 NSString *const SUAppcastElementMaximumSystemVersion = @"sparkle:maximumSystemVersion";
+NSString *const SUAppcastElementMinimumUpdateVersion = @"sparkle:minimumUpdateVersion";
 NSString *const SUAppcastElementHardwareRequirements = @"sparkle:hardwareRequirements";
 NSString *const SUAppcastElementHardwareRequirementARM64 = @"arm64";
 NSString *const SUAppcastElementReleaseNotesLink = @"sparkle:releaseNotesLink";

--- a/Tests/Resources/testappcast_minimumUpdateVersion.xml
+++ b/Tests/Resources/testappcast_minimumUpdateVersion.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 2.0</title>
+        <description>desc</description>
+        <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="2.0" />
+    </item>
+    <item>
+        <title>Version 3.0</title>
+        <sparkle:tags><sparkle:criticalUpdate /></sparkle:tags>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="3.0" length="1346234" />
+        <sparkle:minimumUpdateVersion>0.9.1</sparkle:minimumUpdateVersion>
+        <sparkle:deltas>
+            <enclosure url="http://localhost:1337/3.0_from_2.0.patch"
+            sparkle:version="3.0"
+            sparkle:deltaFrom="2.0"
+            length="1235"
+            type="application/octet-stream"
+            sparkle:edSignature="..." />
+            
+            <enclosure url="http://localhost:1337/3.0_from_1.0.patch"
+            sparkle:version="3.0"
+            sparkle:deltaFrom="1.0"
+            length="1485"
+            type="application/octet-stream"
+            sparkle:edSignature="..." />
+        </sparkle:deltas>
+    </item>
+    <item>
+        <title>Version 4.0</title>
+        <sparkle:version>4.0</sparkle:version>
+        <pubDate>Sat, 26 Jul 2014 15:20:13 +0000</pubDate>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+        <sparkle:minimumUpdateVersion>1.0.0</sparkle:minimumUpdateVersion>
+    </item>
+    <item>
+        <title>Version 5.0</title>
+        <sparkle:version>5.0</sparkle:version>
+        <pubDate>Sat, 26 Jul 2014 15:20:13 +0000</pubDate>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="1346234" />
+        <sparkle:minimumUpdateVersion>4.0</sparkle:minimumUpdateVersion>
+    </item>
+  </channel>
+</rss>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -139,6 +139,33 @@ class SUAppcastTest: XCTestCase {
         }
     }
     
+    func testMinimumUpdateVersion() {
+        let testURL = Bundle(for: SUAppcastTest.self).url(forResource: "testappcast_minimumUpdateVersion", withExtension: "xml")!
+        
+        do {
+            let testData = try Data(contentsOf: testURL)
+            
+            let versionComparator = SUStandardVersionComparator.default
+            let hostVersion = "1.0"
+            let stateResolver = SPUAppcastItemStateResolver(hostVersion: hostVersion, applicationVersionComparator: versionComparator, standardVersionComparator: versionComparator)
+            
+            let appcast = try SUAppcast(xmlData: testData, relativeTo: nil, stateResolver: stateResolver)
+            XCTAssertEqual(4, appcast.items.count)
+            
+            do {
+                let filteredAppcast = SUAppcastDriver.filterAppcast(appcast, forMacOSAndAllowedChannels: [])
+                XCTAssertEqual(3, filteredAppcast.items.count)
+                
+                XCTAssertEqual("2.0", filteredAppcast.items[0].versionString)
+                XCTAssertEqual("3.0", filteredAppcast.items[1].versionString)
+                XCTAssertEqual("4.0", filteredAppcast.items[2].versionString)
+            }
+        } catch let err as NSError {
+            NSLog("%@", err)
+            XCTFail(err.localizedDescription)
+        }
+    }
+    
     func testCriticalUpdateVersion() {
         let testURL = Bundle(for: SUAppcastTest.self).url(forResource: "testappcast", withExtension: "xml")!
         

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -243,6 +243,13 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                 if !item.supportsDSA && item.publicEdKey == nil {
                     continue
                 }
+                
+                // No need to generate delta updates that don't match minimumUpdateVersion
+                if let latestUpdateBranch = feedUpdateBranches[latestItem.version] ?? newUpdateBranches[latestItem.version],
+                   let latestMinimumUpdateVersion = latestUpdateBranch.minimumUpdateVersion,
+                   standardComparator.compareVersion(item.version, toVersion: latestMinimumUpdateVersion) == .orderedAscending {
+                    continue
+                }
 
                 let deltaBaseName = appBaseName + latestItem.version + "-" + item.version
                 let deltaPath = archivesSourceDir.appendingPathComponent(deltaBaseName).appendingPathExtension("delta")

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -23,7 +23,7 @@ struct Appcast {
     let deltaFromVersionsUsed: Set<UpdateVersion>
 }
 
-func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory cacheDir: URL, keys: PrivateKeys, versions: Set<String>?, maxVersionsPerBranchInFeed: Int, newChannel: String?, majorVersion: String?, maximumDeltas: Int, deltaCompressionModeDescription: String, deltaCompressionLevel: UInt8, disableNestedCodeCheck: Bool, downloadURLPrefix: URL?, releaseNotesURLPrefix: URL?, verbose: Bool) throws -> [FeedName: Appcast] {
+func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory cacheDir: URL, keys: PrivateKeys, versions: Set<String>?, maxVersionsPerBranchInFeed: Int, newChannel: String?, newMinimumUpdateVersion: String?, majorVersion: String?, maximumDeltas: Int, deltaCompressionModeDescription: String, deltaCompressionLevel: UInt8, disableNestedCodeCheck: Bool, downloadURLPrefix: URL?, releaseNotesURLPrefix: URL?, verbose: Bool) throws -> [FeedName: Appcast] {
     let standardComparator = SUStandardVersionComparator()
     let descendingVersionComparator: (String, String) -> Bool = {
         return standardComparator.compareVersion($0, toVersion: $1) == .orderedDescending
@@ -114,7 +114,7 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
         do {
             for update in updates {
                 if !ignoredOldVersions.contains(update.version) && !ignoredVersionsToInsert.contains(update.version) && feedUpdateBranches[update.version] == nil {
-                    newUpdateBranches[update.version] = UpdateBranch(minimumSystemVersion: update.minimumSystemVersion, maximumSystemVersion: nil, minimumAutoupdateVersion: majorVersion, hardwareRequirements: update.hardwareRequirements, channel: newChannel)
+                    newUpdateBranches[update.version] = UpdateBranch(minimumUpdateVersion: newMinimumUpdateVersion, minimumSystemVersion: update.minimumSystemVersion, maximumSystemVersion: nil, minimumAutoupdateVersion: majorVersion, hardwareRequirements: update.hardwareRequirements, channel: newChannel)
                 }
             }
         }
@@ -147,7 +147,7 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                         continue
                     }
                     
-                    let defaultChannelBranch = UpdateBranch(minimumSystemVersion: branch.minimumSystemVersion, maximumSystemVersion: branch.maximumSystemVersion, minimumAutoupdateVersion: branch.minimumAutoupdateVersion, hardwareRequirements: branch.hardwareRequirements, channel: nil)
+                    let defaultChannelBranch = UpdateBranch(minimumUpdateVersion: branch.minimumUpdateVersion, minimumSystemVersion: branch.minimumSystemVersion, maximumSystemVersion: branch.maximumSystemVersion, minimumAutoupdateVersion: branch.minimumAutoupdateVersion, hardwareRequirements: branch.hardwareRequirements, channel: nil)
                     
                     guard let defaultChannelVersions = updatesGroupedByBranch[defaultChannelBranch] else {
                         continue

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -7,6 +7,7 @@ import Foundation
 import UniformTypeIdentifiers
 
 struct UpdateBranch: Hashable {
+    let minimumUpdateVersion: String?
     let minimumSystemVersion: String?
     let maximumSystemVersion: String?
     let minimumAutoupdateVersion: String?

--- a/generate_appcast/FeedXML.swift
+++ b/generate_appcast/FeedXML.swift
@@ -98,6 +98,13 @@ func readAppcast(archives: [String: ArchiveItem], appcastURL: URL) throws -> [St
             continue
         }
         
+        let minimumUpdateVersion: String?
+        if let minUpdateVer = findElement(name: SUAppcastElementMinimumUpdateVersion, parent: item) {
+            minimumUpdateVersion = minUpdateVer.stringValue
+        } else {
+            minimumUpdateVersion = nil
+        }
+        
         let minimumSystemVersion: String?
         if let minVer = findElement(name: SUAppcastElementMinimumSystemVersion, parent: item) {
             minimumSystemVersion = minVer.stringValue
@@ -135,7 +142,7 @@ func readAppcast(archives: [String: ArchiveItem], appcastURL: URL) throws -> [St
             sparkleChannel = nil
         }
         
-        let updateBranch = UpdateBranch(minimumSystemVersion: minimumSystemVersion, maximumSystemVersion: maximumSystemVersion, minimumAutoupdateVersion: minimumAutoupdateVersion, hardwareRequirements: hardwareRequirements, channel: sparkleChannel)
+        let updateBranch = UpdateBranch(minimumUpdateVersion: minimumUpdateVersion, minimumSystemVersion: minimumSystemVersion, maximumSystemVersion: maximumSystemVersion, minimumAutoupdateVersion: minimumAutoupdateVersion, hardwareRequirements: hardwareRequirements, channel: sparkleChannel)
         
         updateBranches[version] = updateBranch
     }
@@ -143,7 +150,7 @@ func readAppcast(archives: [String: ArchiveItem], appcastURL: URL) throws -> [St
     return updateBranches
 }
 
-func writeAppcast(appcastDestPath: URL, appcast: Appcast, fullReleaseNotesLink: String?, preferToEmbedReleaseNotes: Bool, link: String?, newChannel: String?, majorVersion: String?, ignoreSkippedUpgradesBelowVersion: String?, phasedRolloutInterval: Int?, criticalUpdateVersion: String?, informationalUpdateVersions: [String]?) throws -> (numNewUpdates: Int, numExistingUpdates: Int, numUpdatesRemoved: Int) {
+func writeAppcast(appcastDestPath: URL, appcast: Appcast, fullReleaseNotesLink: String?, preferToEmbedReleaseNotes: Bool, link: String?, newChannel: String?, newMinimumUpdateVersion: String?, majorVersion: String?, ignoreSkippedUpgradesBelowVersion: String?, phasedRolloutInterval: Int?, criticalUpdateVersion: String?, informationalUpdateVersions: [String]?) throws -> (numNewUpdates: Int, numExistingUpdates: Int, numUpdatesRemoved: Int) {
     let appBaseName = appcast.inferredAppName
 
     let sparkleNS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
@@ -291,6 +298,7 @@ func writeAppcast(appcastDestPath: URL, appcast: Appcast, fullReleaseNotesLink: 
                 item.addChild(linkElement)
             }
             
+            // Set full release notes
             if let fullReleaseNotesLink = fullReleaseNotesLink,
                let fullReleaseNotesElement = XMLElement.element(withName: SUAppcastElementFullReleaseNotesLink, uri: sparkleNS) as? XMLElement {
                 fullReleaseNotesElement.setChildren([text(fullReleaseNotesLink)])
@@ -302,6 +310,13 @@ func writeAppcast(appcastDestPath: URL, appcast: Appcast, fullReleaseNotesLink: 
                let channelNameElement = XMLElement.element(withName: SUAppcastElementChannel, uri: sparkleNS) as? XMLElement {
                 channelNameElement.setChildren([text(newChannelName)])
                 item.addChild(channelNameElement)
+            }
+            
+            // Set minimum update version
+            if let newMinimumUpdateVersion,
+               let minimumUpdateVersionElement = XMLElement.element(withName: SUAppcastElementMinimumUpdateVersion, uri: sparkleNS) as? XMLElement {
+                minimumUpdateVersionElement.setChildren([text(newMinimumUpdateVersion)])
+                item.addChild(minimumUpdateVersionElement)
             }
             
             // Set last major version

--- a/generate_appcast/main.swift
+++ b/generate_appcast/main.swift
@@ -138,6 +138,9 @@ struct GenerateAppcast: ParsableCommand {
     @Option(name: .long, help: ArgumentHelp("The Sparkle channel name that will be used for generating new updates. By default, no channel is used. Old applications need to be using Sparkle 2 to use this feature.", valueName: "channel-name"))
     var channel: String?
     
+    @Option(name: .long, help: ArgumentHelp("The minimum update version requirement that will be used for generating new updates. By default, no minimum update version is used.", valueName: "minimum-update-version"))
+    var minimumUpdateVersion: String?
+    
     @Option(name: .long, help: ArgumentHelp("The last major or minimum autoupdate sparkle:version that will be used for generating new updates. By default, no last major version is used.", valueName: "major-version"))
     var majorVersion: String?
     
@@ -315,7 +318,7 @@ struct GenerateAppcast: ParsableCommand {
         }
         
         do {
-            let appcastsByFeed = try makeAppcasts(archivesSourceDir: archivesSourceDir, outputPathURL: outputPathURL, cacheDirectory: GenerateAppcast.cacheDirectory, keys: keys, versions: versions, maxVersionsPerBranchInFeed: maxVersionsPerBranchInFeed, newChannel: channel, majorVersion: majorVersion, maximumDeltas: maximumDeltas, deltaCompressionModeDescription: deltaCompression, deltaCompressionLevel: deltaCompressionLevel, disableNestedCodeCheck: disableNestedCodeCheck, downloadURLPrefix: downloadURLPrefix, releaseNotesURLPrefix: releaseNotesURLPrefix, verbose: verbose)
+            let appcastsByFeed = try makeAppcasts(archivesSourceDir: archivesSourceDir, outputPathURL: outputPathURL, cacheDirectory: GenerateAppcast.cacheDirectory, keys: keys, versions: versions, maxVersionsPerBranchInFeed: maxVersionsPerBranchInFeed, newChannel: channel, newMinimumUpdateVersion: minimumUpdateVersion, majorVersion: majorVersion, maximumDeltas: maximumDeltas, deltaCompressionModeDescription: deltaCompression, deltaCompressionLevel: deltaCompressionLevel, disableNestedCodeCheck: disableNestedCodeCheck, downloadURLPrefix: downloadURLPrefix, releaseNotesURLPrefix: releaseNotesURLPrefix, verbose: verbose)
             
             let oldFilesDirectory = archivesSourceDir.appendingPathComponent(GenerateAppcast.oldFilesDirectoryName)
             
@@ -328,7 +331,7 @@ struct GenerateAppcast: ParsableCommand {
                                                                 relativeTo: archivesSourceDir)
 
                 // Write the appcast
-                let (numNewUpdates, numExistingUpdates, numUpdatesRemoved) = try writeAppcast(appcastDestPath: appcastDestPath, appcast: appcast, fullReleaseNotesLink: fullReleaseNotesURL, preferToEmbedReleaseNotes: embedReleaseNotes, link: link, newChannel: channel, majorVersion: majorVersion, ignoreSkippedUpgradesBelowVersion: ignoreSkippedUpgradesBelowVersion, phasedRolloutInterval: phasedRolloutInterval, criticalUpdateVersion: criticalUpdateVersion, informationalUpdateVersions: informationalUpdateVersions)
+                let (numNewUpdates, numExistingUpdates, numUpdatesRemoved) = try writeAppcast(appcastDestPath: appcastDestPath, appcast: appcast, fullReleaseNotesLink: fullReleaseNotesURL, preferToEmbedReleaseNotes: embedReleaseNotes, link: link, newChannel: channel, newMinimumUpdateVersion: minimumUpdateVersion, majorVersion: majorVersion, ignoreSkippedUpgradesBelowVersion: ignoreSkippedUpgradesBelowVersion, phasedRolloutInterval: phasedRolloutInterval, criticalUpdateVersion: criticalUpdateVersion, informationalUpdateVersions: informationalUpdateVersions)
 
                 // Inform the user, pluralizing "update" if necessary
                 let pluralizeUpdates = { pluralizeWord($0, "update") }


### PR DESCRIPTION
This allows specifying a minimum version the host bundle needs to be on before upgrading. This may be useful for new appcast features where this requirement can be used instead of switching to a new appcast.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Added unit tests, tested test app trying out the new element, tested generate_appcast's new `--minimum-update-version` flag applies only to new update items.

macOS version tested: 26.2 (25C56)
