### PR TITLE
Fix QoS warning when running Test app server on main thread

### DIFF
--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -297,45 +297,47 @@
                 abort();
             }
             self->_webServer = webServer;
-            
-            // Set up updater and the updater settings window
-            {
-                self->_updateSettingsWindowController = [[SUUpdateSettingsWindowController alloc] init];
-                
-                NSWindow *settingsWindow = self->_updateSettingsWindowController.window;
-                
-                NSBundle *hostBundle = [NSBundle mainBundle];
-                NSBundle *applicationBundle = hostBundle;
-                
-                id<SPUUserDriver> userDriver;
+
+            [webServer startWithReadyHandler:^{
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    // Set up updater and the updater settings window
+                    self->_updateSettingsWindowController = [[SUUpdateSettingsWindowController alloc] init];
+
+                    NSWindow *settingsWindow = self->_updateSettingsWindowController.window;
+
+                    NSBundle *hostBundle = [NSBundle mainBundle];
+                    NSBundle *applicationBundle = hostBundle;
+
+                    id<SPUUserDriver> userDriver;
 #if SPARKLE_BUILD_UI_BITS
-                if (shiftKeyHeldDown) {
-                    userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:settingsWindow];
-                } else {
-                    userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:nil];
-                }
+                    if (shiftKeyHeldDown) {
+                        userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:settingsWindow];
+                    } else {
+                        userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:nil];
+                    }
 #else
-                userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:settingsWindow];
+                    userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:settingsWindow];
 #endif
-                
-                SPUUpdater *updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:applicationBundle userDriver:userDriver delegate:self];
-                
-                self->_updater = updater;
-                self->_updateSettingsWindowController.updater = updater;
-                
-                NSError *updaterError = nil;
-                if (![updater startUpdater:&updaterError]) {
-                    NSLog(@"Failed to start updater with error: %@", updaterError);
-                    
-                    NSAlert *alert = [[NSAlert alloc] init];
-                    alert.messageText = @"Updater Error";
-                    alert.informativeText = @"The Updater failed to start. For detailed error information, check the Console.app log.";
-                    [alert addButtonWithTitle:@"OK"];
-                    [alert runModal];
-                }
-                
-                [self->_updateSettingsWindowController showWindow:nil];
-            }
+
+                    SPUUpdater *updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:applicationBundle userDriver:userDriver delegate:self];
+
+                    self->_updater = updater;
+                    self->_updateSettingsWindowController.updater = updater;
+
+                    NSError *updaterError = nil;
+                    if (![updater startUpdater:&updaterError]) {
+                        NSLog(@"Failed to start updater with error: %@", updaterError);
+
+                        NSAlert *alert = [[NSAlert alloc] init];
+                        alert.messageText = @"Updater Error";
+                        alert.informativeText = @"The Updater failed to start. For detailed error information, check the Console.app log.";
+                        [alert addButtonWithTitle:@"OK"];
+                        [alert runModal];
+                    }
+
+                    [self->_updateSettingsWindowController showWindow:nil];
+                });
+            }];
         });
     }];
 }
@@ -364,11 +366,6 @@
         
         completionBlock();
     }];
-}
-
-- (void)applicationWillTerminate:(NSNotification * __unused)notification
-{
-    [_webServer close];
 }
 
 - (IBAction)checkForUpdates:(id __unused)sender

--- a/TestApplication/SUTestWebServer.h
+++ b/TestApplication/SUTestWebServer.h
@@ -12,6 +12,6 @@ SPU_OBJC_DIRECT_MEMBERS @interface SUTestWebServer : NSObject
 
 - (instancetype)initWithPort:(int)port workingDirectory:(NSString*)workingDirectory;
 
-- (void)close;
+- (void)startWithReadyHandler:(dispatch_block_t)readyHandler;
 
 @end

--- a/TestApplication/SUTestWebServer.m
+++ b/TestApplication/SUTestWebServer.m
@@ -174,6 +174,7 @@
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUTestWebServer () <SUTestWebServerConnectionDelegate> {
     CFSocketRef _socket;
+    NSThread *_serverThread;
 }
 
 @property (nonatomic) NSMutableArray *connections;
@@ -227,12 +228,21 @@ static void connectCallback(CFSocketRef __unused s, CFSocketCallBackType type, C
     _connections = [[NSMutableArray alloc] init];
     _workingDirectory = workingDirectory;
 
-    CFRunLoopSourceRef source = CFSocketCreateRunLoopSource(NULL, _socket, 0);
-    assert(source != NULL);
-    CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopDefaultMode);
-    CFRelease(source);
-    
     return self;
+}
+
+- (void)startWithReadyHandler:(dispatch_block_t)readyHandler
+{
+    _serverThread = [[NSThread alloc] initWithBlock:^{
+        CFRunLoopSourceRef source = CFSocketCreateRunLoopSource(NULL, self->_socket, 0);
+        assert(source != NULL);
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopDefaultMode);
+        CFRelease(source);
+        readyHandler();
+        [[NSRunLoop currentRunLoop] run];
+    }];
+    
+    [_serverThread start];
 }
 
 - (void)connectionDidClose:(SUTestWebServerConnection *)sender
@@ -249,18 +259,6 @@ static void connectCallback(CFSocketRef __unused s, CFSocketCallBackType type, C
     if (conn) {
         assert(_connections != nil);
         [_connections addObject:conn];
-    }
-}
-
-- (void)close
-{
-    for (SUTestWebServerConnection *conn in _connections) {
-        [conn close];
-    }
-    if (_socket) {
-        CFSocketInvalidate(_socket);
-        CFRelease(_socket);
-        _socket = NULL;
     }
 }
 


### PR DESCRIPTION
Move web server work on background thread and don't block main thread. No need to close connection on termination.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested running test app locally and relaunching it.

macOS version tested: 26.4.1 (25E253)
