### PR TITLE
Handle .service bundle identifiers in cache paths

### DIFF
--- a/Sparkle.xcodeproj/project.pbxproj
+++ b/Sparkle.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		142E0E0019A6954400E4312B /* Sparkle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		142E0E0219A6A14700E4312B /* Sparkle.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		142E0E0919A83AAC00E4312B /* SUBinaryDeltaTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 142E0E0819A83AAC00E4312B /* SUBinaryDeltaTest.m */; };
+		F1A5E00231DE010100F1A5E0 /* SPULocalCacheDirectoryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A5E00131DE010100F1A5E0 /* SPULocalCacheDirectoryTest.m */; };
 		14652F8019A9740F00959E44 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B5F8F609C4CEB300B25A18 /* Security.framework */; };
 		14652F8219A9746000959E44 /* SULog.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C14F05136EF6DB00649790 /* SULog.m */; };
 		14652F8419A978C200959E44 /* SUExport.h in Headers */ = {isa = PBXBuildFile; fileRef = 14652F8319A9759F00959E44 /* SUExport.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -987,6 +988,7 @@
 		612279D90DB5470200AB99EA /* Sparkle Unit Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Sparkle Unit Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		612279DA0DB5470200AB99EA /* SparkleTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SparkleTests-Info.plist"; sourceTree = "<group>"; };
 		61227A150DB548B800AB99EA /* SUVersionComparisonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUVersionComparisonTest.m; sourceTree = "<group>"; };
+		F1A5E00131DE010100F1A5E0 /* SPULocalCacheDirectoryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPULocalCacheDirectoryTest.m; sourceTree = "<group>"; };
 		61299A5B09CA6D4500B7442F /* SUConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SUConstants.h; sourceTree = "<group>"; };
 		61299A5F09CA6EB100B7442F /* SUConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SUConstants.m; sourceTree = "<group>"; };
 		61299B3509CB04E000B7442F /* Sparkle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sparkle.h; sourceTree = "<group>"; };
@@ -1934,6 +1936,7 @@
 				72C56E1E2F04AC890005A484 /* SUFeedSignatureVerifierTest.swift */,
 				72A4A23F1BB6567D00E7820D /* SUFileManagerTest.swift */,
 				5AF6C74C1AEA40760014A3AB /* SUInstallerTest.m */,
+				F1A5E00131DE010100F1A5E0 /* SPULocalCacheDirectoryTest.m */,
 				7210C7671B9A9A1500EB90AC /* SUUnarchiverTest.swift */,
 				5A5DD400249585E70045EB3E /* SUUpdateValidatorTest.swift */,
 				14950074195FDF5900BC5B5B /* SUUpdaterTest.m */,
@@ -3384,6 +3387,7 @@
 				5A5DD401249585E70045EB3E /* SUUpdateValidatorTest.swift in Sources */,
 				7267E5EC1D3D912900D1BF90 /* SUInstaller.m in Sources */,
 				5AF6C7541AEA49840014A3AB /* SUInstallerTest.m in Sources */,
+				F1A5E00231DE010100F1A5E0 /* SPULocalCacheDirectoryTest.m in Sources */,
 				14652F8219A9746000959E44 /* SULog.m in Sources */,
 				7267E5F81D3D91A800D1BF90 /* SUPipedUnarchiver.m in Sources */,
 				7267E5F71D3D919600D1BF90 /* SUPlainInstaller.m in Sources */,

--- a/Sparkle/SPULocalCacheDirectory.h
+++ b/Sparkle/SPULocalCacheDirectory.h
@@ -10,6 +10,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// If an app's bundle identifier ends with a package extension recognized by macOS,
+// append ".sparkle" so the cache directory is not treated as an app or service bundle.
+// https://github.com/sparkle-project/Sparkle/discussions/2881
+static inline NSString *SPUCacheIdentifierForBundleIdentifier(NSString *bundleIdentifier)
+{
+    NSString *bundleIdentifierExtension = bundleIdentifier.pathExtension.lowercaseString;
+    if ([bundleIdentifierExtension isEqualToString:@"app"] || [bundleIdentifierExtension isEqualToString:@"service"]) {
+        return [bundleIdentifier stringByAppendingString:@".sparkle"];
+    }
+    return bundleIdentifier;
+}
+
 SPU_OBJC_DIRECT_MEMBERS @interface SPULocalCacheDirectory : NSObject
 
 // Returns a path to a suitable cache directory to create specifically for Sparkle

--- a/Sparkle/SPULocalCacheDirectory.m
+++ b/Sparkle/SPULocalCacheDirectory.m
@@ -18,15 +18,7 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
 
 + (NSString *)_cachePathForCacheDirectory:(NSURL *)cacheURL bundleIdentifier:(NSString *)bundleIdentifier SPU_OBJC_DIRECT
 {
-    // If an app has an ill-formed bundle identifier that ends with ".app" we will append ".sparkle" to it
-    // so that the cache directory doesn't look like an app bundle directory, which can cause other systematic issues
-    // https://github.com/sparkle-project/Sparkle/discussions/2881
-    NSString *appCacheIdentifier;
-    if ([bundleIdentifier hasSuffix:@".app"] || [bundleIdentifier hasSuffix:@".APP"]) {
-        appCacheIdentifier = [bundleIdentifier stringByAppendingString:@".sparkle"];
-    } else {
-        appCacheIdentifier = bundleIdentifier;
-    }
+    NSString *appCacheIdentifier = SPUCacheIdentifierForBundleIdentifier(bundleIdentifier);
     
     NSString *resultPath = [[[cacheURL URLByAppendingPathComponent:appCacheIdentifier isDirectory:YES] URLByAppendingPathComponent:@SPARKLE_BUNDLE_IDENTIFIER isDirectory:YES] path];
     assert(resultPath != nil);

--- a/Tests/SPULocalCacheDirectoryTest.m
+++ b/Tests/SPULocalCacheDirectoryTest.m
@@ -1,0 +1,35 @@
+//
+//  SPULocalCacheDirectoryTest.m
+//  Sparkle
+//
+//  Copyright © 2026 Sparkle Project. All rights reserved.
+//
+
+#import "SPULocalCacheDirectory.h"
+#import <XCTest/XCTest.h>
+
+@interface SPULocalCacheDirectoryTest : XCTestCase
+@end
+
+@implementation SPULocalCacheDirectoryTest
+
+- (NSString *)cacheIdentifierForBundleIdentifier:(NSString *)bundleIdentifier
+{
+    return SPUCacheIdentifierForBundleIdentifier(bundleIdentifier);
+}
+
+- (void)testNeutralizesPackageLikeBundleIdentifierExtensionsCaseInsensitively
+{
+    XCTAssertEqualObjects([self cacheIdentifierForBundleIdentifier:@"com.example.application.app"], @"com.example.application.app.sparkle");
+    XCTAssertEqualObjects([self cacheIdentifierForBundleIdentifier:@"com.example.application.ApP"], @"com.example.application.ApP.sparkle");
+    XCTAssertEqualObjects([self cacheIdentifierForBundleIdentifier:@"com.example.helper.service"], @"com.example.helper.service.sparkle");
+    XCTAssertEqualObjects([self cacheIdentifierForBundleIdentifier:@"com.example.helper.SeRvIcE"], @"com.example.helper.SeRvIcE.sparkle");
+}
+
+- (void)testPreservesOrdinaryBundleIdentifiers
+{
+    XCTAssertEqualObjects([self cacheIdentifierForBundleIdentifier:@"com.example.application"], @"com.example.application");
+    XCTAssertEqualObjects([self cacheIdentifierForBundleIdentifier:@"com.example.service.worker"], @"com.example.service.worker");
+}
+
+@end


### PR DESCRIPTION
## Summary

Sparkle already appends `.sparkle` when a bundle identifier ends in `.app`, preventing the cache directory from being treated as an application bundle. macOS also recognizes `.service` as a Service Application bundle, so identifiers ending in `.service` need the same neutral cache suffix.

This change normalizes the final identifier extension case-insensitively, appends `.sparkle` for `.app` and `.service`, and preserves ordinary bundle identifiers. It also adds focused regression tests for both package-like extensions and unaffected identifiers.

This change was prepared with Codex assistance. I reviewed the complete diff and ran Sparkle's official unit-test workflow locally.

Related discussion: https://github.com/sparkle-project/Sparkle/discussions/2881

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explained in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [x] My own app
- [x] Other: Sparkle's CI `build-for-testing` and `test-without-building` commands

The regression tests cover `.app` and `.service` suffixes with mixed casing, plus ordinary identifiers that must remain unchanged. The full `Distribution` unit-test suite passed with 183 tests, 0 failures, and 0 skipped tests.

macOS version tested: 26.5.2 (Xcode 26.6)
