### PR TITLE
Remove sparkle-cli (sparkle.app) from binary distribution

### DIFF
--- a/Configurations/make-release-package.sh
+++ b/Configurations/make-release-package.sh
@@ -16,7 +16,6 @@ function verify_code_signatures() {
     find "${verification_directory}" -name "Sparkle.framework" -type d -exec codesign --verify -vvv --deep {} \;
     
     if [ "$check_aux_apps" = true ] ; then
-        codesign --verify -vvv --deep "${verification_directory}/sparkle.app"
         codesign --verify -vvv --deep "${verification_directory}/Sparkle Test App.app"
     fi
     codesign --verify -vvv --deep "${verification_directory}/bin/BinaryDelta"
@@ -42,7 +41,6 @@ if [ "$ACTION" = "" ] ; then
     cp "$CONFIGURATION_BUILD_DIR/generate_keys" "$CONFIGURATION_BUILD_DIR/staging/bin"
     cp "$CONFIGURATION_BUILD_DIR/sign_update" "$CONFIGURATION_BUILD_DIR/staging/bin"
     cp -R "$CONFIGURATION_BUILD_DIR/Sparkle Test App.app" "$CONFIGURATION_BUILD_DIR/staging"
-    cp -R "$CONFIGURATION_BUILD_DIR/sparkle.app" "$CONFIGURATION_BUILD_DIR/staging"
     cp -R "$CONFIGURATION_BUILD_DIR/Sparkle.framework" "$CONFIGURATION_BUILD_DIR/staging"
     cp -R "$CONFIGURATION_BUILD_DIR/Sparkle.xcframework" "$CONFIGURATION_BUILD_DIR/staging-spm"
 
@@ -60,8 +58,6 @@ if [ "$ACTION" = "" ] ; then
         cp -R "$CONFIGURATION_BUILD_DIR/sign_update.dSYM" "$CONFIGURATION_BUILD_DIR/staging/Symbols"
         
         cp -R "$CONFIGURATION_BUILD_DIR/Sparkle Test App.app.dSYM" "$CONFIGURATION_BUILD_DIR/staging/Symbols"
-        
-        cp -R "$CONFIGURATION_BUILD_DIR/sparkle.app.dSYM" "$CONFIGURATION_BUILD_DIR/staging/Symbols"
         
         cp -R "$CONFIGURATION_BUILD_DIR/Sparkle.framework.dSYM" "$CONFIGURATION_BUILD_DIR/staging/Symbols"
         

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -746,13 +746,6 @@
 			remoteGlobalIDString = 721C24441CB753E6005440CB;
 			remoteInfo = "Installer Progress";
 		};
-		72DBA3791D5FDE95002594A8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 72D9549D1CBB415B006F28BD;
-			remoteInfo = "sparkle-cli";
-		};
 		72EF30B826747E39008CE987 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2601,7 +2594,6 @@
 			buildWorkingDirectory = "";
 			dependencies = (
 				14732BCB1960F73500593899 /* PBXTargetDependency */,
-				72DBA37A1D5FDE95002594A8 /* PBXTargetDependency */,
 				72F94F6B1CC4A0C8002DEE68 /* PBXTargetDependency */,
 				725148E9266D918900247C9C /* PBXTargetDependency */,
 				7218EC352623ED97008FECF3 /* PBXTargetDependency */,
@@ -3896,11 +3888,6 @@
 			isa = PBXTargetDependency;
 			target = 721C24441CB753E6005440CB /* Installer Progress */;
 			targetProxy = 72D954B91CBB6E27006F28BD /* PBXContainerItemProxy */;
-		};
-		72DBA37A1D5FDE95002594A8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 72D9549D1CBB415B006F28BD /* sparkle-cli */;
-			targetProxy = 72DBA3791D5FDE95002594A8 /* PBXContainerItemProxy */;
 		};
 		72EF30B926747E39008CE987 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
External updater software usually (and often should) use `SPUUpdater` directly. sparkle-cli is a show case for this. Although the utility app is useful and software may want to rely on it, I think if they want to do that, they should also build/deploy with a custom `PRODUCT_BUNDLE_IDENTIFIER` that doesn't clash other client's usages.

Note this app is already not in the SPM distribution.

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested `make release` locally and verified sparkle.app is not in there.

macOS version tested: 26.2 (25C56)
