### PR TITLE
Improve detecting non-canonical Sparkle bundles in generate_appcast

### DIFF
--- a/generate_appcast/ArchiveItem.swift
+++ b/generate_appcast/ArchiveItem.swift
@@ -301,8 +301,8 @@ class ArchiveItem: CustomStringConvertible {
                         for case let fileURL as URL in enumerator {
                             let name = fileURL.lastPathComponent
                             
-                            // Skip Contents/Resources entirely because frameworks shouldn't be in there and we don't want to pay the cost of scanning in there
-                            guard name != "Resources" || fileURL.deletingLastPathComponent().lastPathComponent != "Contents" else {
+                            // Skip Resources in bundles entirely because frameworks shouldn't be in there and we don't want to pay the cost of scanning in there
+                            guard name != "Resources" else {
                                 enumerator.skipDescendants()
                                 continue
                             }


### PR DESCRIPTION
Don't check for Contents parent directory when checking for "Resources"

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast locally on bundle with non-canonical location of Sparkle.framework

macOS version tested: 26.2 (25C56)
