### PR TITLE
Appcast order deltas

### DIFF
--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -349,13 +349,13 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                     delta = DeltaUpdate(fromVersion: item.version, archivePath: deltaPath, sparkleExecutableFileSize: item.sparkleExecutableFileSize, sparkleLocales: item.sparkleLocales)
                 }
 
-                latestItem.deltas.insert(delta, at: 0)
-
                 // Require delta to be a bit smaller
                 if delta.fileSize / 7 > latestItem.fileSize / 8 {
                     markDeltaAsIgnored(delta: delta, markerPath: ignoreMarkerPath)
                     continue
                 }
+                
+                latestItem.deltas.append(delta)
 
                 group.enter()
                 DispatchQueue.global().async {

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -406,6 +406,21 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
             throw signingError
         }
     }
+    
+    for appcast in appcastByFeed.values {
+        for archiveItem in appcast.archives.values {
+            archiveItem.deltas.sort {
+                guard
+                    let leftIntVersion = Int($0.fromVersion),
+                    let rightIntVersion = Int($1.fromVersion)
+                else {
+                    return $0.fromVersion > $1.fromVersion
+                }
+                
+                return leftIntVersion > rightIntVersion
+            }
+        }
+    }
 
     return appcastByFeed
 }

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -227,6 +227,7 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
             // but we still wanted to record the used delta updates for a batch of recent updates
             // This is to support rollback in case the top newly generated update isn't exactly what the user wants
             let generatingDeltas = latestVersionPerBranch.contains(version)
+            let itemDeltasLock = NSLock()
             var numDeltas = 0
             let appBaseName = latestItem.appPath.deletingPathExtension().lastPathComponent
             for item in updates {
@@ -386,10 +387,10 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                             markDeltaAsIgnored(delta: delta, markerPath: ignoreMarkerPath)
                             print("Delta \(delta.archivePath.path) ignored, because it could not be signed")
                             
-                            DispatchQueue.main.async {
-                                latestItem.deltas.removeAll { $0 === delta }
-                                group.leave()
-                            }
+                            itemDeltasLock.lock()
+                            latestItem.deltas.removeAll { $0 === delta }
+                            group.leave()
+                            itemDeltasLock.unlock()
                         }
                     }
                 }

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -349,6 +349,8 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                     delta = DeltaUpdate(fromVersion: item.version, archivePath: deltaPath, sparkleExecutableFileSize: item.sparkleExecutableFileSize, sparkleLocales: item.sparkleLocales)
                 }
 
+                latestItem.deltas.insert(delta, at: 0)
+
                 // Require delta to be a bit smaller
                 if delta.fileSize / 7 > latestItem.fileSize / 8 {
                     markDeltaAsIgnored(delta: delta, markerPath: ignoreMarkerPath)
@@ -379,14 +381,15 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                         hasAnyDSASignature = hasAnyDSASignature || (delta.dsaSignature != nil)
 #endif
                         if hasAnyDSASignature {
-                            DispatchQueue.main.async {
-                                latestItem.deltas.append(delta)
-                                group.leave()
-                            }
+                            group.leave()
                         } else {
                             markDeltaAsIgnored(delta: delta, markerPath: ignoreMarkerPath)
                             print("Delta \(delta.archivePath.path) ignored, because it could not be signed")
-                            group.leave()
+                            
+                            DispatchQueue.main.async {
+                                latestItem.deltas.removeAll { $0 === delta }
+                                group.leave()
+                            }
                         }
                     }
                 }
@@ -404,21 +407,6 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
     for update in updateArchivesToSign {
         if let signingError = update.signingError {
             throw signingError
-        }
-    }
-    
-    for appcast in appcastByFeed.values {
-        for archiveItem in appcast.archives.values {
-            archiveItem.deltas.sort {
-                guard
-                    let leftIntVersion = Int($0.fromVersion),
-                    let rightIntVersion = Int($1.fromVersion)
-                else {
-                    return $0.fromVersion > $1.fromVersion
-                }
-                
-                return leftIntVersion > rightIntVersion
-            }
         }
     }
 

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -379,13 +379,16 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                         hasAnyDSASignature = hasAnyDSASignature || (delta.dsaSignature != nil)
 #endif
                         if hasAnyDSASignature {
-                            latestItem.deltas.append(delta)
+                            DispatchQueue.main.async {
+                                latestItem.deltas.append(delta)
+                                group.leave()
+                            }
                         } else {
                             markDeltaAsIgnored(delta: delta, markerPath: ignoreMarkerPath)
                             print("Delta \(delta.archivePath.path) ignored, because it could not be signed")
+                            group.leave()
                         }
                     }
-                    group.leave()
                 }
             }
         }

--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -356,7 +356,9 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
                     continue
                 }
                 
+                itemDeltasLock.lock()
                 latestItem.deltas.append(delta)
+                itemDeltasLock.unlock()
 
                 group.enter()
                 DispatchQueue.global().async {
@@ -381,18 +383,16 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
 #if GENERATE_APPCAST_BUILD_LEGACY_DSA_SUPPORT
                         hasAnyDSASignature = hasAnyDSASignature || (delta.dsaSignature != nil)
 #endif
-                        if hasAnyDSASignature {
-                            group.leave()
-                        } else {
+                        if !hasAnyDSASignature {
                             markDeltaAsIgnored(delta: delta, markerPath: ignoreMarkerPath)
                             print("Delta \(delta.archivePath.path) ignored, because it could not be signed")
                             
                             itemDeltasLock.lock()
                             latestItem.deltas.removeAll { $0 === delta }
-                            group.leave()
                             itemDeltasLock.unlock()
                         }
                     }
+                    group.leave()
                 }
             }
         }


### PR DESCRIPTION
Makes order of deltas stable in appcasts generated by generate_appcast.

Also (probably?) makes the insertion of new deltas thread-safe.

Fixes #2846.

I tested and verified my change by using one or multiple of these methods:

- [X] My own app

Checked updating the Retcon appcast with the new code.

macOS version tested: 26.3
