### PR TITLE
Use activateIgnoringOtherApps: again for backgrounded apps

### DIFF
--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -128,11 +128,10 @@
 
 - (void)_activateApplication SPU_OBJC_DIRECT
 {
-    if (@available(macOS 14, *)) {
-        [NSApp activate];
-    } else {
-        [NSApp activateIgnoringOtherApps:YES];
-    }
+    // -[NSApp activate] does not always work reliably from backgrounded apps when the user initiates checks for updates
+    // from e.g. a menu bar. The OS should grant active focus to the appliation, but it is inconsistent (last tested on 26.5.1).
+    // For now we will prefer the deprecated more reliant API
+    [NSApp activateIgnoringOtherApps:YES];
 }
 
 - (void)showUpdatePermissionRequest:(SPUUpdatePermissionRequest *)request reply:(void (^)(SUUpdatePermissionResponse *))reply


### PR DESCRIPTION
Use activateIgnoringOtherApps: again for backgrounded apps which is more reliable than recommended `-[NSApp activate]` API for now.

Sparkle is already very careful about when is appropriate to activate the application based on user initiated actions so I am not worried about unexpected focus stealing.

Fixes #2889

## Misc Checklist

- [x] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested with one of my sample apps. I had trouble reproducing the issue with the one in #2889

macOS version tested: 26.5.1 (25F80)
