### PR TITLE
Reject package based installs when signing validation failed

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		725CB9571C7120410064365A /* SPUUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 725CB9561C7120410064365A /* SPUUserDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		725CB95A1C7121830064365A /* SPUStandardUserDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 725CB9581C7121830064365A /* SPUStandardUserDriver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		725CB95B1C7121830064365A /* SPUStandardUserDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 725CB9591C7121830064365A /* SPUStandardUserDriver.m */; };
+		725EA4B23027D2AF0041BFA6 /* test-package-update.xml in Resources */ = {isa = PBXBuildFile; fileRef = 725EA4B13027D2AF0041BFA6 /* test-package-update.xml */; };
 		725EE480277BF13B00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
 		725EE482277BF44A00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
 		725EE483277C767A00D820CE /* SPUXarDeltaArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = 725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */; };
@@ -1189,6 +1190,7 @@
 		725CB9581C7121830064365A /* SPUStandardUserDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPUStandardUserDriver.h; sourceTree = "<group>"; };
 		725CB9591C7121830064365A /* SPUStandardUserDriver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPUStandardUserDriver.m; sourceTree = "<group>"; };
 		725DED72263D10C400E7FA8F /* SUAppcast+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SUAppcast+Private.h"; sourceTree = "<group>"; };
+		725EA4B13027D2AF0041BFA6 /* test-package-update.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "test-package-update.xml"; sourceTree = "<group>"; };
 		725EE47E277BF13A00D820CE /* SPUXarDeltaArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUXarDeltaArchive.h; path = Autoupdate/SPUXarDeltaArchive.h; sourceTree = SOURCE_ROOT; };
 		725EE47F277BF13B00D820CE /* SPUXarDeltaArchive.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPUXarDeltaArchive.m; path = Autoupdate/SPUXarDeltaArchive.m; sourceTree = SOURCE_ROOT; };
 		725EE481277BF17A00D820CE /* SPUDeltaArchiveProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPUDeltaArchiveProtocol.h; path = Autoupdate/SPUDeltaArchiveProtocol.h; sourceTree = SOURCE_ROOT; };
@@ -1847,6 +1849,7 @@
 				5A5DD41B249F0F4B0045EB3E /* test-relative-urls.xml */,
 				729F7EAB27366353004592DC /* test-links.xml */,
 				723AD12E29922B5F006BB02F /* test-dangerous-link.xml */,
+				725EA4B13027D2AF0041BFA6 /* test-package-update.xml */,
 				72C56E212F04C28B0005A484 /* testreleasenotes.html */,
 				5A5DD40324958AFF0045EB3E /* SUUpdateValidatorTest */,
 			);
@@ -3141,6 +3144,7 @@
 				72C56E262F04C28B0005A484 /* testreleasenotes.html in Resources */,
 				723AD12F29922B5F006BB02F /* test-dangerous-link.xml in Resources */,
 				72EB736129BEB36100FBCEE7 /* DevSignedAppVersion2.zip in Resources */,
+				725EA4B23027D2AF0041BFA6 /* test-package-update.xml in Resources */,
 				723EDC3F26885A8E000BCBA4 /* testappcast_channels.xml in Resources */,
 				720DC50427A51A6500DFF3EC /* testappcast_minimumAutoupdateVersionSkipping.xml in Resources */,
 				72E6D9712C04DE1A005496E4 /* SparkleTestCodeSign_pkg.dmg in Resources */,

--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -773,6 +773,13 @@ static NSString *SPUSanitizeUntrustedVersionString(NSString *versionString, NSSt
         chosenInstallationType = SPUInstallationTypeApplication;
 #endif
         
+        if (signingValidationStatus == SPUAppcastSigningValidationStatusFailed && ![chosenInstallationType isEqualToString:SPUInstallationTypeApplication]) {
+            if (error != NULL) {
+                *error = @"Package based install update is rejected because signing validation on feed failed";
+            }
+            return nil;
+        }
+        
         _installationType = [chosenInstallationType copy];
         
         NSString *enclosureDeltaSparkleExecutableSize = [enclosure objectForKey:SUAppcastAttributeDeltaFromSparkleExecutableSize];

--- a/Tests/Resources/test-package-update.xml
+++ b/Tests/Resources/test-package-update.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 2.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <sparkle:version>2.0</sparkle:version>
+        <enclosure url="https://sparkle-project.org/release-2.0.pkg" sparkle:installationType="package" length="1346234" />
+    </item>
+    <item>
+        <title>Version 1.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <sparkle:version>1.0</sparkle:version>
+        <enclosure url="https://sparkle-project.org/release-1.0.zip" length="1346234" />
+    </item>
+  </channel>
+</rss>

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -8,6 +8,25 @@
 
 import XCTest
 
+private let packageInstallationAppcastXML = """
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>For unit test only</title>
+    <item>
+        <title>Version 2.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <enclosure url="https://sparkle-project.org/release-2.0.pkg" sparkle:version="2.0" sparkle:installationType="package" length="1346234" />
+    </item>
+    <item>
+        <title>Version 1.0</title>
+        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
+        <enclosure url="https://sparkle-project.org/release-1.0.zip" sparkle:version="1.0" length="1346234" />
+    </item>
+  </channel>
+</rss>
+"""
+
 class SUAppcastTest: XCTestCase {
 
     func testParseAppcast() {
@@ -1161,6 +1180,44 @@ class SUAppcastTest: XCTestCase {
         } catch let err as NSError {
             NSLog("Expected error: %@", err)
             XCTFail("Appcast creation should have passed when encountering dangerous link of one item")
+        }
+    }
+
+    func testPackageInstallAllowedWithSkippedSigningValidation() {
+        let testFile = Bundle(for: SUAppcastTest.self).path(forResource: "test-package-update", ofType: "xml")!
+        let testData = NSData(contentsOfFile: testFile)!
+
+        do {
+            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default, standardVersionComparator: SUStandardVersionComparator.default)
+
+            let appcast = try SUAppcast(xmlData: testData as Data, relativeTo: nil, stateResolver: stateResolver, signingValidationStatus: .skipped)
+
+            XCTAssertEqual(appcast.items.count, 2)
+            XCTAssertEqual(appcast.items[0].installationType, SPUInstallationTypeGuidedPackage)
+            XCTAssertEqual(appcast.items[1].installationType, SPUInstallationTypeApplication)
+        } catch let err as NSError {
+            NSLog("Unexpected error: %@", err)
+            XCTFail("Appcast creation should have passed when signing validation is skipped")
+        }
+    }
+
+    func testPackageInstallRejectedWithFailedSigningValidation() {
+        let testFile = Bundle(for: SUAppcastTest.self).path(forResource: "test-package-update", ofType: "xml")!
+        let testData = NSData(contentsOfFile: testFile)!
+
+        do {
+            let stateResolver = SPUAppcastItemStateResolver(hostVersion: "1.0", applicationVersionComparator: SUStandardVersionComparator.default, standardVersionComparator: SUStandardVersionComparator.default)
+
+            let appcast = try SUAppcast(xmlData: testData as Data, relativeTo: nil, stateResolver: stateResolver, signingValidationStatus: .failed)
+
+            // The package-based item should be rejected because signing validation on the feed failed;
+            // only the application-based item should remain
+            XCTAssertEqual(appcast.items.count, 1)
+            XCTAssertEqual(appcast.items[0].installationType, SPUInstallationTypeApplication)
+            XCTAssertEqual(appcast.items[0].versionString, "1.0")
+        } catch let err as NSError {
+            NSLog("Unexpected error: %@", err)
+            XCTFail("Appcast creation should have passed, dropping only the rejected package item")
         }
     }
 }


### PR DESCRIPTION
Package updates require EdDSA signing, therefore there is no code signing mechanism to fallback on for key rotation.

Used AI assistance for writing tests.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Verified in test app that failed signed appcast fallback doesn't allow showing update for pkg based update.

macOS version tested: 26.5.1 (25F80)
