### PR TITLE
[codex] Add titlebar update reminders

### DIFF
--- a/Sparkle/Base.lproj/Sparkle.strings
+++ b/Sparkle/Base.lproj/Sparkle.strings
@@ -182,7 +182,13 @@
 "Update Error!" = "Update Error!";
 
 /* No comment provided by engineer. */
+"Update Available" = "Update Available";
+
+/* No comment provided by engineer. */
 "Update Installed" = "Update Installed";
+
+/* No comment provided by engineer. */
+"Update Ready" = "Update Ready";
 
 /* No comment provided by engineer. */
 "Updating %@" = "Updating %@";
@@ -219,6 +225,12 @@
 
 /* Skip This Version choice for update alert */
 "Skip This Version" = "Skip This Version";
+
+/* Skip for Now choice for titlebar update reminder */
+"Skip for Now" = "Skip for Now";
+
+/* Show Update choice for titlebar update reminder */
+"Show Update…" = "Show Update…";
 
 /* Install Update choice for update alert */
 "Install Update" = "Install Update";

--- a/Sparkle/SPUStandardUpdaterController.h
+++ b/Sparkle/SPUStandardUpdaterController.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SPUUpdater;
 @class SPUStandardUserDriver;
 @class NSMenuItem;
+@class NSWindow;
 @protocol SPUUserDriver, SPUUpdaterDelegate, SPUStandardUserDriverDelegate;
 
 /**
@@ -67,6 +68,20 @@ SU_EXPORT NS_SWIFT_UI_ACTOR @interface SPUStandardUpdaterController : NSObject
  Accessible property for the updater's user driver.
  */
 @property (nonatomic, readonly) SPUStandardUserDriver *userDriver;
+
+/**
+ Shows scheduled update reminders as a titlebar item on `scheduledUpdateReminderWindow` instead of immediately showing Sparkle's update alert.
+
+ This forwards to the receiver's `userDriver`. This only affects update checks Sparkle performs automatically in the background. User-initiated update checks continue to show Sparkle's regular update UI immediately.
+ */
+@property (nonatomic) BOOL showsScheduledUpdateRemindersInTitlebar;
+
+/**
+ The window where Sparkle should attach its titlebar reminder when `showsScheduledUpdateRemindersInTitlebar` is enabled.
+
+ Sparkle keeps a weak reference to this window. The application is responsible for keeping it alive and for selecting the window that best represents where update reminders should appear.
+ */
+@property (nonatomic, weak, nullable) IBOutlet NSWindow *scheduledUpdateReminderWindow;
 
 /**
  Create a new `SPUStandardUpdaterController` from a nib.

--- a/Sparkle/SPUStandardUpdaterController.m
+++ b/Sparkle/SPUStandardUpdaterController.m
@@ -32,6 +32,8 @@
 
 @synthesize updater = _updater;
 @synthesize userDriver = _userDriver;
+@synthesize scheduledUpdateReminderWindow = _scheduledUpdateReminderWindow;
+@synthesize showsScheduledUpdateRemindersInTitlebar = _showsScheduledUpdateRemindersInTitlebar;
 
 - (void)awakeFromNib
 {
@@ -48,6 +50,8 @@
 {
     NSBundle *hostBundle = [NSBundle mainBundle];
     SPUStandardUserDriver *userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:self->userDriverDelegate];
+    userDriver.showsScheduledUpdateRemindersInTitlebar = _showsScheduledUpdateRemindersInTitlebar;
+    userDriver.scheduledUpdateReminderWindow = _scheduledUpdateReminderWindow;
     
     SPUUpdater *updater = [[SPUUpdater alloc] initWithHostBundle:hostBundle applicationBundle:hostBundle userDriver:userDriver delegate:self->updaterDelegate];
     [self setUpdater:updater];
@@ -73,6 +77,18 @@
         }
     }
     return self;
+}
+
+- (void)setShowsScheduledUpdateRemindersInTitlebar:(BOOL)showsScheduledUpdateRemindersInTitlebar
+{
+    _showsScheduledUpdateRemindersInTitlebar = showsScheduledUpdateRemindersInTitlebar;
+    _userDriver.showsScheduledUpdateRemindersInTitlebar = showsScheduledUpdateRemindersInTitlebar;
+}
+
+- (void)setScheduledUpdateReminderWindow:(NSWindow *)scheduledUpdateReminderWindow
+{
+    _scheduledUpdateReminderWindow = scheduledUpdateReminderWindow;
+    _userDriver.scheduledUpdateReminderWindow = scheduledUpdateReminderWindow;
 }
 
 - (void)startUpdater

--- a/Sparkle/SPUStandardUserDriver.h
+++ b/Sparkle/SPUStandardUserDriver.h
@@ -23,6 +23,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol SPUStandardUserDriverDelegate;
+@class NSWindow;
 
 /**
  Sparkle's standard built-in user driver for updater interactions
@@ -36,6 +37,21 @@ SU_EXPORT NS_SWIFT_UI_ACTOR @interface SPUStandardUserDriver : NSObject <SPUUser
  @param delegate The optional delegate to this user driver. Note the standard user driver weakly references the delegate, so you are responsible for keeping it alive.
  */
 - (instancetype)initWithHostBundle:(NSBundle *)hostBundle delegate:(nullable id<SPUStandardUserDriverDelegate>)delegate;
+
+/**
+ Shows scheduled update reminders as a titlebar item on `scheduledUpdateReminderWindow` instead of immediately showing Sparkle's update alert.
+
+ This only affects update checks Sparkle performs automatically in the background. User-initiated update checks continue to show Sparkle's regular update UI immediately.
+ If no `scheduledUpdateReminderWindow` is set, Sparkle falls back to the regular standard user interface.
+ */
+@property (nonatomic) BOOL showsScheduledUpdateRemindersInTitlebar;
+
+/**
+ The window where Sparkle should attach its titlebar reminder when `showsScheduledUpdateRemindersInTitlebar` is enabled.
+
+ Sparkle keeps a weak reference to this window. The application is responsible for keeping it alive and for selecting the window that best represents where update reminders should appear.
+ */
+@property (nonatomic, weak, nullable) NSWindow *scheduledUpdateReminderWindow;
 
 /**
  Use initWithHostBundle:delegate: instead.

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -41,10 +41,175 @@
 @end
 #endif
 
+static NSString *const SPUTitlebarUpdateReminderAccessibilityIdentifier = @"SPUTitlebarUpdateReminder";
+
+@interface SPUTitlebarUpdateReminderController : NSObject
+
+- (instancetype)initWithWindow:(NSWindow *)window hostName:(NSString *)hostName updateDownloaded:(BOOL)updateDownloaded showUpdate:(void (^)(void))showUpdate dismissUpdate:(void (^)(void))dismissUpdate;
+- (void)showReminder;
+- (void)dismissReminder;
+
+@end
+
+@implementation SPUTitlebarUpdateReminderController
+{
+    __weak NSWindow *_window;
+    NSTitlebarAccessoryViewController *_accessoryViewController;
+    NSButton *_button;
+    NSString *_hostName;
+    void (^_showUpdate)(void);
+    void (^_dismissUpdate)(void);
+    id<NSObject> _windowWillCloseObserver;
+    BOOL _updateDownloaded;
+    BOOL _showingReminder;
+}
+
+- (instancetype)initWithWindow:(NSWindow *)window hostName:(NSString *)hostName updateDownloaded:(BOOL)updateDownloaded showUpdate:(void (^)(void))showUpdate dismissUpdate:(void (^)(void))dismissUpdate
+{
+    self = [super init];
+    if (self != nil) {
+        _window = window;
+        _hostName = [hostName copy];
+        _updateDownloaded = updateDownloaded;
+        _showUpdate = [showUpdate copy];
+        _dismissUpdate = [dismissUpdate copy];
+    }
+    return self;
+}
+
+- (NSString *)buttonTitle SPU_OBJC_DIRECT
+{
+#if SPARKLE_COPY_LOCALIZATIONS
+    NSBundle *sparkleBundle = SUSparkleBundle();
+#endif
+
+    if (_updateDownloaded) {
+        return SULocalizedStringFromTableInBundle(@"Update Ready", SPARKLE_TABLE, sparkleBundle, nil);
+    } else {
+        return SULocalizedStringFromTableInBundle(@"Update Available", SPARKLE_TABLE, sparkleBundle, nil);
+    }
+}
+
+- (NSString *)toolTip SPU_OBJC_DIRECT
+{
+#if SPARKLE_COPY_LOCALIZATIONS
+    NSBundle *sparkleBundle = SUSparkleBundle();
+#endif
+
+    if (_updateDownloaded) {
+        return [NSString stringWithFormat:SULocalizedStringFromTableInBundle(@"A new version of %@ is ready to install!", SPARKLE_TABLE, sparkleBundle, nil), _hostName];
+    } else {
+        return [NSString stringWithFormat:SULocalizedStringFromTableInBundle(@"A new version of %@ is available!", SPARKLE_TABLE, sparkleBundle, nil), _hostName];
+    }
+}
+
+- (NSButton *)makeButton SPU_OBJC_DIRECT
+{
+    NSButton *button = [NSButton buttonWithTitle:[self buttonTitle] target:self action:@selector(showMenu:)];
+    button.bezelStyle = NSBezelStyleTexturedRounded;
+    button.controlSize = NSControlSizeSmall;
+    button.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+    button.toolTip = [self toolTip];
+    button.accessibilityIdentifier = SPUTitlebarUpdateReminderAccessibilityIdentifier;
+    button.accessibilityLabel = [self buttonTitle];
+
+    [button sizeToFit];
+
+    NSRect buttonFrame = button.frame;
+    buttonFrame.size.width = MIN(MAX(ceil(buttonFrame.size.width) + 14.0, 118.0), 180.0);
+    buttonFrame.size.height = 22.0;
+    button.frame = buttonFrame;
+
+    return button;
+}
+
+- (void)showReminder
+{
+    if (_showingReminder) {
+        return;
+    }
+
+    NSWindow *window = _window;
+    if (window == nil) {
+        return;
+    }
+
+    _button = [self makeButton];
+
+    _accessoryViewController = [[NSTitlebarAccessoryViewController alloc] init];
+    _accessoryViewController.layoutAttribute = NSLayoutAttributeTrailing;
+    _accessoryViewController.view = _button;
+
+    [window addTitlebarAccessoryViewController:_accessoryViewController];
+
+    __weak __typeof__(self) weakSelf = self;
+    _windowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:window queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * __unused notification) {
+        __typeof__(self) strongSelf = weakSelf;
+        [strongSelf dismissReminder];
+    }];
+
+    _showingReminder = YES;
+}
+
+- (void)dismissReminder
+{
+    if (!_showingReminder) {
+        return;
+    }
+
+    if (_windowWillCloseObserver != nil) {
+        [[NSNotificationCenter defaultCenter] removeObserver:_windowWillCloseObserver];
+        _windowWillCloseObserver = nil;
+    }
+
+    [_accessoryViewController removeFromParentViewController];
+    _accessoryViewController = nil;
+    _button = nil;
+    _showingReminder = NO;
+}
+
+- (void)showMenu:(NSButton *)sender
+{
+#if SPARKLE_COPY_LOCALIZATIONS
+    NSBundle *sparkleBundle = SUSparkleBundle();
+#endif
+
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+
+    NSMenuItem *showUpdateItem = [[NSMenuItem alloc] initWithTitle:SULocalizedStringFromTableInBundle(@"Show Update…", SPARKLE_TABLE, sparkleBundle, nil) action:@selector(showUpdate:) keyEquivalent:@""];
+    showUpdateItem.target = self;
+    [menu addItem:showUpdateItem];
+
+    NSMenuItem *skipForNowItem = [[NSMenuItem alloc] initWithTitle:SULocalizedStringFromTableInBundle(@"Skip for Now", SPARKLE_TABLE, sparkleBundle, nil) action:@selector(skipForNow:) keyEquivalent:@""];
+    skipForNowItem.target = self;
+    [menu addItem:skipForNowItem];
+
+    [menu popUpMenuPositioningItem:nil atLocation:NSMakePoint(0.0, NSHeight(sender.bounds) + 2.0) inView:sender];
+}
+
+- (void)showUpdate:(id)__unused sender
+{
+    if (_showUpdate != nil) {
+        _showUpdate();
+    }
+}
+
+- (void)skipForNow:(id)__unused sender
+{
+    if (_dismissUpdate != nil) {
+        _dismissUpdate();
+    }
+}
+
+@end
+
 @interface SPUStandardUserDriver () <SPUGentleUserDriverReminders>
 
 // Note: we expose a private interface for activeUpdateAlert property in SPUStandardUserDriver+Private.h as NSWindowController
 @property (nonatomic, readonly, nullable) NSWindowController *activeUpdateAlert;
+
+- (void)setUpActiveUpdateAlertForScheduledUpdate:(SUAppcastItem * _Nullable)updateItem state:(SPUUserUpdateState * _Nullable)state SPU_OBJC_DIRECT;
+- (void)dismissTitlebarUpdateReminder SPU_OBJC_DIRECT;
 
 @end
 
@@ -66,9 +231,11 @@
     
     SUUpdateAlert *_activeUpdateAlert;
     SPUUpdaterSettings *_updaterSettings;
+    SPUTitlebarUpdateReminderController *_titlebarUpdateReminderController;
     
     SUStatusController *_statusController;
     SUUpdatePermissionPrompt *_permissionPrompt;
+    __weak NSWindow *_scheduledUpdateReminderWindow;
     
     __weak id <SPUStandardUserDriverDelegate> _delegate;
     
@@ -82,9 +249,12 @@
     BOOL _loggedGentleUpdateReminderWarning;
     BOOL _regularApplicationUpdate;
     BOOL _updateReceivedUserAttention;
+    BOOL _showsScheduledUpdateRemindersInTitlebar;
 }
 
 @synthesize activeUpdateAlert = _activeUpdateAlert;
+@synthesize scheduledUpdateReminderWindow = _scheduledUpdateReminderWindow;
+@synthesize showsScheduledUpdateRemindersInTitlebar = _showsScheduledUpdateRemindersInTitlebar;
 
 #pragma mark Birth
 
@@ -107,6 +277,25 @@
         }
     }
     return self;
+}
+
+- (void)setShowsScheduledUpdateRemindersInTitlebar:(BOOL)showsScheduledUpdateRemindersInTitlebar
+{
+    _showsScheduledUpdateRemindersInTitlebar = showsScheduledUpdateRemindersInTitlebar;
+
+    if (!showsScheduledUpdateRemindersInTitlebar) {
+        [self dismissTitlebarUpdateReminder];
+    }
+}
+
+- (void)setScheduledUpdateReminderWindow:(NSWindow *)scheduledUpdateReminderWindow
+{
+    if (_scheduledUpdateReminderWindow == scheduledUpdateReminderWindow) {
+        return;
+    }
+
+    [self dismissTitlebarUpdateReminder];
+    _scheduledUpdateReminderWindow = scheduledUpdateReminderWindow;
 }
 
 - (double)currentTime SPU_OBJC_DIRECT
@@ -172,6 +361,46 @@
     }
 }
 
+- (void)dismissTitlebarUpdateReminder SPU_OBJC_DIRECT
+{
+    [_titlebarUpdateReminderController dismissReminder];
+    _titlebarUpdateReminderController = nil;
+}
+
+- (BOOL)shouldShowTitlebarReminderForScheduledUpdate:(SUAppcastItem *)updateItem SPU_OBJC_DIRECT
+{
+    if (!_showsScheduledUpdateRemindersInTitlebar || _scheduledUpdateReminderWindow == nil) {
+        return NO;
+    }
+
+    // Critical updates should continue to use Sparkle's immediate standard UI.
+    return !updateItem.criticalUpdate;
+}
+
+- (void)showTitlebarReminderForScheduledUpdate:(SUAppcastItem *)updateItem state:(SPUUserUpdateState *)state SPU_OBJC_DIRECT
+{
+    assert(!state.userInitiated);
+
+    [self dismissTitlebarUpdateReminder];
+
+    __weak __typeof__(self) weakSelf = self;
+    _titlebarUpdateReminderController = [[SPUTitlebarUpdateReminderController alloc] initWithWindow:(NSWindow * _Nonnull)_scheduledUpdateReminderWindow hostName:_host.name updateDownloaded:(state.stage != SPUUserUpdateStageNotDownloaded) showUpdate:^{
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf != nil) {
+            [strongSelf dismissTitlebarUpdateReminder];
+            [strongSelf setUpActiveUpdateAlertForScheduledUpdate:nil state:nil];
+        }
+    } dismissUpdate:^{
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf != nil) {
+            [strongSelf dismissTitlebarUpdateReminder];
+            [strongSelf->_activeUpdateAlert finishWithUserUpdateChoice:SPUUserUpdateChoiceDismiss];
+        }
+    }];
+
+    [_titlebarUpdateReminderController showReminder];
+}
+
 // updateItem should be non-nil when showing an update for first time for scheduled updates
 // If appcastItem is != nil, then state must be != nil
 - (void)setUpActiveUpdateAlertForScheduledUpdate:(SUAppcastItem * _Nullable)updateItem state:(SPUUserUpdateState * _Nullable)state SPU_OBJC_DIRECT
@@ -183,6 +412,8 @@
     
     if (updateItem == nil) {
         // This is a user initiated check or a check to bring the already shown update back in focus
+        [self dismissTitlebarUpdateReminder];
+
         if (![NSApp isActive]) {
             // If the user initiated an update check, we should make the app active,
             // regardless if it's a background running app or not
@@ -316,6 +547,11 @@
                 [delegate standardUserDriverWillHandleShowingUpdate:handleShowingUpdates forUpdate:(SUAppcastItem * _Nonnull)updateItem state:(SPUUserUpdateState * _Nonnull)state];
             }
             
+            if ([self shouldShowTitlebarReminderForScheduledUpdate:(SUAppcastItem * _Nonnull)updateItem]) {
+                [self showTitlebarReminderForScheduledUpdate:(SUAppcastItem * _Nonnull)updateItem state:(SPUUserUpdateState * _Nonnull)state];
+                return;
+            }
+
             if (!driverShowingUpdateNow) {
                 [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:NSApplicationDidBecomeActiveNotification object:NSApp];
             } else {
@@ -392,6 +628,7 @@
             strongSelf->_updateAlertWindowFrameValue = [NSValue valueWithRect:windowFrame];
             strongSelf->_updateAlertWindowWasInactive = !wasKeyWindow;
             
+            [strongSelf dismissTitlebarUpdateReminder];
             strongSelf->_activeUpdateAlert = nil;
         }
     } didBecomeKeyBlock:^{
@@ -780,6 +1017,8 @@
 {
     assert(NSThread.isMainThread);
     
+    [self dismissTitlebarUpdateReminder];
+
     _cancellation = [cancellation copy];
     
     [self createAndShowStatusControllerWithClosable:NO];
@@ -930,6 +1169,8 @@
 {
     assert(NSThread.isMainThread);
     
+    [self dismissTitlebarUpdateReminder];
+
     id<SPUStandardUserDriverDelegate> delegate = _delegate;
     if ([delegate respondsToSelector:@selector(standardUserDriverWillFinishUpdateSession)]) {
         [delegate standardUserDriverWillFinishUpdateSession];

--- a/Sparkle/SUUpdateAlert.h
+++ b/Sparkle/SUUpdateAlert.h
@@ -27,6 +27,7 @@ SPU_OBJC_DIRECT_MEMBERS @interface SUUpdateAlert : NSWindowController
 - (void)showReleaseNotesFailedToDownloadWithError:(NSError *)error;
 
 - (void)setInstallButtonFocus:(BOOL)focus;
+- (void)finishWithUserUpdateChoice:(SPUUserUpdateChoice)choice;
 
 @end
 

--- a/Sparkle/SUUpdateAlert.m
+++ b/Sparkle/SUUpdateAlert.m
@@ -158,6 +158,11 @@ typedef NS_ENUM(NSInteger, SUReleaseNotesFormat)
     [self endWithSelection:SPUUserUpdateChoiceDismiss];
 }
 
+- (void)finishWithUserUpdateChoice:(SPUUserUpdateChoice)choice
+{
+    [self endWithSelection:choice];
+}
+
 - (void)displayReleaseNotesSpinner SPU_OBJC_DIRECT
 {
     // Stick a nice big spinner in the middle of the release notes view until the page is loaded.

--- a/TestApplication/SUTestApplicationDelegate.m
+++ b/TestApplication/SUTestApplicationDelegate.m
@@ -55,6 +55,7 @@
 #if SPARKLE_BUILD_UI_BITS
     // Detect as early as possible if the shift key is held down
     BOOL shiftKeyHeldDown = ([NSEvent modifierFlags] & NSEventModifierFlagShift) != 0;
+    BOOL titlebarRemindersEnabled = [[[[NSProcessInfo processInfo] environment] objectForKey:@"TITLEBAR_REMINDERS"] boolValue];
 #endif
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -310,7 +311,12 @@
 
                     id<SPUUserDriver> userDriver;
 #if SPARKLE_BUILD_UI_BITS
-                    if (shiftKeyHeldDown) {
+                    if (titlebarRemindersEnabled) {
+                        SPUStandardUserDriver *standardUserDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:nil];
+                        standardUserDriver.showsScheduledUpdateRemindersInTitlebar = YES;
+                        standardUserDriver.scheduledUpdateReminderWindow = settingsWindow;
+                        userDriver = standardUserDriver;
+                    } else if (shiftKeyHeldDown) {
                         userDriver = [[SUPopUpTitlebarUserDriver alloc] initWithWindow:settingsWindow];
                     } else {
                         userDriver = [[SPUStandardUserDriver alloc] initWithHostBundle:hostBundle delegate:nil];

--- a/UITests/SUTestApplicationTest.swift
+++ b/UITests/SUTestApplicationTest.swift
@@ -103,6 +103,43 @@ class SUTestApplicationTest: XCTestCase
         sleep(10)
     }
     
+    func test0TitlebarScheduledReminder() {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-SUHasLaunchedBefore",
+            "YES",
+            "-SUEnableAutomaticChecks",
+            "YES",
+            "-SUAutomaticallyUpdate",
+            "NO",
+            "-SUScheduledCheckInterval",
+            "60"
+        ]
+        app.launchEnvironment = [
+            "TEST_MODE": "REGULAR",
+            "TITLEBAR_REMINDERS": "1"
+        ]
+        app.launch()
+
+        XCTAssertFalse(app.dialogs["alert"].staticTexts["Update succeeded!"].exists, "Update is already installed; please do a clean build")
+
+        let reminderButton = app.buttons["SPUTitlebarUpdateReminder"]
+        XCTAssertTrue(reminderButton.waitForExistence(timeout: 120), "Expected scheduled update to appear as a titlebar reminder")
+        XCTAssertFalse(app.windows["SUUpdateAlert"].exists, "Scheduled update should not immediately show the modal update alert")
+
+        reminderButton.click()
+
+        let showUpdateMenuItem = app.menuItems["Show Update…"]
+        XCTAssertTrue(showUpdateMenuItem.waitForExistence(timeout: 5), "Expected titlebar reminder menu to offer showing the update")
+        showUpdateMenuItem.click()
+
+        XCTAssertTrue(app.windows["SUUpdateAlert"].waitForExistence(timeout: 5), "Expected titlebar reminder to open the regular update alert")
+        app.windows["SUUpdateAlert"].buttons["SPUUserUpdateChoiceDismiss"].click()
+
+        app.terminate()
+        sleep(5)
+    }
+
     func test1RegularUpdate() {
         runTestApplication(testMode: "REGULAR", automatic: false, expectedFinalVersion: "2.0", launchSleep: 60, extractSleep: 30)
     }


### PR DESCRIPTION
## Summary

Adds an opt-in non-modal update reminder flow for Sparkle's standard UI. Apps can configure `SPUStandardUserDriver` or `SPUStandardUpdaterController` to show scheduled automatic update reminders as a titlebar item on a chosen window instead of immediately presenting the update alert.

The titlebar item offers:

- `Show Update…`, which opens the existing Sparkle update alert and continues through the normal flow
- `Skip for Now`, which dismisses the reminder until the next scheduled update check

Manual update checks and critical updates continue to present Sparkle's existing update UI immediately.

## Details

- Adds `showsScheduledUpdateRemindersInTitlebar` and `scheduledUpdateReminderWindow` to the standard user driver and updater controller.
- Implements the reminder with `NSTitlebarAccessoryViewController` so it can live in app titlebars/toolbars without adding a modal interruption.
- Adds localized strings for the reminder button and menu.
- Wires the test app to enable the flow with `TITLEBAR_REMINDERS=1`.
- Adds focused UI coverage that verifies a scheduled check shows the titlebar reminder, does not immediately show `SUUpdateAlert`, and can open the regular update alert from the reminder.

## Validation

- `xcodebuild build-for-testing -project Sparkle.xcodeproj -scheme UITests -configuration Debug -derivedDataPath build/titlebar-reminders`
- `xcodebuild test-without-building -project Sparkle.xcodeproj -scheme UITests -configuration Debug -derivedDataPath build/titlebar-reminders -only-testing:"UI Tests/SUTestApplicationTest/test0TitlebarScheduledReminder"`
- `xcodebuild build-for-testing -project Sparkle.xcodeproj -scheme Distribution -enableCodeCoverage YES -derivedDataPath build/titlebar-distribution`
- `xcodebuild test-without-building -project Sparkle.xcodeproj -scheme Distribution -enableCodeCoverage YES -derivedDataPath build/titlebar-distribution`
- `xcodebuild build -project Sparkle.xcodeproj -scheme Sparkle -configuration Debug -derivedDataPath build/titlebar-sparkle-debug`
- `git diff --check`
