### PR TITLE
Add breadcrumb for updating swift-tools-version in future

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let url = "https://github.com/sparkle-project/Sparkle/releases/download/\(tag)/S
 
 let package = Package(
     name: "Sparkle",
-    platforms: [.macOS(.v12)], // leaving "12.0" as a breadcrumb for searching
+    platforms: [.macOS(.v12)], // leaving "12.0" as a breadcrumb for searching; aligned with swift-tools-version at top of file (see https://developer.apple.com/documentation/packagedescription/supportedplatform/macosversion)
     products: [
         .library(
             name: "Sparkle",


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

NA, just CI testing

macOS version tested: NA
