### PR TITLE
Fix updating not working the first time if bundle ID ends with ".app"

### DIFF
--- a/Sparkle/SPULocalCacheDirectory.m
+++ b/Sparkle/SPULocalCacheDirectory.m
@@ -18,7 +18,17 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
 
 + (NSString *)_cachePathForCacheDirectory:(NSURL *)cacheURL bundleIdentifier:(NSString *)bundleIdentifier SPU_OBJC_DIRECT
 {
-    NSString *resultPath = [[[cacheURL URLByAppendingPathComponent:bundleIdentifier isDirectory:YES] URLByAppendingPathComponent:@SPARKLE_BUNDLE_IDENTIFIER isDirectory:YES] path];
+    // If an app has an ill-formed bundle identifier that ends with ".app" we will append ".sparkle" to it
+    // so that the cache directory doesn't look like an app bundle directory, which can cause other systematic issues
+    // https://github.com/sparkle-project/Sparkle/discussions/2881
+    NSString *appCacheIdentifier;
+    if ([bundleIdentifier hasSuffix:@".app"] || [bundleIdentifier hasSuffix:@".APP"]) {
+        appCacheIdentifier = [bundleIdentifier stringByAppendingString:@".sparkle"];
+    } else {
+        appCacheIdentifier = bundleIdentifier;
+    }
+    
+    NSString *resultPath = [[[cacheURL URLByAppendingPathComponent:appCacheIdentifier isDirectory:YES] URLByAppendingPathComponent:@SPARKLE_BUNDLE_IDENTIFIER isDirectory:YES] path];
     assert(resultPath != nil);
     
     return resultPath;
@@ -90,6 +100,8 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
     if ([templateString getFileSystemRepresentation:buffer maxLength:sizeof(buffer)]) {
         if (mkdtemp(buffer) != NULL) {
             return [[NSString alloc] initWithUTF8String:buffer];
+        } else {
+            SULog(SULogLevelError, @"Failed to create templated intermediate cache directory using mkdtemp() with error: %d", errno);
         }
     }
     return nil;


### PR DESCRIPTION
Use a different app cache directory if bundle ID ends with ".app" so that the cache directory Sparkle writes into does not look like an app bundle and cause other systematic issues. This can occur if a developer uses an ill-formed bundle identifier rather than conventional reverse-DNS one.

Fixes issue brought up in discussion #2881

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Created a test app that has a bundle ID ending with ".app" and notarized it.
Confirmed "app modification prompt" and installation failure issue occurs without this fix, and that it is resolved with this change. After attempting to reproduce, I removed the app cache directory in `~/Library/Caches/`, removed the app in Settings > Privacy & Security > App Management.

macOS version tested: 26.5 (25F71)
