### PR TITLE
Update CI runners to use Xcode 26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: ['xcode26.2', 'xcode16.4']
+        xcode: ['xcode26.6', 'xcode16.4']
         include:
             - xcode: 'xcode16.4'
               xcode-path: '/Applications/Xcode_16.4.app/Contents/Developer'
               upload-dist: false
               run-analyzer: false
               macos: 'macos-15'
-            - xcode: 'xcode26.2'
-              xcode-path: '/Applications/Xcode_26.2.app/Contents/Developer'
+            - xcode: 'xcode26.6'
+              xcode-path: '/Applications/Xcode_26.6.app/Contents/Developer'
               upload-dist: true
               run-analyzer: true
               macos: 'macos-26'

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -2,7 +2,7 @@ name: "Create Draft Release"
 
 env:
   BUILDDIR: "build"
-  DEVELOPER_DIR: "/Applications/Xcode_26.2.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_26.6.app/Contents/Developer"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
We're not upgrading to Xcode 27.0 as the action runners don't seem to work well yet.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI

macOS version tested: NA
