### PR TITLE
Fix binary delta testFileSystemCompression failing on macOS 27

### DIFF
--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -450,10 +450,16 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
             fprintf(stderr, "\nApplying file system compression...");
         }
         
-        NSTask *dittoTask = [[NSTask alloc] init];
+        NSMutableArray<NSString *> *dittoArguments = [@[@"--hfsCompression"] mutableCopy];
+        if (@available(macOS 27, *)) {
+            // Compression won't be applied on macOS 27 without passing --noclone
+            [dittoArguments addObject:@"--noclone"];
+        }
+        [dittoArguments addObjectsFromArray:@[destination, finalDestination]];
         
+        NSTask *dittoTask = [[NSTask alloc] init];
         dittoTask.executableURL = [NSURL fileURLWithPath:@"/usr/bin/ditto" isDirectory:NO];
-        dittoTask.arguments = @[@"--hfsCompression", destination, finalDestination];
+        dittoTask.arguments = [dittoArguments copy];
         
         // If we fail to apply file system compression, we will try falling back to not doing this
         BOOL failedToApplyFileSystemCompression = NO;

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -1377,7 +1377,7 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
         NSTask *dittoTask = [[NSTask alloc] init];
         dittoTask.executableURL = [NSURL fileURLWithPath:@"/usr/bin/ditto" isDirectory:NO];
         
-        dittoTask.arguments = @[@"--hfsCompression", destinationFile, destinationFile2];
+        dittoTask.arguments = @[@"--hfsCompression", @"--noclone", destinationFile, destinationFile2];
         
         NSError *launchError = nil;
         BOOL launched = [dittoTask launchAndReturnError:&launchError];


### PR DESCRIPTION
We need to pass --noclone for HFS / file system compression to be applied.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Verified testFileSystemCompression now passes on macOS 27. CI will verify older versions.

macOS version tested: 27.0 Beta (26A5421a)
