### PR TITLE
Don't copy progress tool for root user

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -32,7 +32,7 @@
 
 @implementation SUInstallerLauncher
 
-- (BOOL)submitProgressToolAtPath:(NSString *)progressToolPath withHostBundle:(NSBundle *)hostBundle inSystemDomainForInstaller:(BOOL)inSystemDomainForInstaller SPU_OBJC_DIRECT
+- (BOOL)submitProgressToolAtPath:(NSString *)progressToolPath withHostBundle:(NSBundle *)hostBundle inSystemDomainForInstaller:(BOOL)inSystemDomainForInstaller copiedApplication:(BOOL)copiedApplication SPU_OBJC_DIRECT
 {
     SUFileManager *fileManager = [[SUFileManager alloc] init];
     
@@ -53,7 +53,7 @@
     NSString *hostBundleIdentifier = hostBundle.bundleIdentifier;
     assert(hostBundleIdentifier != nil);
     
-    NSArray<NSString *> *arguments = @[executablePath, hostBundlePath, @(inSystemDomainForInstaller).stringValue];
+    NSArray<NSString *> *arguments = @[executablePath, hostBundlePath, @(inSystemDomainForInstaller).stringValue, @(copiedApplication).stringValue];
     
     // The progress tool can only be ran as the logged in user, not as root
     CFStringRef domain = kSMDomainUserLaunchd;
@@ -498,8 +498,6 @@ static BOOL SPUUsesSystemDomainForBundlePath(NSString *path, BOOL rootUser
         
         NSString *userName;
         NSString *homeDirectory;
-        uid_t uid = 0;
-        gid_t gid = 0;
         if (!rootUser) {
             // Normal path
             homeDirectory = NSHomeDirectory();
@@ -510,7 +508,7 @@ static BOOL SPUUsesSystemDomainForBundlePath(NSString *path, BOOL rootUser
         } else {
             // As the root user we need to obtain the user name and home directory reflecting
             // the user's console session.
-            CFStringRef userNameRef = SCDynamicStoreCopyConsoleUser(NULL, &uid, &gid);
+            CFStringRef userNameRef = SCDynamicStoreCopyConsoleUser(NULL, NULL, NULL);
             if (userNameRef == NULL) {
                 SULog(SULogLevelError, @"Failed to retrieve user name from the console user");
                 completionHandler(SUInstallerLauncherFailure, inSystemDomain);
@@ -531,55 +529,48 @@ static BOOL SPUUsesSystemDomainForBundlePath(NSString *path, BOOL rootUser
         // We can't compare the signature of this framework/XPC service (depending how it's run) to the host bundle because
         // they could be different (eg: take a look at sparkle-cli). We also can't easily tell if the signature of the service/framework is the same as the bundle it's inside.
         // The service/framework also need not even be signed in the first place. We'll just assume for now the original bundle hasn't been tampered with
-        NSString *cachePath = rootUser ?
-            [SPULocalCacheDirectory cachePathForBundleIdentifier:hostBundleIdentifier userName:userName] :
-            [SPULocalCacheDirectory cachePathForBundleIdentifier:hostBundleIdentifier];
         
-        NSString *rootLauncherCachePath = [cachePath stringByAppendingPathComponent:@"Launcher"];
-        
-        [SPULocalCacheDirectory removeOldItemsInDirectory:rootLauncherCachePath];
-        
-        NSDictionary<NSFileAttributeKey, id> *fileAttributes = rootUser ?
-            @{NSFileOwnerAccountID: @(uid), NSFileGroupOwnerAccountID: @(gid)} :
-            nil;
-        
-        NSString *launcherCachePath = [SPULocalCacheDirectory createUniqueDirectoryInDirectory:rootLauncherCachePath intermediateDirectoryFileAttributes:fileAttributes];
-        
-        if (launcherCachePath == nil) {
-            SULog(SULogLevelError, @"Failed to create cache directory for progress tool in %@", rootLauncherCachePath);
-            completionHandler(SUInstallerLauncherFailure, inSystemDomain);
-            return;
-        }
-        
-        SUFileManager *fileManager = [[SUFileManager alloc] init];
-        
-        if (rootUser) {
-            // Ensure the console user has ownership of the launcher cache directory
-            // Otherwise the updater may not launch and not be able to clean up itself
-            NSError *changeOwnerAndGroupError = nil;
-            if (![fileManager changeOwnerAndGroupOfItemAtURL:[NSURL fileURLWithPath:launcherCachePath] ownerID:uid groupID:gid error:&changeOwnerAndGroupError]) {
-                SULog(SULogLevelError, @"Failed to change owner and group for launcher cache directory: %@", changeOwnerAndGroupError);
-                
+        // Don't create cache directories or copy the progress tool app outside of the bundle for root user,
+        // because the app will not start if it's contained inside directories owned by root,
+        // and un-doing that opens up potential security issues.
+        // Eventually we will also want to not copy the tool app in the !rootUser case, minimizing risk
+        // by not making that change yet.
+        BOOL copyProgressTool = !rootUser;
+        NSString *progressToolPath;
+        if (copyProgressTool) {
+            NSString *cachePath = [SPULocalCacheDirectory cachePathForBundleIdentifier:hostBundleIdentifier];
+            
+            NSString *rootLauncherCachePath = [cachePath stringByAppendingPathComponent:@"Launcher"];
+            
+            [SPULocalCacheDirectory removeOldItemsInDirectory:rootLauncherCachePath];
+            
+            NSString *launcherCachePath = [SPULocalCacheDirectory createUniqueDirectoryInDirectory:rootLauncherCachePath];
+            
+            if (launcherCachePath == nil) {
+                SULog(SULogLevelError, @"Failed to create cache directory for progress tool in %@", rootLauncherCachePath);
                 completionHandler(SUInstallerLauncherFailure, inSystemDomain);
                 return;
             }
-        }
-        
-        NSString *progressToolPath = [launcherCachePath stringByAppendingPathComponent:@""SPARKLE_INSTALLER_PROGRESS_TOOL_NAME@".app"];
-        
-        NSError *copyError = nil;
-        // SUFileManager is more reliable for copying files around
-        if (![fileManager copyItemAtURL:[NSURL fileURLWithPath:progressToolResourcePath] toURL:[NSURL fileURLWithPath:progressToolPath] error:&copyError]) {
-            SULog(SULogLevelError, @"Failed to copy progress tool to cache: %@", copyError);
-            completionHandler(SUInstallerLauncherFailure, inSystemDomain);
-            return;
+            
+            progressToolPath = [launcherCachePath stringByAppendingPathComponent:@""SPARKLE_INSTALLER_PROGRESS_TOOL_NAME@".app"];
+            
+            NSError *copyError = nil;
+            // SUFileManager is more reliable for copying files around
+            SUFileManager *fileManager = [[SUFileManager alloc] init];
+            if (![fileManager copyItemAtURL:[NSURL fileURLWithPath:progressToolResourcePath] toURL:[NSURL fileURLWithPath:progressToolPath] error:&copyError]) {
+                SULog(SULogLevelError, @"Failed to copy progress tool to cache: %@", copyError);
+                completionHandler(SUInstallerLauncherFailure, inSystemDomain);
+                return;
+            }
+        } else {
+            progressToolPath = progressToolResourcePath;
         }
         
         SUInstallerLauncherStatus installerStatus = [self submitInstallerAtPath:installerPath withHostBundle:hostBundle iconBundlePath:mainBundle.bundlePath updaterIdentifier:updaterIdentifier userName:userName homeDirectory:homeDirectory mainBundleName:mainBundleName inSystemDomain:inSystemDomain rootUser:rootUser];
         
         BOOL submittedProgressTool = NO;
         if (installerStatus == SUInstallerLauncherSuccess) {
-            submittedProgressTool = [self submitProgressToolAtPath:progressToolPath withHostBundle:hostBundle inSystemDomainForInstaller:inSystemDomain];
+            submittedProgressTool = [self submitProgressToolAtPath:progressToolPath withHostBundle:hostBundle inSystemDomainForInstaller:inSystemDomain copiedApplication:copyProgressTool];
             
             if (!submittedProgressTool) {
                 SULog(SULogLevelError, @"Failed to submit progress tool job");

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -62,13 +62,14 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
     BOOL _submittedLauncherJob;
     BOOL _willTerminate;
     BOOL _applicationInitiallyAlive;
+    BOOL _copiedApplication;
 }
 
 - (instancetype)initWithApplication:(NSApplication *)application arguments:(NSArray<NSString *> *)arguments delegate:(id<InstallerProgressDelegate>)delegate
 {
     self = [super init];
     if (self != nil) {
-        if (arguments.count != 3) {
+        if (arguments.count != 4) {
             SULog(SULogLevelError, @"Error: Invalid number of arguments supplied: %@", arguments);
             [self cleanupAndExitWithStatus:EXIT_FAILURE error:nil];
         }
@@ -114,7 +115,9 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
         _application = application;
         _delegate = delegate;
         
-        [delegate loadLocalizationStringsFromHost:host];
+        BOOL copiedApplication = arguments[3].boolValue;
+        [delegate loadLocalizationStringsFromHost:host copiedApplication:copiedApplication];
+        _copiedApplication = copiedApplication;
         
         _connection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(SPUInstallerAgentProtocol)];
         _connection.exportedObject = self;
@@ -193,21 +196,23 @@ static const NSTimeInterval SUTerminationTimeDelay = 0.3;
     [_statusInfo invalidate];
     [_connection invalidate];
     
-    // Remove the agent bundle; it is assumed this bundle is in a temporary/cache/support directory
-    NSError *theError = nil;
-    NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
-    
-    if (![[NSFileManager defaultManager] removeItemAtPath:bundlePath error:&theError]) {
-        SULog(SULogLevelError, @"Couldn't remove agent bundle: %@.", theError);
-    } else {
-        // There should be nothing else in the parent temporary directory given to us,
-        // so let us try to remove it. Note rmdir() will fail if there are unexpectably other
-        // items present
-        NSString *parentDirectory = bundlePath.stringByDeletingLastPathComponent;
-        const char *fileSystemRepresentation = parentDirectory.fileSystemRepresentation;
-        if (fileSystemRepresentation != NULL) {
-            if (rmdir(fileSystemRepresentation) != 0) {
-                SULog(SULogLevelError, @"Failed to remove parent agent bundle directory: %@: %d", parentDirectory, errno);
+    if (_copiedApplication) {
+        // Remove the agent bundle; it is assumed this bundle is in a temporary/cache/support directory
+        NSError *theError = nil;
+        NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
+        
+        if (![[NSFileManager defaultManager] removeItemAtPath:bundlePath error:&theError]) {
+            SULog(SULogLevelError, @"Couldn't remove agent bundle: %@.", theError);
+        } else {
+            // There should be nothing else in the parent temporary directory given to us,
+            // so let us try to remove it. Note rmdir() will fail if there are unexpectably other
+            // items present
+            NSString *parentDirectory = bundlePath.stringByDeletingLastPathComponent;
+            const char *fileSystemRepresentation = parentDirectory.fileSystemRepresentation;
+            if (fileSystemRepresentation != NULL) {
+                if (rmdir(fileSystemRepresentation) != 0) {
+                    SULog(SULogLevelError, @"Failed to remove parent agent bundle directory: %@: %d", parentDirectory, errno);
+                }
             }
         }
     }

--- a/Sparkle/InstallerProgress/InstallerProgressDelegate.h
+++ b/Sparkle/InstallerProgress/InstallerProgressDelegate.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol InstallerProgressDelegate <NSObject>
 
-- (void)loadLocalizationStringsFromHost:(SUHost *)host;
+- (void)loadLocalizationStringsFromHost:(SUHost *)host copiedApplication:(BOOL)copiedApplication;
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host;
 - (void)installerProgressShouldStop;
 

--- a/Sparkle/InstallerProgress/ShowInstallerProgress.m
+++ b/Sparkle/InstallerProgress/ShowInstallerProgress.m
@@ -20,7 +20,12 @@
     NSString *_installingUpdateTitle;
 }
 
-- (void)loadLocalizationStringsFromHost:(SUHost *)host
+- (void)createStatusControllerWithHost:(SUHost *)host SPU_OBJC_DIRECT
+{
+    _statusController = [[SUStatusController alloc] initWithHost:host windowTitle:_updatingString centerPointValue:nil minimizable:NO closable:NO];
+}
+
+- (void)loadLocalizationStringsFromHost:(SUHost *)host copiedApplication:(BOOL)copiedApplication
 {
     // Try to retrieve localization strings from the old bundle if possible
     // We won't display these strings until installerProgressShouldDisplayWithHost:
@@ -90,11 +95,19 @@
 #endif
     
     _installingUpdateTitle = installingUpdateTitle;
+    
+    // Initialize status controller immediately if app isn't copied, before the app may be swapped/removed
+    // This gaurantees we will be able to load the nib
+    if (!copiedApplication) {
+        [self createStatusControllerWithHost:host];
+    }
 }
 
 - (void)installerProgressShouldDisplayWithHost:(SUHost *)host
 {
-    _statusController = [[SUStatusController alloc] initWithHost:host windowTitle:_updatingString centerPointValue:nil minimizable:NO closable:NO];
+    if (_statusController == nil) {
+        [self createStatusControllerWithHost:host];
+    }
     
     [_statusController setButtonTitle:_cancelUpdateTitle target:nil action:nil isDefault:NO accessibilityIdentifier:@"SUStatusCancel"];
     

--- a/Sparkle/SPULocalCacheDirectory.h
+++ b/Sparkle/SPULocalCacheDirectory.h
@@ -21,10 +21,6 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPULocalCacheDirectory : NSObject
 // and then create a unique temporary directory inside it (using +createUniqueDirectoryInDirectory:)
 + (NSString *)cachePathForBundleIdentifier:(NSString *)bundleIdentifier;
 
-// Variant of cachePathForBundleIdentifier: that specifies a userName to create the cache path for
-// Only use this when running from as root
-+ (NSString *)cachePathForBundleIdentifier:(NSString *)bundleIdentifier userName:(NSString *)userName;
-
 // Remove old files inside a directory
 // A caller may want to invoke this on a directory they own rather than remove and re-create an entire directory
 // This does nothing if the supplied directory does not exist yet
@@ -33,7 +29,6 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPULocalCacheDirectory : NSObject
 // Create a unique directory inside a parent directory
 // The parent directory doesn't have to exist yet. If it doesn't exist, intermediate directories will be created.
 + (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory;
-+ (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory intermediateDirectoryFileAttributes:(nullable NSDictionary<NSFileAttributeKey, id> *)attributes;
 
 @end
 

--- a/Sparkle/SPULocalCacheDirectory.m
+++ b/Sparkle/SPULocalCacheDirectory.m
@@ -44,19 +44,6 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
     return [self _cachePathForCacheDirectory:cacheURL bundleIdentifier:bundleIdentifier];
 }
 
-+ (NSString *)cachePathForBundleIdentifier:(NSString *)bundleIdentifier userName:(NSString *)userName
-{
-    NSString *homeDirectory = NSHomeDirectoryForUser(userName);
-    assert(homeDirectory != nil);
-    
-    NSURL *homeDirectoryURL = [NSURL fileURLWithPath:homeDirectory isDirectory:YES];
-    
-    NSURL *cacheURL = [[homeDirectoryURL URLByAppendingPathComponent:@"Library" isDirectory:YES] URLByAppendingPathComponent:@"Caches" isDirectory:YES];
-    assert(cacheURL != nil);
-    
-    return [self _cachePathForCacheDirectory:cacheURL bundleIdentifier:bundleIdentifier];
-}
-
 + (void)removeOldItemsInDirectory:(NSString *)directory
 {
     NSMutableArray<NSString *> *filePathsToRemove = [NSMutableArray array];
@@ -86,11 +73,11 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
     }
 }
 
-+ (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory intermediateDirectoryFileAttributes:(NSDictionary<NSFileAttributeKey, id> *)intermediateDirectoryFileAttributes
++ (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *createError = nil;
-    if (![fileManager createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:intermediateDirectoryFileAttributes error:&createError]) {
+    if (![fileManager createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:nil error:&createError]) {
         SULog(SULogLevelError, @"Failed to create directory with intermediate components at %@ with error %@", directory, createError);
         return nil;
     }
@@ -105,11 +92,6 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
         }
     }
     return nil;
-}
-
-+ (NSString * _Nullable)createUniqueDirectoryInDirectory:(NSString *)directory
-{
-    return [self createUniqueDirectoryInDirectory:directory intermediateDirectoryFileAttributes:nil];
 }
 
 @end


### PR DESCRIPTION
This way we don't have to create cache directories under a different user to launch the progress tool. Longer term I want to never copy the tool.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested updating app with sparkle-cli as root, when app is owned by local user or by root.

macOS version tested: 26.5.1 (25F80)
