### PR TITLE
Handle stored dates that are in the future

### DIFF
--- a/Sparkle/SPULocalCacheDirectory.m
+++ b/Sparkle/SPULocalCacheDirectory.m
@@ -58,28 +58,31 @@ static NSTimeInterval OLD_ITEM_DELETION_INTERVAL = 86400 * 10; // 10 days
 {
     NSMutableArray<NSString *> *filePathsToRemove = [NSMutableArray array];
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    if ([fileManager fileExistsAtPath:directory]) {
-        NSDirectoryEnumerator *directoryEnumerator = [fileManager enumeratorAtPath:directory];
-        NSDate *currentDate = [NSDate date];
-        for (NSString *filename in directoryEnumerator)
-        {
-            NSDictionary<NSString *, id> *fileAttributes = [fileManager attributesOfItemAtPath:[directory stringByAppendingPathComponent:filename] error:NULL];
-            if (fileAttributes != nil)
-            {
-                NSDate *lastModificationDate = [fileAttributes objectForKey:NSFileModificationDate];
-                if ([currentDate timeIntervalSinceDate:lastModificationDate] >= OLD_ITEM_DELETION_INTERVAL)
-                {
-                    [filePathsToRemove addObject:[directory stringByAppendingPathComponent:filename]];
+    
+    NSDirectoryEnumerator *directoryEnumerator = [fileManager enumeratorAtPath:directory];
+    NSDate *currentDate = [NSDate date];
+    for (NSString *filename in directoryEnumerator) {
+        NSString *filePath = [directory stringByAppendingPathComponent:filename];
+        NSDictionary<NSString *, id> *fileAttributes = [fileManager attributesOfItemAtPath:filePath error:NULL];
+        if (fileAttributes != nil) {
+            NSDate *lastModificationDate = [fileAttributes objectForKey:NSFileModificationDate];
+            NSTimeInterval timeIntervalSinceLastModificationDate = [currentDate timeIntervalSinceDate:lastModificationDate];
+            if (timeIntervalSinceLastModificationDate >= OLD_ITEM_DELETION_INTERVAL) {
+                [filePathsToRemove addObject:[directory stringByAppendingPathComponent:filename]];
+            } else if (timeIntervalSinceLastModificationDate < 0) {
+                // Reset the modification date if it's far out in the future
+                NSError *resetModificationDateError = nil;
+                if (![fileManager setAttributes:@{NSFileModificationDate: currentDate} ofItemAtPath:filePath error:&resetModificationDateError]) {
+                    SULog(SULogLevelError, @"Failed to reset modification date of file modified in future: %@", resetModificationDateError.localizedDescription);
                 }
             }
-            
-            [directoryEnumerator skipDescendants];
         }
         
-        for (NSString *filename in filePathsToRemove)
-        {
-            [fileManager removeItemAtPath:filename error:NULL];
-        }
+        [directoryEnumerator skipDescendants];
+    }
+    
+    for (NSString *filename in filePathsToRemove) {
+        [fileManager removeItemAtPath:filename error:NULL];
     }
 }
 

--- a/Sparkle/SPUUpdater.m
+++ b/Sparkle/SPUUpdater.m
@@ -1249,14 +1249,21 @@ static NSString *escapeURLComponent(NSString *str) {
     BOOL sendingSystemProfile = [self sendsSystemProfile];
 
     // Let's only send the system profiling information once per week at most, so we normalize daily-checkers vs. biweekly-checkers and the such.
+    NSDate *currentDate = [NSDate date];
     if (sendingSystemProfile) {
         NSDate *lastSubmitDate = [_host objectForUserDefaultsKey:SULastProfileSubmitDateKey ofClass:NSDate.class];
         if (!lastSubmitDate) {
             lastSubmitDate = [NSDate distantPast];
         }
         const NSTimeInterval oneWeek = 60 * 60 * 24 * 7;
-        NSTimeInterval timeSinceLastSubmission = [lastSubmitDate timeIntervalSinceNow] * -1;
-        if (timeSinceLastSubmission < oneWeek) {
+        
+        NSTimeInterval timeSinceLastSubmission = [currentDate timeIntervalSinceDate:lastSubmitDate];
+        
+        if (timeSinceLastSubmission < 0) {
+            // Ignore dates far out in the future
+            sendingSystemProfile = NO;
+            [_host setObject:currentDate forUserDefaultsKey:SULastProfileSubmitDateKey];
+        } else if (timeSinceLastSubmission < oneWeek) {
             sendingSystemProfile = NO;
         }
     }
@@ -1272,7 +1279,7 @@ static NSString *escapeURLComponent(NSString *str) {
 	if (sendingSystemProfile)
 	{
         parameters = [parameters arrayByAddingObjectsFromArray:[self systemProfileArray]];
-        [_host setObject:[NSDate date] forUserDefaultsKey:SULastProfileSubmitDateKey];
+        [_host setObject:currentDate forUserDefaultsKey:SULastProfileSubmitDateKey];
     }
 	if ([parameters count] == 0) { return baseFeedURL; }
 

--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -148,7 +148,15 @@
                     [hostForFailedSigningValidationDate setObject:currentDate forUserDefaultsKey:initialFailedFeedSigningValidationDateKey];
                     canRecoverFromSigningValidationFailure = NO;
                 } else {
-                    canRecoverFromSigningValidationFailure = ([currentDate timeIntervalSinceDate:firstFailedSigningValidationDate] >= failureExpirationInterval);
+                    NSTimeInterval timeIntervalSinceFirstFailedValidationDate = [currentDate timeIntervalSinceDate:firstFailedSigningValidationDate];
+                    
+                    if (timeIntervalSinceFirstFailedValidationDate < 0) {
+                        // Record first signing validation date if stored date is far out in future
+                        [hostForFailedSigningValidationDate setObject:currentDate forUserDefaultsKey:initialFailedFeedSigningValidationDateKey];
+                        canRecoverFromSigningValidationFailure = NO;
+                    } else {
+                        canRecoverFromSigningValidationFailure = (timeIntervalSinceFirstFailedValidationDate >= failureExpirationInterval);
+                    }
                 }
             }
             


### PR DESCRIPTION
This is a correctness fix for system profile submission checking and periodic cache cleanup.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested stale directory removal when directory doesn't exist, and items are modified in the future.
Tested system profile info last submission date in the future and in the past.
Tested appcast sign failure expiration date in the future and way in the past.

macOS version tested: 27.0 (26A428)
