### PR TITLE
Fix `'v12' is unavailable` error in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 // Version is technically not required here, SPM doesn't check


### PR DESCRIPTION
This adjusts the `swift-tools-version` in Package.swift from `5.3` to `5.5` as `'v12' was introduced in PackageDescription 5.5`.
d80452a from #2883 increased the minimum deployment target to macOS 12.0, thereby changing `.macOS(.v10_13)` to `.macOS(.v12)` in Package.swift but did not increase `swift-tools-version` accordingly.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [X] [My own app](https://codeberg.org/F1248/Genius) using `xcodebuild -resolvePackageDependencies`
- [X] [VSCodium](https://vscodium.com) with the [Swift extension](https://github.com/swiftlang/vscode-swift)

macOS version tested: 26.6 `25G72`
