### PR TITLE
Probe agent & status service as soon as we launch it

### DIFF
--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -26,6 +26,7 @@
 #import "SPUDownloadedUpdate.h"
 #import "SPUInstallationType.h"
 #import "SUConstants.h"
+#import "SPUProbeInstallStatus.h"
 
 
 #include "AppKitPrevention.h"
@@ -459,6 +460,8 @@
     NSString *hostBundlePath = _host.bundle.bundlePath;
     assert(hostBundlePath != nil);
     
+    NSString *hostBundleIdentifier = _host.bundle.bundleIdentifier;
+    
     NSString *installationType = _updateItem.installationType;
     assert(installationType != nil);
     
@@ -484,7 +487,20 @@
                     self->_systemDomain = systemDomain;
                     [self setUpConnection];
                     [self sendInstallationData];
-                    completionHandler(nil);
+                    
+                    // Send a probe/ping to the status service, which should boost/prioritize its startup
+                    if (hostBundleIdentifier != nil) {
+                        [SPUProbeInstallStatus probeInstallerInProgressForHostBundleIdentifier:hostBundleIdentifier completion:^(BOOL stausServiceIsRunning) {
+                            if (!stausServiceIsRunning) {
+                                SULog(SULogLevelError, @"Error: failed to probe status service for %@ from the framework", hostBundleIdentifier);
+                            }
+                            
+                            completionHandler(nil);
+                        }];
+                    } else {
+                        completionHandler(nil);
+                    }
+                    
                     break;
             }
         });


### PR DESCRIPTION
Hopefully this fixes potential issues like #2851 for the last time.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested on macOS 10.14.6 VM, 26.2, 26.4 with sandboxed app and non-sandboxed app
