### PR TITLE
Fix reading release notes content length from appcast

### DIFF
--- a/Sparkle/SUAppcastItem.m
+++ b/Sparkle/SUAppcastItem.m
@@ -843,7 +843,7 @@ static NSString *SPUSanitizeUntrustedVersionString(NSString *versionString, NSSt
     #endif
             ];
             
-            long long releaseNotesLength = [(NSString *)[releaseNotesLinkDictionary objectForKey:@"length"] longLongValue];
+            long long releaseNotesLength = [(NSString *)[releaseNotesLinkDictionary objectForKey:SUAppcastAttributeLength] longLongValue];
             _releaseNotesContentLength = (releaseNotesLength > 0) ? (uint64_t)releaseNotesLength : 0;
         }
         

--- a/Tests/Resources/test-links.xml
+++ b/Tests/Resources/test-links.xml
@@ -5,7 +5,7 @@
     <item>
         <title>Version 3.0</title>
         <pubDate>Sat, 26 Jul 2014 15:20:12 +0000</pubDate>
-        <sparkle:releaseNotesLink>https://sparkle-project.org/notes/relnote-3.0.txt</sparkle:releaseNotesLink>
+        <sparkle:releaseNotesLink sparkle:length="1234">https://sparkle-project.org/notes/relnote-3.0.txt</sparkle:releaseNotesLink>
         <sparkle:fullReleaseNotesLink>https://sparkle-project.org/fullnotes.txt</sparkle:fullReleaseNotesLink>
         <link>https://sparkle-project.org</link>
         <enclosure url="https://sparkle-project.org/release-3.0.zip" sparkle:version="3.0" length="1346234" />

--- a/Tests/SUAppcastTest.swift
+++ b/Tests/SUAppcastTest.swift
@@ -1037,12 +1037,14 @@ class SUAppcastTest: XCTestCase {
             
             // Test https
             XCTAssertEqual("https://sparkle-project.org/notes/relnote-3.0.txt", items[0].releaseNotesURL?.absoluteString)
+            XCTAssertEqual(1234, items[0].releaseNotesContentLength)
             XCTAssertEqual("https://sparkle-project.org/fullnotes.txt", items[0].fullReleaseNotesURL?.absoluteString)
             XCTAssertEqual("https://sparkle-project.org", items[0].infoURL?.absoluteString)
             XCTAssertEqual("https://sparkle-project.org/release-3.0.zip", items[0].fileURL?.absoluteString)
             
             // Test http
             XCTAssertEqual("http://sparkle-project.org/notes/relnote-2.0.txt", items[1].releaseNotesURL?.absoluteString)
+            XCTAssertEqual(0, items[1].releaseNotesContentLength)
             XCTAssertEqual("http://sparkle-project.org/fullnotes.txt", items[1].fullReleaseNotesURL?.absoluteString)
             XCTAssertEqual("http://sparkle-project.org", items[1].infoURL?.absoluteString)
             XCTAssertEqual("http://sparkle-project.org/release-2.0.zip", items[1].fileURL?.absoluteString)

--- a/Tests/Sparkle Unit Tests-Bridging-Header.h
+++ b/Tests/Sparkle Unit Tests-Bridging-Header.h
@@ -12,6 +12,7 @@
 #import "SUAppcast.h"
 #import "SUAppcast+Private.h"
 #import "SUAppcastItem.h"
+#import "SUAppcastItem+Private.h"
 #import "SUAppcastDriver.h"
 #import "SUVersionComparisonProtocol.h"
 #import "SUStandardVersionComparator.h"


### PR DESCRIPTION
While reading how release notes signatures are verified, I noticed that `SUAppcast` stores the `sparkle:length` attribute of `<sparkle:releaseNotesLink>` in the link dictionary under the `SUAppcastAttributeLength` key (`sparkle:length`), but `SUAppcastItem` reads it back with `@"length"`. That lookup always returns nil, so `releaseNotesContentLength` is always 0, even for feeds generated by `generate_appcast` or `sign_update`, which both emit `sparkle:length` on the release notes link.

The effect is limited to diagnostics: `SPUReleaseNotesDriver` passes that length to `SPUVerifierInformation`, and `SUSignatureVerifier` only adds its "expected content length differs from the downloaded file length" hint when the expected length is non-zero. So when release notes fail validation, that hint never shows up today. Verification itself doesn't use the length, so nothing about acceptance or rejection changes.

The fix reads the value with `SUAppcastAttributeLength`, the same constant the parser writes with. I added `sparkle:length="1234"` to the first release notes link in `test-links.xml` and checked `releaseNotesContentLength` in `testLinks` (1234 for that item, 0 for an item without the attribute). That needed `SUAppcastItem+Private.h` in the unit test bridging header.

This change was found, written and tested with an AI coding assistant (Claude Code): it traced the key mismatch between `SUAppcast.m` and `SUAppcastItem.m`, wrote the test, and ran it before and after the fix on CI. The diff is small (one line of code plus the test), and I checked it against the parser and verifier code paths described above.

## Misc Checklist

- [ ] My change requires a documentation update on [Sparkle's website repository](https://github.com/sparkle-project/sparkle-project.github.io)
- [ ] My change requires changes to generate_appcast, generate_keys, or sign_update
- [x] My change was generated/assisted using AI and if so was reviewed by me in whole (explain in detail in the summary)

## Testing

I tested and verified my change by using one or multiple of these methods:

- [ ] Sparkle Test App
- [x] Unit Tests
- [ ] My own app
- [ ] Other (please specify)

I ran `SUAppcastTest` on a GitHub Actions macos-26 runner (Xcode 26.6) on my fork, with a workflow reduced to building the unit tests and running that class:

- test only, without the fix: `testLinks` fails with `XCTAssertEqual failed: ("1234") is not equal to ("0")` (https://github.com/Dev-next-gen/Sparkle/actions/runs/34736708106)
- test with the fix: all 19 `SUAppcastTest` tests pass (https://github.com/Dev-next-gen/Sparkle/actions/runs/34736718659)

I did not run it on a local Mac.

macOS version tested: macOS 26 (GitHub Actions runner)
