### PR TITLE
Fix minor temporary file leaks on binary delta failure

### DIFF
--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -294,7 +294,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
                 if (error != NULL) {
                     *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Unable to extract diffed file to %@", tempDiffFile], NSUnderlyingErrorKey: (NSError * _Nonnull)archive.error }];
                 }
-                
+
+                unlink(tempDiffFile.fileSystemRepresentation);
+
                 *stop = YES;
                 return;
             }
@@ -307,6 +309,9 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
                     if (error != NULL) {
                         *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteUnknownError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Relative path for clone '%@' contains '..' path component", clonedRelativePath] }];
                     }
+
+                    unlink(tempDiffFile.fileSystemRepresentation);
+
                     *stop = YES;
                     return;
                 }

--- a/Autoupdate/SUBinaryDeltaCommon.h
+++ b/Autoupdate/SUBinaryDeltaCommon.h
@@ -76,7 +76,6 @@ extern BOOL copyTree(NSFileManager *fileManager, NSString *source, NSString *des
 extern BOOL modifyPermissions(NSString *path, mode_t desiredPermissions);
 extern NSString *pathRelativeToDirectory(NSString *directory, NSString *path);
 NSString *temporaryFilename(NSString *base);
-NSString *temporaryDirectory(NSString *base);
 NSString *stringWithFileSystemRepresentation(const char*);
 uint16_t latestMinorVersionForMajorVersion(SUBinaryDeltaMajorVersion majorVersion);
 #endif

--- a/Autoupdate/SUBinaryDeltaCommon.m
+++ b/Autoupdate/SUBinaryDeltaCommon.m
@@ -143,22 +143,6 @@ NSString *temporaryFilename(NSString *base)
     return stringWithFileSystemRepresentation(buffer);
 }
 
-NSString *temporaryDirectory(NSString *base)
-{
-    NSString *template = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.XXXXXXXXXX", base]];
-    NSMutableData *data = [NSMutableData data];
-    [data appendBytes:template.fileSystemRepresentation length:strlen(template.fileSystemRepresentation) + 1];
-
-    char *buffer = (char *)data.mutableBytes;
-    char *templateResult = mkdtemp(buffer);
-    if (templateResult == NULL) {
-        perror("mkdtemp");
-        return nil;
-    }
-
-    return stringWithFileSystemRepresentation(templateResult);
-}
-
 static void sha1HashOfBuffer(unsigned char *hash, const char *buffer, ssize_t bufferLength)
 {
     assert(bufferLength >= 0 && bufferLength <= UINT32_MAX);

--- a/Autoupdate/SUBinaryDeltaCreate.m
+++ b/Autoupdate/SUBinaryDeltaCreate.m
@@ -81,6 +81,8 @@ extern int bsdiff(int argc, const char **argv);
     int result = bsdiff(4, argv);
     if (result == 0) {
         _resultPath = temporaryFile;
+    } else {
+        unlink(temporaryFile.fileSystemRepresentation);
     }
 }
 

--- a/Tests/SUBinaryDeltaTest.m
+++ b/Tests/SUBinaryDeltaTest.m
@@ -22,6 +22,22 @@ typedef void (^SUDeltaHandler)(NSFileManager *fileManager, NSString *sourceDirec
 
 @implementation SUBinaryDeltaTest
 
+static NSString *temporaryDirectory(NSString *base)
+{
+    NSString *template = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.XXXXXXXXXX", base]];
+    NSMutableData *data = [NSMutableData data];
+    [data appendBytes:template.fileSystemRepresentation length:strlen(template.fileSystemRepresentation) + 1];
+
+    char *buffer = (char *)data.mutableBytes;
+    char *templateResult = mkdtemp(buffer);
+    if (templateResult == NULL) {
+        perror("mkdtemp");
+        return nil;
+    }
+
+    return stringWithFileSystemRepresentation(templateResult);
+}
+
 - (void)testTemporaryDirectory
 {
     NSString *tmp1 = temporaryDirectory(@"Sparklęエンジン");

--- a/Tests/SUUpdateValidatorTest.swift
+++ b/Tests/SUUpdateValidatorTest.swift
@@ -146,13 +146,14 @@ class SUUpdateValidatorTest: XCTestCase {
         let signatures = self.signatures(signatureConfig)
 
         let validator = SUUpdateValidator(downloadPath: self.signedTestFilePath, signatures: signatures, host: host, verifierInformation: nil)
+        
+        let updateDirectory = try! FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true), create: true)
 
-        let updateDirectory = temporaryDirectory("SUUpdateValidatorTest")!
-        defer { try! FileManager.default.removeItem(atPath: updateDirectory) }
+        defer { try! FileManager.default.removeItem(at: updateDirectory) }
         let newBundle = self.bundle(newBundleConfig)
-        try! FileManager.default.copyItem(at: newBundle.bundleURL, to: URL(fileURLWithPath: updateDirectory).appendingPathComponent(oldBundle.bundleURL.lastPathComponent))
+        try! FileManager.default.copyItem(at: newBundle.bundleURL, to: updateDirectory.appendingPathComponent(oldBundle.bundleURL.lastPathComponent))
 
-        let result = (try? validator.validate(withUpdateDirectory: updateDirectory)) != nil
+        let result = (try? validator.validate(withUpdateDirectory: updateDirectory.path)) != nil
         XCTAssertEqual(result, expectedResult, "oldBundle: \(oldBundleConfig), newBundle: \(newBundleConfig), signatures: \(signatureConfig)", line: line)
     }
 


### PR DESCRIPTION
Also move temporaryDirectory() to unit tests only.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

macOS version tested: 27.0 Beta (26A5421a)
