### PR TITLE
Improve synchronization of _receivedAppcastItemData

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -599,18 +599,20 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
         });
     } else if (identifier == SPUSentUpdateAppcastItemData) {
         os_unfair_lock_lock(&_newConnectionLock);
-        _receivedAppcastItemData = YES;
-        os_unfair_lock_unlock(&_newConnectionLock);
-        
-        SUAppcastItem *updateItem = (data != nil) ? (SUAppcastItem *)SPUUnarchiveRootObjectSecurely(data, [SUAppcastItem class]) : nil;
-        if (updateItem != nil) {
-            SPUInstallationInfo *installationInfo = [[SPUInstallationInfo alloc] initWithAppcastItem:updateItem];
+        if (!_receivedAppcastItemData) {
+            _receivedAppcastItemData = YES;
             
-            NSData *archivedData = SPUArchiveRootObjectSecurely(installationInfo);
-            if (archivedData != nil) {
-                [_agentConnection.agent registerInstallationInfoData:archivedData];
+            SUAppcastItem *updateItem = (data != nil) ? (SUAppcastItem *)SPUUnarchiveRootObjectSecurely(data, [SUAppcastItem class]) : nil;
+            if (updateItem != nil) {
+                SPUInstallationInfo *installationInfo = [[SPUInstallationInfo alloc] initWithAppcastItem:updateItem];
+                
+                NSData *archivedData = SPUArchiveRootObjectSecurely(installationInfo);
+                if (archivedData != nil) {
+                    [_agentConnection.agent registerInstallationInfoData:archivedData];
+                }
             }
         }
+        os_unfair_lock_unlock(&_newConnectionLock);
     } else if (identifier == SPUResumeInstallationToStage2 && data.length == sizeof(uint8_t) * 2) {
         // Because anyone can ask us to resume the installation, it may be wise to think about backwards compatibility here if IPC changes
         uint8_t relaunch = *((const uint8_t *)data.bytes);

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 * Polish and update Spanish translations to be gender neutral (#2874, #2875) (Emilio P Egido)
 * Guard against NULL CFRelease() on failure condition in fallback path (#2867) (Zorg)
 * Guard against symlinks when applying delta update files (fe7b718) (Zorg, fg0x0)
-* Enforce connection to installer to be validated before receiving appcast item data (#2876) (Zorg, fg0x0)
+* Enforce connection to installer to be validated before receiving appcast item data (#2876, #2877) (Zorg, fg0x0)
 
 # 2.9.1
 


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested test app, other app.

macOS version tested: 26.5 (25F71)
