### PR TITLE
Fix generate_appcast failing if feed URL doesn't have lastPathComponent

### DIFF
--- a/generate_appcast/Appcast.swift
+++ b/generate_appcast/Appcast.swift
@@ -45,7 +45,13 @@ func makeAppcasts(archivesSourceDir: URL, outputPathURL: URL?, cacheDirectory ca
     // Group updates by appcast feed
     var updatesByAppcast: [FeedName: [ArchiveItem]] = [:]
     for update in allUpdates {
-        let appcastFile = update.feedURL?.lastPathComponent ?? "appcast.xml"
+        let appcastFile: String
+        if let lastComponent = update.feedURL?.lastPathComponent, !lastComponent.isEmpty {
+            appcastFile = lastComponent
+        } else {
+            appcastFile = "appcast.xml"
+        }
+        
         updatesByAppcast[appcastFile, default: []].append(update)
     }
     


### PR DESCRIPTION
Patch thanks to @JulianPscheid

Fixes #2603

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested generate_appcast before and after this change on a URL like `https://macos-update-xml.hedy.bot` which has empty last path component. Reproduced failure before this change.

macOS version tested: 26.3.1 (25D2128)
