### PR TITLE
Add minimal framework support for building arm64e through build configuration

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -48,8 +48,8 @@ OTHER_SWIFT_FLAGS_COMMON = -DSPARKLE_BUILD_LEGACY_DSA_SUPPORT -DGENERATE_APPCAST
 // Minimum supported macOS version
 MACOSX_DEPLOYMENT_TARGET = 10.13
 
-// Supported architectures
-ARCHS = $(ARCHS_STANDARD)
+// Set to arm64e to also build Sparkle framework as arm64e (requires Xcode 26 or later)
+EXTENDED_ARCHS =
 
 // Default Sparkle names
 SPARKLE_BUNDLE_IDENTIFIER = org.sparkle-project.Sparkle

--- a/Configurations/ConfigFramework.xcconfig
+++ b/Configurations/ConfigFramework.xcconfig
@@ -13,6 +13,8 @@ WRAPPER_EXTENSION = framework
 // so as a better workaround we have changed the FRAMEWORK_VERSION from A to B
 FRAMEWORK_VERSION = B
 
+ARCHS = $(ARCHS_STANDARD) $(EXTENDED_ARCHS)
+
 INFOPLIST_FILE = Sparkle/Sparkle-Info.plist
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) BUILDING_SPARKLE=1
 SKIP_INSTALL = YES

--- a/Configurations/ed25519-Shared.xcconfig
+++ b/Configurations/ed25519-Shared.xcconfig
@@ -15,3 +15,5 @@ WARNING_CFLAGS = $(inherited) -Wno-cast-qual -Wno-conversion -Wno-sign-conversio
 
 // Disable dead stores analyzer warning
 CLANG_ANALYZER_DEADCODE_DEADSTORES = NO
+
+ARCHS = $(ARCHS_STANDARD) $(EXTENDED_ARCHS)


### PR DESCRIPTION
Currently you have to build Sparkle from source by adding `arm64e` to `EXTENDED_ARCHS`

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested using arm64e built version of Sparkle in a test app.

macOS version tested: 26.3.1 (25D2128)
