### PR TITLE
Handle markdown paths for localized release notes in generate_appcast

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -504,6 +504,8 @@ class ArchiveItem: CustomStringConvertible {
             
             let htmlLocalizedReleaseNoteURL = baseLocalizedReleaseNoteURL.appendingPathExtension("html")
             let plainTextLocalizedReleaseNoteURL = baseLocalizedReleaseNoteURL.appendingPathExtension("txt")
+            let markdownLocalizedReleaseNoteURL = baseLocalizedReleaseNoteURL.appendingPathExtension("md")
+            let markdownSecondaryLocalizedReleaseNoteURL = baseLocalizedReleaseNoteURL.appendingPathExtension("markdown")
             
             let localizedReleaseNoteURL: URL?
             
@@ -511,6 +513,10 @@ class ArchiveItem: CustomStringConvertible {
                 localizedReleaseNoteURL = htmlLocalizedReleaseNoteURL
             } else if (try? plainTextLocalizedReleaseNoteURL.checkResourceIsReachable()) ?? false {
                 localizedReleaseNoteURL = plainTextLocalizedReleaseNoteURL
+            } else if (try? markdownLocalizedReleaseNoteURL.checkResourceIsReachable()) ?? false {
+                localizedReleaseNoteURL = markdownLocalizedReleaseNoteURL
+            } else if (try? markdownSecondaryLocalizedReleaseNoteURL.checkResourceIsReachable()) ?? false {
+                localizedReleaseNoteURL = markdownSecondaryLocalizedReleaseNoteURL
             } else {
                 localizedReleaseNoteURL = nil
             }


### PR DESCRIPTION
I missed this while adding markdown support.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast can generate localized release notes for markdown.

macOS version tested: 26.2 (25C56)
