### PR TITLE
Fix crash in clearDownloadedUpdate when no downloaded update is tracked

### DIFF
--- a/Sparkle/SPUCoreBasedUpdateDriver.m
+++ b/Sparkle/SPUCoreBasedUpdateDriver.m
@@ -198,9 +198,13 @@
 - (void)clearDownloadedUpdate
 {
     id<NSObject> downloadedUpdateObject = (_resumableUpdate != nil) ? _resumableUpdate : _downloadedUpdateForRemoval;
-    assert(downloadedUpdateObject != nil);
-    
-    if (downloadedUpdateObject != nil && [downloadedUpdateObject isKindOfClass:[SPUDownloadedUpdate class]]) {
+
+    if (downloadedUpdateObject == nil) {
+        SULog(SULogLevelError, @"Warning: clearDownloadedUpdate called but no downloaded update is tracked");
+        return;
+    }
+
+    if ([downloadedUpdateObject isKindOfClass:[SPUDownloadedUpdate class]]) {
         if (_downloadDriver == nil) {
             _downloadDriver = [[SPUDownloadDriver alloc] initWithHost:_host];
         }

--- a/Sparkle/SPUInstallerDriver.m
+++ b/Sparkle/SPUInstallerDriver.m
@@ -487,18 +487,22 @@
                     self->_systemDomain = systemDomain;
                     [self setUpConnection];
                     [self sendInstallationData];
-                    
+
+                    // Complete immediately so the caller can set up state (e.g., _downloadedUpdateForRemoval)
+                    // before installer messages arrive on the main queue.
+                    // Previously, completionHandler was called inside the probe callback, which meant
+                    // installer messages (SPUExtractionStarted, SPUArchiveExtractionFailed) could be
+                    // processed before the completion handler fired, leaving _downloadedUpdateForRemoval
+                    // unset and causing an assertion crash in clearDownloadedUpdate.
+                    completionHandler(nil);
+
                     // Send a probe/ping to the status service, which should boost/prioritize its startup
                     if (hostBundleIdentifier != nil) {
                         [SPUProbeInstallStatus probeInstallerInProgressForHostBundleIdentifier:hostBundleIdentifier completion:^(BOOL stausServiceIsRunning) {
                             if (!stausServiceIsRunning) {
                                 SULog(SULogLevelError, @"Error: failed to probe status service for %@ from the framework", hostBundleIdentifier);
                             }
-                            
-                            completionHandler(nil);
                         }];
-                    } else {
-                        completionHandler(nil);
                     }
                     
                     break;


### PR DESCRIPTION
`clearDownloadedUpdate` asserts that either `_resumableUpdate` or `_downloadedUpdateForRemoval` is non-nil, but several code paths can reach it when both are nil. The code after the assert already handles nil correctly (the `if` check on line 203), so the assert is the sole cause of the crash.

We're seeing this in production as a SIGABRT — 519 occurrences across 279 users on Sparkle 2.9.0, macOS 14 through 26. The call paths that trigger it:

- `installerDidFailToApplyDeltaUpdate` (delta application failure)
- `extractUpdate:` completion handler (extraction error, non-auth)
- `SPUUIBasedUpdateDriver` (user skips a downloaded update)

The fix replaces the assert with an early return + `SULog` warning, so the condition is still logged for diagnostics without taking down the app.

## Checklist

- [x] My change is being tested and reviewed against the Sparkle 2.x branch.
- [ ] My change is being backported to master branch (Sparkle 1.x). Not applicable, this code doesn't exist in 1.x.
- [x] I have reviewed and commented my code, particularly in hard-to-understand areas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Sparkle Test App
- [x] My own app