### PR TITLE
Modernise the status dialog

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -53,10 +53,11 @@
 		14958C6F19AEBC980061B14F /* test-pubkey.pem in Resources */ = {isa = PBXBuildFile; fileRef = 14958C6C19AEBC610061B14F /* test-pubkey.pem */; };
 		1EAA4C8B2132C7BF00604473 /* ReleaseNotesColorStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = 1EAA4C8A2132C7BF00604473 /* ReleaseNotesColorStyle.css */; };
 		3772FEA913DE0B6B00F79537 /* SUVersionDisplayProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3772FEA813DE0B6B00F79537 /* SUVersionDisplayProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		55C14BEF136EF21700649790 /* SUStatus.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BD8136EF00C00649790 /* SUStatus.xib */; };
+		55C14BEF136EF21700649790 /* SUStatus_legacy.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BD8136EF00C00649790 /* SUStatus_legacy.xib */; };
 		55C14F06136EF6DB00649790 /* SULog.h in Headers */ = {isa = PBXBuildFile; fileRef = 55C14F04136EF6DB00649790 /* SULog.h */; };
 		55C14F07136EF6DB00649790 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		55E6F33319EC9F6C00005E76 /* SUErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 55E6F33219EC9F6C00005E76 /* SUErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		566A90D72FA138EA00D80C62 /* SUStatus.xib in Resources */ = {isa = PBXBuildFile; fileRef = 566A90D62FA138EA00D80C62 /* SUStatus.xib */; };
 		5A06357023FE332300478A72 /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E282D22B660BE004AA304 /* libed25519.a */; };
 		5A06357323FE333600478A72 /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E282D22B660BE004AA304 /* libed25519.a */; };
 		5A06357423FE33A400478A72 /* libed25519.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E282D22B660BE004AA304 /* libed25519.a */; };
@@ -433,7 +434,7 @@
 		72EB736129BEB36100FBCEE7 /* DevSignedAppVersion2.zip in Resources */ = {isa = PBXBuildFile; fileRef = 72EB736029BEB36100FBCEE7 /* DevSignedAppVersion2.zip */; };
 		72EB87EA1CB8798800C37F42 /* ShowInstallerProgress.m in Sources */ = {isa = PBXBuildFile; fileRef = 72EB87E91CB8798800C37F42 /* ShowInstallerProgress.m */; };
 		72EB87EB1CB8859100C37F42 /* Updater.app in Copy Tools */ = {isa = PBXBuildFile; fileRef = 721C24451CB753E6005440CB /* Updater.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		72EB87EC1CB8887E00C37F42 /* SUStatus.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BD8136EF00C00649790 /* SUStatus.xib */; };
+		72EB87EC1CB8887E00C37F42 /* SUStatus_legacy.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55C14BD8136EF00C00649790 /* SUStatus_legacy.xib */; };
 		72EE17FB26D1CC8800C58B19 /* SUInstallerLauncher+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 72EE17FA26D1CBC000C58B19 /* SUInstallerLauncher+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72EE17FC26D1CC9D00C58B19 /* SPUInstallationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 7214B8851D45AD9A00CB5CED /* SPUInstallationType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72EE181926DAE70900C58B19 /* SPUUpdateCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 72EE181826DAE6E100C58B19 /* SPUUpdateCheck.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -957,11 +958,12 @@
 		4607BEA21948443800EF8DA4 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Sparkle.strings; sourceTree = "<group>"; };
 		525A278F133D6AE900FD8D70 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		555CF29A196C52330000B31E /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Sparkle.strings; sourceTree = "<group>"; };
-		55C14BD8136EF00C00649790 /* SUStatus.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SUStatus.xib; sourceTree = "<group>"; };
+		55C14BD8136EF00C00649790 /* SUStatus_legacy.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SUStatus_legacy.xib; sourceTree = "<group>"; };
 		55C14F04136EF6DB00649790 /* SULog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SULog.h; sourceTree = "<group>"; };
 		55C14F05136EF6DB00649790 /* SULog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SULog.m; sourceTree = "<group>"; };
 		55C14F31136EFC2400649790 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		55E6F33219EC9F6C00005E76 /* SUErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUErrors.h; sourceTree = "<group>"; };
+		566A90D62FA138EA00D80C62 /* SUStatus.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SUStatus.xib; sourceTree = "<group>"; };
 		5A5DD400249585E70045EB3E /* SUUpdateValidatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SUUpdateValidatorTest.swift; sourceTree = "<group>"; };
 		5A5DD40324958AFF0045EB3E /* SUUpdateValidatorTest */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SUUpdateValidatorTest; sourceTree = "<group>"; };
 		5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "test-relative-urls.xml"; sourceTree = "<group>"; };
@@ -1726,7 +1728,8 @@
 			children = (
 				8DC2EF5A0486A6940098B216 /* Sparkle-Info.plist */,
 				61AAE8220A321A7F00D8810D /* Sparkle.strings */,
-				55C14BD8136EF00C00649790 /* SUStatus.xib */,
+				55C14BD8136EF00C00649790 /* SUStatus_legacy.xib */,
+				566A90D62FA138EA00D80C62 /* SUStatus.xib */,
 				729C51272E58015600D7365A /* SUUpdatePermissionPrompt.xib */,
 				72FE54412E56A14100227A91 /* SUUpdateAlert.xib */,
 			);
@@ -3195,7 +3198,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72EB87EC1CB8887E00C37F42 /* SUStatus.xib in Resources */,
+				72EB87EC1CB8887E00C37F42 /* SUStatus_legacy.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3248,7 +3251,8 @@
 				61AAE8280A321A7F00D8810D /* Sparkle.strings in Resources */,
 				1EAA4C8B2132C7BF00604473 /* ReleaseNotesColorStyle.css in Resources */,
 				72FE54422E56A14100227A91 /* SUUpdateAlert.xib in Resources */,
-				55C14BEF136EF21700649790 /* SUStatus.xib in Resources */,
+				566A90D72FA138EA00D80C62 /* SUStatus.xib in Resources */,
+				55C14BEF136EF21700649790 /* SUStatus_legacy.xib in Resources */,
 				729C51282E58015600D7365A /* SUUpdatePermissionPrompt.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sparkle/SUStatus.xib
+++ b/Sparkle/SUStatus.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24764" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24764"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -10,7 +10,7 @@
             <connections>
                 <outlet property="_actionButton" destination="12" id="0jE-Zn-L18"/>
                 <outlet property="_progressBar" destination="11" id="Cwm-99-fCT"/>
-                <outlet property="_statusTextField" destination="16" id="oOr-uc-6cX"/>
+                <outlet property="_titleTextField" destination="8" id="o2G-wY-MOX"/>
                 <outlet property="window" destination="5" id="25"/>
             </connections>
         </customObject>
@@ -20,59 +20,43 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="200" y="222" width="400" height="107"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1470" height="923"/>
+            <rect key="contentRect" x="200" y="222" width="343" height="196"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1084"/>
             <value key="minSize" type="size" width="213" height="107"/>
-            <view key="contentView" misplaced="YES" id="6">
-                <rect key="frame" x="0.0" y="0.0" width="400" height="107"/>
+            <view key="contentView" id="6">
+                <rect key="frame" x="0.0" y="0.0" width="343" height="188"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView translatesAutoresizingMaskIntoConstraints="NO" id="7">
-                        <rect key="frame" x="20" y="42" width="64" height="64"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="64" id="BT1-iv-l2H"/>
-                            <constraint firstAttribute="width" constant="64" id="eYK-yn-PVe"/>
-                        </constraints>
-                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="NSApplicationIcon" id="53"/>
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8">
+                        <rect key="frame" x="18" y="88" width="307" height="16"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Status Text (set by loc. string in code)" id="54">
+                            <font key="font" metaFont="systemBold"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
                         <connections>
-                            <binding destination="-2" name="value" keyPath="applicationIcon" id="9"/>
+                            <binding destination="-2" name="displayPatternValue2" keyPath="statusText" previousBinding="ZYe-VF-9Uu" id="Hv6-Db-1d8">
+                                <dictionary key="options">
+                                    <string key="NSDisplayPattern">%{value1}@ %{value2}@</string>
+                                </dictionary>
+                            </binding>
+                            <binding destination="-2" name="displayPatternValue1" keyPath="title" id="ZYe-VF-9Uu">
+                                <dictionary key="options">
+                                    <string key="NSDisplayPattern">%{value1}@ %{value2}@</string>
+                                </dictionary>
+                            </binding>
                         </connections>
-                    </imageView>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="E7u-iB-1VW" userLabel="Status text and progress">
-                        <rect key="frame" x="92" y="52" width="288" height="44"/>
-                        <subviews>
-                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                                <rect key="frame" x="-2" y="28" width="292" height="16"/>
-                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Status Text (set by loc. string in code)" id="54">
-                                    <font key="font" metaFont="systemBold"/>
-                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                                <connections>
-                                    <binding destination="-2" name="value" keyPath="title" id="26"/>
-                                </connections>
-                            </textField>
-                            <progressIndicator wantsLayer="YES" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="20"/>
-                                <connections>
-                                    <binding destination="-2" name="maxValue" keyPath="maxProgressValue" id="13"/>
-                                    <binding destination="-2" name="value" keyPath="progressValue" previousBinding="13" id="27"/>
-                                </connections>
-                            </progressIndicator>
-                        </subviews>
-                        <constraints>
-                            <constraint firstAttribute="trailing" secondItem="8" secondAttribute="trailing" id="9Rq-vq-cJo"/>
-                            <constraint firstAttribute="bottom" secondItem="11" secondAttribute="bottom" id="PDQ-9x-h82"/>
-                            <constraint firstItem="8" firstAttribute="top" secondItem="E7u-iB-1VW" secondAttribute="top" id="Rtg-8u-ed1"/>
-                            <constraint firstAttribute="trailing" secondItem="11" secondAttribute="trailing" id="YFJ-Gi-yRc"/>
-                            <constraint firstItem="8" firstAttribute="leading" secondItem="E7u-iB-1VW" secondAttribute="leading" id="f16-mO-wfq"/>
-                            <constraint firstItem="11" firstAttribute="leading" secondItem="E7u-iB-1VW" secondAttribute="leading" id="jvG-0L-tcl"/>
-                            <constraint firstItem="11" firstAttribute="top" secondItem="8" secondAttribute="bottom" constant="8" symbolic="YES" id="mKu-OU-ujj"/>
-                        </constraints>
-                    </customView>
+                    </textField>
+                    <progressIndicator wantsLayer="YES" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="11">
+                        <rect key="frame" x="20" y="60" width="303" height="20"/>
+                        <connections>
+                            <binding destination="-2" name="maxValue" keyPath="maxProgressValue" id="13"/>
+                            <binding destination="-2" name="value" keyPath="progressValue" previousBinding="13" id="27"/>
+                        </connections>
+                    </progressIndicator>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                        <rect key="frame" x="280" y="20" width="100" height="24"/>
-                        <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="55">
+                        <rect key="frame" x="122" y="20" width="100" height="28"/>
+                        <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" controlSize="large" borderStyle="border" inset="2" id="55">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
@@ -84,39 +68,35 @@
                             <binding destination="-2" name="title" keyPath="buttonTitle" id="21"/>
                         </connections>
                     </button>
-                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="16">
-                        <rect key="frame" x="90" y="24" width="146" height="16"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Small System Font Text" id="56">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
+                    <imageView translatesAutoresizingMaskIntoConstraints="NO" id="7">
+                        <rect key="frame" x="140" y="112" width="64" height="64"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="64" id="BT1-iv-l2H"/>
+                            <constraint firstAttribute="width" constant="64" id="eYK-yn-PVe"/>
+                        </constraints>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="NSApplicationIcon" id="53"/>
                         <connections>
-                            <binding destination="-2" name="value" keyPath="statusText" id="17"/>
-                            <binding destination="-2" name="hidden" keyPath="statusText" id="33">
-                                <dictionary key="options">
-                                    <string key="NSValueTransformerName">NSIsNil</string>
-                                </dictionary>
-                            </binding>
+                            <binding destination="-2" name="value" keyPath="applicationIcon" id="9"/>
                         </connections>
-                    </textField>
+                    </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="E7u-iB-1VW" secondAttribute="trailing" constant="20" symbolic="YES" id="3uo-mB-Q9M"/>
-                    <constraint firstItem="7" firstAttribute="top" secondItem="6" secondAttribute="top" constant="4" id="9Mg-Ac-X6m"/>
-                    <constraint firstItem="E7u-iB-1VW" firstAttribute="centerY" secondItem="7" secondAttribute="centerY" id="Jcg-BS-tJ1"/>
-                    <constraint firstItem="16" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="8" symbolic="YES" id="LTo-e9-myp"/>
-                    <constraint firstItem="7" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="ZLG-dr-gmv"/>
-                    <constraint firstItem="12" firstAttribute="top" secondItem="E7u-iB-1VW" secondAttribute="bottom" constant="8" id="dHH-r0-at5"/>
-                    <constraint firstItem="16" firstAttribute="firstBaseline" secondItem="12" secondAttribute="firstBaseline" id="dHQ-hW-3QN"/>
-                    <constraint firstAttribute="bottom" secondItem="12" secondAttribute="bottom" constant="20" symbolic="YES" id="iY3-LJ-ivz"/>
-                    <constraint firstItem="12" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="16" secondAttribute="trailing" constant="25" id="k07-gJ-v9t"/>
-                    <constraint firstAttribute="trailing" secondItem="12" secondAttribute="trailing" constant="20" symbolic="YES" id="onJ-J5-mra"/>
-                    <constraint firstItem="E7u-iB-1VW" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="8" symbolic="YES" id="wiO-j2-ud9"/>
+                    <constraint firstAttribute="trailing" secondItem="8" secondAttribute="trailing" constant="20" symbolic="YES" id="3J3-bp-rF8"/>
+                    <constraint firstItem="7" firstAttribute="top" secondItem="6" secondAttribute="top" constant="12" id="7HP-wm-iW8"/>
+                    <constraint firstItem="7" firstAttribute="centerX" secondItem="6" secondAttribute="centerX" id="IjX-Ku-1un"/>
+                    <constraint firstItem="11" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="R7N-Dd-DEV"/>
+                    <constraint firstItem="12" firstAttribute="centerX" secondItem="6" secondAttribute="centerX" id="Rj7-RK-3I5"/>
+                    <constraint firstItem="11" firstAttribute="top" secondItem="8" secondAttribute="bottom" constant="8" symbolic="YES" id="YyK-kn-aLg"/>
+                    <constraint firstItem="8" firstAttribute="top" secondItem="7" secondAttribute="bottom" constant="8" symbolic="YES" id="eIv-Jc-faQ"/>
+                    <constraint firstAttribute="trailing" secondItem="11" secondAttribute="trailing" constant="20" symbolic="YES" id="k4L-5p-ooj"/>
+                    <constraint firstAttribute="bottom" secondItem="12" secondAttribute="bottom" constant="20" symbolic="YES" id="mLD-Rm-FI9"/>
+                    <constraint firstItem="12" firstAttribute="top" secondItem="11" secondAttribute="bottom" constant="12" id="o9k-Rx-Usj"/>
+                    <constraint firstItem="8" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="p0d-Y5-54Q"/>
                 </constraints>
             </view>
-            <point key="canvasLocation" x="-158" y="132"/>
+            <point key="canvasLocation" x="-186.5" y="198"/>
         </window>
+        <userDefaultsController representsSharedInstance="YES" id="aYd-OU-XcW"/>
     </objects>
     <resources>
         <image name="NSApplicationIcon" width="32" height="32"/>

--- a/Sparkle/SUStatusController.m
+++ b/Sparkle/SUStatusController.m
@@ -35,6 +35,7 @@ static NSString *const SUStatusControllerTouchBarIdentifier = @"" SPARKLE_BUNDLE
     
     IBOutlet NSButton *_actionButton;
     IBOutlet NSTextField *_statusTextField;
+    IBOutlet NSTextField *_titleTextField;
     IBOutlet NSProgressIndicator *_progressBar;
     
     BOOL _minimizable;
@@ -49,9 +50,16 @@ static NSString *const SUStatusControllerTouchBarIdentifier = @"" SPARKLE_BUNDLE
 
 - (instancetype)initWithHost:(SUHost *)aHost windowTitle:(NSString *)windowTitle centerPointValue:(NSValue *)centerPointValue minimizable:(BOOL)minimizable closable:(BOOL)closable
 {
-    self = [super initWithWindowNibName:@"SUStatus" owner:self];
-	if (self)
-	{
+    NSString *nibName;
+    if (@available(macOS 11, *)) {
+        nibName = @"SUStatus";
+    }
+    else {
+        nibName = @"SUStatus_legacy";
+    }
+    self = [super initWithWindowNibName:nibName owner:self];
+    if (self)
+    {
         _host = aHost;
         _centerPointValue = centerPointValue;
         _minimizable = minimizable;
@@ -86,8 +94,13 @@ static NSString *const SUStatusControllerTouchBarIdentifier = @"" SPARKLE_BUNDLE
         window.styleMask = (NSWindowStyleMask)(window.styleMask | NSWindowStyleMaskClosable);
     }
     [_progressBar setUsesThreadedAnimation:YES];
-    [_statusTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightRegular]];
-    
+
+    if (@available(macOS 11, *)) {
+        [_titleTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightSemibold]];
+    } else {
+        [_statusTextField setFont:[NSFont monospacedDigitSystemFontOfSize:0 weight:NSFontWeightRegular]];
+    }
+
     if (@available(macOS 26, *)) {
         _actionButton.controlSize = NSControlSizeLarge;
     }

--- a/Sparkle/SUStatus_legacy.xib
+++ b/Sparkle/SUStatus_legacy.xib
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="SUStatusController">
+            <connections>
+                <outlet property="_actionButton" destination="12" id="0jE-Zn-L18"/>
+                <outlet property="_progressBar" destination="11" id="Cwm-99-fCT"/>
+                <outlet property="_statusTextField" destination="16" id="oOr-uc-6cX"/>
+                <outlet property="window" destination="5" id="25"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window identifier="SUStatus" title="Set in Code" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window">
+            <windowStyleMask key="styleMask" titled="YES"/>
+            <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="200" y="222" width="400" height="107"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1084"/>
+            <value key="minSize" type="size" width="213" height="107"/>
+            <view key="contentView" misplaced="YES" id="6">
+                <rect key="frame" x="0.0" y="0.0" width="400" height="107"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView translatesAutoresizingMaskIntoConstraints="NO" id="7">
+                        <rect key="frame" x="20" y="42" width="64" height="64"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="64" id="BT1-iv-l2H"/>
+                            <constraint firstAttribute="width" constant="64" id="eYK-yn-PVe"/>
+                        </constraints>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="NSApplicationIcon" id="53"/>
+                        <connections>
+                            <binding destination="-2" name="value" keyPath="applicationIcon" id="9"/>
+                        </connections>
+                    </imageView>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="E7u-iB-1VW" userLabel="Status text and progress">
+                        <rect key="frame" x="92" y="52" width="288" height="44"/>
+                        <subviews>
+                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8">
+                                <rect key="frame" x="-2" y="28" width="292" height="16"/>
+                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Status Text (set by loc. string in code)" id="54">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <binding destination="-2" name="value" keyPath="title" id="26"/>
+                                </connections>
+                            </textField>
+                            <progressIndicator wantsLayer="YES" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="11">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="20"/>
+                                <connections>
+                                    <binding destination="-2" name="maxValue" keyPath="maxProgressValue" id="13"/>
+                                    <binding destination="-2" name="value" keyPath="progressValue" previousBinding="13" id="27"/>
+                                </connections>
+                            </progressIndicator>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="8" secondAttribute="trailing" id="9Rq-vq-cJo"/>
+                            <constraint firstAttribute="bottom" secondItem="11" secondAttribute="bottom" id="PDQ-9x-h82"/>
+                            <constraint firstItem="8" firstAttribute="top" secondItem="E7u-iB-1VW" secondAttribute="top" id="Rtg-8u-ed1"/>
+                            <constraint firstAttribute="trailing" secondItem="11" secondAttribute="trailing" id="YFJ-Gi-yRc"/>
+                            <constraint firstItem="8" firstAttribute="leading" secondItem="E7u-iB-1VW" secondAttribute="leading" id="f16-mO-wfq"/>
+                            <constraint firstItem="11" firstAttribute="leading" secondItem="E7u-iB-1VW" secondAttribute="leading" id="jvG-0L-tcl"/>
+                            <constraint firstItem="11" firstAttribute="top" secondItem="8" secondAttribute="bottom" constant="8" symbolic="YES" id="mKu-OU-ujj"/>
+                        </constraints>
+                    </customView>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                        <rect key="frame" x="280" y="20" width="100" height="24"/>
+                        <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="55">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="3tI-Ef-LLb"/>
+                        </constraints>
+                        <accessibility identifier="SUStatusButton"/>
+                        <connections>
+                            <binding destination="-2" name="title" keyPath="buttonTitle" id="21"/>
+                        </connections>
+                    </button>
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="16">
+                        <rect key="frame" x="90" y="24" width="146" height="16"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Small System Font Text" id="56">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="-2" name="value" keyPath="statusText" id="17"/>
+                            <binding destination="-2" name="hidden" keyPath="statusText" id="33">
+                                <dictionary key="options">
+                                    <string key="NSValueTransformerName">NSIsNil</string>
+                                </dictionary>
+                            </binding>
+                        </connections>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="E7u-iB-1VW" secondAttribute="trailing" constant="20" symbolic="YES" id="3uo-mB-Q9M"/>
+                    <constraint firstItem="7" firstAttribute="top" secondItem="6" secondAttribute="top" constant="4" id="9Mg-Ac-X6m"/>
+                    <constraint firstItem="E7u-iB-1VW" firstAttribute="centerY" secondItem="7" secondAttribute="centerY" id="Jcg-BS-tJ1"/>
+                    <constraint firstItem="16" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="8" symbolic="YES" id="LTo-e9-myp"/>
+                    <constraint firstItem="7" firstAttribute="leading" secondItem="6" secondAttribute="leading" constant="20" symbolic="YES" id="ZLG-dr-gmv"/>
+                    <constraint firstItem="12" firstAttribute="top" secondItem="E7u-iB-1VW" secondAttribute="bottom" constant="8" id="dHH-r0-at5"/>
+                    <constraint firstItem="16" firstAttribute="firstBaseline" secondItem="12" secondAttribute="firstBaseline" id="dHQ-hW-3QN"/>
+                    <constraint firstAttribute="bottom" secondItem="12" secondAttribute="bottom" constant="20" symbolic="YES" id="iY3-LJ-ivz"/>
+                    <constraint firstItem="12" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="16" secondAttribute="trailing" constant="25" id="k07-gJ-v9t"/>
+                    <constraint firstAttribute="trailing" secondItem="12" secondAttribute="trailing" constant="20" symbolic="YES" id="onJ-J5-mra"/>
+                    <constraint firstItem="E7u-iB-1VW" firstAttribute="leading" secondItem="7" secondAttribute="trailing" constant="8" symbolic="YES" id="wiO-j2-ud9"/>
+                </constraints>
+            </view>
+            <point key="canvasLocation" x="-158" y="132"/>
+        </window>
+    </objects>
+    <resources>
+        <image name="NSApplicationIcon" width="32" height="32"/>
+    </resources>
+</document>


### PR DESCRIPTION
Adapt the status dialog to the style of Big Sur alert dialogs.
<img width="455" height="332" alt="Bildschirmfoto 2026-06-14 um 10 24 22" src="https://github.com/user-attachments/assets/fc74ae06-0e45-4bdd-ad8a-6db5260d8950" />

All macOS versions before Bug Sur get the original UI.