### PR TITLE
Use TextKit 1 on older systems for plain text release notes view

### DIFF
--- a/Sparkle/SUPlainTextReleaseNotesView.m
+++ b/Sparkle/SUPlainTextReleaseNotesView.m
@@ -51,7 +51,11 @@
         
         _delegate = delegate;
         
-        if (@available(macOS 12, *)) {
+        // On macOS 12.7, TextKit 2 is very buggy in handling our simple text with NSParagraphStyle attributes.
+        // So even though macOS 12 supports TextKit 2 we do not use it there.
+        // My development machines are currently on macOS 26 so I know TextKit 2 works well there.
+        // macOS 13 - 15 requires more testing if we care to make the switch there.
+        if (@available(macOS 16, *)) {
             // Create NSTextView using TextKit 2
             // https://developer.apple.com/documentation/appkit/nstextview/1449347-initwithframe
             
@@ -256,6 +260,7 @@ static void processMarkdownFragmentAttributedString(NSAttributedString *fragment
 // This was ultimatily given up on and they all have various tradeoffs. NSCell based text attachments don't work in Catalyst,
 // view based attachments take up additional space, and TextKit2 CALayer decorations are hard to (re)size/position correctly.
 // Also each increases code complexity and risk. In the end, changelogs can can live without these.
+// Furthermore we currently support TextKit 1 (on older systems) and TextKit 2 so this function needs to handle both paths.
 static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *originalAttributedString, CGFloat defaultFontPointSize) API_AVAILABLE(macos(12.0))
 {
     // Create our fonts and cache some common attributed strings up front (list bullets, newline)


### PR DESCRIPTION
I was trying out a markdown release notes file on my macOS 12.7 VM and noticed the text view was incredibly buggy formatting wise and prone to crashing on resize. On earlier OS's I'm reverting plain text release notes view implementation back to using TextKit 1. I don't have macOS 13 - 15 setups at the moment, so they're going to get TextKit 1 for now too.

TextKit 2 adoption was introduced in #2810

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested a test app using markdown release notes.

macOS version tested:
macOS 26
macOS 12.7 VM
