### PR TITLE
Unarchive disk images using diskutil on macOS 27+

### DIFF
--- a/Autoupdate/AppInstaller.m
+++ b/Autoupdate/AppInstaller.m
@@ -247,8 +247,15 @@ static const NSTimeInterval SUDisplayProgressTimeDelay = 0.7;
     [_communicator handleMessageWithIdentifier:SPUExtractionStarted data:[NSData data]];
     
     NSString *archivePath = [_updateDirectoryPath stringByAppendingPathComponent:_downloadName];
-    
-    id<SUUnarchiverProtocol> unarchiver = [SUUnarchiver unarchiverForPath:archivePath extractionDirectory:_extractionDirectory updatingHostBundlePath:_host.bundlePath decryptionPassword:_decryptionPassword expectingInstallationType:_installationType];
+
+    NSString *extractionMountDirectory;
+    if ([SUUnarchiver requiresExtractionMountDirectory:archivePath]) {
+        extractionMountDirectory = [SPULocalCacheDirectory createUniqueDirectoryInDirectory:_updateDirectoryPath];
+    } else {
+        extractionMountDirectory = nil;
+    }
+
+    id<SUUnarchiverProtocol> unarchiver = [SUUnarchiver unarchiverForPath:archivePath extractionDirectory:_extractionDirectory extractionMountDirectory:extractionMountDirectory updatingHostBundlePath:_host.bundlePath decryptionPassword:_decryptionPassword expectingInstallationType:_installationType];
     
     NSError *prevalidationError = nil;
     BOOL success = NO;

--- a/Autoupdate/SUDiskImageUnarchiver.h
+++ b/Autoupdate/SUDiskImageUnarchiver.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUDiskImageUnarchiver : NSObject <SUUnarchiverProtocol>
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory decryptionPassword:(nullable NSString *)decryptionPassword;
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory extractionMountDirectory:(nullable NSString *)extractionMountDirectory decryptionPassword:(nullable NSString *)decryptionPassword;
 
 + (BOOL)canUnarchivePath:(NSString *)path;
 

--- a/Autoupdate/SUDiskImageUnarchiver.m
+++ b/Autoupdate/SUDiskImageUnarchiver.m
@@ -22,8 +22,10 @@
     NSString *_archivePath;
     NSString *_decryptionPassword;
     NSString *_extractionDirectory;
+    NSString *_extractionMountDirectory;
     
     SUUnarchiverNotifier *_notifier;
+
     double _currentExtractionProgress;
     double _fileProgressIncrement;
 }
@@ -38,13 +40,14 @@
     return NO;
 }
 
-- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory decryptionPassword:(nullable NSString *)decryptionPassword
+- (instancetype)initWithArchivePath:(NSString *)archivePath extractionDirectory:(NSString *)extractionDirectory extractionMountDirectory:(nullable NSString *)extractionMountDirectory decryptionPassword:(nullable NSString *)decryptionPassword
 {
     self = [super init];
     if (self != nil) {
         _archivePath = [archivePath copy];
         _decryptionPassword = [decryptionPassword copy];
         _extractionDirectory = [extractionDirectory copy];
+        _extractionMountDirectory = [extractionMountDirectory copy];
     }
     return self;
 }
@@ -86,18 +89,30 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
 {
 	@autoreleasepool {
         BOOL mountedSuccessfully = NO;
+
+        // Only use modern diskutil extraction over hdiutil if extraction mount directory has been specified
+        BOOL useModernDiskUtilImplementation = (_extractionMountDirectory != nil);
         
         // get a unique mount point path
-        NSString *mountPoint = nil;
-        NSFileManager *manager;
+        NSString *mountPoint;
         NSError *error = nil;
-        NSArray *contents = nil;
-        do {
-            NSString *uuidString = [[NSUUID UUID] UUIDString];
-            mountPoint = [@"/Volumes" stringByAppendingPathComponent:uuidString];
+        if (useModernDiskUtilImplementation) {
+            mountPoint = _extractionMountDirectory;
+        } else {
+            do {
+                NSString *uuidString = [[NSUUID UUID] UUIDString];
+                mountPoint = [@"/Volumes" stringByAppendingPathComponent:uuidString];
+            }
+            // Note: this check does not follow symbolic links, which is what we want
+            while ([[NSURL fileURLWithPath:mountPoint] checkResourceIsReachableAndReturnError:NULL]);
         }
-        // Note: this check does not follow symbolic links, which is what we want
-        while ([[NSURL fileURLWithPath:mountPoint] checkResourceIsReachableAndReturnError:NULL]);
+        
+        if (mountPoint == nil) {
+            error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{ NSLocalizedDescriptionKey:@"Extraction failed because mountPoint failed to be created"}];
+            
+            [notifier notifyFailureWithError:error];
+            return;
+        }
         
         NSMutableData *inputData = [NSMutableData data];
         
@@ -110,20 +125,31 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
                 [inputData appendData:decryptionPasswordData];
             }
             
-            // From the hdiutil docs:
-            // read a null-terminated passphrase from standard input
-            //
-            // Add the null terminator
-            [inputData appendBytes:"\0" length:1];
-            
+            if (useModernDiskUtilImplementation) {
+                // Unlike hdiutil, diskutil's --stdinpassphrase expects the passphrase to be
+                // newline-terminated rather than null-terminated
+                [inputData appendBytes:"\n" length:1];
+            } else {
+                // From the hdiutil docs:
+                // read a null-terminated passphrase from standard input
+                //
+                // Add the null terminator
+                [inputData appendBytes:"\0" length:1];
+            }
+
             // Append prompt data for license agreements
             [inputData appendBytes:"yes\n" length:4];
         }
         
-        // Finder doesn't verify disk images anymore beyond the code signing signature (if available)
-        // Opt out of the old CRC checksum checks
-        // Also always pass -stdinpass so we gracefully handle password protected disk images even if we aren't expecting them
-        NSArray *arguments = @[@"attach", _archivePath, @"-mountpoint", mountPoint, @"-noverify", @"-nobrowse", @"-noautoopen", @"-stdinpass"];
+        // Always pass -stdinpass / --stdinpassphrase so we gracefully handle password protected disk images even if we aren't expecting them
+        NSArray<NSString *> *arguments;
+        if (useModernDiskUtilImplementation) {
+            arguments = @[@"image", @"attach", _archivePath, @"--mountPoint", mountPoint, @"--nobrowse", @"--stdinpassphrase"];
+        } else {
+            // Finder doesn't verify disk images anymore beyond the code signing signature (if available)
+            // Opt out of the old CRC checksum checks
+            arguments = @[@"attach", _archivePath, @"-mountpoint", mountPoint, @"-noverify", @"-nobrowse", @"-noautoopen", @"-stdinpass"];
+        }
         
         NSData *output = nil;
         NSInteger taskResult = -1;
@@ -133,12 +159,20 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
         NSMutableArray<NSString *> *itemsToExtract = [NSMutableArray array];
         NSUInteger totalFileExtractionCount = 0;
         
+        NSFileManager *manager = nil;
+        NSArray *contents = nil;
+        
         BOOL success = YES;
         
         {
             NSTask *task = [[NSTask alloc] init];
-            task.launchPath = @"/usr/bin/hdiutil";
-            task.currentDirectoryPath = @"/";
+            if (useModernDiskUtilImplementation) {
+                task.executableURL = [NSURL fileURLWithPath:@"/usr/sbin/diskutil" isDirectory:NO];
+            } else {
+                task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/hdiutil" isDirectory:NO];
+                task.currentDirectoryPath = @"/";
+            }
+            
             task.arguments = arguments;
             
             NSPipe *inputPipe = [NSPipe pipe];
@@ -179,9 +213,9 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
         
         if (taskResult != 0) {
             NSString *resultStr = output ? [[NSString alloc] initWithData:output encoding:NSUTF8StringEncoding] : nil;
-            SULog(SULogLevelError, @"hdiutil failed with code: %ld data: <<%@>>", (long)taskResult, resultStr);
+            SULog(SULogLevelError, @"%@ failed with code: %ld data: <<%@>>", (useModernDiskUtilImplementation ? @"diskutil" : @"hdiutil"), (long)taskResult, resultStr);
             
-            error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Extraction failed due to hdiutil returning %ld status: %@", (long)taskResult, resultStr]}];
+            error = [NSError errorWithDomain:SUSparkleErrorDomain code:SUUnarchivingError userInfo:@{NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Extraction failed due to %@ returning %ld status: %@", useModernDiskUtilImplementation ? @"diskutil" : @"hdiutil", (long)taskResult, resultStr]}];
             
             goto reportError;
         }
@@ -284,14 +318,20 @@ static NSUInteger fileCountForDirectory(NSFileManager *fileManager, NSString *it
     finally:
         if (mountedSuccessfully) {
             NSTask *task = [[NSTask alloc] init];
-            task.launchPath = @"/usr/bin/hdiutil";
-            task.arguments = @[@"detach", mountPoint, @"-force"];
+            
+            if (useModernDiskUtilImplementation) {
+                task.launchPath = @"/usr/sbin/diskutil";
+                task.arguments = @[@"eject", mountPoint];
+            } else {
+                task.launchPath = @"/usr/bin/hdiutil";
+                task.arguments = @[@"detach", mountPoint, @"-force"];
+            }
             task.standardOutput = [NSPipe pipe];
             task.standardError = [NSPipe pipe];
             
             NSError *launchCleanupError = nil;
             if (![task launchAndReturnError:&launchCleanupError]) {
-                SULog(SULogLevelError, @"Failed to unmount %@", mountPoint);
+                SULog(SULogLevelError, @"%@ failed to unmount %@", (useModernDiskUtilImplementation ? @"diskutil" : @"hdiutil"), mountPoint);
                 SULog(SULogLevelError, @"Error: %@", launchCleanupError);
             } else if (waitForCleanup) {
                 [task waitUntilExit];

--- a/Autoupdate/SUUnarchiver.h
+++ b/Autoupdate/SUUnarchiver.h
@@ -14,7 +14,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 SPU_OBJC_DIRECT_MEMBERS @interface SUUnarchiver : NSObject
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType;
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory extractionMountDirectory:(nullable NSString *)extractionMountDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType;
+
+// Returns YES if unarchiving path requires an extraction mount directory to be provided to -unarchiverForPath:extractionDirectory:extractionMountDirectory:updatingHostBundlePath:decryptionPassword:expectingInstallationType:
++ (BOOL)requiresExtractionMountDirectory:(NSString *)path;
 
 @end
 

--- a/Autoupdate/SUUnarchiver.m
+++ b/Autoupdate/SUUnarchiver.m
@@ -18,13 +18,28 @@
 
 @implementation SUUnarchiver
 
-+ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType
++ (BOOL)requiresExtractionMountDirectory:(NSString *)path
+{
+    if (![SUDiskImageUnarchiver canUnarchivePath:path]) {
+        return NO;
+    }
+
+    // By providing a directory for mounting, this lets the disk image unarchiver use diskutil over hdiutil
+    // diskutil extraction works well across all dmgs only on macOS 27+
+    if (@available(macOS 27, *)) {
+        return YES;
+    } else {
+        return NO;
+    }
+}
+
++ (nullable id <SUUnarchiverProtocol>)unarchiverForPath:(NSString *)path extractionDirectory:(NSString *)extractionDirectory extractionMountDirectory:(nullable NSString *)extractionMountDirectory updatingHostBundlePath:(nullable NSString *)hostPath decryptionPassword:(nullable NSString *)decryptionPassword expectingInstallationType:(NSString *)installationType
 {
     if ([SUPipedUnarchiver canUnarchivePath:path]) {
         return [[SUPipedUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory];
     }
     else if ([SUDiskImageUnarchiver canUnarchivePath:path]) {
-        return [[SUDiskImageUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory decryptionPassword:decryptionPassword];
+        return [[SUDiskImageUnarchiver alloc] initWithArchivePath:path extractionDirectory:extractionDirectory extractionMountDirectory:extractionMountDirectory decryptionPassword:decryptionPassword];
     }
     else if ([SUBinaryDeltaUnarchiver canUnarchivePath:path]) {
         assert(hostPath != nil);

--- a/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
+++ b/Sparkle.xcodeproj/xcshareddata/xcschemes/Sparkle Test App.xcscheme
@@ -59,6 +59,9 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <MetalAPIValidationSettings
+         isEnabled = "No">
+      </MetalAPIValidationSettings>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/SUUnarchiverTest.swift
+++ b/Tests/SUUnarchiverTest.swift
@@ -45,8 +45,11 @@ class SUUnarchiverTest: XCTestCase
 
     func unarchiveNonExistentFileTestFailureAppWithExtension(_ archiveExtension: String, tempDirectoryURL: URL, password: String?, expectingInstallationType installationType: String, testExpectation: XCTestExpectation) {
         let tempArchiveURL = tempDirectoryURL.deletingLastPathComponent().appendingPathComponent("error-invalid").appendingPathExtension(archiveExtension)
-        
-        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
+
+        // The disk image unarchiver will create and remove this directory automatically
+        let extractionMountDirectory: String? = SUUnarchiver.requiresExtractionMountDirectory(tempArchiveURL.path) ? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString).path : nil
+
+        let unarchiver = SUUnarchiver.unarchiver(forPath: tempArchiveURL.path, extractionDirectory: tempDirectoryURL.path, extractionMountDirectory: extractionMountDirectory, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             XCTAssertNotNil(error)
@@ -56,8 +59,11 @@ class SUUnarchiverTest: XCTestCase
 
     // swiftlint:disable function_parameter_count
     func unarchiveTestAppWithExtension(_ archiveExtension: String, appName: String, tempDirectoryURL: URL, archiveResourceURL: URL, password: String?, expectingInstallationType installationType: String, expectingSuccess: Bool, testExpectation: XCTestExpectation) {
-        
-        let unarchiver = SUUnarchiver.unarchiver(forPath: archiveResourceURL.path, extractionDirectory: tempDirectoryURL.path, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
+
+        // The disk image unarchiver will create and remove this directory automatically
+        let extractionMountDirectory: String? = SUUnarchiver.requiresExtractionMountDirectory(archiveResourceURL.path) ? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString).path : nil
+
+        let unarchiver = SUUnarchiver.unarchiver(forPath: archiveResourceURL.path, extractionDirectory: tempDirectoryURL.path, extractionMountDirectory: extractionMountDirectory, updatingHostBundlePath: nil, decryptionPassword: password, expectingInstallationType: installationType)!
 
         unarchiver.unarchive(completionBlock: {(error: Error?) -> Void in
             if expectingSuccess {

--- a/generate_appcast/Unarchive.swift
+++ b/generate_appcast/Unarchive.swift
@@ -7,12 +7,15 @@ import Foundation
 
 func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) -> Void) {
     let fileManager = FileManager.default
-    let tempDir = archiveDestDir.appendingPathExtension("tmp")
+    let tempExtractionDir = archiveDestDir.appendingPathExtension("tmp")
 
-    _ = try? fileManager.removeItem(at: tempDir)
-    _ = try? fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: [:])
+    _ = try? fileManager.removeItem(at: tempExtractionDir)
+    _ = try? fileManager.createDirectory(at: tempExtractionDir, withIntermediateDirectories: true, attributes: [:])
+    
+    // The disk image unarchiver will create and remove this directory automatically
+    let extractionMountDirectory: String? = SUUnarchiver.requiresExtractionMountDirectory(itemPath.path) ? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString).path : nil
 
-    if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: tempDir.path, updatingHostBundlePath: nil, decryptionPassword: nil, expectingInstallationType: SPUInstallationTypeApplication) {
+    if let unarchiver = SUUnarchiver.unarchiver(forPath: itemPath.path, extractionDirectory: tempExtractionDir.path, extractionMountDirectory: extractionMountDirectory, updatingHostBundlePath: nil, decryptionPassword: nil, expectingInstallationType: SPUInstallationTypeApplication) {
         unarchiver.unarchive(completionBlock: { (error: Error?) in
             if error != nil {
                 callback(error)
@@ -20,7 +23,7 @@ func unarchive(itemPath: URL, archiveDestDir: URL, callback: @escaping (Error?) 
             }
 
             do {
-                try fileManager.moveItem(at: tempDir, to: archiveDestDir)
+                try fileManager.moveItem(at: tempExtractionDir, to: archiveDestDir)
                 callback(nil)
             } catch {
                 callback(error)


### PR DESCRIPTION
This change adopts using diskutil for dmg extraction on macOS 27+ where hdiutil has been deprecated. hdiutil will still be used on older operating systems because diskutil's extraction support is worse prior to macOS 27 (e.g. can't handle license agreements in headless way, stricter --mountPoint policy requiring mount directory to exist).

For further context, diskutil extraction goes through the same extraction Finder has used at least for the past few OS releases. hdiutil (and images with deprecated license agreements) goes through an older path and is often less efficient.

Used AI for minor refactor tweaking and debugging.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [x] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [x] My own app
- [ ] Other (please specify)

Tasks:

- [x] Test unarchiving dmg and license agreement dmg on macOS 27
- [x] Test unarchiving dmg and license agreement dmg on older OS's
- [x] Test unarchiving dmg on macOS 27 when authorization is required
- [x] Test unarchiving dmg and license agreement dmg with generate_appcast
- [x] Unit tests for disk image extraction pass on macOS 27 and macOS 26 (APFS and HFS dmgs, password protected images, images with license agreements, code signed dmgs ...)

macOS version tested:
27.0 Beta (26A5416b)
26.7
12 VM