### PR TITLE
Clean up old availability checks and unused code

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -571,19 +571,15 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
             NSURL *downloadDestinationURL = [resolvedCacheInstallationURL URLByAppendingPathComponent:downloadName isDirectory:NO];
             
             BOOL fallbackToFileCopy;
-            if (@available(macOS 11, *)) {
-                NSError *renameError = nil;
-                if (![fileManager renameItemAtResolvedSymlinkURL:resolvedDownloadURL toResolvedSymlinkURL:downloadDestinationURL error:&renameError]) {
-                    SULog(SULogLevelError, @"Error: failed to rename '%@' to '%@'. Falling back to copy operation.", resolvedDownloadURL.path, downloadDestinationURL.path);
-                    
-                    SULogError(renameError);
-                    
-                    fallbackToFileCopy = YES;
-                } else {
-                    fallbackToFileCopy = NO;
-                }
-            } else {
+            NSError *renameError = nil;
+            if (![fileManager renameItemAtResolvedSymlinkURL:resolvedDownloadURL toResolvedSymlinkURL:downloadDestinationURL error:&renameError]) {
+                SULog(SULogLevelError, @"Error: failed to rename '%@' to '%@'. Falling back to copy operation.", resolvedDownloadURL.path, downloadDestinationURL.path);
+                
+                SULogError(renameError);
+                
                 fallbackToFileCopy = YES;
+            } else {
+                fallbackToFileCopy = NO;
             }
             
             if (fallbackToFileCopy) {

--- a/Sparkle/SUFileManager.h
+++ b/Sparkle/SUFileManager.h
@@ -68,7 +68,7 @@ SUFileManagerDefinitionAttribute
  * sourceURL and destinationURL must reside on the same volume otherwise this operation will fail.
  * If any symbolic links are encountered in these paths during path resolution, this operation will fail.
  */
-- (BOOL)renameItemAtResolvedSymlinkURL:(NSURL *)sourceURL toResolvedSymlinkURL:(NSURL *)destinationURL error:(NSError *__autoreleasing *)error API_AVAILABLE(macosx(11.0));
+- (BOOL)renameItemAtResolvedSymlinkURL:(NSURL *)sourceURL toResolvedSymlinkURL:(NSURL *)destinationURL error:(NSError *__autoreleasing *)error;
 
 /**
  * Returns a URL by resolving links in path.

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -8,25 +8,6 @@
 
 import XCTest
 
-private let packageInstallationAppcastXML = """
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-  <channel>
-    <title>For unit test only</title>
-    <item>
-        <title>Version 2.0</title>
-        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
-        <enclosure url="https://sparkle-project.org/release-2.0.pkg" sparkle:version="2.0" sparkle:installationType="package" length="1346234" />
-    </item>
-    <item>
-        <title>Version 1.0</title>
-        <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
-        <enclosure url="https://sparkle-project.org/release-1.0.zip" sparkle:version="1.0" length="1346234" />
-    </item>
-  </channel>
-</rss>
-"""
-
 class SUAppcastTest: XCTestCase {
 
     func testParseAppcast() {


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing this in CI, ran test app locally,

macOS version tested: 27.0 Beta (26A5406e)
