### PR TITLE
Remove old compile time availability guards

### DIFF
--- a/Autoupdate/SPUDeltaArchiveProtocol.h
+++ b/Autoupdate/SPUDeltaArchiveProtocol.h
@@ -73,8 +73,6 @@ SPU_OBJC_DIRECT_MEMBERS @interface SPUDeltaArchiveItem : NSObject
 // For reading, file items cannot be extracted out of order.
 @protocol SPUDeltaArchiveProtocol <NSObject>
 
-@property (nonatomic, readonly, class) BOOL maySupportSafeExtraction;
-
 // If non-nil, there was an error with reading or writing data from the archive
 @property (nonatomic, readonly, nullable) NSError *error;
 

--- a/Autoupdate/SPUSparkleDeltaArchive.m
+++ b/Autoupdate/SPUSparkleDeltaArchive.m
@@ -52,11 +52,6 @@ typedef struct
 
 @synthesize error = _error;
 
-+ (BOOL)maySupportSafeExtraction
-{
-    return YES;
-}
-
 - (instancetype)initWithPatchFileForWriting:(NSString *)patchFile
 {
     self = [super init];

--- a/Autoupdate/SPUXarDeltaArchive.m
+++ b/Autoupdate/SPUXarDeltaArchive.m
@@ -17,17 +17,9 @@
 
 #include "AppKitPrevention.h"
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
-    #define HAS_XAR_GET_SAFE_PATH 1
-#else
-    #define HAS_XAR_GET_SAFE_PATH 0
-#endif
-
-#if HAS_XAR_GET_SAFE_PATH
 // This is preferred over xar_get_path (which is deprecated) when it's available
 // Don't use OS availability for this API
 extern char *xar_get_safe_path(xar_file_t f) __attribute__((weak_import));
-#endif
 
 // Xar attribute keys
 #define BINARY_DELTA_ATTRIBUTES_KEY "binary-delta-attributes"
@@ -90,12 +82,6 @@ extern char *xar_get_safe_path(xar_file_t f) __attribute__((weak_import));
         xar_close(_x);
         _x = NULL;
     }
-}
-
-// This indicates if safe extraction is available at compile time (SDK), but not if it's available at runtime.
-+ (BOOL)maySupportSafeExtraction
-{
-    return HAS_XAR_GET_SAFE_PATH;
 }
 
 - (nullable SPUDeltaArchiveHeader *)readHeader
@@ -323,7 +309,6 @@ static xar_file_t xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTab
     xar_iter_t iter = xar_iter_new();
     for (xar_file_t file = xar_file_first(_x, iter); file; file = xar_file_next(iter)) {
         char *pathCString;
-#if HAS_XAR_GET_SAFE_PATH
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
         if (xar_get_safe_path != NULL) {
@@ -331,7 +316,6 @@ static xar_file_t xarAddFile(NSMutableDictionary<NSString *, NSValue *> *fileTab
         }
 #pragma clang diagnostic pop
         else
-#endif
         {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Autoupdate/SUBinaryDeltaApply.m
+++ b/Autoupdate/SUBinaryDeltaApply.m
@@ -72,7 +72,7 @@ BOOL applyBinaryDelta(NSString *source, NSString *finalDestination, NSString *pa
     
     // Reject patches that did not generate valid hierarchical xar container paths
     // These will not succeed to patch using recent versions of BinaryDelta
-    if ([[archive class] maySupportSafeExtraction] && majorDiffVersion == SUBinaryDeltaMajorVersion2 && minorDiffVersion < 3) {
+    if (majorDiffVersion == SUBinaryDeltaMajorVersion2 && minorDiffVersion < 3) {
         if (error != NULL) {
             *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadCorruptFileError userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"This patch version (%u.%u) is too old and potentially unsafe to apply. Please re-generate the patch using the latest version of BinaryDelta or generate_appcast. New version %u.%u patches will still be compatible with older versions of Sparkle.", majorDiffVersion, minorDiffVersion, majorDiffVersion, latestMinorVersionForMajorVersion(majorDiffVersion)] }];
         }

--- a/Sparkle/InstallerProgress/InstallerProgressAppController.m
+++ b/Sparkle/InstallerProgress/InstallerProgressAppController.m
@@ -28,12 +28,6 @@
  */
 static const NSTimeInterval SUTerminationTimeDelay = 0.3;
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 140000
-@interface NSApplication (ActivationAPIs)
-- (void)activate;
-@end
-#endif
-
 @interface InstallerProgressAppController () <NSApplicationDelegate, SPUInstallerAgentProtocol>
 @end
 

--- a/Sparkle/SPUStandardUserDriver.m
+++ b/Sparkle/SPUStandardUserDriver.m
@@ -35,12 +35,6 @@
 
 #import <AppKit/AppKit.h>
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 140000
-@interface NSApplication (ActivationAPIs)
-- (void)activate;
-@end
-#endif
-
 // Delay before we need to show the checking for updates progress window when user initiates an update check
 static const NSTimeInterval SUShowCheckingForUpdatesTimeDelay = 0.3;
 


### PR DESCRIPTION

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [ ] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [ ] Unit Tests
- [ ] My own app
- [x] Other (please specify)

Testing in CI

macOS version tested: 27.0 (26A428)
