### PR TITLE
Reduce quick transition change when checking for updates

### DIFF
--- a/Configurations/ConfigCommon.xcconfig
+++ b/Configurations/ConfigCommon.xcconfig
@@ -169,7 +169,7 @@ GCC_WARN_UNUSED_PARAMETER = YES
 GCC_WARN_UNUSED_VARIABLE = YES
 
 // Turn on all warnings, then disable a few which are almost impossible to avoid
-WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Werror=undef
+WARNING_CFLAGS = -Wall -Weverything -Wno-unused-macros -Wno-gnu-statement-expression -Wno-auto-import -Wno-gnu-zero-variadic-macro-arguments -Wno-format-non-iso -Wno-pre-c11-compat -Wno-direct-ivar-access -Wno-declaration-after-statement -Wno-gnu-conditional-omitted-operand -Wno-switch-default -Wno-missing-include-dirs -Werror=undef
 
 // Prevents spurious warnings based on dependency scan considering Sparkle itself a dependency
 DIAGNOSE_MISSING_TARGET_DEPENDENCIES = NO

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -41,6 +41,9 @@
 @end
 #endif
 
+// Delay before we need to show the checking for updates progress window when user initiates an update check
+static const NSTimeInterval SUShowCheckingForUpdatesTimeDelay = 0.3;
+
 @interface SPUStandardUserDriver () <SPUGentleUserDriverReminders>
 
 // Note: we expose a private interface for activeUpdateAlert property in SPUStandardUserDriver+Private.h as NSWindowController
@@ -63,6 +66,7 @@
     id<NSObject> _applicationBecameActiveAfterUpdateAlertBecameKeyObserver;
     NSValue *_updateAlertWindowFrameValue;
     SUStatusController *_checkingController;
+    dispatch_block_t _showCheckingControllerWindowDelayBlock;
     
     SUUpdateAlert *_activeUpdateAlert;
     SPUUpdaterSettings *_updaterSettings;
@@ -476,6 +480,7 @@
         [_statusController showWindow:nil];
         mayNeedToActivateApp = YES;
     } else if (_checkingController != nil) {
+        [self cancelShowCheckingControllerWindowDelayBlock];
         [_checkingController showWindow:nil];
         mayNeedToActivateApp = YES;
     } else if (_retryTerminatingApplication != nil) {
@@ -555,13 +560,34 @@
         [self _activateApplication];
     }
     
-    [_checkingController showWindow:self];
+    // Don't show checking for updates window immediately
+    // Only show it if the check is taking a noticable amount of time.
+    // This reduces the chance of a very sudden/quick transition between
+    // checking for updates and showing the next UI.
+    __weak __typeof__(self) weakSelf = self;
+    _showCheckingControllerWindowDelayBlock = dispatch_block_create_with_qos_class((dispatch_block_flags_t)0, QOS_CLASS_USER_INITIATED, 0, ^{
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf != nil) {
+            [strongSelf->_checkingController showWindow:strongSelf];
+        }
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SUShowCheckingForUpdatesTimeDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), _showCheckingControllerWindowDelayBlock);
+}
+
+- (void)cancelShowCheckingControllerWindowDelayBlock SPU_OBJC_DIRECT
+{
+    if (_showCheckingControllerWindowDelayBlock != nil) {
+        dispatch_cancel(_showCheckingControllerWindowDelayBlock);
+        _showCheckingControllerWindowDelayBlock = nil;
+    }
 }
 
 - (void)closeCheckingWindow SPU_OBJC_DIRECT
 {
     if (_checkingController != nil)
     {
+        [self cancelShowCheckingControllerWindowDelayBlock];
+
         [_checkingController close];
         _checkingController = nil;
         _cancellation = nil;


### PR DESCRIPTION
If the user initiated update check performs fast enough, we won't show the check for updates progress status window, and transition right away to the new update / update not found / update error occurred windows.

Fixes #2878

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [x] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Tested this change with test app and several of the Sparkle-based apps I have installed in /Applications. For about half of them, I can reach their feed in < 0.3 seconds.

macOS version tested: 27.0 (26A428)
