### PR TITLE
Cache and validate feed data downloaded in the background

### DIFF
--- a/Sparkle/SPUDownloadDriver.h
+++ b/Sparkle/SPUDownloadDriver.h
@@ -39,7 +39,7 @@ SPU_OBJC_DIRECT_MEMBERS
 #endif
 @interface SPUDownloadDriver : NSObject
 
-- (instancetype)initWithRequestURL:(NSURL *)requestURL host:(SUHost *)host userAgent:(NSString * _Nullable)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background delegate:(id<SPUDownloadDriverDelegate>)delegate;
+- (instancetype)initWithRequestURL:(NSURL *)requestURL host:(SUHost *)host userAgent:(NSString * _Nullable)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background cachePolicy:(NSURLRequestCachePolicy)cachePolicy delegate:(id<SPUDownloadDriverDelegate>)delegate;
 
 - (instancetype)initWithUpdateItem:(SUAppcastItem *)updateItem secondaryUpdateItem:(SUAppcastItem * _Nullable)secondaryUpdateItem host:(SUHost *)host userAgent:(NSString * _Nullable)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background delegate:(id<SPUDownloadDriverDelegate>)delegate;
 

--- a/Sparkle/SPUDownloadDriver.m
+++ b/Sparkle/SPUDownloadDriver.m
@@ -114,7 +114,7 @@
     return self;
 }
 
-- (instancetype)initWithRequestURL:(NSURL *)requestURL host:(SUHost *)host userAgent:(NSString * _Nullable)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background delegate:(id<SPUDownloadDriverDelegate>)delegate
+- (instancetype)initWithRequestURL:(NSURL *)requestURL host:(SUHost *)host userAgent:(NSString * _Nullable)userAgent httpHeaders:(NSDictionary * _Nullable)httpHeaders inBackground:(BOOL)background cachePolicy:(NSURLRequestCachePolicy)cachePolicy delegate:(id<SPUDownloadDriverDelegate>)delegate
 {
     self = [self initWithHost:host];
     if (self != nil) {
@@ -122,11 +122,7 @@
         _inBackground = background;
         
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL];
-        // Note the cachePolicy has no effect on persistent downloads on disk (i.e downloading update archives)
-        // It impacts temporary in-memory downloads such as appcast feeds and release notes.
-        // For now we don't use caching, but with more testing/experimenting that could change
-        // (e.g. not downloading same feed unmodified from previous request).
-        request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+        request.cachePolicy = cachePolicy;
         
         if (userAgent != nil) {
             [request setValue:(NSString * _Nonnull)userAgent forHTTPHeaderField:@"User-Agent"];
@@ -151,7 +147,7 @@
     NSURL *updateFileURL = updateItem.fileURL;
     assert(updateFileURL != nil);
     
-    self = [self initWithRequestURL:updateFileURL host:host userAgent:userAgent httpHeaders:httpHeaders inBackground:background delegate:delegate];
+    self = [self initWithRequestURL:updateFileURL host:host userAgent:userAgent httpHeaders:httpHeaders inBackground:background cachePolicy:NSURLRequestReloadIgnoringLocalCacheData delegate:delegate];
     if (self != nil) {
         _updateItem = updateItem;
         _secondaryUpdateItem = secondaryUpdateItem;

--- a/Sparkle/SPUUIBasedUpdateDriver.m
+++ b/Sparkle/SPUUIBasedUpdateDriver.m
@@ -52,7 +52,7 @@
         _host = host;
         _signatures = signatures;
         _contentLength = contentLength;
-        _downloadDriver = [[SPUDownloadDriver alloc] initWithRequestURL:releaseNotesURL host:host userAgent:userAgent httpHeaders:httpHeaders inBackground:NO delegate:self];
+        _downloadDriver = [[SPUDownloadDriver alloc] initWithRequestURL:releaseNotesURL host:host userAgent:userAgent httpHeaders:httpHeaders inBackground:NO cachePolicy:NSURLRequestReloadIgnoringLocalCacheData delegate:self];
         _completionHandler = [completionHandler copy];
     } else {
         assert(false);

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -35,8 +35,10 @@
 #include "AppKitPrevention.h"
 
 #define SUInitialFailedFeedSigningValidationDateKey @"SUInitialFailedFeedSigningValidationDate"
+#define SUFeedLastCacheBypassCheckTimeKey @"SUFeedLastCacheBypassCheckTime"
 
 #define DEFAULT_APPCAST_FAILURE_EXPIRATION_INTERVAL 1728000 // 20 days
+#define CACHE_BYPASS_CHECK_INTERVAL 1814400 // 3 weeks
 
 @interface SUAppcastDriver () <SPUDownloadDriverDelegate>
 @end
@@ -73,13 +75,47 @@
     }
     requestHTTPHeaders[@"Accept"] = @"application/rss+xml,*/*;q=0.1";
     
-    _downloadDriver = [[SPUDownloadDriver alloc] initWithRequestURL:appcastURL host:_host userAgent:userAgent httpHeaders:requestHTTPHeaders inBackground:background delegate:self];
+    NSURLRequestCachePolicy cachePolicy;
+    if (!background || [_host boolForInfoDictionaryKey:SUDisableFeedCacheValidationKey]) {
+        // Always fetch the freshest feed when the user explicitly asks us to check,
+        // or if the developer disabled feed cache validation
+        cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    } else {
+        // With NSURLRequestReloadRevalidatingCacheData ETag / If-Modified-Since can be used so that
+        // a previously cached file can be used if it hasn't changed on the server.
+        // However we have a bypass check interval periodically to force ignoring the cache data if
+        // something happens to go wrong.
+        SUHost *hostForCacheBypassCheckTime = _host;
+        NSString *cacheBypassCheckTimeKey = [SUHost mainBundleUserDefaultsKey:SUFeedLastCacheBypassCheckTimeKey forHost:&hostForCacheBypassCheckTime];
+
+        NSDate *lastCacheBypassCheckDate = [hostForCacheBypassCheckTime objectForUserDefaultsKey:cacheBypassCheckTimeKey ofClass:NSDate.class];
+
+        BOOL needsCacheBypass;
+        if (lastCacheBypassCheckDate == nil) {
+            needsCacheBypass = YES;
+        } else {
+            NSTimeInterval intervalSinceLastCacheBypassCheck = [[NSDate date] timeIntervalSinceDate:lastCacheBypassCheckDate];
+            needsCacheBypass = (intervalSinceLastCacheBypassCheck < 0 || intervalSinceLastCacheBypassCheck >= CACHE_BYPASS_CHECK_INTERVAL);
+        }
+
+        cachePolicy = needsCacheBypass ? NSURLRequestReloadIgnoringLocalCacheData : NSURLRequestReloadRevalidatingCacheData;
+    }
+
+    _downloadDriver = [[SPUDownloadDriver alloc] initWithRequestURL:appcastURL host:_host userAgent:userAgent httpHeaders:requestHTTPHeaders inBackground:background cachePolicy:cachePolicy delegate:self];
     
     [_downloadDriver downloadFile];
 }
 
 - (void)downloadDriverDidDownloadData:(SPUDownloadData *)downloadData
 {
+    if (_downloadDriver.request.cachePolicy == NSURLRequestReloadIgnoringLocalCacheData) {
+        // Reset the cache bypass any time the feed has been downloaded successfully
+        SUHost *hostForCacheBypassCheckTime = _host;
+        NSString *cacheBypassCheckTimeKey = [SUHost mainBundleUserDefaultsKey:SUFeedLastCacheBypassCheckTimeKey forHost:&hostForCacheBypassCheckTime];
+
+        [hostForCacheBypassCheckTime setObject:[NSDate date] forUserDefaultsKey:cacheBypassCheckTimeKey];
+    }
+
     SPUAppcastItemStateResolver *stateResolver = [[SPUAppcastItemStateResolver alloc] initWithHostVersion:_host.version applicationVersionComparator:[self versionComparator] standardVersionComparator:[SUStandardVersionComparator defaultComparator]];
     
     NSData *downloadedAppcastData = downloadData.data;
@@ -113,21 +149,8 @@
         // If a significant period of time passes with verification still failing, we may operate in a 'safe' mode as fallback
         // and allow an app to be updated through key rotation
         
-        // If main bundle and host bundle differ, use the main bundle (updater) with a host bundle identifier to record the validation failure date
-        // This ensures external updaters record this date separately from an app updating itself.
-        SUHost *hostForFailedSigningValidationDate;
-        
-        NSString *initialFailedFeedSigningValidationDateKey;
-        NSBundle *mainBundle = NSBundle.mainBundle;
-        if ([mainBundle isEqual:_host.bundle]) {
-            hostForFailedSigningValidationDate = _host;
-            initialFailedFeedSigningValidationDateKey = SUInitialFailedFeedSigningValidationDateKey;
-        } else {
-            hostForFailedSigningValidationDate = [[SUHost alloc] initWithBundle:mainBundle];
-            
-            NSString *hostBundleIdentifier = _host.bundle.bundleIdentifier;
-            initialFailedFeedSigningValidationDateKey = (hostBundleIdentifier != nil) ? [SUInitialFailedFeedSigningValidationDateKey"_" stringByAppendingString:hostBundleIdentifier] : nil;
-        }
+        SUHost *hostForFailedSigningValidationDate = _host;
+        NSString *initialFailedFeedSigningValidationDateKey = [SUHost mainBundleUserDefaultsKey:SUInitialFailedFeedSigningValidationDateKey forHost:&hostForFailedSigningValidationDate];
         
         NSError *verifyAppcastDataInnerError = nil;
         if (![signatureVerifier verifyData:verifiedAppcastData signatures:signatures fileKind:@"appcast" verifierInformation:verifierInformation error:&verifyAppcastDataInnerError]) {

--- a/Sparkle/SUConstants.h
+++ b/Sparkle/SUConstants.h
@@ -48,6 +48,7 @@ extern NSString *const SUPublicDSAKeyFileKey;
 extern NSString *const SUPublicEDKeyKey;
 extern NSString *const SURequireSignedFeedKey;
 extern NSString *const SUVerifyUpdateBeforeExtractionKey;
+extern NSString *const SUDisableFeedCacheValidationKey;
 extern NSString *const SUAutomaticallyUpdateKey;
 extern NSString *const SUAllowsAutomaticUpdatesKey;
 extern NSString *const SUEnableAutomaticChecksKey;

--- a/Sparkle/SUConstants.m
+++ b/Sparkle/SUConstants.m
@@ -35,6 +35,7 @@ NSString *const SUPublicDSAKeyFileKey = @"SUPublicDSAKeyFile";
 NSString *const SUPublicEDKeyKey = @"SUPublicEDKey";
 NSString *const SURequireSignedFeedKey = @"SURequireSignedFeed";
 NSString *const SUVerifyUpdateBeforeExtractionKey = @"SUVerifyUpdateBeforeExtraction";
+NSString *const SUDisableFeedCacheValidationKey = @"SUDisableFeedCacheValidation";
 NSString *const SUAutomaticallyUpdateKey = @"SUAutomaticallyUpdate";
 NSString *const SUAllowsAutomaticUpdatesKey = @"SUAllowsAutomaticUpdates";
 NSString *const SUEnableSystemProfilingKey = @"SUEnableSystemProfiling";

--- a/Sparkle/SUHost.h
+++ b/Sparkle/SUHost.h
@@ -22,6 +22,10 @@ SUHostDefinitionAttribute
 
 @property (nonatomic, readonly) NSBundle *bundle;
 
+// Returns the user defaults key and host used for storing a user default that is keyed based on the
+// main bundle updating the host (which may differ if an external updater is updating another bundle)
++ (NSString *)mainBundleUserDefaultsKey:(NSString *)key forHost:(SUHost * _Nonnull __autoreleasing * _Nonnull)outHost;
+
 - (instancetype)initWithBundle:(NSBundle *)aBundle;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -38,6 +38,28 @@ static void *SUHostObservableContext = &SUHostObservableContext;
 
 @synthesize bundle = _bundle;
 
++ (NSString *)mainBundleUserDefaultsKey:(NSString *)key forHost:(SUHost * _Nonnull __autoreleasing * _Nonnull)outHost
+{
+    SUHost *host = *outHost;
+    SUHost *storageHost;
+    
+    NSString *userDefaultsKey;
+    if (host->_isMainBundle) {
+        storageHost = host;
+        userDefaultsKey = key;
+    } else {
+        NSBundle *mainBundle = NSBundle.mainBundle;
+        storageHost = [[SUHost alloc] initWithBundle:mainBundle];
+        
+        NSString *hostBundleIdentifier = host.bundle.bundleIdentifier;
+        userDefaultsKey = (hostBundleIdentifier != nil) ? [NSString stringWithFormat:@"%@_%@", key, hostBundleIdentifier] : key;
+    }
+    
+    *outHost = storageHost;
+    
+    return userDefaultsKey;
+}
+
 - (instancetype)initWithBundle:(NSBundle *)aBundle
 {
 	if ((self = [super init]))


### PR DESCRIPTION
When downloading feeds in the background (not manually), we opt into using `NSURLRequestReloadRevalidatingCacheData` which checks Etag / If-Modified-Since / etc if the server supports it. This avoids downloading full contents of appcast feed if it hasn't changed since the last request.

As a fail safe, we will have a periodic 3 week interval bypass for forcing loading the request without caching, and provide developer a (private) way to opt out.

Used AI for debugging HTTP requests and testing if caching was used from my server.

Fixes #371

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested background update check on my own app & modifying the feed on server to ensure it gets refreshed.
Tested user initiated check forces ignoring cache.
Tested Info.plist key opt-out
Tested with a sample app to ensure NSURLSession requests using NSURLRequestReloadRevalidatingCacheData get cached & cache-invalidated responses correctly
Tested checking updates from sparkle-cli
Tested with downloader XPC service enabled

macOS version tested:
27.0 Beta (26A5425a)
26.7
12 VM
