### PR TITLE
Fix build when disabling SPARKLE_BUILD_LEGACY_DSA_SUPPORT

### DIFF
--- a/Sparkle/SUSignatures.h
+++ b/Sparkle/SUSignatures.h
@@ -64,10 +64,7 @@ SUPublicKeysDefinitionAttribute
 @property (nonatomic, readonly) BOOL hasAnyKeys;
 
 - (instancetype)initWithEd:(NSString * _Nullable)ed
-#if SPARKLE_BUILD_LEGACY_DSA_SUPPORT
-                       dsa:(NSString * _Nullable)dsa
-#endif
-;
+                       dsa:(NSString * _Nullable)dsa;
 
 @end
 


### PR DESCRIPTION
Accidentally made this change from appcast signing changes.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested `make release` with SPARKLE_BUILD_LEGACY_DSA_SUPPORT=0

macOS version tested: 26.2 (25C56)
