### PR TITLE
Polish Spanish localization in Sparkle.strings

### DIFF
--- a/Sparkle/es.lproj/Sparkle.strings
+++ b/Sparkle/es.lproj/Sparkle.strings
@@ -2,13 +2,13 @@
 "%@ %@ is currently the newest version available." = "%1$@ %2$@ es la versión más nueva disponible.";
 
 /* No comment provided by engineer. */
-"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ es la versión más nueva disponible.\n(Actualmente estás corriendo la versión %3$@.)";
+"%@ %@ is currently the newest version available.\n(You are currently running version %@.)" = "%1$@ %2$@ es la versión más nueva disponible.\n(Actualmente estás ejecutando la versión %3$@.)";
 
 /* Description text for SUUpdateAlert when the update is downloadable. */
-"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ ya está disponible (tienes la %3$@). ¿Quisieras descargarla ahora?";
+"%@ %@ is now available—you have %@. Would you like to download it now?" = "%1$@ %2$@ ya está disponible (tienes la %3$@). ¿Querrías descargarla ahora?";
 
 /* Description text for SUUpdateAlert when the update informational with no download. */
-"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ya está disponible--tú tienes la %3$@. ¿Quisieras aprender más acerca de esta actualización en la red?";
+"%@ %@ is now available—you have %@. Would you like to learn more about this update on the web?" = "%1$@ %2$@ ya está disponible--tú tienes la %3$@. ¿Querrías aprender más acerca de esta actualización en la red?";
 
 /* The download progress in a unit of bytes, e.g. 100 KB */
 "%@ downloaded" = "%@ descargado";
@@ -23,7 +23,7 @@
 "%1$@ %2$@ has been downloaded and is ready to use! Would you like to install it and relaunch %1$@ now?" = "¡%1$@ %2$@ se ha descargado y está lista para usarse! ¿Te gustaría instalarla y volver a abrir %1$@ ahora?";
 
 /* No comment provided by engineer. */
-"%1$@ can’t be updated because it was opened from a read-only or a temporary location." = "%1$@ no se puede actualizar porque fue abierta desde una ubicación temporal o de solo lectura.";
+"%1$@ can’t be updated because it was opened from a read-only or a temporary location." = "%1$@ no se puede actualizar porque fue abierta desde una ubicación temporal o de sólo lectura.";
 
 /* No comment provided by engineer. */
 "A new version of %@ is available!" = "¡Una nueva versión de %@ está disponible!";
@@ -74,7 +74,7 @@
 "OK" = "Aceptar";
 
 /* No comment provided by engineer. */
-"Ready to Install" = "Listo para instalarse";
+"Ready to Install" = "Lista para instalarse";
 
 /* No comment provided by engineer. */
 "Should %1$@ automatically check for updates? You can always check for updates manually from the %1$@ menu." = "¿Debería %1$@ buscar actualizaciones automáticamente? Siempre puedes buscar actualizaciones manualmente desde el menú %1$@.";
@@ -125,4 +125,4 @@
 "Automatically download and install updates" = "Descargar e instalar actualizaciones automáticamente";
 
 /* Anonymous system profile information disclosure for update permission dialog */
-"Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.\n\nThis is the information that would be sent:" = "La información de perfil de sistema anónimo se usa para ayudarnos a planear el trabajo de desarrollo futuro. Por favor, póngase en contacto con nosotros si tiene preguntas sobre esto.\n\nEsta es la información que nos enviaría:";
+"Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.\n\nThis is the information that would be sent:" = "La información de perfil de sistema anónimo se usa para ayudarnos a planear el trabajo de desarrollo futuro. Por favor, ponte en contacto con nosotros si tienes preguntas sobre esto.\n\nEsta es la información que nos enviaría:";


### PR DESCRIPTION
A few minor updates to the Spanish localization:

- Gender agreement: 'Ready to Install' translation adjusted to feminine 'Lista para instalarse'
- Verb tense improvement: '¿Quisieras' -> '¿Querrías' (two strings); 'corriendo -> 'ejecutando'
- Accent mark added: 'sólo' (read only)
- Only one string addresses the user formally; the rest use informal 'tú'. It is proposed to change the formal to informal address so that all strings use the same form of address: 'póngase en contacto' -> 'ponte en contacto'.

No English source keys were modified.

Thanks for your work!

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ x] My own app

macOS version tested: [macOS 26.5 Tahoe]
