### PR TITLE
Update you're up to date Spanish translation to be gender neutral

### DIFF
--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -92,7 +92,7 @@
 "Version History" = "Historial de versiones";
 
 /* Status message shown when the user checks for updates but is already current or the feed doesn't contain any updates. */
-"You’re up to date!" = "¡Está actualizado!";
+"You’re up to date!" = "¡Estás al día!";
 
 /* Software Update title/label */
 "Software Update" = "Actualización de software";


### PR DESCRIPTION
Fixes #2872.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Checked you're up to date alert with updated translation in Spanish.

macOS version tested: 26.4.1 (25E253)
