### PR TITLE
Add API annotations for Swift concurrency

### DIFF
--- a/Sparkle/SPUDownloadData.h
+++ b/Sparkle/SPUDownloadData.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A class for containing downloaded data along with some information about it.
  */
-SU_EXPORT @interface SPUDownloadData : NSObject <NSSecureCoding>
+SU_EXPORT NS_SWIFT_SENDABLE @interface SPUDownloadData : NSObject <NSSecureCoding>
 
 /**
  * The raw data that was downloaded.

--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  This class must be used on the main thread.
   */
-SU_EXPORT @interface SPUStandardUpdaterController : NSObject
+SU_EXPORT NS_SWIFT_UI_ACTOR @interface SPUStandardUpdaterController : NSObject
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-interface-ivars"

--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Sparkle's standard built-in user driver for updater interactions
  */
-SU_EXPORT @interface SPUStandardUserDriver : NSObject <SPUUserDriver>
+SU_EXPORT NS_SWIFT_UI_ACTOR @interface SPUStandardUserDriver : NSObject <SPUUserDriver>
 
 /**
  Initializes a Sparkle's standard user driver for user update interactions

--- a/Sparkle/SPUUpdatePermissionRequest.h
+++ b/Sparkle/SPUUpdatePermissionRequest.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This class represents information needed to make a permission request for checking updates.
  */
-SU_EXPORT @interface SPUUpdatePermissionRequest : NSObject<NSSecureCoding>
+SU_EXPORT NS_SWIFT_SENDABLE @interface SPUUpdatePermissionRequest : NSObject<NSSecureCoding>
 
 /**
  Initializes a new update permission request instance.

--- a/Sparkle/SPUUpdater.h
+++ b/Sparkle/SPUUpdater.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  This class must be used on the main thread.
  */
-SU_EXPORT @interface SPUUpdater : NSObject
+SU_EXPORT NS_SWIFT_UI_ACTOR @interface SPUUpdater : NSObject
 
 /**
  Initializes a new `SPUUpdater` instance

--- a/Sparkle/SPUUpdaterDelegate.h
+++ b/Sparkle/SPUUpdaterDelegate.h
@@ -66,7 +66,7 @@ SU_EXPORT extern NSString *const SUSystemProfilerPreferredLanguageKey;
 /**
  Provides delegation methods to control the behavior of an `SPUUpdater` object.
  */
-@protocol SPUUpdaterDelegate <NSObject>
+NS_SWIFT_UI_ACTOR @protocol SPUUpdaterDelegate <NSObject>
 @optional
 
 /**

--- a/Sparkle/SPUUpdaterSettings.h
+++ b/Sparkle/SPUUpdaterSettings.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  For updating updater settings, changes are made in the host's user defaults.
  */
-SU_EXPORT @interface SPUUpdaterSettings : NSObject
+SU_EXPORT NS_SWIFT_UI_ACTOR @interface SPUUpdaterSettings : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Sparkle/SPUUserDriver.h
+++ b/Sparkle/SPUUserDriver.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  Every method in this protocol can be assumed to be called from the main thread.
  */
-SU_EXPORT @protocol SPUUserDriver <NSObject>
+SU_EXPORT NS_SWIFT_UI_ACTOR @protocol SPUUserDriver <NSObject>
 
 /**
  * Show an updater permission request to the user
@@ -140,7 +140,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param error The error associated with why a new update was not found. See above discussion for more details.
  * @param acknowledgement Acknowledge to the updater that no update found error was shown.
  */
-- (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement;
+- (void)showUpdateNotFoundWithError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement NS_SWIFT_ASYNC(2);
 
 /**
  * Show the user an update error occurred
@@ -153,7 +153,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param error The error associated with what update error occurred.
  * @param acknowledgement Acknowledge to the updater that the error was shown.
  */
-- (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement;
+- (void)showUpdaterError:(NSError *)error acknowledgement:(void (^)(void))acknowledgement NS_SWIFT_ASYNC(2);
 
 /**
  * Show the user that downloading the new update initiated
@@ -256,7 +256,7 @@ SU_EXPORT @protocol SPUUserDriver <NSObject>
  * @param relaunched Indicates if the update was relaunched.
  * @param acknowledgement Acknowledge to the updater that the finished installation was shown.
  */
-- (void)showUpdateInstalledAndRelaunched:(BOOL)relaunched acknowledgement:(void (^)(void))acknowledgement;
+- (void)showUpdateInstalledAndRelaunched:(BOOL)relaunched acknowledgement:(void (^)(void))acknowledgement NS_SWIFT_ASYNC(2);
 
 /**
  * Dismiss the current update installation

--- a/Sparkle/SPUUserUpdateState.h
+++ b/Sparkle/SPUUserUpdateState.h
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, SPUUserUpdateStage) {
 /**
  This represents the user's current update state.
  */
-SU_EXPORT @interface SPUUserUpdateState : NSObject
+SU_EXPORT NS_SWIFT_SENDABLE @interface SPUUserUpdateState : NSObject<NSSecureCoding>
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Sparkle/SPUUserUpdateState.m
+++ b/Sparkle/SPUUserUpdateState.m
@@ -17,9 +17,6 @@
 #define SPUUserUpdateStateMajorUpgradeKey @"SPUUserUpdateStateMajorUpgrade"
 #define SPUUserUpdateStateCriticalUpdateKey @"SPUUserUpdateStateCriticalUpdate"
 
-@interface SPUUserUpdateState () <NSSecureCoding>
-@end
-
 @implementation SPUUserUpdateState
 
 @synthesize stage = _stage;

--- a/Sparkle/SUAppcast.h
+++ b/Sparkle/SUAppcast.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The appcast representing a collection of `SUAppcastItem` items in the feed.
  */
-SU_EXPORT @interface SUAppcast : NSObject
+SU_EXPORT NS_SWIFT_SENDABLE @interface SUAppcast : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Sparkle/SUAppcastItem.h
+++ b/Sparkle/SUAppcastItem.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  Extended documentation and examples on using appcast item features are available at:
  https://sparkle-project.org/documentation/publishing/
  */
-SU_EXPORT @interface SUAppcastItem : NSObject<NSSecureCoding>
+SU_EXPORT NS_SWIFT_SENDABLE @interface SUAppcastItem : NSObject<NSSecureCoding>
 
 /**
  The version of the update item.

--- a/Sparkle/SUUpdatePermissionResponse.h
+++ b/Sparkle/SUUpdatePermissionResponse.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This class represents a response for permission to check updates.
 */
-SU_EXPORT @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
+SU_EXPORT NS_SWIFT_SENDABLE @interface SUUpdatePermissionResponse : NSObject<NSSecureCoding>
 
 /**
  Initializes a new update permission response instance.


### PR DESCRIPTION
This should probably make Swift 6 async usage easier.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested using Sparkle / SPUUserDriver in Swift 6 app.

macOS version tested: 26.2 (25C56)
