### PR TITLE
Preserve XML whitespace better when signing appcast feed

### DIFF
--- a/common_cli/Signing.swift
+++ b/common_cli/Signing.swift
@@ -40,14 +40,14 @@ func addSignWarningToAppcast(data inputData: Data) -> Data {
         let signWarningPrefix = " sparkle-sign-warning:"
         let signWarningMessage = "\nIMPORTANT: This file was signed by Sparkle. Any modifications to this file requires re-signing this file with generate_appcast or sign_update! The signed signature will be embedded at the end of this file.\n"
         
-        let readOptions: XMLNode.Options = [
+        let readAndWriteOptions: XMLNode.Options = [
             XMLNode.Options.nodeLoadExternalEntitiesNever,
             XMLNode.Options.nodePreserveCDATA,
             XMLNode.Options.nodePreserveWhitespace,
         ]
         
         do {
-            let document = try XMLDocument(data: inputData, options: readOptions)
+            let document = try XMLDocument(data: inputData, options: readAndWriteOptions)
             
             var foundSignWarningComment: Bool = false
             if let documentChildren = document.children {
@@ -66,8 +66,7 @@ func addSignWarningToAppcast(data inputData: Data) -> Data {
                 newCommentNode.stringValue = newSigningWarningMessage
                 document.insertChild(newCommentNode, at: 0)
                 
-                let writeOptions: XMLNode.Options = [.nodeCompactEmptyElement, .nodePrettyPrint]
-                xmlData = document.xmlData(options: writeOptions)
+                xmlData = document.xmlData(options: readAndWriteOptions)
             } else {
                 xmlData = inputData
             }


### PR DESCRIPTION
We don't force pretty print when writing new XML data now when we insert a signing warning. This may mean the signing warning prefix may start on the same line as the first XML element, but I think this is alright since the rest of the warning starts on its own line.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested signing XML file with inconsistent whitespace structure and another XML file with standard pretty printing using sign_update.

macOS version tested: 26.2 (25C56)
