### PR TITLE
Find non-canonical Sparkle.framework locations in generate_appcast

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -287,23 +287,36 @@ class ArchiveItem: CustomStringConvertible {
             let sparkleExecutableFileSize: Int?
             let sparkleLocales: String?
             do {
-                let canonicalFrameworksURL = appPath.appendingPathComponent("Contents/Frameworks/Sparkle.framework")
+                let fileManager = FileManager.default
                 
                 let frameworksURL: URL?
-                let usingLegacySparkleCore: Bool
-                if !FileManager.default.fileExists(atPath: canonicalFrameworksURL.path) {
-                    // Try legacy SparkleCore framework that was shipping in early 2.0 betas
-                    let sparkleCoreFrameworksURL = appPath.appendingPathComponent("Contents/Frameworks/SparkleCore.framework")
-                    if FileManager.default.fileExists(atPath: sparkleCoreFrameworksURL.path) {
-                        frameworksURL = sparkleCoreFrameworksURL
-                        usingLegacySparkleCore = true
+                let canonicalFrameworksURL = appPath.appendingPathComponent("Contents/Frameworks/Sparkle.framework")
+                if fileManager.fileExists(atPath: canonicalFrameworksURL.path) {
+                    frameworksURL = canonicalFrameworksURL
+                } else {
+                    // The framework may be inside another framework or plug-in. Find it.
+                    if let enumerator = fileManager.enumerator(at: appPath, includingPropertiesForKeys: [], options: [.skipsHiddenFiles], errorHandler: nil) {
+                        var foundFrameworksURL: URL?
+                        
+                        for case let fileURL as URL in enumerator {
+                            let name = fileURL.lastPathComponent
+                            
+                            // Skip Contents/Resources entirely because frameworks shouldn't be in there and we don't want to pay the cost of scanning in there
+                            guard name != "Resources" || fileURL.deletingLastPathComponent().lastPathComponent != "Contents" else {
+                                enumerator.skipDescendants()
+                                continue
+                            }
+                            
+                            if name == "Sparkle.framework" {
+                                foundFrameworksURL = fileURL
+                                break
+                            }
+                        }
+                        
+                        frameworksURL = foundFrameworksURL
                     } else {
                         frameworksURL = nil
-                        usingLegacySparkleCore = false
                     }
-                } else {
-                    frameworksURL = canonicalFrameworksURL
-                    usingLegacySparkleCore = false
                 }
                 
                 if let frameworksURL = frameworksURL {
@@ -313,7 +326,7 @@ class ArchiveItem: CustomStringConvertible {
                         frameworkVersion = frameworkInfoPlist[kCFBundleVersionKey as String] as? String
                     }
                     
-                    let frameworkExecutableURL = frameworksURL.appendingPathComponent(!usingLegacySparkleCore ? "Sparkle" : "SparkleCore").resolvingSymlinksInPath()
+                    let frameworkExecutableURL = frameworksURL.appendingPathComponent("Sparkle").resolvingSymlinksInPath()
                     do {
                         let resourceValues = try frameworkExecutableURL.resourceValues(forKeys: [.fileSizeKey])
                         
@@ -323,7 +336,6 @@ class ArchiveItem: CustomStringConvertible {
                     }
                     
                     do {
-                        let fileManager = FileManager.default
                         let resourcesDirectoryContents = try fileManager.contentsOfDirectory(atPath: resourcesURL.path)
                         let localeExtension = ".lproj"
                         let localeExtensionCount = localeExtension.count


### PR DESCRIPTION
If Sparkle.framework isn't in Contents/Frameworks/ then we do a deep scan in the app bundle (but ignore Contents/Resources/). Sparkle may be placed in a plug-in or other parent framework.

Also remove legacy SparkleCore lookup which is no longer needed.

Fixes #2832

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast on app bundle with non-standard Sparkle.framework location. Tested generate_appcast on standard bundles as well.

macOS version tested: 26.2 (25C56)
