### PR TITLE
Fix signature verifier class collisions in unit tests

### DIFF
--- a/Autoupdate/SUSignatureVerifier.h
+++ b/Autoupdate/SUSignatureVerifier.h
@@ -22,7 +22,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SPU_OBJC_DIRECT_MEMBERS @interface SUSignatureVerifier : NSObject
+#ifndef BUILDING_SPARKLE_TESTS
+#define SUSignatureVerifierDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SUSignatureVerifierDefinitionAttribute __attribute__((objc_runtime_name("SUTestSignatureVerifier")))
+#endif
+
+SUSignatureVerifierDefinitionAttribute @interface SUSignatureVerifier : NSObject
 
 // Helper for verifying downloaded updates
 + (BOOL)validatePath:(NSString *)path withSignatures:(SUSignatures *)signatures withPublicKeys:(SUPublicKeys *)pkeys verifierInformation:(SPUVerifierInformation * _Nullable)verifierInformation error:(NSError * __autoreleasing *)error;

--- a/Sparkle/SPUVerifierInformation.h
+++ b/Sparkle/SPUVerifierInformation.h
@@ -9,7 +9,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SPU_OBJC_DIRECT_MEMBERS @interface SPUVerifierInformation : NSObject
+#ifndef BUILDING_SPARKLE_TESTS
+#define SPUVerifierInformationDefinitionAttribute SPU_OBJC_DIRECT_MEMBERS
+#else
+#define SPUVerifierInformationDefinitionAttribute __attribute__((objc_runtime_name("SPUTestVerifierInformation")))
+#endif
+
+SPUVerifierInformationDefinitionAttribute @interface SPUVerifierInformation : NSObject
 
 - (instancetype)initWithExpectedVersion:(NSString * _Nullable)expectedVersion expectedContentLength:(uint64_t)expectedContentLength;
 


### PR DESCRIPTION
These classes are defined in framework and test target and aren't public.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Test unit tests here, and test app.

macOS version tested: 26.2 (25C56)
