### PR TITLE
Add missing nn and vi languages to Installer progress Info.plist

### DIFF
--- a/Sparkle/InstallerProgress/InstallerProgress-Info.plist
+++ b/Sparkle/InstallerProgress/InstallerProgress-Info.plist
@@ -37,7 +37,6 @@
 		<string>da</string>
 		<string>de</string>
 		<string>el</string>
-		<string>en</string>
 		<string>es</string>
 		<string>fa</string>
 		<string>fi</string>
@@ -51,6 +50,7 @@
 		<string>ko</string>
 		<string>nb</string>
 		<string>nl</string>
+		<string>nn</string>
 		<string>pl</string>
 		<string>pt-BR</string>
 		<string>pt-PT</string>
@@ -62,6 +62,7 @@
 		<string>th</string>
 		<string>tr</string>
 		<string>uk</string>
+		<string>vi</string>
 		<string>zh_CN</string>
 		<string>zh_HK</string>
 		<string>zh_TW</string>


### PR DESCRIPTION
This is for the Updater / installer progress app if the installation takes a while to complete. The status UI is most likely to surface for pkg installations or installations on different volumes/portable drives and such.

Also remove duplicate 'en' entry.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested test app by inserting artificial sleep() in installer code with system set to Vietnamese.

macOS version tested: 26.2 (25C56)
