### PR TITLE
Download temporary files in-memory using NSURLSessionDataTask

### DIFF
--- a/Downloader/SPUDownloader.m
+++ b/Downloader/SPUDownloader.m
@@ -29,11 +29,10 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 
 @implementation SPUDownloader
 {
-    NSURLSessionDownloadTask *_download;
+    NSURLSessionTask *_sessionTask;
     NSURLSession *_downloadSession;
     NSString *_bundleIdentifier;
     NSString *_desiredFilename;
-    NSString *_downloadFilename;
     
     // Delegate is intentionally strongly referenced; see header
     id <SPUDownloaderDelegate> _delegate;
@@ -85,8 +84,21 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
         sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
         delegate:self
         delegateQueue:[NSOperationQueue mainQueue]];
-    _download = [_downloadSession downloadTaskWithRequest:request];
-    [_download resume];
+    
+    switch (_mode) {
+        case SPUDownloadModePersistent:
+            _sessionTask = [_downloadSession downloadTaskWithRequest:request];
+            break;
+        case SPUDownloadModeTemporary: {
+            __weak __typeof__(self) weakSelf = self;
+            _sessionTask = [_downloadSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                [weakSelf temporaryDownloadDidFinishWithData:data response:response error:error];
+            }];
+            break;
+        }
+    }
+    
+    [_sessionTask resume];
 }
 
 // Don't implement dealloc - make the client call cleanup, which is the only way to remove the reference cycle from the delegate anyway
@@ -94,7 +106,7 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 - (void)startPersistentDownloadWithRequest:(NSURLRequest *)request bundleIdentifier:(NSString *)bundleIdentifier desiredFilename:(NSString *)desiredFilename
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (self->_download == nil && self->_delegate != nil) {
+        if (self->_sessionTask == nil && self->_delegate != nil) {
             // Prevent service from automatically terminating while downloading the update asynchronously without any reply blocks
             [[NSProcessInfo processInfo] disableAutomaticTermination:SUDownloadingReason];
             self->_disabledAutomaticTermination = YES;
@@ -111,7 +123,7 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 - (void)startTemporaryDownloadWithRequest:(NSURLRequest *)request
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (self->_download == nil && self->_delegate != nil) {
+        if (self->_sessionTask == nil && self->_delegate != nil) {
             // Prevent service from automatically terminating while downloading the update asynchronously without any reply blocks
             [[NSProcessInfo processInfo] disableAutomaticTermination:SUDownloadingReason];
             self->_disabledAutomaticTermination = YES;
@@ -158,17 +170,11 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 - (void)_cleanup SPU_OBJC_DIRECT
 {
     [self enableAutomaticTermination];
-    [_download cancel];
+    [_sessionTask cancel];
     [_downloadSession finishTasksAndInvalidate];
-    _download = nil;
+    _sessionTask = nil;
     _downloadSession = nil;
     _delegate = nil;
-    
-    if (_mode == SPUDownloadModeTemporary && _downloadFilename != nil)
-    {
-        [[NSFileManager defaultManager] removeItemAtPath:_downloadFilename error:NULL];
-        _downloadFilename = nil;
-    }
 }
 
 - (void)cleanup:(void (^)(void))completionHandler
@@ -182,76 +188,119 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
     });
 }
 
-- (void)URLSession:(NSURLSession *)__unused session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
+static bool SPUValidateStatusCodeAndFailIfInvalid(NSURLResponse * _Nullable response, NSURL *url, id<SPUDownloaderDelegate> delegate)
 {
-    NSInteger statusCode = [downloadTask.response isKindOfClass:[NSHTTPURLResponse class]] ? ((NSHTTPURLResponse *)downloadTask.response).statusCode : 200;
+    NSInteger statusCode = [response isKindOfClass:[NSHTTPURLResponse class]] ? ((NSHTTPURLResponse *)response).statusCode : 200;
+    
     if ((statusCode < 200) || (statusCode >= 400))
     {
-        NSString *message = [NSString stringWithFormat:@"A network error occurred while downloading %@. %@ (%ld)", downloadTask.originalRequest.URL.absoluteString, [NSHTTPURLResponse localizedStringForStatusCode:statusCode], (long)statusCode];
+        NSString *message = [NSString stringWithFormat:@"A network error occurred while downloading %@. %@ (%ld)", url.absoluteString, [NSHTTPURLResponse localizedStringForStatusCode:statusCode], (long)statusCode];
         NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUDownloadError userInfo:@{ NSLocalizedDescriptionKey: message }];
-        [_delegate downloaderDidFailWithError:error];
-    }
-    else if (_mode == SPUDownloadModeTemporary)
-    {
-        _downloadFilename = location.path;
-        [self downloadDidFinish]; // file is already in a system temp dir
-    }
-    else
-    {
-        // Remove our old caches path so we don't start accumulating files in there
-        NSString *rootPersistentDownloadCachePath = [self rootPersistentDownloadCachePathForBundleIdentifier:_bundleIdentifier];
-
-        [SPULocalCacheDirectory removeOldItemsInDirectory:rootPersistentDownloadCachePath];
+        [delegate downloaderDidFailWithError:error];
         
-        NSString *tempDir = [SPULocalCacheDirectory createUniqueDirectoryInDirectory:rootPersistentDownloadCachePath];
-        if (tempDir == nil)
-        {
-            // Okay, something's really broken with this user's file structure.
-            [_download cancel];
-            _download = nil;
-            
-            NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUTemporaryDirectoryError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Can't make a temporary directory for the update download at %@.", tempDir] }];
+        return false;
+    } else {
+        return true;
+    }
+}
+
+- (void)temporaryDownloadDidFinishWithData:(NSData * _Nullable)data response:(NSURLResponse * _Nullable)response error:(NSError * _Nullable)error SPU_OBJC_DIRECT
+{
+    if (!SPUValidateStatusCodeAndFailIfInvalid(response, _sessionTask.originalRequest.URL, _delegate)) {
+        return;
+    }
+    
+    SPUDownloadData *downloadData = nil;
+    if (data != nil) {
+        NSURL *responseURL = response.URL;
+        if (responseURL == nil) {
+            responseURL = _sessionTask.currentRequest.URL;
+        }
+        if (responseURL == nil) {
+            responseURL = _sessionTask.originalRequest.URL;
+        }
+        assert(responseURL != nil);
+
+        downloadData = [[SPUDownloadData alloc] initWithData:(NSData * _Nonnull)data URL:responseURL textEncodingName:response.textEncodingName MIMEType:response.MIMEType];
+    }
+    
+    _sessionTask = nil;
+    
+    if (downloadData != nil) {
+        [_delegate downloaderDidFinishWithTemporaryDownloadData:downloadData];
+    } else {
+        NSMutableDictionary *userInfo = [@{NSLocalizedDescriptionKey: @"Failed to download temporary data."} mutableCopy];
+        
+        if (error != nil) {
+            userInfo[NSUnderlyingErrorKey] = error;
+        }
+        
+        [_delegate downloaderDidFailWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUDownloadError userInfo:userInfo]];
+    }
+    
+    [self _cleanup];
+}
+
+- (void)URLSession:(NSURLSession *)__unused session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
+{
+    if (!SPUValidateStatusCodeAndFailIfInvalid(downloadTask.response, downloadTask.originalRequest.URL, _delegate)) {
+        return;
+    }
+    
+    // Remove our old caches path so we don't start accumulating files in there
+    NSString *rootPersistentDownloadCachePath = [self rootPersistentDownloadCachePathForBundleIdentifier:_bundleIdentifier];
+
+    [SPULocalCacheDirectory removeOldItemsInDirectory:rootPersistentDownloadCachePath];
+    
+    NSString *tempDir = [SPULocalCacheDirectory createUniqueDirectoryInDirectory:rootPersistentDownloadCachePath];
+    if (tempDir == nil)
+    {
+        // Okay, something's really broken with this user's file structure.
+        [_sessionTask cancel];
+        _sessionTask = nil;
+        
+        NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUTemporaryDirectoryError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Can't make a temporary directory for the update download at %@.", tempDir] }];
+        
+        [_delegate downloaderDidFailWithError:error];
+    } else {
+        NSString *downloadFileName = _desiredFilename;
+        NSString *downloadFileNameDirectory = [tempDir stringByAppendingPathComponent:downloadFileName];
+        
+        NSError *createError = nil;
+        if (![[NSFileManager defaultManager] createDirectoryAtPath:downloadFileNameDirectory withIntermediateDirectories:NO attributes:nil error:&createError]) {
+            NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUTemporaryDirectoryError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Can't make a download file name %@ directory inside temporary directory for the update download at %@.", downloadFileName, downloadFileNameDirectory] }];
             
             [_delegate downloaderDidFailWithError:error];
         } else {
-            NSString *downloadFileName = _desiredFilename;
-            NSString *downloadFileNameDirectory = [tempDir stringByAppendingPathComponent:downloadFileName];
-            
-            NSError *createError = nil;
-            if (![[NSFileManager defaultManager] createDirectoryAtPath:downloadFileNameDirectory withIntermediateDirectories:NO attributes:nil error:&createError]) {
-                NSError *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUTemporaryDirectoryError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Can't make a download file name %@ directory inside temporary directory for the update download at %@.", downloadFileName, downloadFileNameDirectory] }];
+            NSString *name = _sessionTask.response.suggestedFilename;
+            if (!name) {
+                name = location.lastPathComponent; // This likely contains nothing useful to identify the file (e.g. CFNetworkDownload_87LVIz.tmp)
+            }
+            NSString *toPath = [downloadFileNameDirectory stringByAppendingPathComponent:name];
+            NSString *fromPath = location.path; // suppress moveItemAtPath: non-null warning
+            NSError *error = nil;
+            if ([[NSFileManager defaultManager] moveItemAtPath:fromPath toPath:toPath error:&error]) {
+                // Create a bookmark for the download
+                // Don't pass any options (we don't want a persistent security scoped bookmark)
                 
-                [_delegate downloaderDidFailWithError:error];
-            } else {
-                NSString *name = _download.response.suggestedFilename;
-                if (!name) {
-                    name = location.lastPathComponent; // This likely contains nothing useful to identify the file (e.g. CFNetworkDownload_87LVIz.tmp)
-                }
-                NSString *toPath = [downloadFileNameDirectory stringByAppendingPathComponent:name];
-                NSString *fromPath = location.path; // suppress moveItemAtPath: non-null warning
-                NSError *error = nil;
-                if ([[NSFileManager defaultManager] moveItemAtPath:fromPath toPath:toPath error:&error]) {
-                    _downloadFilename = toPath;
-                    
-                    // Create a bookmark for the download
-                    // Don't pass any options (we don't want a persistent security scoped bookmark)
-                    
-                    NSURL *downloadURL = [NSURL fileURLWithPath:toPath isDirectory:NO];
-                    
-                    NSError *bookmarkError = nil;
-                    NSData *bookmarkData = [downloadURL bookmarkDataWithOptions:0 includingResourceValuesForKeys:@[] relativeToURL:nil error:&bookmarkError];
-                    if (bookmarkData == nil) {
-                        [_delegate downloaderDidFailWithError:bookmarkError];
-                    } else {
-                        // The download token may be provided later to the downloader for removing a download
-                        // and its temporary directory
-                        NSString *downloadToken = tempDir.lastPathComponent;
-                        [_delegate downloaderDidSetDownloadBookmarkData:bookmarkData downloadToken:downloadToken];
-                        [self downloadDidFinish];
-                    }
+                NSURL *downloadURL = [NSURL fileURLWithPath:toPath isDirectory:NO];
+                
+                NSError *bookmarkError = nil;
+                NSData *bookmarkData = [downloadURL bookmarkDataWithOptions:0 includingResourceValuesForKeys:@[] relativeToURL:nil error:&bookmarkError];
+                if (bookmarkData == nil) {
+                    [_delegate downloaderDidFailWithError:bookmarkError];
                 } else {
-                    [_delegate downloaderDidFailWithError:error];
+                    // The download token may be provided later to the downloader for removing a download
+                    // and its temporary directory
+                    NSString *downloadToken = tempDir.lastPathComponent;
+                    [_delegate downloaderDidSetDownloadBookmarkData:bookmarkData downloadToken:downloadToken];
+                    
+                    _sessionTask = nil;
+                    
+                    [_delegate downloaderDidFinishWithTemporaryDownloadData:nil];
                 }
+            } else {
+                [_delegate downloaderDidFailWithError:error];
             }
         }
     }
@@ -259,67 +308,26 @@ static NSString *SUDownloadingReason = @"Downloading update related file";
 
 - (void)URLSession:(NSURLSession *)__unused session downloadTask:(NSURLSessionDownloadTask *)__unused downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)__unused totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
-        
-    if (_mode == SPUDownloadModePersistent && totalBytesExpectedToWrite > 0 && !_receivedExpectedBytes) {
+    if (_mode != SPUDownloadModePersistent) {
+        return;
+    }
+    
+    if (totalBytesExpectedToWrite > 0 && !_receivedExpectedBytes) {
         _receivedExpectedBytes = YES;
         [_delegate downloaderDidReceiveExpectedContentLength:totalBytesExpectedToWrite];
     }
     
-    if (_mode == SPUDownloadModePersistent && bytesWritten >= 0) {
+    if (bytesWritten >= 0) {
         [_delegate downloaderDidReceiveDataOfLength:(uint64_t)bytesWritten];
-    }
-}
-
-- (void)downloadDidFinish SPU_OBJC_DIRECT
-{
-    assert(_downloadFilename != nil);
-    
-    SPUDownloadData *downloadData = nil;
-    if (_mode == SPUDownloadModeTemporary) {
-        NSData *data = [NSData dataWithContentsOfFile:_downloadFilename];
-        if (data != nil) {
-            NSURLResponse *response = _download.response;
-
-            NSURL *responseURL = response.URL;
-            if (responseURL == nil) {
-                responseURL = _download.currentRequest.URL;
-            }
-            if (responseURL == nil) {
-                responseURL = _download.originalRequest.URL;
-            }
-            assert(responseURL != nil);
-
-            downloadData = [[SPUDownloadData alloc] initWithData:data URL:responseURL textEncodingName:response.textEncodingName MIMEType:response.MIMEType];
-        }
-    }
-    
-    _download = nil;
-    
-    switch (_mode) {
-        case SPUDownloadModeTemporary:
-            if (downloadData != nil) {
-                [_delegate downloaderDidFinishWithTemporaryDownloadData:downloadData];
-            } else {
-                [_delegate downloaderDidFailWithError:[NSError errorWithDomain:SUSparkleErrorDomain code:SUDownloadError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed to read temporary downloaded data from %@", _downloadFilename]}]];
-            }
-            
-            [self _cleanup];
-            break;
-        case SPUDownloadModePersistent:
-            [_delegate downloaderDidFinishWithTemporaryDownloadData:nil];
-            break;
     }
 }
 
 - (void)URLSession:(NSURLSession *)__unused session task:(NSURLSessionTask *)__unused task didCompleteWithError:(NSError *)error
 {
-    _download = nil;
+    _sessionTask = nil;
     if (error != nil) {
         [_delegate downloaderDidFailWithError:error];
     }
 }
-
-// NSURLDownload has a [download:shouldDecodeSourceDataOfMIMEType:] to determine if the data should be decoded.
-// This does not exist for NSURLSessionDownloadTask and appears unnecessary. Data tasks will decode data, but not download tasks.
 
 @end

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -122,6 +122,10 @@
         _inBackground = background;
         
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL];
+        // Note the cachePolicy has no effect on persistent downloads on disk (i.e downloading update archives)
+        // It impacts temporary in-memory downloads such as appcast feeds and release notes.
+        // For now we don't use caching, but with more testing/experimenting that could change
+        // (e.g. not downloading same feed unmodified from previous request).
         request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
         
         if (userAgent != nil) {


### PR DESCRIPTION
I also ventured a bit in changing the `cachePolicy` which is related to #371 but decided not to make such a change yet.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested test app and updating other apps with sparkle-cli

macOS version tested: 26.2 (25C56)
