### PR TITLE
Guard against NULL CFRelease() on failure condition in fallback path

### DIFF
--- a/Autoupdate/SUCodeSigningVerifier.m
+++ b/Autoupdate/SUCodeSigningVerifier.m
@@ -471,7 +471,9 @@ finally:
         SecCodeRef code = NULL;
         OSStatus result = SecCodeCopyGuestWithAttributes(NULL, (__bridge CFDictionaryRef _Nullable)(attributes), kSecCSDefaultFlags, &code);
         if (result != errSecSuccess) {
-            CFRelease(code);
+            if (code != NULL) {
+                CFRelease(code);
+            }
             
             if (error != NULL) {
                 *error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUInsufficientSigningError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"The client connection could not be validated because SecCodeCopyGuestWithAttributes() failed with error %d", result] }];


### PR DESCRIPTION
This was caught by analysis for XPC validation path. This is very unlikely to be hit practically.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

None, low-risk NULL check. Testing through CI.

macOS version tested: NA
