### PR TITLE
Improve extracting signed markdown content

### DIFF
--- a/Autoupdate/SUSignatureVerifier.m
+++ b/Autoupdate/SUSignatureVerifier.m
@@ -173,7 +173,7 @@
         case SUSigningInputStatusPresent: {
             assert(data != nil);
             if (ed25519_verify(signatures.ed25519Signature, data.bytes, data.length, _pubKeys.ed25519PubKey)) {
-                SULog(SULogLevelDefault, @"OK: EdDSA signature is correct");
+                SULog(SULogLevelDefault, @"OK: EdDSA signature is correct for %@", fileKind);
 #if SPARKLE_BUILD_LEGACY_DSA_SUPPORT
                 // No need to check DSA when EdDSA verification succeeded, unless a DSA signature is provided and it's
                 // erroneously invalid

--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -340,8 +340,8 @@
 		728337A61C9E6FF40085AA99 /* SPUProbeInstallStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 728337A41C9E6FF40085AA99 /* SPUProbeInstallStatus.h */; };
 		728337A71C9E6FF40085AA99 /* SPUProbeInstallStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 728337A51C9E6FF40085AA99 /* SPUProbeInstallStatus.m */; };
 		728638ED1CAF50CE00783084 /* SUConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 61299A5F09CA6EB100B7442F /* SUConstants.m */; };
-		7286EE5F28CEC84900163C1D /* SUPlainTextReleaseNotesView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7286EE5D28CEC84900163C1D /* SUPlainTextReleaseNotesView.h */; };
-		7286EE6028CEC84900163C1D /* SUPlainTextReleaseNotesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7286EE5E28CEC84900163C1D /* SUPlainTextReleaseNotesView.m */; };
+		7286EE5F28CEC84900163C1D /* SUTextViewReleaseNotesView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7286EE5D28CEC84900163C1D /* SUTextViewReleaseNotesView.h */; };
+		7286EE6028CEC84900163C1D /* SUTextViewReleaseNotesView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7286EE5E28CEC84900163C1D /* SUTextViewReleaseNotesView.m */; };
 		728ED34A277DA23400D9238F /* SPUSparkleDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 728ED349277DA23400D9238F /* SPUSparkleDeltaArchive.m */; };
 		728ED34B277DA23400D9238F /* SPUSparkleDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 728ED349277DA23400D9238F /* SPUSparkleDeltaArchive.m */; };
 		728ED34C277DA23400D9238F /* SPUSparkleDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 728ED349277DA23400D9238F /* SPUSparkleDeltaArchive.m */; };
@@ -396,12 +396,12 @@
 		72C56E042EFB45B10005A484 /* SUSignatureVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 7267E59B1D3D8A5A00D1BF90 /* SUSignatureVerifier.m */; };
 		72C56E052EFB45BD0005A484 /* SPUVerifierInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 72D04F3C2B094C8400A6DEAA /* SPUVerifierInformation.m */; };
 		72C56E062EFB45C80005A484 /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E282D22B660BE004AA304 /* libed25519.a */; };
-		72C56E092EFDFB850005A484 /* SPUExtractAppcast.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */; };
-		72C56E0A2EFDFB850005A484 /* SPUExtractAppcast.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */; };
-		72C56E0B2EFDFB850005A484 /* SPUExtractAppcast.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */; };
-		72C56E0C2EFDFB850005A484 /* SPUExtractAppcast.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C56E072EFDFB850005A484 /* SPUExtractAppcast.h */; };
-		72C56E0D2EFE002D0005A484 /* SPUExtractAppcast.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */; };
-		72C56E0E2EFEEF8B0005A484 /* SPUExtractAppcast.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */; };
+		72C56E092EFDFB850005A484 /* SPUExtractSignedFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */; };
+		72C56E0A2EFDFB850005A484 /* SPUExtractSignedFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */; };
+		72C56E0B2EFDFB850005A484 /* SPUExtractSignedFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */; };
+		72C56E0C2EFDFB850005A484 /* SPUExtractSignedFeed.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C56E072EFDFB850005A484 /* SPUExtractSignedFeed.h */; };
+		72C56E0D2EFE002D0005A484 /* SPUExtractSignedFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */; };
+		72C56E0E2EFEEF8B0005A484 /* SPUExtractSignedFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */; };
 		72C56E102EFEF10B0005A484 /* Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E0F2EFEF10B0005A484 /* Signing.swift */; };
 		72C56E112EFEF10B0005A484 /* Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E0F2EFEF10B0005A484 /* Signing.swift */; };
 		72C56E122EFEF10B0005A484 /* Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C56E0F2EFEF10B0005A484 /* Signing.swift */; };
@@ -1285,8 +1285,8 @@
 		728337A41C9E6FF40085AA99 /* SPUProbeInstallStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUProbeInstallStatus.h; sourceTree = "<group>"; };
 		728337A51C9E6FF40085AA99 /* SPUProbeInstallStatus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUProbeInstallStatus.m; sourceTree = "<group>"; };
 		728638EE1CAF589C00783084 /* ConfigDownloader.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigDownloader.xcconfig; sourceTree = "<group>"; };
-		7286EE5D28CEC84900163C1D /* SUPlainTextReleaseNotesView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUPlainTextReleaseNotesView.h; sourceTree = "<group>"; };
-		7286EE5E28CEC84900163C1D /* SUPlainTextReleaseNotesView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUPlainTextReleaseNotesView.m; sourceTree = "<group>"; };
+		7286EE5D28CEC84900163C1D /* SUTextViewReleaseNotesView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUTextViewReleaseNotesView.h; sourceTree = "<group>"; };
+		7286EE5E28CEC84900163C1D /* SUTextViewReleaseNotesView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUTextViewReleaseNotesView.m; sourceTree = "<group>"; };
 		728ED348277DA23400D9238F /* SPUSparkleDeltaArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUSparkleDeltaArchive.h; path = Autoupdate/SPUSparkleDeltaArchive.h; sourceTree = SOURCE_ROOT; };
 		728ED349277DA23400D9238F /* SPUSparkleDeltaArchive.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPUSparkleDeltaArchive.m; path = Autoupdate/SPUSparkleDeltaArchive.m; sourceTree = SOURCE_ROOT; };
 		728FBA1B2BB5013300651EDF /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/MainMenu.strings; sourceTree = "<group>"; };
@@ -1341,8 +1341,8 @@
 		72B767E51C9CFD7200A07552 /* SPUAutomaticUpdateDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUAutomaticUpdateDriver.m; sourceTree = "<group>"; };
 		72BC6C3C275027BF0083F14B /* SparkleTestCodeSign_apfs.dmg */ = {isa = PBXFileReference; lastKnownFileType = file; path = SparkleTestCodeSign_apfs.dmg; sourceTree = "<group>"; };
 		72BEBFEE1D7287560019146B /* SUSpotlightImporterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SUSpotlightImporterTest.swift; sourceTree = "<group>"; };
-		72C56E072EFDFB850005A484 /* SPUExtractAppcast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUExtractAppcast.h; sourceTree = "<group>"; };
-		72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPUExtractAppcast.m; sourceTree = "<group>"; };
+		72C56E072EFDFB850005A484 /* SPUExtractSignedFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUExtractSignedFeed.h; sourceTree = "<group>"; };
+		72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SPUExtractSignedFeed.m; sourceTree = "<group>"; };
 		72C56E0F2EFEF10B0005A484 /* Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signing.swift; sourceTree = "<group>"; };
 		72C56E182F04343D0005A484 /* SPUAppcastSigningValidationStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPUAppcastSigningValidationStatus.h; sourceTree = "<group>"; };
 		72C56E1E2F04AC890005A484 /* SUFeedSignatureVerifierTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SUFeedSignatureVerifierTest.swift; sourceTree = "<group>"; };
@@ -2075,8 +2075,8 @@
 				7267E5991D3D8A5A00D1BF90 /* SUCodeSigningVerifier.m */,
 				7267E59A1D3D8A5A00D1BF90 /* SUSignatureVerifier.h */,
 				7267E59B1D3D8A5A00D1BF90 /* SUSignatureVerifier.m */,
-				72C56E072EFDFB850005A484 /* SPUExtractAppcast.h */,
-				72C56E082EFDFB850005A484 /* SPUExtractAppcast.m */,
+				72C56E072EFDFB850005A484 /* SPUExtractSignedFeed.h */,
+				72C56E082EFDFB850005A484 /* SPUExtractSignedFeed.m */,
 				72D04F3B2B094C8400A6DEAA /* SPUVerifierInformation.h */,
 				72D04F3C2B094C8400A6DEAA /* SPUVerifierInformation.m */,
 			);
@@ -2187,8 +2187,8 @@
 				723ABFC3259D4CB300BDB4FA /* SUWKWebView.m */,
 				723ABF2E259D062F00BDB4FA /* SULegacyWebView.h */,
 				723ABF2F259D062F00BDB4FA /* SULegacyWebView.m */,
-				7286EE5D28CEC84900163C1D /* SUPlainTextReleaseNotesView.h */,
-				7286EE5E28CEC84900163C1D /* SUPlainTextReleaseNotesView.m */,
+				7286EE5D28CEC84900163C1D /* SUTextViewReleaseNotesView.h */,
+				7286EE5E28CEC84900163C1D /* SUTextViewReleaseNotesView.m */,
 			);
 			name = "Release Notes Views";
 			sourceTree = "<group>";
@@ -2517,7 +2517,7 @@
 				721BC20E1D1CDE55002BC71E /* SPULocalCacheDirectory.h in Headers */,
 				7267E5B11D3D8AD500D1BF90 /* SPUMessageTypes.h in Headers */,
 				728337A61C9E6FF40085AA99 /* SPUProbeInstallStatus.h in Headers */,
-				7286EE5F28CEC84900163C1D /* SUPlainTextReleaseNotesView.h in Headers */,
+				7286EE5F28CEC84900163C1D /* SUTextViewReleaseNotesView.h in Headers */,
 				723C8A541E2D60DB00C14942 /* SUTouchBarButtonGroup.h in Headers */,
 				72B767D21C9C7B9300A07552 /* SPUProbingUpdateDriver.h in Headers */,
 				7229E1B91C97CC4D00CB50D0 /* SPUScheduledUpdateDriver.h in Headers */,
@@ -2532,7 +2532,7 @@
 				72EF30BE2675CF38008CE987 /* SPUAppcastItemStateResolver.h in Headers */,
 				72EF30C7267C716A008CE987 /* SUAppcastItem+Private.h in Headers */,
 				72EE17FB26D1CC8800C58B19 /* SUInstallerLauncher+Private.h in Headers */,
-				72C56E0C2EFDFB850005A484 /* SPUExtractAppcast.h in Headers */,
+				72C56E0C2EFDFB850005A484 /* SPUExtractSignedFeed.h in Headers */,
 				61299A5C09CA6D4500B7442F /* SUConstants.h in Headers */,
 				726DF88E1C84277600188804 /* SPUUserUpdateState.h in Headers */,
 				72B767DA1C9CD2E400A07552 /* SPUUIBasedUpdateDriver.h in Headers */,
@@ -3384,7 +3384,7 @@
 				7210C7681B9A9A1500EB90AC /* SUUnarchiverTest.swift in Sources */,
 				5AE459001C34118500E3BB47 /* SUUpdaterTest.m in Sources */,
 				5AE459021C34118500E3BB47 /* SUVersionComparisonTest.m in Sources */,
-				72C56E092EFDFB850005A484 /* SPUExtractAppcast.m in Sources */,
+				72C56E092EFDFB850005A484 /* SPUExtractSignedFeed.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3411,7 +3411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72C56E0E2EFEEF8B0005A484 /* SPUExtractAppcast.m in Sources */,
+				72C56E0E2EFEEF8B0005A484 /* SPUExtractSignedFeed.m in Sources */,
 				729743AB279D1BD2009910B2 /* SUCodeSigningVerifier.m in Sources */,
 				725EE489277D39B400D820CE /* SPUDeltaArchive.m in Sources */,
 				725EE48A277D39B400D820CE /* SPUXarDeltaArchive.m in Sources */,
@@ -3571,7 +3571,7 @@
 				7267E5C31D3D8B2700D1BF90 /* SUInstaller.m in Sources */,
 				5A6DD17123FE1FFC000AEF33 /* SUSignatures.m in Sources */,
 				721D5A8525C65D3F00D23BEA /* SUFlatPackageUnarchiver.m in Sources */,
-				72C56E0A2EFDFB850005A484 /* SPUExtractAppcast.m in Sources */,
+				72C56E0A2EFDFB850005A484 /* SPUExtractSignedFeed.m in Sources */,
 				7267E5CE1D3D8C7500D1BF90 /* SULog.m in Sources */,
 				7267E5871D3D89B300D1BF90 /* SUPipedUnarchiver.m in Sources */,
 				7267E5C51D3D8B2700D1BF90 /* SUPlainInstaller.m in Sources */,
@@ -3597,7 +3597,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72C56E0B2EFDFB850005A484 /* SPUExtractAppcast.m in Sources */,
+				72C56E0B2EFDFB850005A484 /* SPUExtractSignedFeed.m in Sources */,
 				72C56E052EFB45BD0005A484 /* SPUVerifierInformation.m in Sources */,
 				72C56E042EFB45B10005A484 /* SUSignatureVerifier.m in Sources */,
 				723ABF31259D062F00BDB4FA /* SULegacyWebView.m in Sources */,
@@ -3651,7 +3651,7 @@
 				61A225A50D1C4AC000430CCD /* SUStandardVersionComparator.m in Sources */,
 				727F340B2605321D00020E85 /* SULog+NSError.m in Sources */,
 				EA1E287022B66621004AA304 /* SUSignatures.m in Sources */,
-				7286EE6028CEC84900163C1D /* SUPlainTextReleaseNotesView.m in Sources */,
+				7286EE6028CEC84900163C1D /* SUTextViewReleaseNotesView.m in Sources */,
 				6196CFFA09C72149000DC222 /* SUStatusController.m in Sources */,
 				72B3DECA1E23472200457642 /* SPUDownloadedUpdate.m in Sources */,
 				72AEB1D929A1CB510033883E /* SPUNoUpdateFoundInfo.m in Sources */,
@@ -3709,7 +3709,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72C56E0D2EFE002D0005A484 /* SPUExtractAppcast.m in Sources */,
+				72C56E0D2EFE002D0005A484 /* SPUExtractSignedFeed.m in Sources */,
 				EA1E287922B666EB004AA304 /* main.swift in Sources */,
 				72666DC82B0B28F4001511B0 /* Secret.swift in Sources */,
 				72C56E112EFEF10B0005A484 /* Signing.swift in Sources */,

--- a/Sparkle/SPUExtractSignedFeed.h
+++ b/Sparkle/SPUExtractSignedFeed.h
@@ -1,5 +1,5 @@
 //
-//  SPUExtractAppcast.h
+//  SPUExtractSignedFeed.h
 //  Sparkle
 //
 //  Created on 12/25/25.
@@ -12,5 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Extracts content from an appcast without the signing block, optionally returning back the signed signature & expected content length
 NSData *SPUExtractAppcastContent(NSData *appcastData, NSString * _Nullable __autoreleasing * _Nullable outEdSignatureBase64, uint64_t * _Nullable outContentLength);
+
+// Extracts HTML or markdown release notes data without the beginning sign warning comment
+NSData *SPUExtractReleaseNotesContent(NSData *data);
 
 NS_ASSUME_NONNULL_END

--- a/Sparkle/SPUExtractSignedFeed.m
+++ b/Sparkle/SPUExtractSignedFeed.m
@@ -1,12 +1,12 @@
 //
-//  SPUExtractAppcast.m
+//  SPUExtractSignedFeed.m
 //  Sparkle
 //
 //  Created on 12/25/25.
 //  Copyright © 2025 Sparkle Project. All rights reserved.
 //
 
-#import "SPUExtractAppcast.h"
+#import "SPUExtractSignedFeed.h"
 
 NSData *SPUExtractAppcastContent(NSData *appcastData, NSString * _Nullable __autoreleasing * _Nullable outEdSignatureBase64, uint64_t * _Nullable outContentLength)
 {
@@ -57,4 +57,39 @@ NSData *SPUExtractAppcastContent(NSData *appcastData, NSString * _Nullable __aut
     }
     
     return contentFeedData;
+}
+
+NSData *SPUExtractReleaseNotesContent(NSData *data)
+{
+    NSData *signWarningCommentPrefix = [@"<!-- sparkle-sign-warning:" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *signWarningComment = [@"-->" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    if (signWarningCommentPrefix.length == 0 || signWarningComment.length == 0) {
+        return data;
+    }
+    
+    if (data.length < signWarningCommentPrefix.length + signWarningComment.length) {
+        return data;
+    }
+    
+    if (![[data subdataWithRange:NSMakeRange(0, signWarningCommentPrefix.length)] isEqualToData:signWarningCommentPrefix]) {
+        return data;
+    }
+    
+    NSRange commentSuffixRange = [data rangeOfData:signWarningComment options:0 range:NSMakeRange(signWarningCommentPrefix.length, data.length - signWarningCommentPrefix.length)];
+    
+    if (commentSuffixRange.location == NSNotFound) {
+        return data;
+    }
+    
+    // A newline is usually inserted after the signing warning comment
+    // Ignore that character too if present
+    NSUInteger endOfCommentSuffix = NSMaxRange(commentSuffixRange);
+    NSUInteger endOfCommentSuffixAccountingForNewline =
+        (data.length > endOfCommentSuffix && *((const uint8_t *)data.bytes + endOfCommentSuffix) == '\n') ?
+        (endOfCommentSuffix + 1) :
+        endOfCommentSuffix;
+    
+    NSData *contentData = [data subdataWithRange:NSMakeRange(endOfCommentSuffixAccountingForNewline, data.length - endOfCommentSuffixAccountingForNewline)];
+    return contentData;
 }

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -15,6 +15,8 @@
 #import "SUAppcastItem.h"
 #import "SUErrors.h"
 #import "SPUDownloadData.h"
+#import "SPUDownloadDataPrivate.h"
+#import "SPUExtractSignedFeed.h"
 #import "SPUResumableUpdate.h"
 #import "SPUDownloadDriver.h"
 #import "SPUSkippedUpdate.h"
@@ -63,16 +65,35 @@
     [_downloadDriver downloadFile];
 }
 
-- (void)downloadDriverDidDownloadData:(SPUDownloadData *)downloadData
+- (void)downloadDriverDidDownloadData:(SPUDownloadData *)downloadDataToValidate
 {
     if (_completionHandler != nil) {
+        SPUDownloadData *downloadDataToPassToUserDriver;
+        
+        // Strip out any sign warning comment prefix for markdown data so that user drivers
+        // will not have to deal with parsing them (if their markdown parsers don't handle decoding HTML)
+        NSString *MIMEType = downloadDataToValidate.MIMEType;
+        NSString *pathExtension = _downloadDriver.request.URL.pathExtension;
+        if ([MIMEType isEqualToString:@"text/markdown"] || [MIMEType isEqualToString:@"text/x-markdown"] ||
+            [pathExtension caseInsensitiveCompare:@"md"] == NSOrderedSame || [pathExtension caseInsensitiveCompare:@"markdown"] == NSOrderedSame) {
+            
+            NSData *contentData = SPUExtractReleaseNotesContent(downloadDataToValidate.data);
+            if (contentData.length != downloadDataToValidate.data.length) {
+                downloadDataToPassToUserDriver = [[SPUDownloadData alloc] initWithData:contentData URL:downloadDataToValidate.URL textEncodingName:downloadDataToValidate.textEncodingName MIMEType:downloadDataToValidate.MIMEType];
+            } else {
+                downloadDataToPassToUserDriver = downloadDataToValidate;
+            }
+        } else {
+            downloadDataToPassToUserDriver = downloadDataToValidate;
+        }
+        
         if (_host.requiresSignedAppcast) {
             SUSignatureVerifier *signatureVerifier = [[SUSignatureVerifier alloc] initWithPublicKeys:_host.publicKeys];
             SPUVerifierInformation *verifierInformation = [[SPUVerifierInformation alloc] initWithExpectedVersion:nil expectedContentLength:_contentLength];
-            verifierInformation.actualContentLength = downloadData.data.length;
+            verifierInformation.actualContentLength = downloadDataToValidate.data.length;
             
             NSError *verifierError = nil;
-            if (![signatureVerifier verifyData:downloadData.data signatures:_signatures fileKind:@"release notes" verifierInformation:verifierInformation error:&verifierError]) {
+            if (![signatureVerifier verifyData:downloadDataToValidate.data signatures:_signatures fileKind:@"release notes" verifierInformation:verifierInformation error:&verifierError]) {
                 NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:@{NSLocalizedDescriptionKey:SULocalizedStringFromTableInBundle(@"The release notes is improperly signed and could not be validated. Please contact the app developer for more information.", SPARKLE_TABLE, SUSparkleBundle(), nil)}];
                 
                 if (verifierError != nil) {
@@ -81,10 +102,10 @@
                 
                 _completionHandler(nil, [NSError errorWithDomain:SUSparkleErrorDomain code:SUDownloadError userInfo:userInfo]);
             } else {
-                _completionHandler(downloadData, nil);
+                _completionHandler(downloadDataToPassToUserDriver, nil);
             }
         } else {
-            _completionHandler(downloadData, nil);
+            _completionHandler(downloadDataToPassToUserDriver, nil);
         }
         
         _completionHandler = nil;

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -27,7 +27,7 @@
 #import "SPUAppcastItemStateResolver+Private.h"
 #import "SPUAppcastItemState.h"
 #import "SUSignatureVerifier.h"
-#import "SPUExtractAppcast.h"
+#import "SPUExtractSignedFeed.h"
 #import "SUSignatures.h"
 #import "SPUVerifierInformation.h"
 

--- a/Sparkle/SUTextViewReleaseNotesView.h
+++ b/Sparkle/SUTextViewReleaseNotesView.h
@@ -1,5 +1,5 @@
 //
-//  SUPlainTextReleaseNotesView.h
+//  SUTextViewReleaseNotesView.h
 //  Sparkle
 //
 //  Created on 9/11/22.
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SPU_OBJC_DIRECT_MEMBERS @interface SUPlainTextReleaseNotesView : NSObject <SUReleaseNotesView>
+SPU_OBJC_DIRECT_MEMBERS @interface SUTextViewReleaseNotesView : NSObject <SUReleaseNotesView>
 
 - (instancetype)initWithFontPointSize:(int)fontPointSize appcastItem:(SUAppcastItem *)appcastItem host:(SUHost *)host delegate:(id<SPUStandardUserDriverDelegate>)delegate prefersMarkdown:(BOOL)prefersMarkdown customAllowedURLSchemes:(NSArray<NSString *> *)customAllowedURLSchemes;
 

--- a/Sparkle/SUTextViewReleaseNotesView.m
+++ b/Sparkle/SUTextViewReleaseNotesView.m
@@ -1,5 +1,5 @@
 //
-//  SUPlainReleaseNotesView.m
+//  SUTextViewReleaseNotesView.m
 //  Sparkle
 //
 //  Created on 9/11/22.
@@ -8,7 +8,7 @@
 
 #if SPARKLE_BUILD_UI_BITS
 
-#import "SUPlainTextReleaseNotesView.h"
+#import "SUTextViewReleaseNotesView.h"
 #import "SUReleaseNotesCommon.h"
 #import "SPUStandardUserDriverDelegate.h"
 #import "SULog.h"
@@ -17,10 +17,10 @@
 
 #import <AppKit/AppKit.h>
 
-@interface SUPlainTextReleaseNotesView () <NSTextViewDelegate>
+@interface SUTextViewReleaseNotesView () <NSTextViewDelegate>
 @end
 
-@implementation SUPlainTextReleaseNotesView
+@implementation SUTextViewReleaseNotesView
 {
     NSScrollView *_scrollView;
     NSTextView *_textView;
@@ -324,26 +324,6 @@ static NSAttributedString *formatMarkdownAttributedString(NSAttributedString *or
     return outputAttributedString;
 }
 
-// Foundation's markdown parser doesn't handle HTML comments,
-// but the document may begin with a comment for describing a warning for signing
-// Preprocess and skip the document beginning comment
-static NSString *preprocessMarkdownContent(NSString *markdownContent)
-{
-    if (![markdownContent hasPrefix:@"<!--"]) {
-        return markdownContent;
-    }
-    
-    // Our signing tools will insert an extra newline after the HTML comment ends
-    // Try to skip ahead of that newline if present too
-    NSRange endCommentRangeWithNewline = [markdownContent rangeOfString:@"-->\n" options:NSLiteralSearch];
-    NSRange finalEndCommentRange = (endCommentRangeWithNewline.location != NSNotFound ? endCommentRangeWithNewline : [markdownContent rangeOfString:@"-->" options:NSLiteralSearch]);
-    if (finalEndCommentRange.location == NSNotFound) {
-        return markdownContent;
-    }
-    
-    return [markdownContent substringFromIndex:NSMaxRange(finalEndCommentRange)];
-}
-
 - (void)_loadAttributedString:(NSAttributedString * _Nullable)attributedString completionHandler:(void (^)(NSError * _Nullable))completionHandler SPU_OBJC_DIRECT
 {
     if (attributedString == nil) {
@@ -391,10 +371,7 @@ static NSString *preprocessMarkdownContent(NSString *markdownContent)
     [_scrollView setHasVerticalScroller:YES];
     [_scrollView setHasHorizontalScroller:NO];
     
-    NSString *preprocessedContents;
     if (_prefersMarkdown) {
-        preprocessedContents = preprocessMarkdownContent(contents);
-        
         if (@available(macOS 12, *)) {
             dispatch_queue_attr_t queuePriority = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
             
@@ -402,12 +379,12 @@ static NSString *preprocessMarkdownContent(NSString *markdownContent)
             
             dispatch_async(markdownDispatchQueue, ^{
                 NSError *loadMarkdownError = nil;
-                NSAttributedString *originalMarkdownAttributedString = [[NSAttributedString alloc] initWithMarkdownString:preprocessedContents options:nil baseURL:baseURL error:&loadMarkdownError];
+                NSAttributedString *originalMarkdownAttributedString = [[NSAttributedString alloc] initWithMarkdownString:contents options:nil baseURL:baseURL error:&loadMarkdownError];
                 
                 if (originalMarkdownAttributedString == nil) {
                     // Fallback to plain-text
                     
-                    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:preprocessedContents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)self->_fontPointSize] }];
+                    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)self->_fontPointSize] }];
                     
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [self _loadAttributedString:attributedString completionHandler:completionHandler];
@@ -425,11 +402,9 @@ static NSString *preprocessMarkdownContent(NSString *markdownContent)
         } else {
             SULog(SULogLevelDefault, @"Warning: falling back to plain text because markdown support requires macOS 12 or newer");
         }
-    } else {
-        preprocessedContents = contents;
     }
     
-    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:preprocessedContents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)_fontPointSize] }];
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:contents attributes:@{ NSFontAttributeName : [NSFont systemFontOfSize:(CGFloat)_fontPointSize] }];
     
     [self _loadAttributedString:attributedString completionHandler:completionHandler];
 }

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -18,7 +18,7 @@
 #import "SUReleaseNotesView.h"
 #import "SUWKWebView.h"
 #import "SULegacyWebView.h"
-#import "SUPlainTextReleaseNotesView.h"
+#import "SUTextViewReleaseNotesView.h"
 
 #import "SUConstants.h"
 #import "SULog.h"
@@ -336,10 +336,10 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
     id<SPUStandardUserDriverDelegate> delegate = _delegate;
     switch (usedReleaseNotesFormat) {
         case SUReleaseNotesFormatPlainText:
-            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize appcastItem:_updateItem host:_host delegate:delegate prefersMarkdown:NO customAllowedURLSchemes:customAllowedURLSchemes];
+            _releaseNotesView = [[SUTextViewReleaseNotesView alloc] initWithFontPointSize:defaultFontSize appcastItem:_updateItem host:_host delegate:delegate prefersMarkdown:NO customAllowedURLSchemes:customAllowedURLSchemes];
             break;
         case SUReleaseNotesFormatMarkdown:
-            _releaseNotesView = [[SUPlainTextReleaseNotesView alloc] initWithFontPointSize:defaultFontSize appcastItem:_updateItem host:_host delegate:delegate prefersMarkdown:YES customAllowedURLSchemes:customAllowedURLSchemes];
+            _releaseNotesView = [[SUTextViewReleaseNotesView alloc] initWithFontPointSize:defaultFontSize appcastItem:_updateItem host:_host delegate:delegate prefersMarkdown:YES customAllowedURLSchemes:customAllowedURLSchemes];
             break;
         case SUReleaseNotesFormatHTML:
         {

--- a/TestApplication/SUInstallUpdateViewController.m
+++ b/TestApplication/SUInstallUpdateViewController.m
@@ -42,11 +42,17 @@
         [self displayReleaseNotes:_preloadedReleaseNotes];
         _preloadedReleaseNotes = nil;
     } else if (_appcastItem.releaseNotesURL == nil) {
-        NSString *descriptionHTML = _appcastItem.itemDescription;
-        if (descriptionHTML != nil) {
-            NSData *htmlData = [descriptionHTML dataUsingEncoding:NSUTF8StringEncoding];
-            NSAttributedString *attributedString = [[NSAttributedString alloc] initWithHTML:htmlData documentAttributes:NULL];
-            [self displayReleaseNotes:attributedString];
+        NSString *descriptionString = _appcastItem.itemDescription;
+        if (descriptionString != nil) {
+            NSString *descriptionFormat = _appcastItem.itemDescriptionFormat;
+            if ([descriptionFormat isEqualToString:@"plain-text"] || [descriptionFormat isEqualToString:@"markdown"]) {
+                NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:descriptionString];
+                [self displayReleaseNotes:attributedString];
+            } else {
+                NSData *htmlData = [descriptionString dataUsingEncoding:NSUTF8StringEncoding];
+                NSAttributedString *attributedString = [[NSAttributedString alloc] initWithHTML:htmlData documentAttributes:NULL];
+                [self displayReleaseNotes:attributedString];
+            }
         }
     }
 }

--- a/TestApplication/SUInstallUpdateViewController.xib
+++ b/TestApplication/SUInstallUpdateViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,11 +16,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="370" height="182"/>
+            <rect key="frame" x="0.0" y="0.0" width="406" height="182"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JaG-xU-cSv">
-                    <rect key="frame" x="128" y="6" width="114" height="32"/>
+                    <rect key="frame" x="146" y="6" width="114" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Install Later" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vGh-C9-cmI">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -34,7 +34,7 @@ Gw
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GnO-99-FrA">
-                    <rect key="frame" x="14" y="6" width="114" height="32"/>
+                    <rect key="frame" x="20" y="6" width="114" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Skip Update" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Q9S-re-mYe">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -45,18 +45,18 @@ Gw
                     </connections>
                 </button>
                 <scrollView fixedFrame="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Cj-JW-f43">
-                    <rect key="frame" x="0.0" y="46" width="370" height="136"/>
+                    <rect key="frame" x="0.0" y="46" width="406" height="136"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" drawsBackground="NO" id="CIT-u4-hRg">
-                        <rect key="frame" x="1" y="1" width="368" height="134"/>
+                        <rect key="frame" x="1" y="1" width="404" height="134"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" findStyle="panel" allowsNonContiguousLayout="YES" id="hvq-rZ-gUG">
-                                <rect key="frame" x="0.0" y="0.0" width="368" height="134"/>
+                                <rect key="frame" x="0.0" y="0.0" width="404" height="134"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="368" height="134"/>
+                                <size key="minSize" width="404" height="134"/>
                                 <size key="maxSize" width="463" height="10000000"/>
                                 <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             </textView>
@@ -67,12 +67,12 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="dth-jh-Csr">
-                        <rect key="frame" x="353" y="1" width="16" height="134"/>
+                        <rect key="frame" x="388" y="1" width="17" height="134"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cYY-dW-0o8">
-                    <rect key="frame" x="242" y="6" width="114" height="32"/>
+                    <rect key="frame" x="272" y="6" width="114" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Install Update" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="AoI-0t-LLU">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -86,7 +86,7 @@ DQ
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="174" y="251"/>
+            <point key="canvasLocation" x="192" y="251"/>
         </customView>
     </objects>
 </document>

--- a/Tests/SUFeedSignatureVerifierTest.swift
+++ b/Tests/SUFeedSignatureVerifierTest.swift
@@ -142,5 +142,43 @@ class SUFeedSignatureVerifierTest: XCTestCase {
             let byteDifference = releaseNotesDataWithSigningWarning.count - releaseNotesData.count
             XCTAssertEqual(releaseNotesDataWithSigningWarning.subdata(in: releaseNotesDataWithSigningWarning.startIndex.advanced(by: byteDifference) ..< releaseNotesDataWithSigningWarning.endIndex), releaseNotesData)
         }
+        
+        // Test the content using SPUExtractReleaseNotesContent()
+        do {
+            let releaseNotesContent = SPUExtractReleaseNotesContent(releaseNotesDataWithSigningWarning)
+            XCTAssertEqual(releaseNotesContent, releaseNotesData)
+            
+            // Extracting content again should return same data
+            let releaseNotesContentAgain = SPUExtractReleaseNotesContent(releaseNotesContent)
+            XCTAssertEqual(releaseNotesContentAgain, releaseNotesData)
+        }
+        
+        // Test signing warning data without newline
+        do {
+            let signWarning = "<!-- sparkle-sign-warning:-->foobar"
+            let signWarningData = Data(signWarning.utf8)
+            
+            let releaseNotesContent = SPUExtractReleaseNotesContent(signWarningData)
+            XCTAssertEqual(releaseNotesContent, Data("foobar".utf8))
+        }
+        
+        // Test minimal signing warning data
+        do {
+            let signWarning = "<!-- sparkle-sign-warning:-->"
+            let signWarningData = Data(signWarning.utf8)
+            
+            let releaseNotesContent = SPUExtractReleaseNotesContent(signWarningData)
+            XCTAssertEqual(releaseNotesContent.count, 0)
+        }
+        
+        // Test minimal signing warning data with just a newline
+        do {
+            let signWarning = "<!-- sparkle-sign-warning:-->\n"
+            let signWarningData = Data(signWarning.utf8)
+            
+            // This should skip over the newline
+            let releaseNotesContent = SPUExtractReleaseNotesContent(signWarningData)
+            XCTAssertEqual(releaseNotesContent.count, 0)
+        }
     }
 }

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -22,7 +22,7 @@
 #import "SUSignatures.h"
 #import "SPUInstallationType.h"
 #import "SPUAppcastItemStateResolver.h"
-#import "SPUExtractAppcast.h"
+#import "SPUExtractSignedFeed.h"
 #import "SUSignatureVerifier.h"
 #import "ed25519.h"
 

--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -445,26 +445,35 @@ class ArchiveItem: CustomStringConvertible {
     }
 
     private func getReleaseNotesAsFragment(_ path: URL, _ embedReleaseNotesAlways: Bool) -> (content: String, format: String)?  {
-        guard let content = try? String(contentsOf: path) else {
+        guard let data = try? Data(contentsOf: path) else {
             return nil
         }
         
+        let contentData: Data
         let format: String
         let pathExtension = path.pathExtension
         switch pathExtension {
-        case "txt":
+        case "txt", "TXT":
             format = "plain-text"
-        case "md", "markdown":
+            contentData = data
+        case "md", "MD", "markdown", "MARKDOWN":
             format = "markdown"
+            contentData = SPUExtractReleaseNotesContent(data)
         default:
             format = "html"
+            contentData = SPUExtractReleaseNotesContent(data)
         }
         
         if embedReleaseNotesAlways {
-            return (content, format)
-        } else if path.pathExtension.caseInsensitiveCompare("html") == .orderedSame && !content.localizedCaseInsensitiveContains("<!DOCTYPE") && !content.localizedCaseInsensitiveContains("<body")  {
+            guard let contentString = String(data: contentData, encoding: .utf8) else {
+                print("Error: failed to read release notes as UTF8 string: \(path.lastPathComponent)")
+                return nil
+            }
+            
+            return (contentString, format)
+        } else if format == "html", let contentString = String(data: contentData, encoding: .utf8), !contentString.localizedCaseInsensitiveContains("<!DOCTYPE") && !contentString.localizedCaseInsensitiveContains("<body")  {
             // HTML fragments should always be embedded
-            return (content, format)
+            return (contentString, format)
         } else {
             return nil
         }

--- a/generate_appcast/Bridging-Header.h
+++ b/generate_appcast/Bridging-Header.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#import "SPUExtractAppcast.h"
+#import "SPUExtractSignedFeed.h"
 #import "SUStandardVersionComparator.h"
 #import "SUConstants.h"
 #import "SUErrors.h"

--- a/sign_update/Bridging-Header.h
+++ b/sign_update/Bridging-Header.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#import "SPUExtractAppcast.h"
+#import "SPUExtractSignedFeed.h"
 #import "SUConstants.h"
 #import "SUErrors.h"
 #import "SUSignatures.h"

--- a/sparkle-cli/SPUCommandLineUserDriver.m
+++ b/sparkle-cli/SPUCommandLineUserDriver.m
@@ -82,7 +82,7 @@
             NSData *descriptionData = [appcastItem.itemDescription dataUsingEncoding:NSUTF8StringEncoding];
             if (descriptionData != nil) {
                 NSString *itemDescriptionFormat = appcastItem.itemDescriptionFormat;
-                if (itemDescriptionFormat != nil && [itemDescriptionFormat isEqualToString:@"plain-text"]) {
+                if (itemDescriptionFormat != nil && ([itemDescriptionFormat isEqualToString:@"plain-text"] || [itemDescriptionFormat isEqualToString:@"markdown"])) {
                     [self displayPlainTextReleaseNotes:descriptionData encoding:NSUTF8StringEncoding];
                 } else {
                     [self displayHTMLReleaseNotes:descriptionData];
@@ -124,7 +124,9 @@
 - (void)showUpdateReleaseNotesWithDownloadData:(SPUDownloadData *)downloadData
 {
     if (_verbose) {
-        if (downloadData.MIMEType != nil && [downloadData.MIMEType isEqualToString:@"text/plain"]) {
+        NSString *MIMEType = downloadData.MIMEType;
+        NSString *fileExtension = downloadData.URL.pathExtension;
+        if ([MIMEType isEqualToString:@"text/plain"] || [MIMEType isEqualToString:@"text/markdown"] || [MIMEType isEqualToString:@"text/x-markdown"] || [fileExtension caseInsensitiveCompare:@"txt"] == NSOrderedSame || [fileExtension caseInsensitiveCompare:@"md"] == NSOrderedSame || [fileExtension caseInsensitiveCompare:@"markdown"] == NSOrderedSame) {
             NSStringEncoding encoding;
             if (downloadData.textEncodingName == nil) {
                 encoding = NSUTF8StringEncoding;


### PR DESCRIPTION
This strips the beginning sparkle sign warning comment (if present) in the release notes downloader driver rather than the user driver. The comment is also stripped (if present) in generate_appcast when inserting embedded release notes.

Also improve markdown compatibility with sparkle-cli and alternative user driver in Sparkle Test App.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested markdown in test app, sparkle-cli, other app.
Added unit tests for release notes extraction.

macOS version tested: 26.2 (25C56)
