### PR TITLE
Add Sparkle Validator reference (doc-only change)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,12 @@ See [getting started guide](https://sparkle-project.org/documentation/). No code
 
   * Make sure the URL specified in [`SUFeedURL`](https://sparkle-project.org/documentation/customization/) is valid (typos/404s are a common error!), and that it uses modern TLS ([test it](https://www.ssllabs.com/ssltest/)).
 
+### Validate your appcast
+
+Before shipping, sanity-check your appcast for the small mistakes that otherwise reach users — malformed XML, missing or mismatched signatures, invalid version comparisons, broken enclosure URLs, and namespace typos.
+
+The official `generate_appcast` tool catches most issues when it builds the feed for you. If you author the feed by hand or want a second opinion, the community-maintained [sparkle-validator](https://sparklevalidator.com) checks 60+ rules grounded in the Sparkle source and runs as a CLI, a GitHub Action, or a browser-only web app — useful for wiring into CI.
+
 ### API symbols
 
 Sparkle is built with `-fvisibility=hidden -fvisibility-inlines-hidden` which means no symbols are exported by default.


### PR DESCRIPTION
This is just a doc-only change that people can validate their appcast.xml with Sparkle Validator. (Free, Open Source, MIT License) It can fit into a GitHub CI/CD workflow or used standalone.

Fixes # (issue)

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [X] Other (please specify)

There are a wide variety of tests that ship with Sparkle Validator. And it itself provides 60+ tests of a provided appcast.xml file.

macOS version tested: N/A
