### PR TITLE
Changed Update Permission Prompt to resemble Tahoe Alert

### DIFF
--- a/Sparkle/SUUpdatePermissionPrompt.m
+++ b/Sparkle/SUUpdatePermissionPrompt.m
@@ -20,6 +20,8 @@
 
 static NSString *const SUUpdatePermissionPromptTouchBarIdentifier = @"" SPARKLE_BUNDLE_IDENTIFIER ".SUUpdatePermissionPrompt";
 
+static const CGFloat SUUpdatePermissionPromptGroupElementSpacing = 12.0;
+
 @interface SUUpdatePermissionPrompt () <NSTouchBarDelegate>
 
 // These properties are used for bindings
@@ -35,14 +37,16 @@ static NSString *const SUUpdatePermissionPromptTouchBarIdentifier = @"" SPARKLE_
     
     IBOutlet NSStackView *_stackView;
     IBOutlet NSView *_promptView;
+    IBOutlet NSImageView *_applicationIconImageView;
+    IBOutlet NSLayoutConstraint *_applicationIconLeadingLayoutConstraint;
     IBOutlet NSView *_moreInfoView;
     IBOutlet NSView *_placeholderView;
-    IBOutlet NSView *_responseView;
     IBOutlet NSView *_infoChoiceView;
     IBOutlet NSView *_automaticallyDownloadUpdatesView;
     IBOutlet NSButton *_cancelButton;
     IBOutlet NSButton *_checkButton;
     IBOutlet NSTextField *_checkForUpdatesAutomaticallyTextField;
+    IBOutlet NSTextField *_promptDescriptionTextField;
     IBOutlet NSButton *_includeAnonymousSystemProfileButton;
     IBOutlet NSButton *_anonymousInfoDisclosureButton;
     IBOutlet NSButton *_automaticallyDownloadAndInstallUpdatesButton;
@@ -88,28 +92,101 @@ static NSString *const SUUpdatePermissionPromptTouchBarIdentifier = @"" SPARKLE_
 
 - (void)windowDidLoad
 {
-    [self.window center];
-    
+    NSWindow *window = self.window;
+
+    window.movableByWindowBackground = YES;
+
     _infoChoiceView.hidden = ![self shouldAskAboutProfile];
     _automaticallyDownloadUpdatesView.hidden = ![self allowsAutomaticUpdates];
-    
-    [_stackView addArrangedSubview:_promptView];
-    [_stackView addArrangedSubview:_automaticallyDownloadUpdatesView];
-    [_stackView addArrangedSubview:_infoChoiceView];
-    [_stackView addArrangedSubview:_placeholderView];
-    [_stackView addArrangedSubview:_moreInfoView];
-    [_stackView addArrangedSubview:_responseView];
-    
+
+    // Give the question and the choices below it better grouping
+    [_stackView setCustomSpacing:SUUpdatePermissionPromptGroupElementSpacing afterView:_promptView];
+
 #if SPARKLE_COPY_LOCALIZATIONS
     NSBundle *sparkleBundle = SUSparkleBundle();
 #endif
-    
+
+    // Keep hidden window title for accessibility
+    window.title = SULocalizedStringFromTableInBundle(@"Software Update", SPARKLE_TABLE, sparkleBundle, nil);
+    window.titleVisibility = NSWindowTitleHidden;
+
+    // The dialog has a fixed width, so let long localized checkbox titles wrap instead of being
+    // truncated. Note button cells only wrap when their width is constrained, which it is here.
+    for (NSButton *checkbox in @[_automaticallyDownloadAndInstallUpdatesButton, _includeAnonymousSystemProfileButton]) {
+        NSCell *cell = checkbox.cell;
+        cell.usesSingleLineMode = NO;
+        cell.lineBreakMode = NSLineBreakByWordWrapping;
+        cell.wraps = YES;
+    }
+
+    if (@available(macOS 26, *)) {
+        _cancelButton.controlSize = NSControlSizeLarge;
+        _checkButton.controlSize = NSControlSizeLarge;
+    } else {
+        // Alerts center their icon and text before macOS 26
+        _applicationIconLeadingLayoutConstraint.active = NO;
+        [_applicationIconImageView.centerXAnchor constraintEqualToAnchor:_promptView.centerXAnchor].active = YES;
+
+        _checkForUpdatesAutomaticallyTextField.alignment = NSTextAlignmentCenter;
+        _promptDescriptionTextField.alignment = NSTextAlignmentCenter;
+    }
+
     _checkButton.title = SULocalizedStringFromTableInBundle(@"Check Automatically", SPARKLE_TABLE, sparkleBundle, nil);
     _cancelButton.title = SULocalizedStringFromTableInBundle(@"Don’t Check", SPARKLE_TABLE, sparkleBundle, nil);
     _checkForUpdatesAutomaticallyTextField.stringValue = SULocalizedStringFromTableInBundle(@"Check for updates automatically?", SPARKLE_TABLE, sparkleBundle, nil);
     _includeAnonymousSystemProfileButton.title = SULocalizedStringFromTableInBundle(@"Include anonymous system profile", SPARKLE_TABLE, sparkleBundle, nil);
     _automaticallyDownloadAndInstallUpdatesButton.title = SULocalizedStringFromTableInBundle(@"Automatically download and install updates", SPARKLE_TABLE, sparkleBundle, nil);
     _anonymousSystemProfileDisclosureInformation.stringValue = SULocalizedStringFromTableInBundle(@"Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.\n\nThis is the information that would be sent:", SPARKLE_TABLE, sparkleBundle, nil);
+
+    // Wrapping labels can only compute the right height once they know their final width. The width
+    // stored in the nib is a design time estimate, so let them adopt the width they ended up with.
+    [window layoutIfNeeded];
+
+    for (NSTextField *label in @[_checkForUpdatesAutomaticallyTextField, _promptDescriptionTextField, _anonymousSystemProfileDisclosureInformation]) {
+        label.preferredMaxLayoutWidth = NSWidth(label.frame);
+    }
+
+    [window layoutIfNeeded];
+
+    [self _embedContentInGlassBackgroundForWindow:window];
+
+    [window center];
+}
+
+// Draw the dialog on a glass background with the corner radius of a system prompt. AppKit has no
+// API for the corner radius of a window, so the rounded background is drawn by a glass effect view
+// inside the window while the window itself stops drawing.
+//
+// Clipping the glass view is what makes the corners work, without it the content is drawn as a
+// rectangle over the rounded glass. The window keeps its title bar style mask so that it can still
+// become the key window, which also means no window subclass is needed. Before macOS 26 the dialog
+// stays a regular window.
+- (void)_embedContentInGlassBackgroundForWindow:(NSWindow *)window
+{
+    if (@available(macOS 26, *)) {
+        // AppKit does not expose the corner radius of a window, and the layout regions only report
+        // content insets rather than corner geometry. This value is measured off a system prompt:
+        // fitting its edge profile against a circle gives 52 pixels at 2x on every sample point.
+        static const CGFloat glassCornerRadius = 26.0;
+
+        NSView *contentView = window.contentView;
+
+        NSGlassEffectView *glassView = [[NSGlassEffectView alloc] initWithFrame:contentView.frame];
+        glassView.cornerRadius = glassCornerRadius;
+        glassView.style = NSGlassEffectViewStyleRegular;
+        glassView.clipsToBounds = YES;
+
+        window.contentView = glassView;
+
+        contentView.frame = glassView.bounds;
+        contentView.autoresizingMask = (NSAutoresizingMaskOptions)(NSViewWidthSizable | NSViewHeightSizable);
+        glassView.contentView = contentView;
+
+        window.backgroundColor = NSColor.clearColor;
+        window.opaque = NO;
+
+        [window invalidateShadow];
+    }
 }
 
 - (BOOL)tableView:(NSTableView *) __unused tableView shouldSelectRow:(NSInteger) __unused row { return NO; }

--- a/Sparkle/SUUpdatePermissionPrompt.xib
+++ b/Sparkle/SUUpdatePermissionPrompt.xib
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SUUpdatePermissionPrompt">
             <connections>
+                <outlet property="_applicationIconImageView" destination="NBn-FN-XAx" id="Bqt-3M-Vzp"/>
+                <outlet property="_applicationIconLeadingLayoutConstraint" destination="Xku-5M-xMC" id="Ldj-8R-Wmq"/>
                 <outlet property="_anonymousInfoDisclosureButton" destination="JW6-0z-Ud3" id="grm-Uj-KJs"/>
                 <outlet property="_anonymousSystemProfileDisclosureInformation" destination="46" id="Ctt-KG-z3I"/>
                 <outlet property="_automaticallyDownloadAndInstallUpdatesButton" destination="BId-kb-eYW" id="FLp-cT-Pth"/>
@@ -20,29 +22,320 @@
                 <outlet property="_moreInfoView" destination="39" id="ceJ-4H-FHd"/>
                 <outlet property="_placeholderHeightLayoutConstraint" destination="yis-HR-OIe" id="npL-hg-wRq"/>
                 <outlet property="_placeholderView" destination="AGr-V0-0al" id="UnQ-rl-QSS"/>
+                <outlet property="_promptDescriptionTextField" destination="tgW-Jp-Aia" id="Kvt-2N-Hsw"/>
                 <outlet property="_promptView" destination="Yrl-Dt-Qvb" id="qbO-fw-1YD"/>
-                <outlet property="_responseView" destination="0CP-x7-YFK" id="AcW-Md-hSP"/>
                 <outlet property="_stackView" destination="qNw-uD-4Bg" id="EIt-kn-pJ0"/>
                 <outlet property="window" destination="5" id="126"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Profile Info">
-            <windowStyleMask key="styleMask" titled="YES"/>
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="5" userLabel="Update Permission Prompt">
+            <windowStyleMask key="styleMask" titled="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenAuxiliary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="83" y="492" width="488" height="379"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1470" height="918"/>
-            <view key="contentView" id="6">
-                <rect key="frame" x="0.0" y="0.0" width="437" height="379"/>
+            <rect key="contentRect" x="83" y="492" width="296" height="262"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="949"/>
+            <view key="contentView" misplaced="YES" id="6">
+                <rect key="frame" x="0.0" y="0.0" width="360" height="254"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qNw-uD-4Bg">
-                        <rect key="frame" x="0.0" y="0.0" width="437" height="379"/>
+                    <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qNw-uD-4Bg">
+                        <rect key="frame" x="0.0" y="0.0" width="360" height="254"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="Yrl-Dt-Qvb" userLabel="Prompt View">
+                                <rect key="frame" x="0.0" y="108" width="360" height="146"/>
+                                <subviews>
+                                    <imageView translatesAutoresizingMaskIntoConstraints="NO" id="NBn-FN-XAx" userLabel="Program icon">
+                                        <rect key="frame" x="148" y="78" width="64" height="64"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="64" id="KbC-i0-ZyN"/>
+                                            <constraint firstAttribute="width" secondItem="NBn-FN-XAx" secondAttribute="height" multiplier="1:1" id="Osy-kb-JTR"/>
+                                        </constraints>
+                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyUpOrDown" image="NSApplicationIcon" id="clc-hq-1NY"/>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="icon" id="JD9-MU-vwB"/>
+                                        </connections>
+                                    </imageView>
+                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" preferredMaxLayoutWidth="260" translatesAutoresizingMaskIntoConstraints="NO" id="IgD-Pj-pc8" userLabel="Title text field">
+                                        <rect key="frame" x="18" y="22" width="324" height="44"/>
+                                        <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Check for updates automatically?" id="gmh-T4-BO0">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" preferredMaxLayoutWidth="260" translatesAutoresizingMaskIntoConstraints="NO" id="tgW-Jp-Aia" userLabel="Description text field">
+                                        <rect key="frame" x="18" y="0.0" width="324" height="14"/>
+                                        <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" title="DO NOT LOCALIZE" id="cfa-j0-Ya4">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="promptDescription" id="dvR-Lp-2jl"/>
+                                        </connections>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="tgW-Jp-Aia" secondAttribute="trailing" constant="20" symbolic="YES" id="Fwc-c2-DDZ"/>
+                                    <constraint firstAttribute="trailing" secondItem="IgD-Pj-pc8" secondAttribute="trailing" constant="20" symbolic="YES" id="HXU-lh-GWa"/>
+                                    <constraint firstItem="IgD-Pj-pc8" firstAttribute="top" secondItem="NBn-FN-XAx" secondAttribute="bottom" constant="16" id="Jbz-hb-8QF"/>
+                                    <constraint firstItem="IgD-Pj-pc8" firstAttribute="leading" secondItem="Yrl-Dt-Qvb" secondAttribute="leading" constant="20" symbolic="YES" id="Wl8-N0-skJ"/>
+                                    <constraint firstItem="NBn-FN-XAx" firstAttribute="leading" secondItem="Yrl-Dt-Qvb" secondAttribute="leading" constant="20" symbolic="YES" id="Xku-5M-xMC"/>
+                                    <constraint firstItem="NBn-FN-XAx" firstAttribute="top" secondItem="Yrl-Dt-Qvb" secondAttribute="top" constant="20" symbolic="YES" id="fad-TA-xIj"/>
+                                    <constraint firstItem="tgW-Jp-Aia" firstAttribute="top" secondItem="IgD-Pj-pc8" secondAttribute="bottom" constant="10" id="nN4-jN-Fdn"/>
+                                    <constraint firstItem="tgW-Jp-Aia" firstAttribute="leading" secondItem="IgD-Pj-pc8" secondAttribute="leading" id="s7w-Aw-JQY"/>
+                                    <constraint firstAttribute="bottom" secondItem="tgW-Jp-Aia" secondAttribute="bottom" id="uS1-FX-kSX"/>
+                                </constraints>
+                            </customView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="37T-Ef-DtX" userLabel="Automatic Download View">
+                                <rect key="frame" x="0.0" y="86" width="360" height="14"/>
+                                <subviews>
+                                    <button focusRingType="none" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="BId-kb-eYW" userLabel="Automatically Download Updates Button">
+                                        <rect key="frame" x="20" y="0.0" width="245" height="14"/>
+                                        <buttonCell key="cell" type="check" title="Automatically download and install updates" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" focusRingType="none" inset="2" id="AUc-33-qGN">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="smallSystem"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="automaticallyDownloadUpdates" id="5Me-7t-mMu"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="BId-kb-eYW" firstAttribute="leading" secondItem="37T-Ef-DtX" secondAttribute="leading" constant="20" symbolic="YES" id="MnW-AM-QzP"/>
+                                    <constraint firstAttribute="bottom" secondItem="BId-kb-eYW" secondAttribute="bottom" id="QXK-90-kUJ"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BId-kb-eYW" secondAttribute="trailing" constant="20" symbolic="YES" id="Vk3-CH-cXd"/>
+                                    <constraint firstItem="BId-kb-eYW" firstAttribute="top" secondItem="37T-Ef-DtX" secondAttribute="top" id="YrX-aL-LAq"/>
+                                </constraints>
+                            </customView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="ov1-yV-Uol" userLabel="Anonymous Info View">
+                                <rect key="frame" x="0.0" y="64" width="360" height="14"/>
+                                <subviews>
+                                    <button focusRingType="none" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="a90-Iq-FgS" userLabel="Include Anonymous System Profile Button">
+                                        <rect key="frame" x="20" y="0.0" width="197" height="14"/>
+                                        <buttonCell key="cell" type="check" title="Include anonymous system profile" lineBreakMode="wordWrap" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" focusRingType="none" inset="2" id="gz7-LM-gNf">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="smallSystem"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="-2" name="value" keyPath="shouldSendProfile" id="HPm-tg-NCZ">
+                                                <dictionary key="options">
+                                                    <integer key="NSNullPlaceholder" value="1"/>
+                                                    <bool key="NSValidatesImmediately" value="YES"/>
+                                                </dictionary>
+                                            </binding>
+                                        </connections>
+                                    </button>
+                                    <button focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JW6-0z-Ud3" userLabel="Anonymous Info Disclosure Button">
+                                        <rect key="frame" x="221" y="-1" width="16" height="16"/>
+                                        <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="overlaps" alignment="center" borderStyle="border" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="yd4-Id-v7q">
+                                            <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="HMA-GI-C0a"/>
+                                            <constraint firstAttribute="width" constant="16" id="Qxo-Ga-nVP"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="toggleMoreInfo:" target="-2" id="AqY-Mp-X0q"/>
+                                            <binding destination="-2" name="hidden" keyPath="shouldAskAboutProfile" id="IJh-ox-Lrn">
+                                                <dictionary key="options">
+                                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                </dictionary>
+                                            </binding>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="JW6-0z-Ud3" firstAttribute="leading" secondItem="a90-Iq-FgS" secondAttribute="trailing" constant="4" id="6Y1-s7-g6r"/>
+                                    <constraint firstItem="JW6-0z-Ud3" firstAttribute="centerY" secondItem="a90-Iq-FgS" secondAttribute="centerY" id="BNJ-xV-faQ"/>
+                                    <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" secondItem="ov1-yV-Uol" secondAttribute="leading" constant="20" symbolic="YES" id="ILg-Qu-R6M"/>
+                                    <constraint firstItem="a90-Iq-FgS" firstAttribute="top" secondItem="ov1-yV-Uol" secondAttribute="top" id="Mh6-5L-xqM"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JW6-0z-Ud3" secondAttribute="trailing" constant="20" symbolic="YES" id="U4G-Eh-HPu"/>
+                                    <constraint firstAttribute="bottom" secondItem="a90-Iq-FgS" secondAttribute="bottom" id="qij-uH-6Yl"/>
+                                </constraints>
+                            </customView>
+                            <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AGr-V0-0al" userLabel="Placeholder View">
+                                <rect key="frame" x="0.0" y="61" width="360" height="193"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="193" id="yis-HR-OIe"/>
+                                </constraints>
+                            </customView>
+                            <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="39" userLabel="More Info View">
+                                <rect key="frame" x="0.0" y="61" width="360" height="193"/>
+                                <subviews>
+                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" preferredMaxLayoutWidth="260" translatesAutoresizingMaskIntoConstraints="NO" id="46" userLabel="System Profile Info">
+                                        <rect key="frame" x="18" y="123" width="324" height="70"/>
+                                        <textFieldCell key="cell" allowsUndo="NO" sendsActionOnEndEditing="YES" id="183">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <string key="title">Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.
+
+This is the information that would be sent:</string>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <scrollView autohidesScrollers="YES" horizontalLineScroll="18" horizontalPageScroll="0.0" verticalLineScroll="18" verticalPageScroll="0.0" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40" userLabel="ScrollView">
+                                        <rect key="frame" x="20" y="0.0" width="320" height="115"/>
+                                        <clipView key="contentView" id="sbp-rk-wxX">
+                                            <rect key="frame" x="1" y="1" width="318" height="113"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="16" id="41">
+                                                    <rect key="frame" x="0.0" y="0.0" width="330" height="113"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                    <tableColumns>
+                                                        <tableColumn editable="NO" width="150" minWidth="40" maxWidth="1000" id="42">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" controlSize="small" selectable="YES" alignment="left" title="Text Cell" id="43">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <connections>
+                                                                <binding destination="24" name="value" keyPath="arrangedObjects.displayKey" id="174"/>
+                                                            </connections>
+                                                        </tableColumn>
+                                                        <tableColumn editable="NO" width="165" minWidth="40" maxWidth="1000" id="44">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" controlSize="small" selectable="YES" alignment="left" title="Text Cell" id="45">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <connections>
+                                                                <binding destination="24" name="value" keyPath="arrangedObjects.displayValue" id="173"/>
+                                                            </connections>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                    <connections>
+                                                        <outlet property="delegate" destination="-2" id="oca-Wx-0pN"/>
+                                                    </connections>
+                                                </tableView>
+                                            </subviews>
+                                        </clipView>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="115" id="g4H-Z1-0xq"/>
+                                        </constraints>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" controlSize="small" horizontal="YES" id="185">
+                                            <rect key="frame" x="-100" y="-100" width="345" height="11"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" controlSize="small" horizontal="NO" id="184">
+                                            <rect key="frame" x="-22" y="1" width="11" height="125"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="46" firstAttribute="top" secondItem="39" secondAttribute="top" id="0rj-EA-SIj"/>
+                                    <constraint firstAttribute="trailing" secondItem="40" secondAttribute="trailing" constant="20" symbolic="YES" id="5Ze-wu-AsK"/>
+                                    <constraint firstItem="40" firstAttribute="leading" secondItem="39" secondAttribute="leading" constant="20" symbolic="YES" id="Qg9-kp-Lzl"/>
+                                    <constraint firstItem="46" firstAttribute="leading" secondItem="39" secondAttribute="leading" constant="20" symbolic="YES" id="TMg-61-Tbj"/>
+                                    <constraint firstAttribute="trailing" secondItem="46" secondAttribute="trailing" constant="20" symbolic="YES" id="fYg-If-EVL"/>
+                                    <constraint firstAttribute="bottom" secondItem="40" secondAttribute="bottom" id="o4Y-3j-NmQ"/>
+                                    <constraint firstItem="40" firstAttribute="top" secondItem="46" secondAttribute="bottom" constant="8" symbolic="YES" id="seb-Gl-jtw"/>
+                                </constraints>
+                            </customView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="0CP-x7-YFK" userLabel="Response View">
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="56"/>
+                                <subviews>
+                                    <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" spacing="6" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rbs-4k-Wq2" userLabel="Response Buttons View">
+                                        <rect key="frame" x="16" y="16" width="268" height="56"/>
+                                        <subviews>
+                                            <button tag="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="sMh-ha-r7R">
+                                                <rect key="frame" x="0.0" y="32" width="268" height="24"/>
+                                                <buttonCell key="cell" type="push" title="Check Automatically" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" tag="1" inset="2" id="OhZ-1K-DmA">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                    <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="finishPrompt:" target="-2" id="sms-z7-2Ij"/>
+                                                </connections>
+                                            </button>
+                                            <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="cFC-wV-H3j">
+                                                <rect key="frame" x="0.0" y="0.0" width="268" height="24"/>
+                                                <buttonCell key="cell" type="push" title="Don’t Check" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="cCJ-V0-aTi">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                    <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="finishPrompt:" target="-2" id="QJG-fs-Y9u"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="sMh-ha-r7R" firstAttribute="width" secondItem="Rbs-4k-Wq2" secondAttribute="width" id="Wjn-5Q-8Rt"/>
+                                            <constraint firstItem="cFC-wV-H3j" firstAttribute="width" secondItem="Rbs-4k-Wq2" secondAttribute="width" id="Xdp-6L-3Kv"/>
+                                        </constraints>
+                                        <visibilityPriorities>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                        </visibilityPriorities>
+                                        <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                        </customSpacing>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Rbs-4k-Wq2" firstAttribute="top" secondItem="0CP-x7-YFK" secondAttribute="top" constant="12" id="Fyr-gv-3TM"/>
+                                    <constraint firstItem="Rbs-4k-Wq2" firstAttribute="leading" secondItem="0CP-x7-YFK" secondAttribute="leading" constant="16" symbolic="YES" id="l3J-Va-WaM"/>
+                                    <constraint firstAttribute="trailing" secondItem="Rbs-4k-Wq2" secondAttribute="trailing" constant="16" symbolic="YES" id="PWc-tb-dWV"/>
+                                    <constraint firstAttribute="bottom" secondItem="Rbs-4k-Wq2" secondAttribute="bottom" constant="16" symbolic="YES" id="B76-mf-2m9"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
                         <constraints>
-                            <constraint firstAttribute="width" constant="437" id="gcK-Q4-n9c"/>
+                            <constraint firstAttribute="trailing" secondItem="0CP-x7-YFK" secondAttribute="trailing" id="Bnq-4X-Lsd"/>
+                            <constraint firstItem="AGr-V0-0al" firstAttribute="leading" secondItem="qNw-uD-4Bg" secondAttribute="leading" id="Cvh-6M-Xbz"/>
+                            <constraint firstAttribute="trailing" secondItem="37T-Ef-DtX" secondAttribute="trailing" id="Hcd-Yv-5Rt"/>
+                            <constraint firstItem="39" firstAttribute="leading" secondItem="qNw-uD-4Bg" secondAttribute="leading" id="Jkm-2P-Wtb"/>
+                            <constraint firstItem="37T-Ef-DtX" firstAttribute="leading" secondItem="qNw-uD-4Bg" secondAttribute="leading" id="Nnu-9x-Sc3"/>
+                            <constraint firstAttribute="trailing" secondItem="Yrl-Dt-Qvb" secondAttribute="trailing" id="Ptu-1S-Kdj"/>
+                            <constraint firstItem="ov1-yV-Uol" firstAttribute="leading" secondItem="qNw-uD-4Bg" secondAttribute="leading" id="Rjc-8T-Uwq"/>
+                            <constraint firstItem="Yrl-Dt-Qvb" firstAttribute="leading" secondItem="qNw-uD-4Bg" secondAttribute="leading" id="Vzq-cB-2Rn"/>
+                            <constraint firstAttribute="trailing" secondItem="ov1-yV-Uol" secondAttribute="trailing" id="Wsk-3D-Gzv"/>
+                            <constraint firstAttribute="trailing" secondItem="39" secondAttribute="trailing" id="Xnr-5V-Bqd"/>
+                            <constraint firstItem="0CP-x7-YFK" firstAttribute="leading" secondItem="qNw-uD-4Bg" secondAttribute="leading" id="Ykt-3J-Fpm"/>
+                            <constraint firstAttribute="trailing" secondItem="AGr-V0-0al" secondAttribute="trailing" id="Zqa-7L-Rnp"/>
+                            <constraint firstAttribute="width" constant="296" id="gcK-Q4-n9c"/>
                         </constraints>
+                        <visibilityPriorities>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                        </visibilityPriorities>
+                        <customSpacing>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                        </customSpacing>
                     </stackView>
                 </subviews>
                 <constraints>
@@ -71,324 +364,6 @@
                 <string>SUSendProfileInfo</string>
             </declaredKeys>
         </userDefaultsController>
-        <view id="Yrl-Dt-Qvb" userLabel="Prompt View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="78"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IgD-Pj-pc8">
-                    <rect key="frame" x="104" y="42" width="315" height="16"/>
-                    <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="J49-m7-iIa"/>
-                    </constraints>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Check for updates automatically?" id="gmh-T4-BO0">
-                        <font key="font" metaFont="systemBold"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="tgW-Jp-Aia">
-                    <rect key="frame" x="104" y="0.0" width="315" height="34"/>
-                    <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="HfG-Lg-91D"/>
-                        <constraint firstAttribute="width" constant="311" id="lNZ-C1-ceR"/>
-                    </constraints>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="DO NOT LOCALIZE" id="cfa-j0-Ya4">
-                        <font key="font" metaFont="smallSystem"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                    <connections>
-                        <binding destination="-2" name="value" keyPath="promptDescription" id="dvR-Lp-2jl"/>
-                    </connections>
-                </textField>
-                <imageView translatesAutoresizingMaskIntoConstraints="NO" id="NBn-FN-XAx">
-                    <rect key="frame" x="23" y="-4" width="64" height="64"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="64" id="KbC-i0-ZyN"/>
-                        <constraint firstAttribute="height" constant="64" id="Osy-kb-JTR"/>
-                    </constraints>
-                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="axesIndependently" image="NSApplicationIcon" id="clc-hq-1NY"/>
-                    <connections>
-                        <binding destination="-2" name="value" keyPath="icon" id="JD9-MU-vwB"/>
-                    </connections>
-                </imageView>
-            </subviews>
-            <constraints>
-                <constraint firstAttribute="trailing" secondItem="tgW-Jp-Aia" secondAttribute="trailing" constant="20" symbolic="YES" id="Fwc-c2-DDZ"/>
-                <constraint firstAttribute="trailing" secondItem="IgD-Pj-pc8" secondAttribute="trailing" constant="20" symbolic="YES" id="HXU-lh-GWa"/>
-                <constraint firstItem="IgD-Pj-pc8" firstAttribute="top" secondItem="Yrl-Dt-Qvb" secondAttribute="top" constant="20" symbolic="YES" id="Wl8-N0-skJ"/>
-                <constraint firstItem="NBn-FN-XAx" firstAttribute="leading" secondItem="Yrl-Dt-Qvb" secondAttribute="leading" constant="23" id="Xku-5M-xMC"/>
-                <constraint firstItem="tgW-Jp-Aia" firstAttribute="leading" secondItem="NBn-FN-XAx" secondAttribute="trailing" constant="19" id="fPB-MW-Oc2"/>
-                <constraint firstItem="NBn-FN-XAx" firstAttribute="top" secondItem="Yrl-Dt-Qvb" secondAttribute="top" constant="18" id="fad-TA-xIj"/>
-                <constraint firstItem="tgW-Jp-Aia" firstAttribute="top" secondItem="IgD-Pj-pc8" secondAttribute="bottom" constant="8" id="nN4-jN-Fdn"/>
-                <constraint firstItem="IgD-Pj-pc8" firstAttribute="leading" secondItem="NBn-FN-XAx" secondAttribute="trailing" constant="19" id="s7w-Aw-JQY"/>
-                <constraint firstAttribute="bottom" secondItem="tgW-Jp-Aia" secondAttribute="bottom" id="uS1-FX-kSX"/>
-            </constraints>
-            <point key="canvasLocation" x="-241" y="-37"/>
-        </view>
-        <customView hidden="YES" id="39" userLabel="MoreInfoView">
-            <rect key="frame" x="0.0" y="0.0" width="434" height="205"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="46" userLabel="SystemProfileInfo">
-                    <rect key="frame" x="104" y="123" width="312" height="70"/>
-                    <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="70" id="Csk-S6-dh4"/>
-                        <constraint firstAttribute="width" constant="308" id="iAG-SY-yVp"/>
-                    </constraints>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="183">
-                        <font key="font" metaFont="smallSystem"/>
-                        <string key="title">Anonymous system profile information is used to help us plan future development work. Please contact us if you have any questions about this.
-
-This is the information that would be sent:</string>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="0.0" verticalLineScroll="16" verticalPageScroll="0.0" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40" userLabel="ScrollView">
-                    <rect key="frame" x="103" y="0.0" width="314" height="115"/>
-                    <clipView key="contentView" id="sbp-rk-wxX">
-                        <rect key="frame" x="1" y="1" width="312" height="113"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="14" id="41">
-                                <rect key="frame" x="0.0" y="0.0" width="312" height="113"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <size key="intercellSpacing" width="3" height="2"/>
-                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                <tableColumns>
-                                    <tableColumn editable="NO" width="128" minWidth="40" maxWidth="1000" id="42">
-                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                        </tableHeaderCell>
-                                        <textFieldCell key="dataCell" controlSize="small" selectable="YES" alignment="left" title="Text Cell" id="43">
-                                            <font key="font" metaFont="smallSystem"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                        <connections>
-                                            <binding destination="24" name="value" keyPath="arrangedObjects.displayKey" id="174"/>
-                                        </connections>
-                                    </tableColumn>
-                                    <tableColumn editable="NO" width="137" minWidth="40" maxWidth="1000" id="44">
-                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                        </tableHeaderCell>
-                                        <textFieldCell key="dataCell" controlSize="small" selectable="YES" alignment="left" title="Text Cell" id="45">
-                                            <font key="font" metaFont="smallSystem"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                        <connections>
-                                            <binding destination="24" name="value" keyPath="arrangedObjects.displayValue" id="173"/>
-                                        </connections>
-                                    </tableColumn>
-                                </tableColumns>
-                                <connections>
-                                    <outlet property="delegate" destination="-2" id="oca-Wx-0pN"/>
-                                </connections>
-                            </tableView>
-                        </subviews>
-                    </clipView>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="115" id="g4H-Z1-0xq"/>
-                    </constraints>
-                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" controlSize="small" horizontal="YES" id="185">
-                        <rect key="frame" x="-100" y="-100" width="345" height="11"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" controlSize="small" horizontal="NO" id="184">
-                        <rect key="frame" x="-22" y="1" width="11" height="125"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                </scrollView>
-            </subviews>
-            <constraints>
-                <constraint firstItem="46" firstAttribute="top" secondItem="39" secondAttribute="top" constant="12" id="0rj-EA-SIj"/>
-                <constraint firstItem="40" firstAttribute="trailing" secondItem="46" secondAttribute="trailing" constant="3" id="5Ze-wu-AsK"/>
-                <constraint firstItem="40" firstAttribute="leading" secondItem="46" secondAttribute="leading" constant="-3" id="Qg9-kp-Lzl"/>
-                <constraint firstItem="46" firstAttribute="leading" secondItem="39" secondAttribute="leading" constant="106" id="TMg-61-Tbj"/>
-                <constraint firstAttribute="trailing" secondItem="46" secondAttribute="trailing" constant="20" id="fYg-If-EVL"/>
-                <constraint firstAttribute="bottom" secondItem="40" secondAttribute="bottom" id="o4Y-3j-NmQ"/>
-                <constraint firstItem="40" firstAttribute="top" secondItem="46" secondAttribute="bottom" constant="8" symbolic="YES" id="seb-Gl-jtw"/>
-            </constraints>
-            <point key="canvasLocation" x="-621" y="194"/>
-        </customView>
-        <customView id="0CP-x7-YFK" userLabel="Response View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="55"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="ilj-QP-33p" userLabel="View">
-                    <rect key="frame" x="0.0" y="0.0" width="437" height="55"/>
-                    <subviews>
-                        <button tag="1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sMh-ha-r7R">
-                            <rect key="frame" x="260" y="13" width="164" height="32"/>
-                            <buttonCell key="cell" type="push" title="Check Automatically" bezelStyle="rounded" alignment="center" state="on" borderStyle="border" tag="1" inset="2" id="OhZ-1K-DmA">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system"/>
-                                <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                            </buttonCell>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="gon-Nu-M8r"/>
-                            </constraints>
-                            <connections>
-                                <action selector="finishPrompt:" target="-2" id="sms-z7-2Ij"/>
-                            </connections>
-                        </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cFC-wV-H3j">
-                            <rect key="frame" x="145" y="13" width="115" height="32"/>
-                            <buttonCell key="cell" type="push" title="Don’t Check" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="cCJ-V0-aTi">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system"/>
-                                <string key="keyEquivalent" base64-UTF8="YES">
-Gw
-</string>
-                            </buttonCell>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="101" id="Fta-eR-U3P"/>
-                            </constraints>
-                            <connections>
-                                <action selector="finishPrompt:" target="-2" id="QJG-fs-Y9u"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="cFC-wV-H3j" secondAttribute="bottom" constant="20" id="B76-mf-2m9"/>
-                        <constraint firstItem="cFC-wV-H3j" firstAttribute="top" secondItem="ilj-QP-33p" secondAttribute="top" constant="15" id="Fyr-gv-3TM"/>
-                        <constraint firstItem="sMh-ha-r7R" firstAttribute="leading" secondItem="cFC-wV-H3j" secondAttribute="trailing" constant="14" id="Gse-h5-ctH"/>
-                        <constraint firstAttribute="width" constant="437" id="KXc-Kv-G8j"/>
-                        <constraint firstAttribute="trailing" secondItem="sMh-ha-r7R" secondAttribute="trailing" constant="20" symbolic="YES" id="PWc-tb-dWV"/>
-                        <constraint firstItem="sMh-ha-r7R" firstAttribute="centerY" secondItem="cFC-wV-H3j" secondAttribute="centerY" id="dmL-eu-rzf"/>
-                        <constraint firstItem="cFC-wV-H3j" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ilj-QP-33p" secondAttribute="leading" constant="20" symbolic="YES" id="l3J-Va-WaM"/>
-                    </constraints>
-                </customView>
-            </subviews>
-            <constraints>
-                <constraint firstItem="ilj-QP-33p" firstAttribute="top" secondItem="0CP-x7-YFK" secondAttribute="top" id="5In-8H-mUY"/>
-                <constraint firstAttribute="bottom" secondItem="ilj-QP-33p" secondAttribute="bottom" id="XNF-yO-yBl"/>
-                <constraint firstItem="ilj-QP-33p" firstAttribute="leading" secondItem="0CP-x7-YFK" secondAttribute="leading" id="d3g-7o-f52"/>
-                <constraint firstAttribute="trailing" secondItem="ilj-QP-33p" secondAttribute="trailing" id="jzr-jk-sQQ"/>
-            </constraints>
-            <point key="canvasLocation" x="-291" y="554"/>
-        </customView>
-        <customView id="ov1-yV-Uol" userLabel="Anonymous Info View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="20"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="a0k-dW-Jhx" userLabel="View">
-                    <rect key="frame" x="0.0" y="0.0" width="437" height="20"/>
-                    <subviews>
-                        <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="a90-Iq-FgS" userLabel="IncludeInfoButton">
-                            <rect key="frame" x="104" y="-1" width="200" height="16"/>
-                            <buttonCell key="cell" type="check" title="Include anonymous system profile" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" state="on" focusRingType="none" inset="2" id="gz7-LM-gNf">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="smallSystem"/>
-                            </buttonCell>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="14" id="STF-87-eYy"/>
-                            </constraints>
-                            <connections>
-                                <binding destination="-2" name="value" keyPath="shouldSendProfile" id="HPm-tg-NCZ">
-                                    <dictionary key="options">
-                                        <integer key="NSNullPlaceholder" value="1"/>
-                                        <bool key="NSValidatesImmediately" value="YES"/>
-                                    </dictionary>
-                                </binding>
-                            </connections>
-                        </button>
-                        <button focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JW6-0z-Ud3">
-                            <rect key="frame" x="85" y="-1" width="16" height="16"/>
-                            <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="overlaps" alignment="center" borderStyle="border" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="yd4-Id-v7q">
-                                <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="16" id="HMA-GI-C0a"/>
-                                <constraint firstAttribute="width" constant="16" id="Qxo-Ga-nVP"/>
-                            </constraints>
-                            <connections>
-                                <action selector="toggleMoreInfo:" target="-2" id="AqY-Mp-X0q"/>
-                                <binding destination="-2" name="hidden" keyPath="shouldAskAboutProfile" id="IJh-ox-Lrn">
-                                    <dictionary key="options">
-                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                    </dictionary>
-                                </binding>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="JW6-0z-Ud3" firstAttribute="leading" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="85" id="6Y1-s7-g6r"/>
-                        <constraint firstItem="a90-Iq-FgS" firstAttribute="centerY" secondItem="JW6-0z-Ud3" secondAttribute="centerY" id="BNJ-xV-faQ"/>
-                        <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" secondItem="a0k-dW-Jhx" secondAttribute="leading" constant="105" id="ILg-Qu-R6M"/>
-                        <constraint firstItem="a90-Iq-FgS" firstAttribute="top" secondItem="a0k-dW-Jhx" secondAttribute="top" constant="6" id="Mh6-5L-xqM"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="a90-Iq-FgS" secondAttribute="trailing" constant="20" id="U4G-Eh-HPu"/>
-                        <constraint firstItem="a90-Iq-FgS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="JW6-0z-Ud3" secondAttribute="trailing" constant="4" id="axA-s0-uGg"/>
-                        <constraint firstAttribute="width" constant="437" id="iUc-Zs-h9S"/>
-                        <constraint firstAttribute="bottom" secondItem="a90-Iq-FgS" secondAttribute="bottom" id="qij-uH-6Yl"/>
-                    </constraints>
-                </customView>
-            </subviews>
-            <constraints>
-                <constraint firstItem="a0k-dW-Jhx" firstAttribute="leading" secondItem="ov1-yV-Uol" secondAttribute="leading" id="dE2-R0-ENa"/>
-                <constraint firstItem="a0k-dW-Jhx" firstAttribute="top" secondItem="ov1-yV-Uol" secondAttribute="top" id="ibf-cg-DNR"/>
-                <constraint firstAttribute="trailing" secondItem="a0k-dW-Jhx" secondAttribute="trailing" id="rAn-bJ-Mp6"/>
-                <constraint firstAttribute="bottom" secondItem="a0k-dW-Jhx" secondAttribute="bottom" id="xw5-bj-VOd"/>
-            </constraints>
-            <point key="canvasLocation" x="-135.5" y="242.5"/>
-        </customView>
-        <customView id="37T-Ef-DtX" userLabel="Automatic Download View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="20"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="MEW-2n-kJE" userLabel="View">
-                    <rect key="frame" x="0.0" y="0.0" width="437" height="20"/>
-                    <subviews>
-                        <button focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="BId-kb-eYW" userLabel="automaticallyDownloadUpdatesButton">
-                            <rect key="frame" x="104" y="-1" width="248" height="16"/>
-                            <buttonCell key="cell" type="check" title="Automatically download and install updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" focusRingType="none" inset="2" id="AUc-33-qGN">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="smallSystem"/>
-                            </buttonCell>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="14" id="kJy-g7-0Un"/>
-                            </constraints>
-                            <connections>
-                                <binding destination="-2" name="value" keyPath="automaticallyDownloadUpdates" id="5Me-7t-mMu"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="BId-kb-eYW" firstAttribute="leading" secondItem="MEW-2n-kJE" secondAttribute="leading" constant="105" id="MnW-AM-QzP"/>
-                        <constraint firstAttribute="bottom" secondItem="BId-kb-eYW" secondAttribute="bottom" id="QXK-90-kUJ"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BId-kb-eYW" secondAttribute="trailing" constant="20" id="Vk3-CH-cXd"/>
-                        <constraint firstItem="BId-kb-eYW" firstAttribute="top" secondItem="MEW-2n-kJE" secondAttribute="top" constant="6" id="YrX-aL-LAq"/>
-                        <constraint firstAttribute="width" constant="437" id="n4W-Z4-w9i"/>
-                    </constraints>
-                </customView>
-            </subviews>
-            <constraints>
-                <constraint firstAttribute="bottom" secondItem="MEW-2n-kJE" secondAttribute="bottom" id="4iq-ZN-n9x"/>
-                <constraint firstItem="MEW-2n-kJE" firstAttribute="top" secondItem="37T-Ef-DtX" secondAttribute="top" id="FCe-KY-rHW"/>
-                <constraint firstItem="MEW-2n-kJE" firstAttribute="leading" secondItem="37T-Ef-DtX" secondAttribute="leading" id="dsv-fP-ffg"/>
-                <constraint firstAttribute="trailing" secondItem="MEW-2n-kJE" secondAttribute="trailing" id="puT-Df-xgH"/>
-            </constraints>
-            <point key="canvasLocation" x="-136" y="181"/>
-        </customView>
-        <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AGr-V0-0al" userLabel="Placeholder View">
-            <rect key="frame" x="0.0" y="0.0" width="437" height="205"/>
-            <constraints>
-                <constraint firstAttribute="width" constant="437" id="4p7-cJ-U8Z"/>
-                <constraint firstAttribute="height" constant="205" id="yis-HR-OIe"/>
-            </constraints>
-            <point key="canvasLocation" x="-643" y="495"/>
-        </customView>
     </objects>
     <resources>
         <image name="NSApplicationIcon" width="32" height="32"/>


### PR DESCRIPTION
Opening this as suggested in #2917 so the approach can be tried out.

The update permission prompt still used the horizontal layout that alerts had before Big Sur, which made it stand out next to the prompts the system and other apps show users today.

It now follows the metrics of a system prompt, 296 points wide with a 64 point app icon on top, the question and description below it, the choices next, and the two response buttons stacked at the bottom. The width and the 26 point corner radius are measured off a system prompt. On macOS 26 the buttons use the large control size and the dialog is drawn on an NSGlassEffectView, since AppKit offers no way to round a window itself. Before macOS 26 it stays a regular window with centered icon and text.

Behavior is identical, same options, same responses, same delegate paths, no new strings. All sections now live inside the window's stack view instead of being added programmatically, so the dialog shows up in Interface Builder again, while hidden sections are still detached by the stack view. Checkbox titles wrap now, which lets the dialog keep a fixed width without truncating longer translations, Ukrainian being the worst case at two lines.

Two things worth pointing out: the corner radius is a measured constant since AppKit does not expose the corner radius of a window, and the wrapping labels get their preferredMaxLayoutWidth set after the first layout pass, because the checkbox width is only known by then. Both are commented in the code.

I left the table view as it is for now so this stays a layout change. This is meant as something to try out rather than a finished proposal, so I'm happy to adjust the details as well as the code style.

Addresses #2917

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

Used Claude Code for the implementation. I made the design decisions and took the measurements against real alerts and system prompts. I also reviewed and tested every change in full, including edge cases like the Ukrainian localization.

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

Tested in English, German and Ukrainian where the long checkbox titles wrap to a second line without truncating and the dialog keeps its width. Checked the system profile disclosure expanding and collapsing, keyboard handling for Return and Escape, and Reduce Transparency. No constraint conflicts were logged in any of those runs.

macOS version tested: 26.5.2
