### PR TITLE
Fix updating not working the first time if bundle ID ends with other bundle-like extensions

### DIFF
--- a/Sparkle/SPULocalCacheDirectory.m
+++ b/Sparkle/SPULocalCacheDirectory.m
@@ -18,14 +18,24 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
 
 + (NSString *)_cachePathForCacheDirectory:(NSURL *)cacheURL bundleIdentifier:(NSString *)bundleIdentifier SPU_OBJC_DIRECT
 {
-    // If an app has an ill-formed bundle identifier that ends with ".app" we will append ".sparkle" to it
-    // so that the cache directory doesn't look like an app bundle directory, which can cause other systematic issues
-    // https://github.com/sparkle-project/Sparkle/discussions/2881
-    NSString *appCacheIdentifier;
-    if ([bundleIdentifier hasSuffix:@".app"] || [bundleIdentifier hasSuffix:@".APP"]) {
-        appCacheIdentifier = [bundleIdentifier stringByAppendingString:@".sparkle"];
-    } else {
-        appCacheIdentifier = bundleIdentifier;
+    NSString *appCacheIdentifier = bundleIdentifier;
+    {
+        // If an app has an ill-formed bundle identifier that ends with ".app" or ".service"
+        // or anything similarly problematic, we will append ".sparkle" to it
+        // so that the cache directory doesn't look like a protected bundle directory,
+        // which can cause other systematic issues
+        // https://github.com/sparkle-project/Sparkle/discussions/2881
+        NSArray<NSString *> *problematicBundleIdentifierExtensions = @[@".app", @".service", @".xpc", @".appex", @".bundle", @".plugin", @".saver", @".kext"];
+        
+        // Transforming the bundle identifier into a lowercased variant for suffix comparison
+        // rather than case-insensitive comparing the pathExtension (which may return "" for ".app")
+        NSString *lowercasedBundleIdentifier = bundleIdentifier.lowercaseString;
+        for (NSString *badExtension in problematicBundleIdentifierExtensions) {
+            if ([lowercasedBundleIdentifier hasSuffix:badExtension]) {
+                appCacheIdentifier = [bundleIdentifier stringByAppendingString:@".sparkle"];
+                break;
+            }
+        }
     }
     
     NSString *resultPath = [[[cacheURL URLByAppendingPathComponent:appCacheIdentifier isDirectory:YES] URLByAppendingPathComponent:@SPARKLE_BUNDLE_IDENTIFIER isDirectory:YES] path];


### PR DESCRIPTION
This is a continuation of #2882. This issue was brought up in #2907 where .service bundle identifiers were also impacted.

Used AI assistance for finding a list of extensions that might be problematic. I don't have time to exhaustively try all of them. I have confirmed `.service` though is indeed problematic on macOS 26.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested updating from notarized test app that has bundle ID ending in ".service" and ".app" on macOS 26. Confirmed this change fixes security & privacy report issue, and confirmed without it, it triggers a warning for ".service" type bundle ID.

macOS version tested: macOS 26.7 (25G220)
