### PR TITLE
Merge MARKDOWN and DELTA test app modes

### DIFF
--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
@@ -55,12 +55,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "TEST_MODE"
-            value = "DELTA"
-            isEnabled = "NO">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "TEST_MODE"
-            value = "MARKDOWN"
+            value = "DELTA_AND_MARKDOWN"
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -43,7 +43,7 @@
     // Check if we are already up to date
     NSString *mainBundleVersion = (NSString *)[mainBundle objectForInfoDictionaryKey:(__bridge NSString *)kCFBundleVersionKey];
     
-    if (([mainBundleVersion hasPrefix:@"2."] && [testMode isEqualToString:@"REGULAR"]) || (([mainBundleVersion isEqualToString:@"2.1"] || [mainBundleVersion isEqualToString:@"2.2"]) && [testMode isEqualToString:@"DELTA"]) || ([mainBundleVersion isEqualToString:@"2.2"] && [testMode isEqualToString:@"AUTOMATIC"])) {
+    if (([mainBundleVersion hasPrefix:@"2."] && [testMode isEqualToString:@"REGULAR"]) || (([mainBundleVersion isEqualToString:@"2.1"] || [mainBundleVersion isEqualToString:@"2.2"]) && [testMode isEqualToString:@"DELTA_AND_MARKDOWN"]) || ([mainBundleVersion isEqualToString:@"2.2"] && [testMode isEqualToString:@"AUTOMATIC"])) {
         NSAlert *alreadyUpdatedAlert = [[NSAlert alloc] init];
         alreadyUpdatedAlert.messageText = @"Update succeeded!";
         alreadyUpdatedAlert.informativeText = @"This is the updated version of Sparkle Test App.\n\nDelete and rebuild the app to test updates again.";
@@ -110,9 +110,7 @@
     NSString *finalUpdatedVersion;
     if ([testMode isEqualToString:@"REGULAR"]) {
         finalUpdatedVersion = @"2.0";
-    } else if ([testMode isEqualToString:@"MARKDOWN"]) {
-        finalUpdatedVersion = @"2.0.1";
-    } else if ([testMode isEqualToString:@"DELTA"]) {
+    } else if ([testMode isEqualToString:@"DELTA_AND_MARKDOWN"]) {
         finalUpdatedVersion = @"2.1";
     } else if ([testMode isEqualToString:@"AUTOMATIC"]) {
         finalUpdatedVersion = @"2.2";
@@ -182,7 +180,7 @@
             const unsigned char public_key[32] = {121, 17, 79, 45, 155, 141, 51, 169, 188, 110, 91, 102, 182, 147, 215, 225, 252, 202, 110, 231, 200, 215, 62, 171, 40, 145, 237, 128, 130, 44, 150, 89};
             unsigned char signature[64];
             
-            if ([testMode isEqualToString:@"DELTA"]) {
+            if ([testMode isEqualToString:@"DELTA_AND_MARKDOWN"]) {
                 NSError *deltaCreationError = nil;
                 NSURL *patchURL = [serverDirectoryURL URLByAppendingPathComponent:@"patch.delta"];
                 if (!createBinaryDelta(bundleURL.path, destinationBundleURL.path, patchURL.path, SUBinaryDeltaMajorVersionDefault, SPUDeltaCompressionModeDefault, 0, NO, &deltaCreationError)) {
@@ -265,10 +263,10 @@
                 }
                 
                 NSUInteger numberOfLengthReplacements = [appcastContents replaceOccurrencesOfString:@"$INSERT_ARCHIVE_LENGTH" withString:[NSString stringWithFormat:@"%llu", archiveFileAttributes.fileSize] options:NSLiteralSearch range:NSMakeRange(0, appcastContents.length)];
-                assert(numberOfLengthReplacements == 3);
+                assert(numberOfLengthReplacements == 2);
                 
                 NSUInteger numberOfSignatureReplacements = [appcastContents replaceOccurrencesOfString:@"$INSERT_EDDSA_SIGNATURE" withString:signatureString options:NSLiteralSearch range:NSMakeRange(0, appcastContents.length)];
-                assert(numberOfSignatureReplacements == 3);
+                assert(numberOfSignatureReplacements == 2);
                 
                 NSRange feedSignaturesPrefixRange = [appcastContents rangeOfString:@"<!-- sparkle-signatures:\n" options:(NSLiteralSearch | NSBackwardsSearch)];
                 assert(feedSignaturesPrefixRange.location != NSNotFound);
@@ -344,12 +342,10 @@
 
 - (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)updater
 {
-    if ([_testMode isEqualToString:@"DELTA"]) {
+    if ([_testMode isEqualToString:@"DELTA_AND_MARKDOWN"]) {
         return [NSSet setWithObject:@"delta"];
     } else if ([_testMode isEqualToString:@"AUTOMATIC"]) {
         return [NSSet setWithObject:@"automatic"];
-    } else if ([_testMode isEqualToString:@"MARKDOWN"]) {
-        return [NSSet setWithObject:@"markdown"];
     } else {
         return [NSSet set];
     }

--- a/TestApplication/sparkletestcast.xml
+++ b/TestApplication/sparkletestcast.xml
@@ -30,44 +30,17 @@ IMPORTANT: This file must be re-signed if modifications are made to this file! T
           <link>https://sparkle-project.org</link>
           <sparkle:channel>delta</sparkle:channel>
           <sparkle:fullReleaseNotesLink>releasenotes.html</sparkle:fullReleaseNotesLink>
-          <description>
-            <![CDATA[
-              <ul>
-                <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
-                <li>Suspendisse sed felis ac ante ultrices rhoncus. Etiam quis elit vel nibh placerat facilisis in id leo.</li>
-              </ul>
-            ]]>
-          </description>
-          <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
-          <!-- Note: this file won't actually exist to ensure delta update works -->
-          <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="100000" type="application/octet-stream" sparkle:edSignature="ootgYIwmnS1wa7Q/5SXDXnOVdKnjkjrFhm/D7ukW77k=" />
-          
-          <sparkle:deltas>
-              <enclosure url="http://localhost:1337/patch.delta"
-                            sparkle:deltaFrom="$INSERT_DELTA_FROM_VERSION"
-                            length="$INSERT_DELTA_ARCHIVE_LENGTH"
-                            type="application/octet-stream"
-                            sparkle:edSignature="$INSERT_DELTA_EDDSA_SIGNATURE" />
-          </sparkle:deltas>
-        </item>
-        
-        <item>
-        <title>Version 2.0.1</title>
-        <sparkle:version>2.0.1</sparkle:version>
-        <link>https://sparkle-project.org</link>
-        <sparkle:fullReleaseNotesLink>releasenotes.html</sparkle:fullReleaseNotesLink>
-        <sparkle:channel>markdown</sparkle:channel>
-        <description sparkle:format="markdown">
+          <description sparkle:format="markdown">
 <![CDATA[## Version 2.0.1
 
 * Added `markdown` support to release notes.
 * Upgraded text kit system to use *improved* TextKit 2.
 * Lists in markdown can contain multiple paragraphs
-  
-  These paragraphs can even span multiple lines if they are long and wide enough to pass over the next line. These paragraphs can also contain useful information.
 
-  * Multiple levels of lists can also exist in Markdown
-  * Indented list items can contain information that are related to a parent list point. For example this could contain information about writing long paragraphs.
+These paragraphs can even span multiple lines if they are long and wide enough to pass over the next line. These paragraphs can also contain useful information.
+
+* Multiple levels of lists can also exist in Markdown
+* Indented list items can contain information that are related to a parent list point. For example this could contain information about writing long paragraphs.
 
 1. Markdown also supports numbered lists.
 2. This is an example of a numbered list.
@@ -111,9 +84,18 @@ Note though, Sparkle's markdown support does not support tables or images. It ne
 * Improved launch performance and reduced memory usage during startup.
 * Fixed an issue where notifications could appear twice in some cases.
 * Addressed several minor visual glitches in dark mode.]]>
-        </description>
-        <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
-        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="$INSERT_ARCHIVE_LENGTH" type="application/octet-stream" sparkle:edSignature="$INSERT_EDDSA_SIGNATURE" />
+          </description>
+          <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+          <!-- Note: this file won't actually exist to ensure delta update works -->
+          <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" length="100000" type="application/octet-stream" sparkle:edSignature="ootgYIwmnS1wa7Q/5SXDXnOVdKnjkjrFhm/D7ukW77k=" />
+          
+          <sparkle:deltas>
+              <enclosure url="http://localhost:1337/patch.delta"
+                            sparkle:deltaFrom="$INSERT_DELTA_FROM_VERSION"
+                            length="$INSERT_DELTA_ARCHIVE_LENGTH"
+                            type="application/octet-stream"
+                            sparkle:edSignature="$INSERT_DELTA_EDDSA_SIGNATURE" />
+          </sparkle:deltas>
         </item>
         
         <item>

--- a/UITests/SUTestApplicationTest.swift
+++ b/UITests/SUTestApplicationTest.swift
@@ -108,7 +108,7 @@ class SUTestApplicationTest: XCTestCase
     }
     
     func test2DeltaUpdate() {
-        runTestApplication(testMode: "DELTA", automatic: false, expectedFinalVersion: "2.1", launchSleep: 75, extractSleep: 45)
+        runTestApplication(testMode: "DELTA_AND_MARKDOWN", automatic: false, expectedFinalVersion: "2.1", launchSleep: 75, extractSleep: 45)
     }
     
     func test3AutomaticUpdate() {


### PR DESCRIPTION
So we get a bit of test coverage of markdown processing.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Testing UI tests in CI as well as test app locally.

macOS version tested: 26.2 (25C56)
